### PR TITLE
installation: Flask-Collect from PyPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 -e git+https://github.com/david-e/flask-admin.git@bootstrap3#egg=Flask-Admin
 -e git+https://github.com/miracle2k/flask-assets.git#egg=Flask-Assets-dev
 -e git+https://github.com/inveniosoftware/flask-breadcrumbs.git#egg=Flask-Breadcrumbs
--e git+https://github.com/greut/Flask-Collect.git@setup-py-fix#egg=Flask-Collect-dev
 -e git+https://github.com/inveniosoftware/flask-menu.git#egg=Flask-Menu
 -e git+https://github.com/inveniosoftware/flask-registry.git#egg=Flask-Registry
 -e git+git://github.com/jirikuncar/flask-sso.git#egg=flask-sso

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ install_requires = [
     "Flask-Babel==0.9",
     "Flask-Breadcrumbs==0.1",
     "Flask-Cache==0.12",
-    "Flask-Collect>0.2.2",
+    "Flask-Collect>=0.2.3",
     "Flask-Email==1.4.4",
     "Flask-Gravatar==0.4.0",
     "Flask-Login==0.2.7",


### PR DESCRIPTION
Removing the custom version as [Flask-Collect 0.2.3](https://pypi.python.org/pypi/Flask-Collect/0.2.3) is on the cheeseshop.

Related to: #1797
