### PR TITLE
installation: jellyfish to 0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 -e git+git://github.com/lnielsen-cern/dictdiffer.git#egg=dictdiffer
 -e git+https://github.com/david-e/flask-admin.git@bootstrap3#egg=Flask-Admin
 -e git+https://github.com/mitsuhiko/flask-sqlalchemy#egg=Flask-SQLAlchemy-dev
+-e git+https://github.com/sunlightlabs/jellyfish#egg=jellyfish-dev
 # requires numpy before it can be installed
 #-e svn://svn.code.sf.net/p/gnuplot-py/code/trunk#egg=gnuplot-py
 https://www.reportlab.com/ftp/pyRXP-1.16-daily-unix.tar.gz#egg=pyRXP

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ install_requires = [
     "Flask-WTF==0.9.5",
     "fs==0.4.0",
     "intbitset==2.0",
-    "jellyfish>=0.2",
+    "jellyfish>=0.3",
     "Jinja2==2.7.3",
     "libmagic==1.0",
     "lxml==3.1.2",


### PR DESCRIPTION
Upgrading jellyfish (levenshtein distance and friend) to 0.3 in edit mode as the PyPI version seems broken.

sunlightlabs/jellyfish#22
