### PR TITLE
WebSearch: collection tree score as in next.

### DIFF
--- a/modules/miscutil/demo/democfgdata.sql
+++ b/modules/miscutil/demo/democfgdata.sql
@@ -1,5 +1,5 @@
 -- This file is part of Invenio.
--- Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2013 CERN.
+-- Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
 --
 -- Invenio is free software; you can redistribute it and/or
 -- modify it under the terms of the GNU General Public License as
@@ -624,41 +624,41 @@ INSERT INTO collectionboxname VALUES (9,'en','r','Browse by division:');
 INSERT INTO collectionboxname VALUES (9,'fr','r','Naviguer par division:');
 
 
-INSERT INTO collection_collection VALUES (1,15,'r',60);
-INSERT INTO collection_collection VALUES (1,16,'r',40);
-INSERT INTO collection_collection VALUES (1,17,'r',30);
--- INSERT INTO collection_collection VALUES (1,23,'r',20);
--- INSERT INTO collection_collection VALUES (1,24,'r',10);
-INSERT INTO collection_collection VALUES (15,6,'r',20);
-INSERT INTO collection_collection VALUES (15,2,'r',10);
-INSERT INTO collection_collection VALUES (15,32,'r',10);
-INSERT INTO collection_collection VALUES (15,26,'r',10);
-INSERT INTO collection_collection VALUES (16,3,'r',30);
-INSERT INTO collection_collection VALUES (16,4,'r',20);
-INSERT INTO collection_collection VALUES (16,5,'r',10);
-INSERT INTO collection_collection VALUES (17,8,'r',30);
-INSERT INTO collection_collection VALUES (17,18,'r',20);
-INSERT INTO collection_collection VALUES (17,22,'r',10);
-INSERT INTO collection_collection VALUES (17,33,'r',30);
-INSERT INTO collection_collection VALUES (22,19,'r',30);
-INSERT INTO collection_collection VALUES (22,20,'r',20);
-INSERT INTO collection_collection VALUES (22,21,'r',10);
-INSERT INTO collection_collection VALUES (1,9,'v',20);
-INSERT INTO collection_collection VALUES (1,10,'v',10);
-INSERT INTO collection_collection VALUES (9,11,'r',10);
-INSERT INTO collection_collection VALUES (9,12,'r',20);
-INSERT INTO collection_collection VALUES (10,13,'r',10);
-INSERT INTO collection_collection VALUES (10,14,'r',20);
-INSERT INTO collection_collection VALUES (13,30,'r',20);
--- INSERT INTO collection_collection VALUES (13,31,'r',10); -- ISOLDE Internal Notes
-INSERT INTO collection_collection VALUES (14,27,'r',20);
-INSERT INTO collection_collection VALUES (14,28,'r',10);
-INSERT INTO collection_collection VALUES (14,29,'r',10);
-INSERT INTO collection_collection VALUES (1,34,'v',5);
-INSERT INTO collection_collection VALUES (34,35,'r',4);
-INSERT INTO collection_collection VALUES (34,36,'r',3);
-INSERT INTO collection_collection VALUES (34,37,'r',2);
-INSERT INTO collection_collection VALUES (34,38,'r',1);
+INSERT INTO collection_collection VALUES (1,15,'r',0);
+INSERT INTO collection_collection VALUES (1,16,'r',1);
+INSERT INTO collection_collection VALUES (1,17,'r',2);
+-- INSERT INTO collection_collection VALUES (1,23,'r',0);
+-- INSERT INTO collection_collection VALUES (1,24,'r',1);
+INSERT INTO `collection_collection` VALUES (15,6,'r',0);
+INSERT INTO `collection_collection` VALUES (15,2,'r',1);
+INSERT INTO `collection_collection` VALUES (15,32,'r',3);
+INSERT INTO `collection_collection` VALUES (15,26,'r',2);
+INSERT INTO `collection_collection` VALUES (16,3,'r',0);
+INSERT INTO `collection_collection` VALUES (16,4,'r',1);
+INSERT INTO `collection_collection` VALUES (16,5,'r',2);
+INSERT INTO `collection_collection` VALUES (17,8,'r',1);
+INSERT INTO `collection_collection` VALUES (17,18,'r',2);
+INSERT INTO `collection_collection` VALUES (17,22,'r',3);
+INSERT INTO `collection_collection` VALUES (17,33,'r',0);
+INSERT INTO `collection_collection` VALUES (22,19,'r',0);
+INSERT INTO `collection_collection` VALUES (22,20,'r',1);
+INSERT INTO `collection_collection` VALUES (22,21,'r',2);
+INSERT INTO `collection_collection` VALUES (1,9,'v',3);
+INSERT INTO `collection_collection` VALUES (1,10,'v',4);
+INSERT INTO `collection_collection` VALUES (9,11,'r',1);
+INSERT INTO `collection_collection` VALUES (9,12,'r',0);
+INSERT INTO `collection_collection` VALUES (10,13,'r',1);
+INSERT INTO `collection_collection` VALUES (10,14,'r',0);
+INSERT INTO `collection_collection` VALUES (13,30,'r',0);
+-- INSERT INTO collection_collection VALUES (13,31,'r',0); -- ISOLDE Internal Notes
+INSERT INTO `collection_collection` VALUES (14,27,'r',0);
+INSERT INTO `collection_collection` VALUES (14,28,'r',2);
+INSERT INTO `collection_collection` VALUES (14,29,'r',1);
+INSERT INTO `collection_collection` VALUES (1,34,'v',5);
+INSERT INTO `collection_collection` VALUES (34,35,'r',0);
+INSERT INTO `collection_collection` VALUES (34,36,'r',1);
+INSERT INTO `collection_collection` VALUES (34,37,'r',2);
+INSERT INTO `collection_collection` VALUES (34,38,'r',3);
 
 INSERT INTO collection_example VALUES (1,1,1);
 INSERT INTO collection_example VALUES (1,5,2);

--- a/modules/miscutil/lib/upgrades/invenio_2014_08_31_next_collection_tree.py
+++ b/modules/miscutil/lib/upgrades/invenio_2014_08_31_next_collection_tree.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2012, 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from __future__ import print_function
+
+from invenio.dbquery import run_sql
+
+depends_on = ['invenio_release_1_1_0']
+
+
+def info():
+    return "Update collection tree definition to match next structure"
+
+
+def do_upgrade():
+    """Change the score to the opposite order."""
+    def change_collections_score(id_dad, collection_list):
+        for i, col in enumerate(collection_list):
+            run_sql("UPDATE collection_collection "
+                    "SET score=%s "
+                    "WHERE id_son=%s AND id_dad=%s",
+                    (i, col[0], id_dad))
+            son_collections = run_sql(
+                "SELECT cc.id_son "
+                "FROM collection_collection as cc, collection as c "
+                "WHERE cc.id_dad=%s and cc.id_son=c.id "
+                "ORDER BY cc.score DESC, c.name ASC",
+                (col[0], ))
+            change_collections_score(col[0], son_collections)
+
+    main_collections = run_sql(
+        "SELECT cc.id_son "
+        "FROM collection_collection as cc, collection as c "
+        "WHERE cc.id_dad=1 and cc.id_son=c.id "
+        "ORDER BY cc.score DESC, c.name ASC")
+    change_collections_score(1, main_collections)
+
+
+def estimate():
+    return 1
+
+
+def post_upgrade():
+    print(
+        'Running webcoll is highly recommended to update the collection tree.')

--- a/modules/miscutil/sql/tabcreate.sql
+++ b/modules/miscutil/sql/tabcreate.sql
@@ -5042,5 +5042,6 @@ INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_03_13_new_index_fil
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_08_12_format_code_varchar20',NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_08_13_tag_recjsonvalue',NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_11_04_format_recjson',NOW());
+INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_08_31_next_collection_tree',NOW());
 
 -- end of file

--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -712,7 +712,7 @@ def get_nicely_ordered_collection_list(collid=1, level=0, ln=CFG_SITE_LANG):
        Suitable for create_search_box()."""
     colls_nicely_ordered = []
     res = run_sql("""SELECT c.name,cc.id_son FROM collection_collection AS cc, collection AS c
-                     WHERE c.id=cc.id_son AND cc.id_dad=%s ORDER BY score DESC""", (collid, ))
+                     WHERE c.id=cc.id_son AND cc.id_dad=%s ORDER BY score ASC""", (collid, ))
     for c, cid in res:
         # make a nice printable name (e.g. truncate c_printable for
         # long collection names in given language):
@@ -1887,7 +1887,7 @@ def get_coll_sons(coll, coll_type='r', public_only=1):
             "LEFT JOIN collection_collection AS cc ON c.id=cc.id_son "\
             "LEFT JOIN collection AS ccc ON ccc.id=cc.id_dad "\
             "WHERE cc.type%s AND ccc.name=%%s" % coll_type_query
-    query += " ORDER BY cc.score DESC"
+    query += " ORDER BY cc.score ASC"
     res = run_sql(query, query_params)
     for name in res:
         if not public_only or not collection_restricted_p(name[0]):
@@ -1958,7 +1958,7 @@ def get_coll_real_descendants(coll, coll_type='_', get_hosted_colls=True):
     res = run_sql("""SELECT c.name,c.dbquery FROM collection AS c
                      LEFT JOIN collection_collection AS cc ON c.id=cc.id_son
                      LEFT JOIN collection AS ccc ON ccc.id=cc.id_dad
-                     WHERE ccc.name=%s AND cc.type LIKE %s ORDER BY cc.score DESC""",
+                     WHERE ccc.name=%s AND cc.type LIKE %s ORDER BY cc.score ASC""",
                   (coll, coll_type,))
     for name, dbquery in res:
         if dbquery: # this is 'real' collection, so return it:

--- a/modules/websearch/lib/websearch_webcoll.py
+++ b/modules/websearch/lib/websearch_webcoll.py
@@ -274,7 +274,7 @@ class Collection:
         sons = []
         id_dad = self.id
         query = "SELECT cc.id_son,c.name FROM collection_collection AS cc, collection AS c "\
-                "WHERE cc.id_dad=%d AND cc.type='%s' AND c.id=cc.id_son ORDER BY score DESC, c.name ASC" % (int(id_dad), type)
+                "WHERE cc.id_dad=%d AND cc.type='%s' AND c.id=cc.id_son ORDER BY score ASC, c.name ASC" % (int(id_dad), type)
         res = run_sql(query)
         for row in res:
             sons.append(get_collection(row[1]))
@@ -286,7 +286,7 @@ class Collection:
         descendant_ids = intbitset()
         id_dad = self.id
         query = "SELECT cc.id_son,c.name FROM collection_collection AS cc, collection AS c "\
-                "WHERE cc.id_dad=%d AND cc.type='%s' AND c.id=cc.id_son ORDER BY score DESC" % (int(id_dad), type)
+                "WHERE cc.id_dad=%d AND cc.type='%s' AND c.id=cc.id_son ORDER BY score ASC" % (int(id_dad), type)
         res = run_sql(query)
         for row in res:
             col_desc = get_collection(row[1])

--- a/modules/websearch/lib/websearchadminlib.py
+++ b/modules/websearch/lib/websearchadminlib.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013 CERN.
+## Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -91,8 +91,8 @@ def fix_collection_scores():
     Re-calculate and re-normalize de scores of the collection relationship.
     """
     for id_dad in intbitset(run_sql("SELECT id_dad FROM collection_collection")):
-        for index, id_son in enumerate(run_sql("SELECT id_son FROM collection_collection WHERE id_dad=%s ORDER BY score DESC", (id_dad, ))):
-            run_sql("UPDATE collection_collection SET score=%s WHERE id_dad=%s AND id_son=%s", (index * 10 + 10, id_dad, id_son[0]))
+        for index, id_son in enumerate(run_sql("SELECT id_son FROM collection_collection WHERE id_dad=%s ORDER BY score ASC", (id_dad, ))):
+            run_sql("UPDATE collection_collection SET score=%s WHERE id_dad=%s AND id_son=%s", (index, id_dad, id_son[0]))
 
 def perform_modifytranslations(colID, ln, sel_type='', trans=[], confirm=-1, callback='yes'):
     """Modify the translations of a collection
@@ -2760,9 +2760,9 @@ def get_col_tree(colID, rtype=''):
         while len(stack) > 0:
             ccolID = stack.pop()
             if ccolID == colID and rtype:
-                res = run_sql("SELECT id_son, score, type FROM collection_collection WHERE id_dad=%s AND type=%s ORDER BY score ASC,id_son", (ccolID, rtype))
+                res = run_sql("SELECT id_son, score, type FROM collection_collection WHERE id_dad=%s AND type=%s ORDER BY score DESC,id_son", (ccolID, rtype))
             else:
-                res = run_sql("SELECT id_son, score, type FROM collection_collection WHERE id_dad=%s ORDER BY score ASC,id_son", (ccolID, ))
+                res = run_sql("SELECT id_son, score, type FROM collection_collection WHERE id_dad=%s ORDER BY score DESC,id_son", (ccolID, ))
             ssize += 1
             ntree = []
             for i in range(0, len(res)):


### PR DESCRIPTION
- Updates how the `score` value from `collection_collection` is used
  adopting next way, the lower the score the higher the position.
- Provides an upgrade recipe to update the `collection_collection`
  relationships. It changes the score setting its value from 0 to the
  number of "son collections".

Signed-off-by: Esteban J. G. Gabancho esteban.gabancho@gmail.com
