### PR TITLE
errorlib: optional support for Sentry

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -223,6 +223,11 @@ CFG_SITE_RECORD = record
 ## notification become more and more rare.
 CFG_ERRORLIB_RESET_EXCEPTION_NOTIFICATION_COUNTER_AFTER = 14400
 
+## CFG_ERRORLIB_SENTRY_URI -- optionally, if you use Sentry for logging.
+## Sentry notifies you when your users experience errors.
+## Enables logging of exceptions in invenio to given Sentry server. 
+CFG_ERRORLIB_SENTRY_URI =
+
 ## CFG_CERN_SITE -- do we want to enable CERN-specific code?
 ## Put "1" for "yes" and "0" for "no".
 CFG_CERN_SITE = 0

--- a/modules/miscutil/lib/errorlib.py
+++ b/modules/miscutil/lib/errorlib.py
@@ -36,7 +36,8 @@ from invenio.config import CFG_SITE_LANG, CFG_LOGDIR, \
     CFG_SITE_EMERGENCY_EMAIL_ADDRESSES, \
     CFG_SITE_ADMIN_EMAIL_EXCEPTIONS, \
     CFG_ERRORLIB_RESET_EXCEPTION_NOTIFICATION_COUNTER_AFTER, \
-    CFG_PROPAGATE_EXCEPTIONS
+    CFG_PROPAGATE_EXCEPTIONS, \
+    CFG_ERRORLIB_SENTRY_URI
 from invenio.urlutils import wash_url_argument
 from invenio.messages import wash_language, gettext_set_language
 from invenio.dateutils import convert_datestruct_to_datetext
@@ -382,6 +383,12 @@ def register_exception(stream='error',
 
     @return: 1 if successfully wrote to stream, 0 if not
     """
+
+    if CFG_ERRORLIB_SENTRY_URI:
+        from raven import Client
+        client = Client(CFG_ERRORLIB_SENTRY_URI)
+        client.captureException()
+
     if CFG_PROPAGATE_EXCEPTIONS:
         raise
 

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -16,3 +16,4 @@ cython
 nose
 nosexcover
 flake8
+raven==4.2.1


### PR DESCRIPTION
- Capture exceptions in register_exception
- add raven to requirements-extra
- add CFG_ERRORLIB_SENTRY_URI to config, used to set sentry uri and enable/disable sentry feature.

Signed-off-by: Fredrik Nygård Carlsen me@frecar.no
