### PR TITLE
base: requirejs bundle ordering fix

### DIFF
--- a/invenio/base/templates/page_base.html
+++ b/invenio/base/templates/page_base.html
@@ -55,9 +55,9 @@
   {%- endif -%}
   {%- if not config.get('ASSETS_DEBUG') or config.get("REQUIREJS_RUN_IN_DEBUG", True) -%}
     {# Almond is a lighter require.js module for compiled files. #}
-    {%- js url_for('static', filename='js/almond.js'), '09-requirejs' -%}
+    {%- js url_for('static', filename='js/almond.js'), '00-requirejs' -%}
   {%- endif -%}
-  {%- js url_for('static', filename='js/settings.js'), '09-requirejs', 'uglifyjs' -%}
+  {%- js url_for('static', filename='js/settings.js'), '00-requirejs', 'uglifyjs' -%}
 
 {%- endblock global_javascript %}
 {%- block page -%}


### PR DESCRIPTION
I forgot to put the fixed bundle numbering (where jquery is `01`) of those two during #1830.
