### PR TITLE
grunt: jquery.hotkeys specify version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "DataTables": "1_9",
     "jquery-flot": "*",
     "form": "https://raw.github.com/malsup/form/master/jquery.form.js",
-    "jquery.hotkeys": "*",
+    "jquery.hotkeys": "http://invenio-software.org/download/jquery/jquery.hotkeys-0.8.js",
     "uploadify": "*",
     "json2": "*",
     "prism": "gh-pages",

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -96,7 +96,6 @@ module.exports = {
             'jquery-flot/excanvas.min.js',
             'jquery-flot/jquery.flot.js',
             'jquery-flot/jquery.flot.selection.js',
-            'jquery.hotkeys/jquery.hotkeys.js',
             'json2/json2.js',
             'prism/prism.js',
             'requirejs/require.js',
@@ -282,6 +281,18 @@ module.exports = {
         rename: function(dest, src) {
             if (src === 'index.js') {
                 return dest + 'jquery.jeditable.mini.js';
+            }
+            return dest + src;
+        }
+    },
+    jqueryhotkeys: {
+        expand: true,
+        cwd: '<%= globalConfig.bower_path %>/jquery.hotkeys/',
+        src: ['index.js'],
+        dest: '<%= globalConfig.installation_path %>/js/',
+        rename: function(dest, src) {
+            if (src === 'index.js') {
+                return dest + 'jquery.hotkeys.js';
             }
             return dest + src;
         }


### PR DESCRIPTION
- jquery.hotkeys version 0.8 from http://invenio-software.org.
- Fixes JS hotkeys conflict in BibEdit.

Signed-off-by: Javier Martin Montull javier.martin.montull@cern.ch
