### PR TITLE
bibtask: Makes AUTH optional for a list of valid processes in bibshced

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -1551,6 +1551,12 @@ CFG_BIBSCHED_FLUSH_LOGS = 0
 ## CFG_BIBSCHED_NEVER_STOPS -- continue queue execution when a task fails
 CFG_BIBSCHED_NEVER_STOPS = 0
 
+## CFG_BIBSCHED_VALID_PROCESSES_NO_AUTH_NEEDED
+## if the process name (webcoll, bibupload etc..) is listed, ignore password in bibsched
+CFG_BIBSCHED_VALID_PROCESSES_NO_AUTH_NEEDED = ('bibupload',)
+
+## CFG_BIBSCHED_TASK_IS_NOT_A_DAEMON
+CFG_BIBSCHED_TASK_IS_NOT_A_DAEMON = ('bibupload',)
 
 ###################################
 ## Part 12: WebBasket parameters ##


### PR DESCRIPTION
- promote CFG_BIBSCHED_VALID_PROCESSES_NO_AUTH_NEEDED to global config
- promote CFG_BIBSCHED_TASK_IS_NOT_A_DEAMON to global config

Signed-off-by: Fredrik Nygård Carlsen me@frecar.no
