### PR TITLE
grunt: dev typeahead installation

### DIFF
--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -121,7 +121,7 @@ module.exports = {
         expand: true,
         flatten: true,
         cwd: '<%= globalConfig.bower_path %>/',
-        src: ['typeahead.js/dist/typeahead.bundle.min.js'],
+        src: ['typeahead.js/dist/typeahead.bundle.js'],
         dest: '<%= globalConfig.installation_path %>/js/',
         rename: function(dest, src) {
             var res = src.replace(src.substring(0),


### PR DESCRIPTION
During development the not minified version is more handy, especially for debugging.
