### PR TITLE
WebSearch: fix for 'rhs is of unknown type'

### DIFF
--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -520,11 +520,10 @@ def get_collection_reclist(coll, recreate_cache_if_needed=True):
         reclist = intbitset()
         query = "SELECT nbrecs,reclist FROM collection WHERE name=%s"
         res = run_sql(query, (coll, ), 1)
-        if res:
-            try:
-                reclist = intbitset(res[0][1])
-            except IndexError:
-                pass
+        try:
+            reclist = intbitset(res[0][1])
+        except (IndexError, TypeError):
+            pass
         collection_reclist_cache.cache[coll] = reclist
     # finally, return reclist:
     return collection_reclist_cache.cache[coll]


### PR DESCRIPTION
- Fixes an error that was occurring when a new collection has been added
  (and it had NULL in 'reclist' column of collection table). Because of
  that, the intbitset in get_collection_reclist function was initialized with
  None as a parameter and was throwing an exception.
