### PR TITLE
installation guide: missing subversion dependency

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -33,7 +33,7 @@ following this tutorial. **Note:** the recommended Python version is 2.7.5+
                            libmysqlclient-dev libxml2-dev libxslt-dev \
                            libjpeg-dev libfreetype6-dev libtiff-dev \
                            software-properties-common python-dev \
-                           virtualenvwrapper
+                           virtualenvwrapper subversion
     $ sudo pip install -U virtualenvwrapper pip
     $ source .bashrc
 


### PR DESCRIPTION
Missing `subversion` dependency on ubuntu 14.04

Error occurred on `bower install jquery-multifile`

``` javascript
// bower.json
......
"jquery-multifile": "svn+http://jquery-multifile-plugin.googlecode.com/svn/",
.....
```
