### PR TITLE
formatter: fix RSS generation

### DIFF
--- a/invenio/modules/formatter/engines/xslt.py
+++ b/invenio/modules/formatter/engines/xslt.py
@@ -183,9 +183,10 @@ def _eval_bibformat(ctx, recID, template_code):
             recID_int = int(recID.text)
 
         bfo = BibFormatObject(recID_int)
-        return format_with_format_template(None, bfo,
-                                           verbose=0,
-                                           format_template_code=template_code)
+        out = format_with_format_template(None, bfo,
+                                          verbose=0,
+                                          format_template_code=template_code)
+        return out[0]
     except Exception as err:
         print("Error during formatting function evaluation: {0}".format(err),
               file=sys.stderr)


### PR DESCRIPTION
Before:

``` python
>>> from invenio.modules.formatter import format_record
>>> format_record(20, of="xr")
Traceback (most recent call last):
  File "/opt/invenio/invenio/modules/formatter/engine.py", line 504, in format_record_1st_pass
    **kwargs)
  File "/opt/invenio/invenio/modules/formatter/engine.py", line 387, in format_record
    out_, needs_2nd_pass = format_with_format_template(template, bfo, verbose)
  File "/opt/invenio/invenio/modules/formatter/engine.py", line 715, in format_with_format_template
    evaluated_format = xslt.format(xml_record, template_source=format_content).decode('utf-8')
  File "/opt/invenio/invenio/modules/formatter/engines/xslt.py", line 284, in format
    temporary_result = xslt(xml)
  File "xslt.pxi", line 585, in lxml.etree.XSLT.__call__ (src/lxml/lxml.etree.c:153659)
  File "lxml.etree.pyx", line 327, in lxml.etree._ExceptionContext._raise_if_stored (src/lxml/lxml.etree.c:10196)
  File "extensions.pxi", line 824, in lxml.etree._extension_function_call (src/lxml/lxml.etree.c:142042)
  File "extensions.pxi", line 610, in lxml.etree._wrapXPathObject (src/lxml/lxml.etree.c:139824)
  File "extensions.pxi", line 606, in lxml.etree._wrapXPathObject (src/lxml/lxml.etree.c:139772)
XPathResultError: This is not a supported node-set result: False
Failed to perform the XSL transformation.
u''
```

After:

``` python
>>> from invenio.modules.formatter import format_record
>>> format_record(20, of="xr")
u'<item>\n  <title>Charge creation and reset mechanisms in an ion guide isotope separator (IGIS)</title>\n  <link>http://0.0.0.0:4000/record/20</link>\n  <description/>\n  <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Arje, J</dc:creator>\n  <pubDate>Sat, 05 Jul 2014 09:45:35 GMT</pubDate>\n  <guid>http://0.0.0.0:4000/record/20</guid>\n  <dc:publisher xmlns:dc="http://purl.org/dc/elements/1.1/">Finland Univ. Dept. Phys.</dc:publisher>\n  <dcterms:issued xmlns:dcterms="http://purl.org/dc/terms/">Jul 1982</dcterms:issued>\n</item>\n'
```
