### PR TITLE
BibDocFile: fix type of bibrec-bibdoc connection

### DIFF
--- a/modules/bibdocfile/lib/bibdocfile.py
+++ b/modules/bibdocfile/lib/bibdocfile.py
@@ -1752,7 +1752,7 @@ class BibDoc(object):
 
     @staticmethod
     def create_instance(docid=None, recid=None, docname=None,
-                        doctype='Fulltext', a_type = 'Main', human_readable=False):
+                        doctype='Fulltext', a_type = '', human_readable=False):
         """
         Parameters of an attachement to the record:
         a_type, recid, docname
@@ -1777,6 +1777,9 @@ class BibDoc(object):
         for dummy, plugin in get_plugins().iteritems():
             if plugin['supports'](doctype, extensions):
                 used_plugin = plugin
+
+        if not a_type:
+            a_type = doctype or 'Main'
 
         if not docid:
             rec_links = []


### PR DESCRIPTION
- Changes the default value of the type in the bibrec_bibdoc
  table to the doctype of the bibdoc, instead of 'Main'.
