### PR TITLE
assets: resolution of jquery to ~1.11

### DIFF
--- a/invenio/ext/assets/commands.py
+++ b/invenio/ext/assets/commands.py
@@ -74,7 +74,7 @@ class BowerCommand(Command):
             "version": pkg_resources.get_distribution("invenio").version,
             "dependencies": {},
             "resolutions": {
-                "jquery": "<2",
+                "jquery": "~1.11",  # <2 would pick 1.7.2 (thx jquery.treeview)
                 "bootstrap": "~3.2"
             }
         }


### PR DESCRIPTION
**Problem**

```
BundleError: 'vendors/jquery/dist/jquery.js' not found in load path: ...
```

**Changes**
- Changes the jquery resolution to ~1.11 instead of <2 since it would pick jquery 1.7.2 as required by jquery.treeview.

**Note**
- Update your `bower.json` accordingly.
