### PR TITLE
WIP BibIndex: bibauthorid performance improvements

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_dbinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_dbinterface.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2011, 2012, 2013 CERN.
+## Copyright (C) 2011, 2012, 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -703,6 +703,16 @@ def get_all_papers():   ### get_all_bibrecs
     @rtype: set set(int,)
     '''
     return set([i[0] for i in _select_from_aidpersonidpapers_where(select=['bibrec'])])
+
+
+def get_author_canonical_ids_for_recid(recID):
+    """
+    Return list of author canonical IDs (e.g. `J.Ellis.1') for the
+    given record.  Done by consulting BibAuthorID module.
+    """
+    return [word[0] for word in run_sql("""SELECT data FROM aidPERSONIDDATA
+        JOIN aidPERSONIDPAPERS USING (personid) WHERE bibrec=%s AND
+        tag='canonical_name' AND flag>-2""", (recID, ))]
 
 
 def get_all_paper_data_of_author(pid):

--- a/modules/bibindex/lib/bibindex_engine.py
+++ b/modules/bibindex/lib/bibindex_engine.py
@@ -2,7 +2,7 @@
 ##
 ## This file is part of Invenio.
 ## Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009,
-##               2010, 2011, 2012, 2013 CERN.
+##               2010, 2011, 2012, 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -47,6 +47,7 @@ from invenio.bibauthority_config import \
     CFG_BIBAUTHORITY_CONTROLLED_FIELDS_BIBLIOGRAPHIC
 from invenio.bibauthority_engine import \
      get_control_nos_from_recID
+from invenio.bibauthorid_dbinterface import get_author_canonical_ids_for_recid
 from invenio.search_engine import perform_request_search, \
      get_index_stemming_language, \
      get_synonym_terms, \
@@ -171,26 +172,6 @@ def get_associated_subfield_value(recID, tag, value, associated_subfield_code):
                 out = row[2]
                 break
     return out
-
-
-def get_author_canonical_ids_for_recid(recID):
-    """
-    Return list of author canonical IDs (e.g. `J.Ellis.1') for the
-    given record.  Done by consulting BibAuthorID module.
-    """
-    from invenio.bibauthorid_dbinterface import get_data_of_papers
-    lwords = []
-    res = get_data_of_papers([recID])
-    if res is None:
-        ## BibAuthorID is not enabled
-        return lwords
-    else:
-        dpersons, dpersoninfos = res
-    for aid in dpersoninfos.keys():
-        author_canonical_id = dpersoninfos[aid].get('canonical_id', '')
-        if author_canonical_id:
-            lwords.append(author_canonical_id)
-    return lwords
 
 
 def swap_temporary_reindex_tables(index_id, reindex_prefix="tmp_"):


### PR DESCRIPTION
* Re-implements get_author_canonical_ids_for_recid() to bypass
  complex BibAuthorID API usage and directly retrieve data
  from the DB for a gain of speed of ~800x.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>
Co-authored-by: Alessio Deiana <alessio.deiana@cern.ch>
Co-authored-by: Samuele Carli <samuele.carli@cern.ch>