### PR TITLE
Websearch: include 'cc' in RSS <channel>'s <link>

### DIFF
--- a/modules/websearch/lib/websearch_templates.py
+++ b/modules/websearch/lib/websearch_templates.py
@@ -3519,9 +3519,11 @@ class Template:
         """Creates XML RSS 2.0 prologue."""
         title = CFG_SITE_NAME
         description = '%s latest documents' % CFG_SITE_NAME
+        link = CFG_SITE_URL
         if cc and cc != CFG_SITE_NAME:
             title += ': ' + cgi.escape(cc)
             description += ' in ' + cgi.escape(cc)
+            link += '/collection/' + quote(cc)
 
         out = """<rss version="2.0"
         xmlns:media="http://search.yahoo.com/mrss/"
@@ -3531,7 +3533,7 @@ class Template:
         xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">
       <channel>
         <title>%(rss_title)s</title>
-        <link>%(siteurl)s</link>
+        <link>%(rss_link)s</link>
         <description>%(rss_description)s</description>
         <language>%(sitelang)s</language>
         <pubDate>%(timestamp)s</pubDate>
@@ -3577,7 +3579,8 @@ class Template:
                'items_per_page': (rg and \
                              '\n<opensearch:itemsPerPage>%i</opensearch:itemsPerPage>' % rg) or '',
                'rss_title': title,
-               'rss_description': description
+               'rss_description': description,
+               'rss_link': link,
         }
         return out
 


### PR DESCRIPTION
- If the 'cc' collection is defined when producing the RSS feed then
  it's included in the <link> tag under the <channel> tag.

(closes #2013)

Signed-off-by: Nikolaos Kasioumis nikolaos.kasioumis@cern.ch
