### PR TITLE
WebSearch: new Journal Hint Service

### DIFF
--- a/modules/docextract/lib/refextract_unit_tests.py
+++ b/modules/docextract/lib/refextract_unit_tests.py
@@ -248,6 +248,16 @@ class SearchTest(InvenioTestCase):
         self.assert_('B76' in pattern)
         self.assert_('477' in pattern)
 
+    def test_not_recognized_unicode_1(self):
+        field, pattern = search_from_reference(u'País Valencià')
+        self.assertEqual(field, '')
+        self.assertEqual(pattern, '')
+
+    def test_not_recognized_unicode_2(self):
+        field, pattern = search_from_reference(u'Capellà Pere')
+        self.assertEqual(field, '')
+        self.assertEqual(pattern, '')
+
 
 class RebuildReferencesTest(InvenioTestCase):
     def setUp(self):

--- a/modules/websearch/lib/Makefile.am
+++ b/modules/websearch/lib/Makefile.am
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2010, 2011 CERN.
+## Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2010, 2011, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -48,6 +48,7 @@ pylib_DATA = \
 	websearch_external_collections_unit_tests.py \
 	websearch_external_collections_utils.py \
 	websearch_services.py \
+	websearch_services_unit_tests.py \
 	websearch_services_regression_tests.py \
     search_engine_summarizer_regression_tests.py
 

--- a/modules/websearch/lib/services/JournalHintService.py
+++ b/modules/websearch/lib/services/JournalHintService.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+"""
+JournalHint service to display
+"Were you looking for a journal reference? Try: <link>"
+when the request is a journal reference
+"""
+from invenio.websearch_services import SearchService
+from invenio.config import (CFG_SITE_URL,
+                            CFG_SITE_LANG)
+from urllib import urlencode
+import re
+from cgi import escape
+
+__plugin_version__ = "Search Service Plugin API 1.0"
+
+
+class JournalHintService(SearchService):
+
+    """Give hints on how to search the journal reference."""
+
+    re_dot_comma_year = re.compile(r',|\([0-9]{4}\)')
+    re_keyword = re.compile(
+        r'^((f|fin|find)\s+)|^([a-zA-Z0-9_-]+\:)',
+        re.IGNORECASE
+    )
+
+    @classmethod
+    def seems_a_journal_reference(cls, reference):
+        """Quickly check if `name` seems to be a journal reference."""
+        # It must not be empty
+        if not reference.strip():
+            return False
+        # There must be a comma or a year in parentesis
+        if not cls.re_dot_comma_year.search(reference):
+            return False
+        # It must not start with a keyword
+        if cls.re_keyword.search(reference):
+            return False
+        return True
+
+    def get_description(self, ln=CFG_SITE_LANG):
+        """Return service description."""
+        return "Give hints on how to search the journal reference"
+
+    def answer(self, req, user_info, of, cc,
+               colls_to_search, p, f, search_units, ln):
+        """Answer question given by context.
+
+        Return (relevance, html_string) where relevance is integer
+        from 0 to 100 indicating how relevant to the question the
+        answer is (see C{CFG_WEBSEARCH_SERVICE_MAX_SERVICE_ANSWER_RELEVANCE}
+        for details), and html_string being a formatted answer.
+        """
+        from invenio.refextract_api import search_from_reference
+
+        if not self.seems_a_journal_reference(p):
+            return (0, "")
+
+        (field, pattern) = search_from_reference(p.decode('utf-8'))
+
+        if field is not "journal":
+            return (0, "")
+
+        query = "journal:\"" + pattern + "\""
+        query_link = CFG_SITE_URL + '/search?' + urlencode({'p': query})
+        return (
+            80,
+            'Were you looking for a journal reference? '
+            'Try: <a href="{0}">{1}</a>'
+            .format(query_link, escape(query))
+        )

--- a/modules/websearch/lib/services/Makefile.am
+++ b/modules/websearch/lib/services/Makefile.am
@@ -21,7 +21,8 @@ pylib_DATA = \
 	__init__.py \
 	CollectionNameSearchService.py \
 	FAQKBService.py \
-	SubmissionNameSearchService.py
+	SubmissionNameSearchService.py \
+	JournalHintService.py
 
 EXTRA_DIST = $(pylib_DATA)
 

--- a/modules/websearch/lib/websearch_services_regression_tests.py
+++ b/modules/websearch/lib/websearch_services_regression_tests.py
@@ -309,10 +309,164 @@ class WebSearchServicesSubmissionNameSearch(InvenioTestCase):
         if error_messages:
             self.fail(merge_error_messages(error_messages))
 
+class WebSearchServicesJournalHintService(InvenioTestCase):
+    """Check JournalHintService plugin"""
+
+    def setUp(self):
+        """Load plugin"""
+        search_service_plugins = PluginContainer(os.path.join(CFG_SEARCH_SERVICES_PATH, '*Service.py'),
+                                                 api_version=__required_plugin_API_version__,
+                                                 plugin_signature=SearchService)
+        self.plugin = search_service_plugins.get('JournalHintService')()
+
+    def test_search_author_Tom(self):
+        """websearch - search for an author using invenio sintax, with JournalHintService"""
+        user_info = collect_user_info(0)
+        pattern = 'author:Tom'
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assertEqual(response,
+                         (0, ''))
+
+    def test_search_find_a_John(self):
+        """websearch - search 'find a John', with JournalHintService"""
+        user_info = collect_user_info(0)
+        pattern = 'find a John'
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assertEqual(response,
+                         (0, ''))
+
+    def test_search_date_after_2001(self):
+        """websearch - search 'find date after 2001', with JournalHintService"""
+        user_info = collect_user_info(0)
+        pattern = 'find date after 2001'
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assertEqual(response,
+                         (0, ''))
+
+    def test_search_year_2001_or_year_2002(self):
+        """websearch - search 'year:2001 OR year:2002', with JournalHintService"""
+        user_info = collect_user_info(0)
+        pattern = 'year:2001 OR year:2002'
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assertEqual(response,
+                         (0, ''))
+
+    def test_search_Monkey(self):
+        """websearch - search 'Monkey', with JournalHintService"""
+        user_info = collect_user_info(0)
+        pattern = 'Monkey'
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assertEqual(response,
+                         (0, ''))
+
+    def test_search_Monkey_monkey(self):
+        """websearch - search 'Monkey monkey', with JournalHintService"""
+        user_info = collect_user_info(0)
+        pattern = 'Monkey monkey'
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assertEqual(response,
+                         (0, ''))
+
+    def test_search_Monkey_monkey_2014(self):
+        """websearch - search 'Monkey monkey (2014)', with JournalHintService"""
+        user_info = collect_user_info(0)
+        pattern = 'Monkey monkey (2014)'
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assertEqual(response,
+                         (0, ''))
+
+    def test_search_empty_string(self):
+        """websearch - search empty string, with JournalHintService"""
+        user_info = collect_user_info(0)
+        pattern = ''
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assertEqual(response,
+                         (0, ''))
+
+    def test_search_Nucl_Phys_B75_1974_461(self):
+        """websearch - search 'Nucl.Phys.,B75,(1974),461', with JournalHintService"""
+        user_info = collect_user_info(1)
+        pattern = "Nucl.Phys.,B75,(1974),461"
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assert_(response[0] >=50)
+        self.assert_('journal:"Nucl. Phys. B75 (1974) 461"' in response[1])
+
+    def test_search_Nucl_Phys_B75_1974_461_with_spaces(self):
+        """websearch - search '  Nucl.  Phys.   B75   (1974)  461   ', with JournalHintService"""
+        user_info = collect_user_info(1)
+        pattern = '  Nucl.  Phys.   B75   (1974)  461   '
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assert_(response[0] >=50)
+        self.assert_('journal:"Nucl. Phys. B75 (1974) 461"' in response[1])
+
+    def test_search_D_S_Salopek_J_R_Bond_and_J_M_Bardeen_Phys_Rev_D40_1989_1753(self):
+        """websearch - search 'D.S. Salopek, J.R.Bond and J.M.Bardeen,Phys.Rev.D40(1989)1753.', with JournalHintService"""
+        user_info = collect_user_info(1)
+        pattern = 'D.S. Salopek, J.R.Bond and J.M.Bardeen,Phys.Rev.D40(1989)1753.'
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assert_(response[0] >=50)
+        self.assert_('journal:"Phys. Rev. D40 (1989) 1753"' in response[1])
+
+    def test_search_Capella_Pere_utf8(self):
+        """websearch - search 'Capellà Pere' utf8, with JournalHintService"""
+        user_info = collect_user_info(0)
+        pattern = u'Capellà Pere'.encode('utf8')
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assertEqual(response,
+                         (0, ''))
+
+    def test_search_Pais_Valencia_utf8(self):
+        """websearch - search 'País Valencià' utf8, with JournalHintService"""
+        user_info = collect_user_info(0)
+        pattern = u'País Valencià'.encode('utf8')
+        search_units = create_basic_search_units(None, pattern, '')
+        response = self.plugin.answer(req=user_info, user_info=user_info, of='hb',
+                                      cc=CFG_SITE_NAME, colls_to_search='', p=pattern,
+                                      f='', search_units=search_units, ln='en')
+        self.assertEqual(response,
+                         (0, ''))
+
+
 TEST_SUITE = make_test_suite(WebSearchServicesLoading,
                              WebSearchServicesCollectionNameSearch,
-                             WebSearchServicesSubmissionNameSearch)
-
+                             WebSearchServicesSubmissionNameSearch,
+                             WebSearchServicesJournalHintService)
 
 if __name__ == "__main__":
     run_test_suite(TEST_SUITE, warn_user=True)

--- a/modules/websearch/lib/websearch_services_unit_tests.py
+++ b/modules/websearch/lib/websearch_services_unit_tests.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""WebSearch services unit tests."""
+
+__revision__ = "$Id$"
+
+import os
+
+from invenio.testutils import InvenioTestCase, make_test_suite, run_test_suite
+from invenio.pluginutils import PluginContainer
+from invenio.websearch_services import (
+    CFG_SEARCH_SERVICES_PATH,
+    __required_plugin_API_version__,
+    SearchService
+)
+
+
+class WebSearchServicesJournalHintService(InvenioTestCase):
+
+    """Check JournalHintService plugin."""
+
+    def setUp(self):
+        """Load plugin."""
+        search_service_plugins = PluginContainer(
+            os.path.join(CFG_SEARCH_SERVICES_PATH, '*Service.py'),
+            api_version=__required_plugin_API_version__,
+            plugin_signature=SearchService
+        )
+        self.plugin = search_service_plugins.get('JournalHintService')()
+
+    def test_seems_a_journal_reference(self):
+        """Check function JournalHintService.seems_a_journal_reference."""
+        test_pairs = [
+            # Empty strings
+            ("", False),
+            (" ", False),
+            ("\t", False),
+            ("\t \t", False),
+            # Invenio and Inspire queries
+            ("author:Tom", False),
+            ("find a John", False),
+            ("find date after 2001", False),
+            ("year:2001 OR year:2002", False),
+            # Invalid journals with bad format
+            ("Monkey", False),
+            ("Monkey monkey", False),
+            ("Monkey monkey (1)", False),
+            ("Monkey monkey 1234", False),
+            # Invalid journals with good format
+            ("Monkey monkey, 1234", True),
+            ("Monkey (2000)", True),
+            # Invalid journals with good format, utf8
+            (u"Capellà Pere (2000)".encode("utf8"), True),
+            (u"País Valencià, 1234".encode("utf8"), True),
+            # Valid journal with good format
+            ("JHEP 9906:028 (1999)", True),
+            ("Phys. Rev. Lett. 83 (1999) 3605", True),
+            ("Nucl.Phys.,B75,(1974),461", True),
+            ("  Nucl.  Phys.   B75   (1974)  461   ", True),
+            ("D.S. Salopek, J.R.Bond and J.M.Bardeen,Phys.Rev.D40(1989)1753.",
+             True),
+        ]
+
+        for test_input, expected in test_pairs:
+            test_output = self.plugin.seems_a_journal_reference(test_input)
+            self.assertEqual(
+                test_output,
+                expected,
+                "JournalHintService.seems_a_journal_reference('%s') "
+                "returned '%s' instead of '%s'"
+                % (repr(test_input), repr(test_output), repr(expected))
+            )
+
+
+TEST_SUITE = make_test_suite()
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
- Adds the Journal Hint Service, that displays
  'Were you looking for a journal reference? Try: [link]'
  when the user search for a raw journal reference.
- Adds unit and regression tests for the new search service.
- Adds two unit tests to `search_from_reference`, just to be sure that
  it accepts unicode

Signed-off-by: Federico Poli federico.poli@cern.ch
