### PR TITLE
global: old bundle names

### DIFF
--- a/invenio/modules/accounts/templates/accounts/index_base.html
+++ b/invenio/modules/accounts/templates/accounts/index_base.html
@@ -23,7 +23,7 @@
 
 {%- block global_bundles %}
   {{ super() }}
-  {%- bundles "11-jquery-ui.js" %}
+  {%- bundles "jquery-ui.js" %}
 {%- endblock %}
 
 {%- block header %}

--- a/invenio/modules/annotations/__init__.py
+++ b/invenio/modules/annotations/__init__.py
@@ -23,6 +23,8 @@ Annotations.
 invenio.modules.annotations
 ---------------------------
 
+**FIXME: Outdated documentation.**
+
 To enable the module, make sure to remove it from ``PACKAGES_EXCLUDE``,
 where it is placed by default.
 

--- a/invenio/modules/comments/templates/comments/add_base.html
+++ b/invenio/modules/comments/templates/comments/add_base.html
@@ -47,7 +47,7 @@
 {%- if not request.is_xhr -%}
   {% extends "records/base.html" %}
   {%- if config.ANNOTATIONS_NOTES_ENABLED -%}
-    {% bundle "10-comments.js" %}
+    {% bundle "comments.js" %}
   {%- endif -%}
   {% block record_content %}
   {{ add_comment() }}

--- a/invenio/modules/comments/templates/comments/base_base.html
+++ b/invenio/modules/comments/templates/comments/base_base.html
@@ -20,7 +20,7 @@
   {%- extends "records/base.html" -%}
 {%- endif -%}
 
-{% bundles "10-comments.js", "10-comments.css" %}
+{% bundles "comments.js", "comments.css" %}
 
 {%- macro controls() -%}
   <div class="pull-right">

--- a/invenio/modules/comments/templates/comments/reviews_base.html
+++ b/invenio/modules/comments/templates/comments/reviews_base.html
@@ -20,7 +20,7 @@
   {% extends "records/base.html" %}
 {%- endif -%}
 
-{% bundle "10-comments.js" %}
+{% bundle "comments.js" %}
 
 {% block record_content %}
   <div class="page-header">

--- a/invenio/modules/messages/templates/messages/add_base.html
+++ b/invenio/modules/messages/templates/messages/add_base.html
@@ -22,7 +22,7 @@
 
 {% block global_bundles %}
   {{ super() }}
-  {% bundles "11-jquery-ui.js" %}
+  {% bundles "jquery-ui.js" %}
 {% endblock %}
 
 {% block header %}

--- a/invenio/modules/messages/templates/messages/index_base.html
+++ b/invenio/modules/messages/templates/messages/index_base.html
@@ -24,7 +24,7 @@
 
 {% block global_bundles %}
   {{ super() }}
-  {% bundle "10-comments.js" %}
+  {% bundle "comments.js" %}
 {% endblock %}
 
 

--- a/invenio/modules/search/templates/search/admin_collection_base.html
+++ b/invenio/modules/search/templates/search/admin_collection_base.html
@@ -29,7 +29,7 @@
 
 {% block global_bundles %}
   {{ super() }}
-  {% bundle "11-jquery-ui.js" %}
+  {% bundle "jquery-ui.js" %}
 {% endblock -%}
 
 {% block body %}

--- a/invenio/modules/search/templates/search/admin_index_base.html
+++ b/invenio/modules/search/templates/search/admin_index_base.html
@@ -26,7 +26,7 @@
 
 {% block global_bundles %}
   {{ super() }}
-  {% bundle "11-jquery-ui.js" %}
+  {% bundle "jquery-ui.js" %}
 {% endblock -%}
 
 {% block header %}


### PR DESCRIPTION
- Fixes the old bundle names that have been left over.
- Leaves a note in the annotation documentation to mark it as outdated.

Sorry... I forgot to fix some bundles.
