### PR TITLE
WIP BibUpload: bibrec.earliest_date

### DIFF
--- a/modules/bibcheck/etc/example_rules.cfg
+++ b/modules/bibcheck/etc/example_rules.cfg
@@ -34,3 +34,7 @@ check.fields = ["100%%a"]
 filter_pattern = 027_a:/.*/
 filter_collection = HEP
 holdingpen = true
+
+[earliest_date]
+check = earliest_date
+check.date_fields = ["111__d", "260__c", "269__c", "542__g", "502__d", "773__y", "111__x", "046__%", "371__t", "909C4y"]

--- a/modules/bibcheck/lib/bibcheck_task.py
+++ b/modules/bibcheck/lib/bibcheck_task.py
@@ -245,8 +245,7 @@ def task_parse_options(key, val, *_):
     """ Must be defined for bibtask to create a task """
 
     if key in ("--all", "-a"):
-        for rule_name in val.split(","):
-            reset_rule_last_run(rule_name)
+        task_set_option("reset_rules", set(val.split(",")))
     elif key in ("--enable-rules", "-e"):
         task_set_option("enabled_rules", set(val.split(",")))
     elif key in ("--id", "-i"):
@@ -272,10 +271,17 @@ def task_run_core():
 
     Returns True when run successfully. False otherwise.
     """
+    rules_to_reset = task_get_option("reset_rules")
+    if rules_to_reset:
+        write_message("Resetting the following rules: %s" % rules_to_reset)
+        for rule in rules_to_reset:
+            reset_rule_last_run(rule)
     plugins = load_plugins()
     rules = load_rules(plugins)
+    write_message("Loaded rules: %s" % rules, verbose=9)
     task_set_option('plugins', plugins)
     recids_for_rules = get_recids_for_rules(rules)
+    write_message("recids for rules: %s" % recids_for_rules, verbose=9)
 
     all_recids = intbitset([])
     single_rules = set()

--- a/modules/bibcheck/lib/plugins/Makefile.am
+++ b/modules/bibcheck/lib/plugins/Makefile.am
@@ -31,7 +31,8 @@ pylib_DATA = __init__.py \
     texkey.py \
     doi.py \
     crossref_checker.py \
-    url.py
+    url.py \
+    earliest_date.py
 
 EXTRA_DIST = $(pylib_DATA)
 

--- a/modules/bibcheck/lib/plugins/earliest_date.py
+++ b/modules/bibcheck/lib/plugins/earliest_date.py
@@ -1,0 +1,85 @@
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""
+Populates the earliest_date of a record to reflect the earliest date information
+available.
+Note in case of partial dates (e.g. just the year or just year-month), if there
+is another valid date within the
+"""
+
+import time
+
+from invenio.dateutils import strftime, strptime
+from invenio.dbquery import run_sql
+## List of MARC fields from where to read dates.
+CFG_DEFAULT_DATE_FIELDS = ["111__d", "260__c", "269__c", "542__g", "502__d", "773__y", "111__x", "046__%", "371__t", "909C4y"]
+CFG_POSSIBLE_DATE_FORMATS_ONLY_YEAR = ["%Y", "%y"]
+CFG_POSSIBLE_DATE_FORMATS_ONLY_YEAR_MONTH = ["%Y-%m", "%Y %b", "%b %Y", "%Y %B", "%B %Y", "%y-%m", "%y %b", "%b %y", "%y %B", "%B %y"]
+CFG_POSSIBLE_DATE_FORMATS = ["%Y-%m-%d", "%d %m %Y", "%x", "%d %b %Y", "%d %B %Y", "%d %b %y", "%d %B %y"]
+
+
+def check_records(records, date_fields=CFG_DEFAULT_DATE_FIELDS):
+    """
+    Backdate the earliest_date of a record to reflect the earliest date information
+    available.
+    Note in case of partial dates (e.g. just the year or just year-month), if there
+    is another valid date within the
+    """
+    for record in records:
+        dates = []
+        recid = int(record["001"][0][3])
+
+        creation_date, modification_date, earliest_date = run_sql("SELECT creation_date, modification_date, earliest_date FROM bibrec WHERE id=%s", (recid, ))[0]
+        creation_date = strftime("%Y-%m-%d %H:%M:%S", creation_date)
+        modification_date = strftime("%Y-%m-%d %H:%M:%S", modification_date)
+        earliest_date = strftime("%Y-%m-%d %H:%M:%S", earliest_date)
+        dates.append(creation_date)
+        dates.append(modification_date)
+
+        if '005' in record:
+            dates.append(strftime("%Y-%m-%d %H:%M:%S", strptime(record["005"][0][3], "%Y%m%d%H%M%S.0")))
+        for position, value in record.iterfields(date_fields):
+            for format in CFG_POSSIBLE_DATE_FORMATS:
+                try:
+                    parsed_date = strftime("%Y-%m-%d 00:00:00", (strptime(value, format)))
+                    dates.append(parsed_date)
+                    break
+                except ValueError:
+                    pass
+            else:
+                for format in CFG_POSSIBLE_DATE_FORMATS_ONLY_YEAR_MONTH:
+                    try:
+                        parsed_date = strftime("%Y-%m-99 00:00:00", (strptime(value, format)))
+                        dates.append(parsed_date)
+                        break
+                    except ValueError:
+                        pass
+                else:
+                    for format in CFG_POSSIBLE_DATE_FORMATS_ONLY_YEAR:
+                        try:
+                            parsed_date = strftime("%Y-99-99 00:00:00", (strptime(value, format)))
+                            dates.append(parsed_date)
+                            break
+                        except ValueError:
+                            pass
+        min_date = min(dates)
+        ## Let's restore meaningful first month and day
+        min_date = min_date.replace("-99", "-01")
+        if min_date != earliest_date:
+            run_sql("UPDATE bibrec SET earliest_date=%s WHERE id=%s", (min_date, recid))
+            record.warn("record earliest_date amended from %s to %s" % (earliest_date, min_date))

--- a/modules/bibedit/lib/bibedit_dblayer.py
+++ b/modules/bibedit/lib/bibedit_dblayer.py
@@ -87,8 +87,8 @@ def get_record_last_modification_date(recid):
 
 def reserve_record_id():
     """Reserve a new record ID in the bibrec table."""
-    return run_sql("""INSERT INTO bibrec (creation_date, modification_date)
-                       VALUES (NOW(), NOW())""")
+    return run_sql("""INSERT INTO bibrec (creation_date, modification_date,
+                      earliest_date) VALUES (NOW(), NOW(), NOW())""")
 
 def get_related_hp_changesets(recId):
     """

--- a/modules/bibsort/etc/bibsort.cfg
+++ b/modules/bibsort/etc/bibsort.cfg
@@ -17,25 +17,30 @@
 
 [sort_field_1]
 name = latest first
-definition = BIBREC: creation_date
+definition = BIBREC: id
 washer = NOOP
 
 [sort_field_2]
+name = earliestdate
+definition = BIBREC: earliest_date
+washer = NOOP
+
+[sort_field_3]
 name = title
 definition = FIELD: title
 washer = sort_alphanumerically_remove_leading_articles:fr
 
-[sort_field_3]
+[sort_field_4]
 name = author
 definition = FIELD: firstauthor
 washer = sort_case_insensitive_strip_accents
 
-[sort_field_4]
+[sort_field_5]
 name = report number
 definition = MARC: 037__a,909C0r,088__a
 washer = sort_case_insensitive
 
-[sort_field_5]
+[sort_field_6]
 name = most cited
 definition = RNK: citation
 washer = NOOP

--- a/modules/bibsort/lib/bibsort_engine.py
+++ b/modules/bibsort/lib/bibsort_engine.py
@@ -198,6 +198,9 @@ def get_data_for_definition_rnk(method_name, rnk_name):
 def get_data_for_definition_bibrec(column_name, recids_copy):
     '''Having a column_name and a list of recids, it returns a dictionary
     mapping each recids with its correspondig value from the column'''
+    if column_name == 'id':
+        ## short-cut for recids:
+        return dict(map(lambda x: (x,x), recids_copy))
     dict_column = {}
     for recid in recids_copy:
         creation_date = run_sql('SELECT %s from bibrec WHERE id = %%s' %column_name, (recid, ))[0][0]

--- a/modules/bibupload/lib/batchuploader_engine.py
+++ b/modules/bibupload/lib/batchuploader_engine.py
@@ -88,7 +88,7 @@ def cli_allocate_record(req):
         _log(msg)
         return _write(req, msg)
 
-    recid = run_sql("insert into bibrec (creation_date,modification_date) values(NOW(),NOW())")
+    recid = run_sql("insert into bibrec (creation_date,modification_date,earliest_date) values(NOW(),NOW(),NOW())")
     return recid
 
 def cli_upload(req, file_content=None, mode=None, callback_url=None, nonce=None, special_treatment=None):

--- a/modules/miscutil/lib/dateutils.py
+++ b/modules/miscutil/lib/dateutils.py
@@ -434,7 +434,7 @@ def guess_datetime(datetime_string):
         except ValueError:
             pass
     else:
-        for format in (None, '%x %X', '%X %x', '%Y-%M-%dT%h:%m:%sZ'):
+        for format in (None, '%x %X', '%X %x', '%Y-%M-%dT%h:%m:%sZ', "%Y-%m-%d", "%d %m %Y"):
             try:
                 return time.strptime(datetime_string, format)
             except ValueError:

--- a/modules/miscutil/lib/inveniocfg.py
+++ b/modules/miscutil/lib/inveniocfg.py
@@ -887,11 +887,13 @@ def cli_cmd_load_demo_records(conf):
                 "%s/bin/webcoll 5" % CFG_PREFIX,
                 "%s/bin/bibrank -u admin" % CFG_PREFIX,
                 "%s/bin/bibrank 6" % CFG_PREFIX,
+                "%s/bin/bibcheck -u admin -e earliest_date -c example_rules.cfg" % CFG_PREFIX,
+                "%s/bin/bibcheck 7" % CFG_PREFIX,
                 "%s/bin/bibsort -u admin -R" % CFG_PREFIX,
-                "%s/bin/bibsort 7" % CFG_PREFIX,
+                "%s/bin/bibsort 8" % CFG_PREFIX,
                 "%s/bin/oairepositoryupdater -u admin" % CFG_PREFIX,
-                "%s/bin/oairepositoryupdater 8" % CFG_PREFIX,
-                "%s/bin/bibupload 9" % CFG_PREFIX,]:
+                "%s/bin/oairepositoryupdater 9" % CFG_PREFIX,
+                "%s/bin/bibupload 10" % CFG_PREFIX,]:
         if os.system(cmd):
             print "ERROR: failed execution of", cmd
             sys.exit(1)

--- a/modules/miscutil/lib/upgrades/invenio_2014_04_15_bibrec_earliest_date.py
+++ b/modules/miscutil/lib/upgrades/invenio_2014_04_15_bibrec_earliest_date.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+import warnings
+from invenio.dbquery import run_sql
+
+depends_on = ['invenio_release_1_1_0']
+
+
+def info():
+    return "Add new earliest column to bibrec table"
+
+
+def do_upgrade():
+    """ Implement your upgrades here  """
+    create_statement = run_sql('SHOW CREATE TABLE bibrec')[0][1]
+    if "earliest_date" not in create_statement:
+        run_sql("ALTER TABLE bibrec ADD COLUMN `earliest_date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00'")
+        run_sql("ALTER TABLE bibrec ADD INDEX earliest_date (earliest_date)")
+        run_sql("UPDATE bibrec SET earliest_date=creation_date")
+
+
+def estimate():
+    """  Estimate running time of upgrade in seconds (optional). """
+    return run_sql("SELECT COUNT(1) FROM bibrec")[0][0] / 10000
+
+
+def pre_upgrade():
+    """  Run pre-upgrade checks (optional). """
+    pass
+
+
+def post_upgrade():
+    """  Run post-upgrade checks (optional). """
+    pass

--- a/modules/miscutil/sql/tabcreate.sql
+++ b/modules/miscutil/sql/tabcreate.sql
@@ -21,10 +21,12 @@ CREATE TABLE IF NOT EXISTS bibrec (
   id mediumint(8) unsigned NOT NULL auto_increment,
   creation_date datetime NOT NULL default '0000-00-00',
   modification_date datetime NOT NULL default '0000-00-00',
+  earliest_date datetime NOT NULL default '0000-00-00',
   master_format varchar(16) NOT NULL default 'marc',
   PRIMARY KEY  (id),
   KEY creation_date (creation_date),
-  KEY modification_date (modification_date)
+  KEY modification_date (modification_date),
+  KEY earliest_date (earliest_date)
 ) ENGINE=MyISAM;
 
 CREATE TABLE IF NOT EXISTS bib00x (
@@ -5041,5 +5043,6 @@ INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2013_12_05_new_index_doi
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_03_13_new_index_filename',NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_08_12_format_code_varchar20',NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_08_13_tag_recjsonvalue',NOW());
+INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_04_15_bibrec_earliest_date',NOW());
 
 -- end of file

--- a/modules/miscutil/sql/tabfill.sql
+++ b/modules/miscutil/sql/tabfill.sql
@@ -63,6 +63,7 @@ INSERT INTO field VALUES (40,'refers to excluding self cites','referstoexcluding
 INSERT INTO field VALUES (41,'cited by excluding self cites','citedbyexcludingselfcites');
 INSERT INTO field VALUES (42,'cataloguer nickname','cataloguer');
 INSERT INTO field VALUES (43,'file name','filename');
+INSERT INTO field VALUES (44,'earliest date','earliestdate');
 
 INSERT INTO field_tag VALUES (10,11,100);
 INSERT INTO field_tag VALUES (11,14,100);

--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -2425,6 +2425,8 @@ def search_unit(p, f=None, m=None, wl=0, ignore_synonyms=None):
         hitset = search_unit_in_bibrec(p, p, 'c')
     elif f == 'datemodified':
         hitset = search_unit_in_bibrec(p, p, 'm')
+    elif f == 'earliestdate':
+        hitset = search_unit_in_bibrec(p, p, 'e')
     elif f == 'refersto':
         # we are doing search by the citation count
         hitset = search_unit_refersto(p)
@@ -2895,6 +2897,8 @@ def search_unit_in_bibrec(datetext1, datetext2, search_type='c'):
     hitset = intbitset()
     if search_type and search_type.startswith("m"):
         search_type = "modification_date"
+    elif search_type and search_type.startswith("e"):
+        search_type = "earliest_date"
     else:
         search_type = "creation_date" # by default we are searching for creation dates
 
@@ -3276,7 +3280,7 @@ def create_nearest_terms_box(urlargd, p, f, t='w', n=5, ln=CFG_SITE_LANG, intro_
         nearest_terms = []
         if index_id:
             nearest_terms = get_nearest_terms_in_idxphrase(p, index_id, n, n)
-        if f == 'datecreated' or f == 'datemodified':
+        if f in ('datecreated', 'datemodified', 'earliestdate'):
             nearest_terms = get_nearest_terms_in_bibrec(p, f, n, n)
         if not nearest_terms:
             nearest_terms = get_nearest_terms_in_bibxxx(p, f, n, n)
@@ -3291,7 +3295,7 @@ def create_nearest_terms_box(urlargd, p, f, t='w', n=5, ln=CFG_SITE_LANG, intro_
         else:
             if index_id:
                 hits = get_nbhits_in_idxphrases(term, f)
-            elif f == 'datecreated' or f == 'datemodified':
+            elif f in ('datecreated', 'datemodified', 'earliestdate'):
                 hits = get_nbhits_in_bibrec(term, f)
             else:
                 hits = get_nbhits_in_bibxxx(term, f)
@@ -3472,13 +3476,15 @@ def get_nearest_terms_in_bibxxx(p, f, n_below, n_above):
 
 def get_nearest_terms_in_bibrec(p, f, n_below, n_above):
     """Return list of nearest terms and counts from bibrec table.
-    p is usually a date, and f either datecreated or datemodified.
+    p is usually a date, and f either datecreated or datemodified or earliestdate.
 
     Note: below/above count is very approximative, not really respected.
     """
     col = 'creation_date'
     if f == 'datemodified':
         col = 'modification_date'
+    elif f == 'earliestdate':
+        col = 'earliest_date'
     res_above = run_sql("""SELECT DATE_FORMAT(%s,'%%%%Y-%%%%m-%%%%d %%%%H:%%%%i:%%%%s')
                              FROM bibrec WHERE %s < %%s
                             ORDER BY %s DESC LIMIT %%s""" % (col, col, col),
@@ -3498,10 +3504,12 @@ def get_nearest_terms_in_bibrec(p, f, n_below, n_above):
 
 def get_nbhits_in_bibrec(term, f):
     """Return number of hits in bibrec table.  term is usually a date,
-    and f is either 'datecreated' or 'datemodified'."""
+    and f is either 'datecreated' or 'datemodified' or 'earliestdate'."""
     col = 'creation_date'
     if f == 'datemodified':
         col = 'modification_date'
+    elif f == 'earliestdate':
+        col = 'earliest_date'
     res = run_sql("SELECT COUNT(*) FROM bibrec WHERE %s LIKE %%s" % (col,),
                   (term + '%',))
     return res[0][0]

--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -3867,6 +3867,14 @@ def get_modification_date(recID, fmt="%Y-%m-%d"):
         out = res[0][0]
     return out
 
+def get_earliest_date(recID, fmt="%Y-%m-%d"):
+    "Returns the earliest date for the record 'recID'."
+    out = ""
+    res = run_sql("SELECT DATE_FORMAT(earliest_date,%s) FROM bibrec WHERE id=%s", (fmt, recID), 1)
+    if res:
+        out = res[0][0]
+    return out
+
 def print_search_info(p, f, sf, so, sp, rm, of, ot, collection=CFG_SITE_NAME, nb_found=-1, jrec=1, rg=CFG_WEBSEARCH_DEF_RECORDS_IN_GROUPS,
                       aas=0, ln=CFG_SITE_LANG, p1="", p2="", p3="", f1="", f2="", f3="", m1="", m2="", m3="", op1="", op2="",
                       sc=1, pl_in_url="",
@@ -4808,9 +4816,11 @@ def print_records(req, recIDs, jrec=1, rg=CFG_WEBSEARCH_DEF_RECORDS_IN_GROUPS, f
 
                         creationdate = None
                         modificationdate = None
+                        earliestdate = None
                         if record_exists(recid) == 1:
                             creationdate = get_creation_date(recid)
                             modificationdate = get_modification_date(recid)
+                            earliestdate = get_earliest_date(recid)
 
                         content = print_record(recid, format, ot, ln,
                                                search_pattern=search_pattern,
@@ -4822,6 +4832,7 @@ def print_records(req, recIDs, jrec=1, rg=CFG_WEBSEARCH_DEF_RECORDS_IN_GROUPS, f
                             format=format,
                             creationdate=creationdate,
                             modificationdate=modificationdate,
+                            earliestdate=earliestdate,
                             content=content)
                         # display of the next-hit/previous-hit/back-to-search links
                         # on the detailed record pages
@@ -4834,6 +4845,7 @@ def print_records(req, recIDs, jrec=1, rg=CFG_WEBSEARCH_DEF_RECORDS_IN_GROUPS, f
                                                                                       ln,
                                                                                       creationdate=creationdate,
                                                                                       modificationdate=modificationdate,
+                                                                                      earliestdate=earliestdate,
                                                                                       show_short_rec_p=False))
 
                         if len(tabs) > 0:

--- a/modules/websearch/lib/search_engine_query_parser.py
+++ b/modules/websearch/lib/search_engine_query_parser.py
@@ -425,6 +425,7 @@ class SpiresToInvenioSyntaxConverter:
     # Constants defining fields
     _DATE_ADDED_FIELD = 'datecreated:'
     _DATE_UPDATED_FIELD = 'datemodified:'
+    _EARLIEST_DATE_FIELD = 'earliestdate:'
     _DATE_FIELD = 'year:'
 
     _A_TAG = 'author:'
@@ -481,6 +482,9 @@ class SpiresToInvenioSyntaxConverter:
         'date-updated': _DATE_UPDATED_FIELD,
         'dupd': _DATE_UPDATED_FIELD,
         'du': _DATE_UPDATED_FIELD,
+        'de': _EARLIEST_DATE_FIELD,
+        'dear': _EARLIEST_DATE_FIELD,
+        'earliest-date': _EARLIEST_DATE_FIELD,
         # first author
         'fa' : 'firstauthor:',
         'first-author' : 'firstauthor:',
@@ -717,13 +721,13 @@ class SpiresToInvenioSyntaxConverter:
                 (?=\ and\ not\ |\ and\ |\ or\ |\ not\ |$)''')
 
         # regular expression matching date after pattern
-        self._re_date_after_match = re.compile(r'\b(?P<searchop>d|date|dupd|dadd|da|date-added|du|date-updated)\b\s*(after|>)\s*(?P<search_content>.+?)(?= and not | and | or | not |$)', re.IGNORECASE)
+        self._re_date_after_match = re.compile(r'\b(?P<searchop>d|date|dupd|dadd|da|date-added|du|date-updated|de|dear|earliest-date)\b\s*(after|>)\s*(?P<search_content>.+?)(?= and not | and | or | not |$)', re.IGNORECASE)
 
         # regular expression matching date after pattern
-        self._re_date_before_match = re.compile(r'\b(?P<searchop>d|date|dupd|dadd|da|date-added|du|date-updated)\b\s*(before|<)\s*(?P<search_content>.+?)(?= and not | and | or | not |$)', re.IGNORECASE)
+        self._re_date_before_match = re.compile(r'\b(?P<searchop>d|date|dupd|dadd|da|date-added|du|date-updated|de|dear|earliest-date)\b\s*(before|<)\s*(?P<search_content>.+?)(?= and not | and | or | not |$)', re.IGNORECASE)
 
         # match date searches which have been keyword-substituted
-        self._re_keysubbed_date_expr = re.compile(r'\b(?P<term>(' + self._DATE_ADDED_FIELD + ')|(' + self._DATE_UPDATED_FIELD + ')|(' + self._DATE_FIELD + '))(?P<content>.+?)(?= and not | and | or | not |$)', re.IGNORECASE)
+        self._re_keysubbed_date_expr = re.compile(r'\b(?P<term>(' + self._DATE_ADDED_FIELD + ')|(' + self._DATE_UPDATED_FIELD + ')|(' + self._EARLIEST_DATE_FIELD + ')|(' + self._DATE_FIELD + '))(?P<content>.+?)(?= and not | and | or | not |$)', re.IGNORECASE)
 
         # for finding (and changing) a variety of different SPIRES search keywords
         self._re_spires_find_keyword = re.compile('^(f|fin|find)\s+', re.IGNORECASE)

--- a/modules/websearch/lib/websearch_regression_tests.py
+++ b/modules/websearch/lib/websearch_regression_tests.py
@@ -4898,7 +4898,7 @@ class WebSearchDOIQueryTest(InvenioTestCase):
 
 class WebSearchGetRecordTests(InvenioTestCase):
     def setUp(self):
-        self.recid = run_sql("INSERT INTO bibrec(creation_date, modification_date) VALUES(NOW(), NOW())")
+        self.recid = run_sql("INSERT INTO bibrec(creation_date, modification_date, earliest_date) VALUES(NOW(), NOW(), NOW())")
 
     def tearDown(self):
         run_sql("DELETE FROM bibrec WHERE id=%s", (self.recid,))

--- a/modules/websearch/lib/websearch_templates.py
+++ b/modules/websearch/lib/websearch_templates.py
@@ -3950,7 +3950,8 @@ class Template:
     def tmpl_detailed_record_metadata(self, recID, ln, format,
                                       content,
                                       creationdate=None,
-                                      modificationdate=None):
+                                      modificationdate=None,
+                                      earliestdate=None):
         """Returns the main detailed page of a record
 
         Parameters:
@@ -3966,6 +3967,8 @@ class Template:
           - 'creationdate' *string* - The creation date of the printed record
 
           - 'modificationdate' *string* - The last modification date of the printed record
+
+          - 'earliestdate' *string* - The earliest date of the printed record
         """
         _ = gettext_set_language(ln)
 

--- a/modules/webstyle/lib/webstyle_templates.py
+++ b/modules/webstyle/lib/webstyle_templates.py
@@ -773,7 +773,9 @@ URI: http://%(host)s%(page)s
     def detailed_record_container_top(self, recid, tabs, ln=CFG_SITE_LANG,
                                       show_similar_rec_p=True,
                                       creationdate=None,
-                                      modificationdate=None, show_short_rec_p=True,
+                                      modificationdate=None,
+                                      earliestdate=None,
+                                      show_short_rec_p=True,
                                       citationnum=-1, referencenum=-1, discussionnum=-1,
                                       include_jquery = False, include_mathjax = False):
         """Prints the box displayed in detailed records pages, with tabs at the top.
@@ -789,6 +791,7 @@ URI: http://%(host)s%(page)s
         @param show_similar_rec_p: *bool* print 'similar records' link in the box
         @param creationdate: *string* - the creation date of the displayed record
         @param modificationdate: *string* - the last modification date of the displayed record
+        @param earliestdate: *string* - the earliest date of the displayed record
         @param show_short_rec_p: *boolean* - prints a very short version of the record as reminder.
         @param citationnum: show (this) number of citations in the citations tab
         @param referencenum: show (this) number of references in the references tab
@@ -896,7 +899,9 @@ URI: http://%(host)s%(page)s
     def detailed_record_container_bottom(self, recid, tabs, ln=CFG_SITE_LANG,
                                          show_similar_rec_p=True,
                                          creationdate=None,
-                                         modificationdate=None, show_short_rec_p=True):
+                                         modificationdate=None,
+                                         earliestdate=None,
+                                         show_short_rec_p=True):
         """Prints the box displayed in detailed records pages, with tabs at the top.
 
         Returns content as it is if the number of tabs for this record
@@ -910,6 +915,7 @@ URI: http://%(host)s%(page)s
          - show_similar_rec_p *bool* print 'similar records' link in the box
          - creationdate *string* - the creation date of the displayed record
          - modificationdate *string* - the last modification date of the displayed record
+         - earliestdate *string* - the earliest date of the displayed record
          - show_short_rec_p *boolean* - prints a very short version of the record as reminder.
         """
         # If no tabs, returns nothing
@@ -939,7 +945,7 @@ URI: http://%(host)s%(page)s
     <br/>
     """ % {'similar' : similar,
            'dates' : creationdate and '<div class="recordlastmodifiedbox" style="position:relative;margin-left:1px">&nbsp;%(dates)s</div>' % {
-                'dates': _("Record created %(x_date_creation)s, last modified %(x_date_modification)s") % \
+                'dates': _("Record added %(x_date_creation)s, last modified %(x_date_modification)s") % \
                 {'x_date_creation': creationdate,
                  'x_date_modification': modificationdate},
                 } or ''

--- a/modules/websubmit/lib/functions/Create_Recid.py
+++ b/modules/websubmit/lib/functions/Create_Recid.py
@@ -27,7 +27,7 @@ def Create_Recid(parameters, curdir, form, user_info=None):
     """
     global sysno
     if not os.path.exists("%s/SN" % curdir):
-        recid = run_sql("insert into bibrec (creation_date,modification_date) values(NOW(),NOW())")
+        recid = run_sql("insert into bibrec (creation_date,modification_date,earliest_date) values(NOW(),NOW(),NOW())")
         fp = open("%s/SN" % curdir,"w")
         fp.write(str(recid))
         sysno = recid


### PR DESCRIPTION
Introduces support for `bibrec.earliest_date` consequently allowing to independently sorting by earlieast date (i.e. the time when a publication appeared) and creation date (i.e. when the corresponding record was created in the system).