### PR TITLE
BibFormat: max_char, limit adjustment in bfe_abstract

### DIFF
--- a/modules/bibformat/lib/bibformat_engine_unit_tests.py
+++ b/modules/bibformat/lib/bibformat_engine_unit_tests.py
@@ -265,8 +265,8 @@ class FormatElementTest(InvenioTestCase):
         """bibformat - identification of tag usage inside element"""
         bibformat_engine.CFG_BIBFORMAT_ELEMENTS_PATH = self.old_elements_path
         bibformat_engine.CFG_BIBFORMAT_ELEMENTS_IMPORT_PATH = self.old_import_path
-        tags = bibformatadminlib.get_tags_used_by_element('bfe_abstract.py')
-        self.failUnless(len(tags) == 4,
+        tags = bibformatadminlib.get_tags_used_by_element('bfe_additional_report_numbers.py')
+        self.failUnless(tags == ['088__a'],
                         'Could not correctly identify tags used in bfe_abstract.py')
 
 class OutputFormatTest(InvenioTestCase):


### PR DESCRIPTION
Problem:
Current implementation using the max_char parameter might cut the abstract in a mathematical formula, thus making it impossible to render.

Solution:
Basically interpreting each formula as a string with the length 1, so they cannot be cut in the middle.
This is done with the extend_max_chars function, which increases the max_char parameter by the length of the formulas in case the abstract contains some.
