### PR TITLE
global: travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,39 @@
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-notifications:
-  email: false
+language: python
 
 python:
   - "2.6"
+  - "2.7"
+
+services:
+ - mysql
+
+notifications:
+  email: false
+
+before_install:
+ - sudo apt-get update
 
 install:
-  - sudo apt-get update
-  - git clone https://github.com/tiborsimko/invenio-devscripts /tmp/invenio-devscripts
-  - CFG_INVENIO_SRCDIR=$(pwd) /tmp/invenio-devscripts/invenio-kickstart --yes-i-know --yes-i-really-know
+  - travis_retry pip install -U nose
+  # Fix for being in a virtualenv.
+  - |
+      ln -s /opt/invenio/lib/python/invenio \
+        `python -c "import sys; print sys.path[-1]"`/invenio
+  # Installing the devscripts and invenio through them.
+  - |
+      git clone --depth=1 \
+      https://github.com/tiborsimko/invenio-devscripts ../invenio-devscripts
+  - |
+      CFG_INVENIO_SRCDIR=$(pwd) \
+      ../invenio-devscripts/invenio-kickstart --yes-i-know --yes-i-really-know
 
 script:
-  - sudo -u www-data nosetests /opt/invenio/lib/python/invenio/*_unit_tests.py
-  - sudo -u www-data nosetests /opt/invenio/lib/python/invenio/*_regression_tests.py
+  - |
+      sudo -u www-data /bin/bash -c ". $VIRTUAL_ENV/bin/activate && \
+        nosetests /opt/invenio/lib/python/invenio/*_unit_tests.py"
+  - |
+      sudo -u www-data /bin/bash -c ". $VIRTUAL_ENV/bin/activate && \
+        nosetests /opt/invenio/lib/python/invenio/*_regression_tests.py"

--- a/modules/miscutil/lib/inveniocfg.py
+++ b/modules/miscutil/lib/inveniocfg.py
@@ -1136,6 +1136,8 @@ def cli_cmd_create_apache_conf(conf):
                             'invenio-apache-vhost.conf'
     apache_vhost_ssl_file = apache_conf_dir + os.sep + \
                              'invenio-apache-vhost-ssl.conf'
+    virtual_env = os.environ.get('VIRTUAL_ENV')
+    python_path = 'python-path={0}'.format(sys.path[-1]) if virtual_env else ''
     apache_vhost_body = """\
 AddDefaultCharset UTF-8
 ServerSignature Off
@@ -1174,7 +1176,7 @@ WSGIRestrictStdout Off
         AliasMatch /sitemap-(.*) %(webdir)s/sitemap-$1
         Alias /robots.txt %(webdir)s/robots.txt
         Alias /favicon.ico %(webdir)s/favicon.ico
-        WSGIDaemonProcess invenio processes=5 threads=1 display-name=%%{GROUP} inactivity-timeout=3600 maximum-requests=10000
+        WSGIDaemonProcess invenio processes=5 threads=1 display-name=%%{GROUP} inactivity-timeout=3600 maximum-requests=10000 %(python_path)s
         WSGIImportScript %(wsgidir)s/invenio.wsgi process-group=invenio application-group=%%{GLOBAL}
         WSGIScriptAlias / %(wsgidir)s/invenio.wsgi
         WSGIPassAuthorization On
@@ -1199,6 +1201,7 @@ WSGIRestrictStdout Off
        'directory_www_directive': directory_www_directive,
        'directory_wsgi_directive': directory_wsgi_directive,
        'deflate_directive': deflate_directive,
+       'python_path': python_path
        }
     apache_vhost_ssl_body = """\
 ServerSignature Off


### PR DESCRIPTION
* Adds the language key (otherwise, [it's ruby](http://docs.travis-ci.com/user/getting-started/#Step-three%3A-Add-.travis.yml-file-to-your-repository)).
* Downloads the devscripts where they want to be downloaded.
* Moves `apt-get update` to `before_install` as [advised](http://docs.travis-ci.com/user/build-configuration/#Build-Lifecycle)
* Enables the Python 2.6 build, even if it doesn't look like it.

**blockers:**
- [x] tiborsimko/invenio-devscripts#17
- [x] bibknowledge requires libxml2 (#1879)