### PR TITLE
collect: fix for recreation of broken links

### DIFF
--- a/invenio/ext/collect/storage/link.py
+++ b/invenio/ext/collect/storage/link.py
@@ -46,6 +46,9 @@ class Storage(BaseStorage):
                 os.makedirs(destination_dir)
 
             if not os.path.exists(destination):
+                # the path is a link, but points to invalid location
+                if os.path.islink(destination):
+                    os.remove(destination)
                 os.symlink(f, destination)
                 self.log("{0}:{1} symbolink link created".format(bp.name, o))
             else:


### PR DESCRIPTION
Fix for such a problem:

```
Collect static from blueprints
inspire:less/base/variables.less symbolink link created
inspire:less/base/header.less symbolink link created
inspire:less/base/index.less symbolink link created
inspire:less/base/helpers.less symbolink link created
inspire:less/base/footer.less symbolink link created
webaccount:js/accounts/init.js symbolink link created
webaccount:js/accounts/widgets.js symbolink link created
webaccount:css/accounts/index.css symbolink link created
search:js/admin/search/index.js symbolink link created
search:js/admin/search/portalboxes.js symbolink link created
search:js/admin/search/init.js symbolink link created
base:less/sticky-footer.less symbolink link created
base:less/user-menu.less symbolink link created
Traceback (most recent call last):
  File "/mnt/ubuntu/home/kamil/virtualenvs.new/inspire/bin/inveniomanage", line 9, in <module>
    load_entry_point('Invenio==1.9999.2.dev20140804151518', 'console_scripts', 'inveniomanage')()
  File "/mnt/ubuntu/home/kamil/virtualenvs.new/inspire/src/invenio/invenio/base/manage.py", line 103, in main
    manager.run()
  File "/mnt/ubuntu/home/kamil/virtualenvs.new/inspire/lib/python2.7/site-packages/Flask_Script-2.0.5-py2.7.egg/flask_script/__init__.py", line 412, in run
    result = self.handle(sys.argv[0], sys.argv[1:])
  File "/mnt/ubuntu/home/kamil/virtualenvs.new/inspire/lib/python2.7/site-packages/Flask_Script-2.0.5-py2.7.egg/flask_script/__init__.py", line 383, in handle
    res = handle(*args, **config)
  File "/mnt/ubuntu/home/kamil/virtualenvs.new/inspire/src/invenio/invenio/ext/script/__init__.py", line 141, in __call__
    res = super(SignalingCommand, self).__call__(*args, **kwargs)
  File "/mnt/ubuntu/home/kamil/virtualenvs.new/inspire/lib/python2.7/site-packages/Flask_Script-2.0.5-py2.7.egg/flask_script/commands.py", line 216, in __call__
    return self.run(*args, **kwargs)
  File "/mnt/ubuntu/home/kamil/virtualenvs.new/inspire/lib/python2.7/site-packages/flask_collect/collect.py", line 84, in collect
    return self.collect(verbose=verbose)
  File "/mnt/ubuntu/home/kamil/virtualenvs.new/inspire/lib/python2.7/site-packages/flask_collect/collect.py", line 97, in collect
    return storage.run()
  File "/mnt/ubuntu/home/kamil/virtualenvs.new/inspire/src/invenio/invenio/ext/collect/storage/link.py", line 49, in run
    os.symlink(f, destination)
OSError: [Errno 17] File exists
(inspire)
```

In this case `destination` exists but is a link which points to an invalid location. It causes `exists()` method return `False`, but later throws an exception on `symlink()`. The PR overwrites such invalid symlinks with a working ones.
