### PR TITLE
search: fix browse pagination links

### DIFF
--- a/invenio/modules/search/templates/search/browse_base.html
+++ b/invenio/modules/search/templates/search/browse_base.html
@@ -95,7 +95,7 @@ body {
       <tr>
         <td>{{ record[1] }}</td>
         <td>
-          {%- do args.update({'p': f ~ (':' if f) ~ record[0]}) -%}
+          {%- do args.update({'p': (f ~ ':' if f) ~ records[0]}) -%}
           <a href="{{ url_for('search.search',  **args) }}">{{ record[0] }}</a>
         </td>
       </tr>
@@ -104,13 +104,13 @@ body {
 
     <ul class="pager">
       <li class="previous">
-        {%- do args.update({'p': f ~ (':' if f) ~ records[0][0], 'action_browse': ''}) -%}
+        {%- do args.update({'p': (f ~ ':' if f) ~ records[0][0], 'action_browse': ''}) -%}
         <a href="{{ url_for('search.search',  **args) }}">
           &larr; {{ _('Previous') }}
         </a>
       </li>
       <li class="next">
-        {%- do args.update({'p': f ~ (':' if f) ~ records[-1][0], 'action_browse': ''}) -%}
+        {%- do args.update({'p': (f ~ ':' if f) ~ records[-1][0], 'action_browse': ''}) -%}
         <a href="{{ url_for('search.search',  **args) }}">
           {{ _('Next') }} &rarr;
         </a>


### PR DESCRIPTION
- Addresses issue with browsing results using next/prev links without
  field name.  (closes #1824)

Co-authored-by: Petr Broz <petr.broz@gmail.com>
Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>
