### PR TITLE
miscutil: fixes translate_to_ascii

### DIFF
--- a/modules/miscutil/lib/textutils.py
+++ b/modules/miscutil/lib/textutils.py
@@ -584,7 +584,13 @@ def translate_to_ascii(values):
         else:
             encoded_text, encoding = guess_minimum_encoding(value)
             unicode_text = unicode(encoded_text.decode(encoding))
-            ascii_text = unidecode(unicode_text).encode('ascii')
+            decoded_text = ""
+            for unicode_char in unicode_text:
+                decoded_char = unidecode(unicode_char)
+                # Skip unrecognized characters
+                if decoded_char != "[?]":
+                    decoded_text += decoded_char
+            ascii_text = decoded_text.encode('ascii')
         values[index] = ascii_text
     return values
 

--- a/modules/miscutil/lib/textutils_unit_tests.py
+++ b/modules/miscutil/lib/textutils_unit_tests.py
@@ -455,6 +455,7 @@ class TestStripping(InvenioTestCase):
             self.assertEqual(translate_to_ascii(None), None)
             self.assertEqual(translate_to_ascii([]), [])
             self.assertEqual(translate_to_ascii([None]), [None])
+            self.assertEqual(translate_to_ascii("√"), [""])
     else:
         pass
 


### PR DESCRIPTION
- translate_to_ascii() checks the characters one by one in order to
  make sure unrecognized values are ignored ("" instead of
  printing "[?]").
- Adds unit test for this case.

Tested-by: Jan Aage Lavik jan.age.lavik@cern.ch
Signed-off-by: Federico Poli federico.poli@cern.ch
