### PR TITLE
formatter: format record with no record ID

### DIFF
--- a/invenio/modules/formatter/engine.py
+++ b/invenio/modules/formatter/engine.py
@@ -1929,7 +1929,7 @@ def get_fresh_output_format_filename(code):
 
 def clear_caches():
     """
-    Clear the caches (Output Format, Format Templates and Format Elements)
+    Clear the caches (Output Format, Format Templates and Format Elements).
 
     @return: None
     """
@@ -2008,19 +2008,19 @@ class BibFormatObject(object):
             # If record is given as parameter
             self.xml_record = xml_record
             self.record = create_record(xml_record)[0]
-            recID = int(record_get_field_value(self.record, "001"))
+            recID = record_get_field_value(self.record, "001") or None
 
-        self.lang = wash_language(ln)
-        if search_pattern is None:
-            search_pattern = []
-        self.search_pattern = search_pattern
         try:
-            assert isinstance(recID, (int, long)), 'Argument of wrong type!'
+            assert isinstance(recID, (int, long, type(None))), 'Argument of wrong type!'
         except AssertionError:
             register_exception(prefix="recid needs to be an integer in BibFormatObject",
                                alert_admin=True)
             recID = int(recID)
         self.recID = recID
+        self.lang = wash_language(ln)
+        if search_pattern is None:
+            search_pattern = []
+        self.search_pattern = search_pattern
         self.output_format = output_format
         self.user_info = user_info
         if self.user_info is None:


### PR DESCRIPTION
- Adds back support of the case where BibFormatObject also
  can support to work with records without any record ID.

Co-authored-by: Jan Aage Lavik jan.age.lavik@cern.ch
Co-authored-by: Guillaume Lastecoueres guillaume.lastecoueres@cern.ch
Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
