### PR TITLE
BibDocFile: register downloads with recid

### DIFF
--- a/modules/bibdocfile/lib/bibdocfile_webinterface.py
+++ b/modules/bibdocfile/lib/bibdocfile_webinterface.py
@@ -219,7 +219,7 @@ class WebInterfaceFilesPages(WebInterfaceDirectory):
                             if not docfile.hidden_p():
                                 if not readonly:
                                     ip = str(req.remote_ip)
-                                    doc.register_download(ip, docfile.get_version(), docformat, uid)
+                                    doc.register_download(ip, docfile.get_version(), docformat, uid, self.recid)
                                 try:
                                     return docfile.stream(req, download=is_download)
                                 except InvenioBibDocFileError, msg:


### PR DESCRIPTION
- Adds self.recid when calling register_download

(closes #1831)

Signed-off-by: Nikolaos Kasioumis nikolaos.kasioumis@cern.ch
