### PR TITLE
WebMessage: alert users by email

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -1603,6 +1603,10 @@ CFG_WEBMESSAGE_MAX_NB_OF_MESSAGES = 30
 ## we delete orphaned messages?
 CFG_WEBMESSAGE_DAYS_BEFORE_DELETE_ORPHANS = 60
 
+## CFG_WEBMESSAGE_ENABLE_MAIL_NOTIFICATION -- whether to enable email
+## notification when webmessages are sent option for users to choose.
+CFG_WEBMESSAGE_ENABLE_MAIL_NOTIFICATION = False
+
 ##################################
 ## Part 15: MiscUtil parameters ##
 ##################################

--- a/modules/websession/lib/webaccount.py
+++ b/modules/websession/lib/webaccount.py
@@ -31,7 +31,8 @@ from invenio.config import \
      CFG_SITE_ADMIN_EMAIL, \
      CFG_SITE_SECURE_URL, \
      CFG_VERSION, \
-     CFG_SITE_RECORD
+     CFG_SITE_RECORD, \
+     CFG_WEBMESSAGE_ENABLE_MAIL_NOTIFICATION
 from invenio.access_control_engine import acc_authorize_action
 from invenio.access_control_config import CFG_EXTERNAL_AUTHENTICATION, \
     SUPERADMINROLE, CFG_EXTERNAL_AUTH_DEFAULT
@@ -347,6 +348,12 @@ def perform_set(email, ln, can_config_bibcatalog=False,
                 ln = ln,
                 preferred_lang = preferred_lang
                 )
+    if CFG_WEBMESSAGE_ENABLE_MAIL_NOTIFICATION:
+        show_mailcheckbox = prefs.get('webmessage_mail_notification', False)
+        out += websession_templates.tmpl_send_mail_on_message(
+                    ln = ln,
+                    show_mailcheckbox = show_mailcheckbox
+                    )
 
     keys_info = web_api_key.show_web_api_keys(uid=uid)
     out+=websession_templates.tmpl_user_api_key(

--- a/modules/websession/lib/websession_templates.py
+++ b/modules/websession/lib/websession_templates.py
@@ -443,6 +443,29 @@ class Template:
             }
         return out
 
+    def tmpl_send_mail_on_message(self, ln, show_mailcheckbox = False):
+        _ = gettext_set_language(ln)
+        out = """
+            <form method="post" action="%(sitesecureurl)s/youraccount/change" name="edit_webmail_settings">
+            <input id='hidden_webmessage_field'  type='hidden' value='No' name='hidden_webmessage_field'>
+              <p><big><strong class="headline">%(edit_webmail_settings)s</strong></big></p>
+              <table>
+                <tr><td align="right"><input type="checkbox" %(checked_mailbox)s value="1" name="mailcheckbox" id="mailcheckbox"/></td>
+                <td valign="top"><b><label for="latestbox">%(show_mailcheckbox)s</label></b></td></tr>
+        """ % {
+          'sitesecureurl' : CFG_SITE_SECURE_URL,
+          'edit_webmail_settings' : _("Edit message-related settings"),
+          'show_mailcheckbox' : _("Receive an email notification for every new message"),
+          'checked_mailbox' : show_mailcheckbox and 'checked="checked"' or '',
+          }
+        out += """<tr><td></td><td><input class="formbutton" type="submit" value="%(update_settings)s" /></td></tr>
+              </table>
+            </form>""" % {
+                'update_settings' : _("Update settings"),
+            }
+        return out
+
+
 
     def tmpl_user_external_auth(self, ln, methods, current, method_disabled):
         """

--- a/modules/websession/lib/websession_webinterface.py
+++ b/modules/websession/lib/websession_webinterface.py
@@ -40,7 +40,8 @@ from invenio.config import \
      CFG_SITE_URL, \
      CFG_CERN_SITE, \
      CFG_WEBSESSION_RESET_PASSWORD_EXPIRE_IN_DAYS, \
-     CFG_OPENAIRE_SITE
+     CFG_OPENAIRE_SITE, \
+     CFG_WEBMESSAGE_ENABLE_MAIL_NOTIFICATION
 from invenio import webuser
 from invenio.webpage import page
 from invenio import webaccount
@@ -342,6 +343,8 @@ class WebInterfaceYourAccountPages(WebInterfaceDirectory):
             'login_method': (str, ""),
             'group_records' : (int, None),
             'latestbox' : (int, None),
+            'hidden_webmessage_field' : (str, None),
+            'mailcheckbox' : (int, None),
             'helpbox' : (int, None),
             'lang' : (str, None),
             'bibcatalog_username' : (str, None),
@@ -536,6 +539,21 @@ class WebInterfaceYourAccountPages(WebInterfaceDirectory):
             act = "/youraccount/display?ln=%s" % args['ln']
             linkname = _("Show account")
             mess += '<p>' + _("User settings saved correctly.")
+
+        ## Change weather to receive mail notification for new messages
+        if CFG_WEBMESSAGE_ENABLE_MAIL_NOTIFICATION:
+            if args['mailcheckbox'] or args['hidden_webmessage_field']:
+                act = "/youraccount/display?ln=%s" % args['ln']
+                title = _("Settings edited")
+                linkname = _("Show account")
+                prefs = webuser.get_user_preferences(uid)
+                if args['mailcheckbox'] == 1:
+                    prefs['webmessage_mail_notification'] = 1
+                elif args['hidden_webmessage_field']:
+                    prefs['webmessage_mail_notification'] = 0
+                webuser.set_user_preferences(uid,prefs)
+                mess += '<p>' + _("User settings saved correctly.")
+
 
         ## Edit cataloging-related settings:
         if args['bibcatalog_username'] or args['bibcatalog_password']:


### PR DESCRIPTION
- Added the feature to receive webmessage notification via email,
  when a new webmessage is sent, both on global level (with the
  configuration variable CFG_WEBMESSAGE_ENABLE_MAIL_NOTIFICATION)
  and on a per user level with the user preference key
  webmessage_mail_notification. (closes #1049)

Signed-off-by: Avraam Tsantekidis makistsantekidis@gmail.com
