### PR TITLE
Miscutils: fix for send_email error on DEV site

### DIFF
--- a/modules/miscutil/lib/mailutils.py
+++ b/modules/miscutil/lib/mailutils.py
@@ -252,6 +252,8 @@ This message would have been sent to the following recipients:
                 server.ehlo()
             if CFG_MISCUTIL_SMTP_USER and CFG_MISCUTIL_SMTP_PASS:
                 server.login(CFG_MISCUTIL_SMTP_USER, CFG_MISCUTIL_SMTP_PASS)
+            if isinstance(toaddr, basestring):
+                toaddr = [toaddr]
             server.sendmail(fromaddr, toaddr + bccaddr, body)
             server.quit()
             sent = True


### PR DESCRIPTION
- For the DEV site send_email function was failing while trying to
  concatenate list and string (because the CFG_SITE_ADMIN_EMAIL
  was not a list).
