### PR TITLE
linkbacks: fix external url creation

### DIFF
--- a/invenio/modules/linkbacks/templates/linkbacks/index_base.html
+++ b/invenio/modules/linkbacks/templates/linkbacks/index_base.html
@@ -30,7 +30,7 @@
     <h4>
       {{ _("Traceback URL") }}
       <small>
-        {{ url_for('weblinkback.sendtraceback', _external=True, recid=recid) }}
+        {{ url_for('weblinkback.sendtraceback', recid=recid, _external=True) }}
       </small>
     </h4>
   </div>


### PR DESCRIPTION
- Fixes the order of keywords arguments in `url_for` that breaks if one
  tries to generate external link.  (closes #1707)

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
