### PR TITLE
formatter: fix recID not an integer

### DIFF
--- a/invenio/modules/formatter/engine.py
+++ b/invenio/modules/formatter/engine.py
@@ -1926,14 +1926,14 @@ class BibFormatObject:
             # If record is given as parameter
             self.xml_record = xml_record
             self.record = create_record(xml_record)[0]
-            recID = record_get_field_value(self.record, "001")
+            recID = int(record_get_field_value(self.record, "001"))
 
         self.lang = wash_language(ln)
         if search_pattern is None:
             search_pattern = []
         self.search_pattern = search_pattern
         try:
-            assert isinstance(recID, int), 'Argument of wrong type!'
+            assert isinstance(recID, (int, long)), 'Argument of wrong type!'
         except AssertionError:
             register_exception(prefix="recid needs to be an integer in BibFormatObject",
                                alert_admin=True)


### PR DESCRIPTION
Fixes the problem in several format elements where the recID is not an integer.

Commits are taken from https://github.com/inspirehep/ops

Shall I prettify/squash the commits or it will be easier to identify them in the future when we rebase inspire/ops and pu if they are kept the same?

This could close https://github.com/jirikuncar/invenio/pull/291
