### PR TITLE
search: layout fix

### DIFF
--- a/invenio/modules/search/static/css/search/searchbar.css
+++ b/invenio/modules/search/static/css/search/searchbar.css
@@ -93,8 +93,12 @@ values copied from bootstrap ones for higher than xs size counterparts -> to be 
 }
 
 /* to prevent shrinking search field after applying typeahead */
-.input-group .form-control {
+.navbar-form .input-group .form-control {
   width: 100%;
+}
+
+.navbar-form .input-group .input-group-btn {
+  width: 1%;
 }
 
 /*


### PR DESCRIPTION
Fixes the shrunk search bar.

![search bar is broken](https://cloud.githubusercontent.com/assets/1388/3466208/66f508c8-027c-11e4-8607-afc58206ddd0.png)

Probably introduced by bootstrap 3.2.0 (#1876)
