### PR TITLE
arXiv: Flask extension database search fix

### DIFF
--- a/invenio/ext/arxiv/__init__.py
+++ b/invenio/ext/arxiv/__init__.py
@@ -158,7 +158,8 @@ class Arxiv(object):
         from invenio.modules.records.utils import get_unique_record_json
 
         # query the database
-        result = get_unique_record_json(arxiv)
+        result = get_unique_record_json(
+            self.app.config.get("ARXIV_SEARCH_PREFIX", "") + arxiv)
         if result["status"] == "notfound":
             # query arxiv
             result = self.get_json(arxiv)


### PR DESCRIPTION
- Adds an instance wide search parameter prefix to perform the database
  search.
- NOTE: for the search to be performed in the database, the arXiv field
  prefix for the corresponding instance config file should be added to
  invenio.cfg as ARXIV_SEARCH_PREFIX
  (e.g. ARXIV_SEARCH_PREFIX = u'035__a:oai:arXiv.org:').
