### PR TITLE
base: global index run during demo site population

### DIFF
--- a/invenio/base/scripts/demosite.py
+++ b/invenio/base/scripts/demosite.py
@@ -87,17 +87,19 @@ def populate(packages=[], default_data=True, files=None,
                 "bin/bibdocfile --textify --all",
                 "bin/bibindex -u admin",
                 "bin/bibindex %d" % (job_id + 1,),
+                "bin/bibindex -u admin -w global",
+                "bin/bibindex %d" % (job_id + 2,),
                 "bin/bibreformat -u admin -o HB",
-                "bin/bibreformat %d" % (job_id + 2,),
+                "bin/bibreformat %d" % (job_id + 3,),
                 "bin/webcoll -u admin",
-                "bin/webcoll %d" % (job_id + 3,),
+                "bin/webcoll %d" % (job_id + 4,),
                 "bin/bibrank -u admin",
-                "bin/bibrank %d" % (job_id + 4,),
+                "bin/bibrank %d" % (job_id + 5,),
                 "bin/bibsort -u admin -R",
-                "bin/bibsort %d" % (job_id + 5,),
+                "bin/bibsort %d" % (job_id + 6,),
                 "bin/oairepositoryupdater -u admin",
-                "bin/oairepositoryupdater %d" % (job_id + 6,),
-                "bin/bibupload %d" % (job_id + 7,)]:
+                "bin/oairepositoryupdater %d" % (job_id + 7,),
+                "bin/bibupload %d" % (job_id + 8,)]:
         cmd = os.path.join(CFG_PREFIX, cmd)
         if os.system(cmd):
             print("ERROR: failed execution of", cmd)


### PR DESCRIPTION
- Adds missing global indexing process that must be run
  during demo site population.  This is necessary after
  the merge of the virtual index facility from master.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
