### PR TITLE
BibCheck: improvements

### DIFF
--- a/modules/bibcheck/lib/plugins/doi.py
+++ b/modules/bibcheck/lib/plugins/doi.py
@@ -24,7 +24,7 @@ from invenio.crossrefutils import get_doi_for_records
 from invenio.bibupload import find_record_from_doi
 
 
-def check_records(records, doi_field="0247_a", extra_subfields=(("2", "DOI"),)):
+def check_records(records, doi_field="0247_a", extra_subfields=(("2", "DOI"), ("9", "bibcheck"))):
     """
     Find the DOI for the records using crossref and add it to the specified
     field.

--- a/modules/bibcheck/lib/plugins/doi.py
+++ b/modules/bibcheck/lib/plugins/doi.py
@@ -43,11 +43,11 @@ def check_records(records, doi_field="0247_a", extra_subfields=(("2", "DOI"),)):
 
     dois = get_doi_for_records(records_to_check.values())
     for record_id, doi in dois.iteritems():
+        record = records_to_check[record_id]
         dup_doi_recid = find_record_from_doi(doi)
         if dup_doi_recid:
             record.warn("DOI %s to be added to record %s already exists in record/s %s" % (doi, record_id, dup_doi_recid))
             continue
-        record = records_to_check[record_id]
         subfields = [(doi_field[5], doi.encode("utf-8"))] + map(tuple, extra_subfields)
         record_add_field(record, tag=doi_field[:3], ind1=doi_field[3],
                 ind2=doi_field[4], subfields=subfields)

--- a/modules/miscutil/lib/crossrefutils.py
+++ b/modules/miscutil/lib/crossrefutils.py
@@ -128,6 +128,10 @@ def get_doi_for_records(records):
             for tag, ind1, ind2 in [("773", "", "")]:
                 val = record_get_field_value(record, tag, ind1, ind2, subfield)
                 if val:
+                    if subfield == "c":
+                        # strip page range to send only starting page
+                        if '-' in val:
+                            val = val.split('-')[0]
                     data[position] = val
                     break
 


### PR DESCRIPTION
* By default, adds $$9 subfield with "bibcheck" value when adding DOIs
  in the doi.py BibCheck plugin.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>
Reviewed-by: Samuele Kaplun <samuele.kaplun@cern.ch>