### PR TITLE
BibField: fix copyright field names

### DIFF
--- a/modules/bibfield/etc/atlantis.cfg
+++ b/modules/bibfield/etc/atlantis.cfg
@@ -301,7 +301,7 @@ publishing_country:
     producer:
         json_for_marc(), {"044__a": ""}
 
-coyright:
+opyright_status:
     creator:
         @legacy((("542", "542__", "542__%"), ""),
                 ("542__d", "holder"),


### PR DESCRIPTION
- Fixes a typo for one of the copyright fields and also changes its name
  to `copyright_information` to avoid duplicate names. (closes #1933)

Signed-off-by: Esteban J. G. Gabancho esteban.gabancho@gmail.com
