### PR TITLE
installation: mercurial addition

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -30,7 +30,8 @@ following this tutorial. **Note:** the recommended Python version is 2.7.5+
                            libmysqlclient-dev libxml2-dev libxslt-dev \
                            libjpeg-dev libfreetype6-dev libtiff-dev \
                            software-properties-common python-dev \
-                           virtualenvwrapper build-essential git
+                           virtualenvwrapper build-essential git \
+                           mercurial
     $ sudo pip install -U virtualenvwrapper pip
     $ source .bashrc
 


### PR DESCRIPTION
In case mercurial is not installed on the system, `$ pip install -r requirements.txt` fails with:

```
Obtaining editdist from hg+https://code.google.com/p/py-editdist/#egg=editdist (from -r requirements.txt (line 2))
  Cloning hg https://code.google.com/p/py-editdist/ to /home/jlavik/envs/nextstructure/src/editdist
Cleaning up...
Cannot find command 'hg'
```

See discussion at #1814 
