### PR TITLE
WebSearch: restricted records in latest additions

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -632,10 +632,10 @@ CFG_WEBSEARCH_PREV_NEXT_HIT_LIMIT = 1000
 CFG_WEBSEARCH_PREV_NEXT_HIT_FOR_GUESTS = 1
 
 ## CFG_WEBSEARCH_VIEWRESTRCOLL_POLICY -- when a record belongs to more than one
-## restricted collection, if the viewrestcoll policy is set to "ALL" (default)
-## then the user must be authorized to all the restricted collections, in
-## order to be granted access to the specific record. If the policy is set to
-## "ANY", then the user need to be authorized to only one of the collections
+## restricted collection, if the viewrestcoll policy is set to "ALL" then the
+## user must be authorized to all the restricted collections, in order to be
+## granted access to the specific record. If the policy is set to "ANY"
+## (default), then the user need to be authorized to only one of the collections
 ## in order to be granted access to the specific record.
 CFG_WEBSEARCH_VIEWRESTRCOLL_POLICY = ANY
 

--- a/modules/websearch/lib/websearch_regression_tests.py
+++ b/modules/websearch/lib/websearch_regression_tests.py
@@ -3308,6 +3308,11 @@ class WebSearchRestrictedCollectionTest(InvenioTestCase):
                             test_web_page_content(CFG_SITE_URL + '/collection/Theses',
                                                   expected_text="Latest additions"))
 
+    def test_restricted_record_not_in_latest_addition(self):
+        """websearch - restricted record never appear in latest addition"""
+        self.assertEqual([], test_web_page_content(CFG_SITE_URL + '/collection/Preprints',
+                                                  unexpected_text="Notes on statistics for physicists"))
+
     def test_restricted_search_as_anonymous_guest(self):
         """websearch - restricted collection not searchable by anonymous guest"""
         browser = Browser()


### PR DESCRIPTION
- When a record belongs to both a public and a restricted collection,
  no longer display it in the list of latest additions of the
  public collection (in accordance to the outcome of an empty search query
  over the public collection).
  (closes #1315)
- Amend documentation of CFG_WEBSEARCH_VIEWRESTRCOLL_POLICY
  WRT default policy value.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
