### PR TITLE
installation: bootstrap 3.2.0 and typeahead 0.10.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "**/*.txt"
   ],
   "dependencies": {
-    "bootstrap": "3.1.1",
+    "bootstrap": "3.2.0",
     "less": "1.7.0",
     "jquery": "2.1.0",
     "font-awesome": "~4.0.3",
@@ -15,7 +15,7 @@
     "ckeditor": "latest"
   },
   "devDependencies": {
-    "typeahead.js": "0.10.1",
+    "typeahead.js": "0.10.2",
     "hogan": "3.0.0",
     "jquery-tokeninput": "*",
     "MathJax": "v2.1-latest",
@@ -46,6 +46,7 @@
     "jquery-migrate": "http://code.jquery.com/jquery-migrate-1.2.1.js"
   },
   "resolutions": {
-    "jquery": "2.1.0"
+    "jquery": "2.1.0",
+    "bootstrap": "3.2.0"
   }
 }

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -38,9 +38,8 @@ module.exports = {
     },
     less_bootstrap: {
         expand: true,
-        flatten: true,
-        cwd: '<%= globalConfig.bower_path %>',
-        src: ['bootstrap/less/*.less'],
+        cwd: '<%= globalConfig.bower_path %>/bootstrap/less/',
+        src: ['*.less', '**/*.less'],
         dest: '<%= globalConfig.installation_path %>/less/bootstrap'
     },
     less_fontawesome: {


### PR DESCRIPTION
> Today we're shipping Bootstrap v3.2.0, a monster of a release that's been in the works for four months. There's lots of new hotness, hundreds of bug fixes, plenty of documentation improvements, and some build tool improvements. All told, there have been over 1,000 commits since our last release.
> http://blog.getbootstrap.com/2014/06/26/bootstrap-3-2-0-released/

Note that [typeahead.js-bootstrap3.less](https://github.com/hyspace/typeahead.js-bootstrap3.less) is still using 3.1.1.
