### PR TITLE
WebSearch: date after, date before bug fix

### DIFF
--- a/modules/websearch/lib/search_engine_query_parser.py
+++ b/modules/websearch/lib/search_engine_query_parser.py
@@ -723,7 +723,7 @@ class SpiresToInvenioSyntaxConverter:
         self._re_date_before_match = re.compile(r'\b(?P<searchop>d|date|dupd|dadd|da|date-added|du|date-updated)\b\s*(before|<)\s*(?P<search_content>.+?)(?= and not | and | or | not |$)', re.IGNORECASE)
 
         # match date searches which have been keyword-substituted
-        self._re_keysubbed_date_expr = re.compile(r'\b(?P<term>(' + self._DATE_ADDED_FIELD + ')|(' + self._DATE_UPDATED_FIELD + ')|(' + self._DATE_FIELD + '))(?P<content>.+?)(?= and not | and | or | not |$)', re.IGNORECASE)
+        self._re_keysubbed_date_expr = re.compile(r'\b(?P<term>(' + self._DATE_ADDED_FIELD + ')|(' + self._DATE_UPDATED_FIELD + ')|(' + self._DATE_FIELD + '))(?P<content>.+?)(?= and not | and | or | not |\)|$)', re.IGNORECASE)
 
         # for finding (and changing) a variety of different SPIRES search keywords
         self._re_spires_find_keyword = re.compile('^(f|fin|find)\s+', re.IGNORECASE)
@@ -810,17 +810,17 @@ class SpiresToInvenioSyntaxConverter:
 
         # this dictionary is used when generating match patterns for months
         self._months = {'jan':'01', 'january':'01',
-                         'feb':'02', 'february':'02',
-                         'mar':'03', 'march':'03',
-                         'apr':'04', 'april':'04',
-                         'may':'05', 'may':'05',
-                         'jun':'06', 'june':'06',
-                         'jul':'07', 'july':'07',
-                         'aug':'08', 'august':'08',
-                         'sep':'09', 'september':'09',
-                         'oct':'10', 'october':'10',
-                         'nov':'11', 'november':'11',
-                         'dec':'12', 'december':'12'}
+                        'feb':'02', 'february':'02',
+                        'mar':'03', 'march':'03',
+                        'apr':'04', 'april':'04',
+                        'may':'05', 'may':'05',
+                        'jun':'06', 'june':'06',
+                        'jul':'07', 'july':'07',
+                        'aug':'08', 'august':'08',
+                        'sep':'09', 'september':'09',
+                        'oct':'10', 'october':'10',
+                        'nov':'11', 'november':'11',
+                        'dec':'12', 'december':'12'}
         # this dictionary is used to transform name of the month
         # to a number used in the date format. By this reason it
         # contains also the numbers itself to simplify the conversion
@@ -1017,7 +1017,10 @@ class SpiresToInvenioSyntaxConverter:
 
         def create_replacement_pattern(match):
             """method used for replacement with regular expression"""
-            return match.group('searchop') + ' ' + match.group('search_content') + '->9999'
+            return '(' \
+            + match.group('searchop') + ' ' + match.group('search_content')+ '->9999' \
+            + ' AND NOT ' + match.group('searchop') + ' ' + match.group('search_content') \
+            + ')'
 
         query = self._re_date_after_match.sub(create_replacement_pattern, query)
 
@@ -1026,9 +1029,12 @@ class SpiresToInvenioSyntaxConverter:
     def _convert_spires_date_before_to_invenio_span_query(self, query):
         """Converts date before SPIRES search term into invenio span query"""
 
-        # method used for replacement with regular expression
         def create_replacement_pattern(match):
-            return match.group('searchop') + ' ' + '0->' + match.group('search_content')
+            """method used for replacement with regular expression"""
+            return ' (' \
+            + match.group('searchop') + ' 0->' + match.group('search_content') \
+            + ' AND NOT ' + match.group('searchop') + ' ' + match.group('search_content') \
+            + ')'
 
         query = self._re_date_before_match.sub(create_replacement_pattern, query)
 

--- a/modules/websearch/lib/search_engine_query_parser_unit_tests.py
+++ b/modules/websearch/lib/search_engine_query_parser_unit_tests.py
@@ -731,13 +731,13 @@ class TestSpiresToInvenioSyntaxConverter(InvenioTestCase):
         def test_date_by_lt_yr(self):
             """SPIRES search syntax - searching by date < year"""
             spi_search = "find date < 2002"
-            inv_search = 'year:0->2002'
+            inv_search = 'year:0->2002 AND NOT year:2002'
             self._compare_searches(inv_search, spi_search)
 
         def test_date_by_gt_yr(self):
             """SPIRES search syntax - searching by date > year"""
             spi_search = "find date > 1980"
-            inv_search = 'year:1980->9999'
+            inv_search = 'year:1980->9999 AND NOT year:1980'
             self._compare_searches(inv_search, spi_search)
 
         def test_date_by_yr_mo(self):
@@ -758,22 +758,34 @@ class TestSpiresToInvenioSyntaxConverter(InvenioTestCase):
             inv_search = 'year:1976-04-05 and title:dog'
             self._compare_searches(inv_search, spi_search)
 
-        def test_date_by_eq_yr_mo(self):
-            """SPIRES search syntax - searching by date 1976-04"""
-            spi_search = "find date 1976-04"
-            inv_search = 'year:1976-04'
+        def test_date_by_yr_mo_d(self):
+            """SPIRES search syntax - searching by date 1978-10-21"""
+            spi_search = "find date 1978-10-21"
+            inv_search = 'year:1978-10-21'
             self._compare_searches(inv_search, spi_search)
 
         def test_date_by_lt_yr_mo(self):
-            """SPIRES search syntax - searching by date < 1978-10-21"""
-            spi_search = "find date < 1978-10-21"
-            inv_search = 'year:0->1978-10-21'
+            """SPIRES search syntax - searching by date < 1978-10"""
+            spi_search = "find date < 1978-10"
+            inv_search = 'year:0->1978-10 AND NOT year:1978-10'
             self._compare_searches(inv_search, spi_search)
 
         def test_date_by_gt_yr_mo(self):
+            """SPIRES search syntax - searching by date > 1978-10"""
+            spi_search = "find date > 1978-10"
+            inv_search = 'year:1978-10->9999 AND NOT year:1978-10'
+            self._compare_searches(inv_search, spi_search)
+
+        def test_date_by_lt_yr_mo_d(self):
+            """SPIRES search syntax - searching by date < 1978-10-21"""
+            spi_search = "find date < 1978-10-21"
+            inv_search = 'year:0->1978-10-21 AND NOT year:1978-10-21'
+            self._compare_searches(inv_search, spi_search)
+
+        def test_date_by_gt_yr_mo_d(self):
             """SPIRES search syntax - searching by date > 1978-10-21"""
             spi_search = "find date > 1978-10-21"
-            inv_search = 'year:1978-10-21->9999'
+            inv_search = 'year:1978-10-21->9999 AND NOT year:1978-10-21'
             self._compare_searches(inv_search, spi_search)
 
         def test_date_before_1900(self):
@@ -821,22 +833,34 @@ class TestSpiresToInvenioSyntaxConverter(InvenioTestCase):
             self._compare_searches(invenio_search, spi_search)
 
         if DATEUTIL_AVAILABLE:
+            def test_date_by_d_MO_yr(self):
+                """SPIRES search syntax - searching by date 23 Sep 2010: will only work with dateutil installed"""
+                spi_search = "find date 23 Sep 2010"
+                inv_search = 'year:2010-09-23'
+                self._compare_searches(inv_search, spi_search)
+
             def test_date_by_lt_d_MO_yr(self):
                 """SPIRES search syntax - searching by date < 23 Sep 2010: will only work with dateutil installed"""
                 spi_search = "find date < 23 Sep 2010"
-                inv_search = 'year:0->2010-09-23'
+                inv_search = 'year:0->2010-09-23 AND NOT year:2010-09-23'
+                self._compare_searches(inv_search, spi_search)
+
+            def test_date_by_d_MO_yr_parentheses(self):
+                """SPIRES search syntax - searching by date 23 Sep 2010 using parentheses: will only work with dateutil installed"""
+                spi_search = "find (date 23 Sep 2010)"
+                inv_search = 'year:2010-09-23'
                 self._compare_searches(inv_search, spi_search)
 
             def test_date_before_1900(self):
                 """SPIRES search syntax - searching by date < 23 Sep 1889: will only work with dateutil installed"""
                 spi_search = "find date < 23 Sep 1889"
-                inv_search = 'year:0->1889-09-23'
+                inv_search = 'year:0->1889-09-23 AND NOT year:1889-09-23'
                 self._compare_searches(inv_search, spi_search)
 
             def test_date_by_gt_d_MO_yr(self):
                 """SPIRES search syntax - searching by date > 12 Jun 1960: will only work with dateutil installed"""
                 spi_search = "find date > 12 Jun 1960"
-                inv_search = 'year:1960-06-12->9999'
+                inv_search = 'year:1960-06-12->9999 AND NOT year:1960-06-12'
                 self._compare_searches(inv_search, spi_search)
 
             def test_date_accept_today(self):


### PR DESCRIPTION
- Fixes unit tests;
- Fixes method '_convert_spires_date_after_to_invenio_span_query';
- Fixes method '_convert_spires_date_before_to_invenio_span_query';
- Fixes regexp used by '_convert_all_dates';
- Fixes indentation for kwalitee.

Signed-off-by: Federico Poli federico.poli@cern.ch
