### PR TITLE
travis: removal of Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ notifications:
 
 services:
   - mysql
-  - rabbitmq
   - redis
   - mongodb
 
 language: python
 
 python:
-  - "2.6"
+# FIXME: the build times out on Python 2.6 (inveniosoftware/invenio#1789)
+#  - "2.6"
   - "2.7"
 
 install:
@@ -63,9 +63,7 @@ before_script:
   - "inveniomanage apache create-config"
   - "sudo ln -s $VIRTUAL_ENV/var/invenio.base-instance/apache/invenio-apache-vhost.conf /etc/apache2/sites-enabled/invenio.conf"
   - "sudo ln -s $VIRTUAL_ENV/var/invenio.base-instance/apache/invenio-apache-vhost-ssl.conf /etc/apache2/sites-enabled/invenio-ssl.conf"
-  - "sudo /usr/sbin/a2dissite default || echo ':('"
-#  - "sudo /usr/sbin/a2ensite invenio || echo ':('" # enable Invenio web site
-#  - "sudo /usr/sbin/a2ensite invenio-ssl || echo ':('" # enable Invenio secure web site
+  - "sudo /usr/sbin/a2dissite *default* || echo ':('"
   - "sudo /usr/sbin/a2enmod ssl" # enable SSL module
   - "sudo /usr/sbin/a2enmod xsendfile || echo ':('"
   - "sudo apachectl configtest && sudo service apache2 restart || echo 'Apache failed ...'"


### PR DESCRIPTION
- Removing python 2.6 from the test matrix as it times out.

See: #1786
