### PR TITLE
OAIHarvest: Fix for call_authorlist_extract

### DIFF
--- a/modules/bibcatalog/lib/bibcatalog_system.py
+++ b/modules/bibcatalog/lib/bibcatalog_system.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2009, 2010, 2011 CERN.
+## Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -68,7 +68,7 @@ class BibCatalogSystem(object):
         raise NotImplementedError("This class cannot be instantiated")
 
     def ticket_submit(self, uid=None, subject="", recordid=-1, text="", queue="", priority="", owner="",requestor=""):
-        """submit a ticket. Return ticket number on success, otherwise None
+        """submit a ticket. Return ticket_id on success, otherwise None
            @param uid: invenio user id. optional
            @type uid: number
            @param subject: set this as the ticket's subject.
@@ -85,7 +85,7 @@ class BibCatalogSystem(object):
            @type owner: number
            @param requestor: set ticket requestor to this email.
            @type requestor: string
-           @return: new ticket id or None
+           @return: new ticket_id or None
         """
         raise NotImplementedError("This class cannot be instantiated")
 

--- a/modules/bibcheck/lib/bibcheck_task.py
+++ b/modules/bibcheck/lib/bibcheck_task.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2013 CERN.
+## Copyright (C) 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -376,15 +376,15 @@ Edit this record: %s
 
     subject = "Bibcheck rule failed in record %s" % record_id
 
-    res = BIBCATALOG_SYSTEM.ticket_submit(
+    ticket_id = BIBCATALOG_SYSTEM.ticket_submit(
         subject=subject,
         recordid=record_id,
         text=subject,
         queue=task_get_option("queue", "Bibcheck")
     )
-    write_message("Bibcatalog returned %s" % res)
-    if res > 0:
-        BIBCATALOG_SYSTEM.ticket_comment(None, res, msg)
+    write_message("Bibcatalog returned %s" % ticket_id)
+    if ticket_id:
+        BIBCATALOG_SYSTEM.ticket_comment(None, ticket_id, msg)
 
 
 def upload_amendments(records, holdingpen):

--- a/modules/oaiharvest/lib/oai_harvest_daemon.py
+++ b/modules/oaiharvest/lib/oai_harvest_daemon.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2009, 2010, 2011 CERN.
+## Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -1011,7 +1011,7 @@ def call_authorlist_extract(active_file, extracted_file,
                         ticketid = create_authorlist_ticket(matching_fields, \
                                                             identifier, queue)
                         if ticketid:
-                            write_message("authorlist RT ticket %d submitted for %s" % (ticketid, identifier))
+                            write_message("authorlist RT ticket %s submitted for %s" % (ticketid, identifier))
                         else:
                             all_err_msg.append("Error while submitting RT ticket for %s" % (identifier,))
                     # Replace 100,700 fields of original record with extracted fields
@@ -1210,7 +1210,7 @@ def create_authorlist_ticket(matching_fields, identifier, queue):
     @type queue: string
 
     @return: return the ID of the created ticket, or None on failure
-    @rtype: int or None
+    @rtype: string or None
     """
     subject = "[OAI Harvest] UNDEFINED affiliations for record %s" % (identifier,)
     text = """
@@ -1245,7 +1245,7 @@ def create_ticket(queue, subject, text=""):
     @type text: string
 
     @return: return the ID of the created ticket, or None on failure
-    @rtype: int or None
+    @rtype: string or None
     """
     # Initialize BibCatalog connection as default user, if possible
     if BIBCATALOG_SYSTEM is not None:


### PR DESCRIPTION
* Fixes the error in string formatting cause by the fact that
  the ticketid returned from create_authorlist_ticket() is not int.

Signed-off-by: Sebastian Witowski <sebastian.witowski@cern.ch>