### PR TITLE
base: baseUrl for require.js

### DIFF
--- a/invenio/base/static/js/settings.js
+++ b/invenio/base/static/js/settings.js
@@ -18,7 +18,7 @@
  */
 
 require.config({
-    baseUrl: '',
+    baseUrl: '/',
     paths: {
         bootstrap: 'js/bootstrap',
         jquery: 'js/jquery',


### PR DESCRIPTION
- Fixes the base path for require.js module which were loaded from a relative path instead of the absolute one.

Reported by: @kneczaj

> Uncaught TypeError: Object [object Object] has no method 'on' 01-jquery--3449646891855156961.js?64b7a863:4
> Uncaught TypeError: Cannot call method 'compile' of undefined 51-webdeposit-3884405452116351265.js?100d2b7a:1471
> Uncaught TypeError: Object [object Object] has no method 'on' 3:704
> Uncaught Error: undefined missing jquery 00-requirejs-2218833842309969803.js?cb72bd76:1
> this is in js console, in deposit form
