### PR TITLE
errorlib: context support in sentry

### DIFF
--- a/modules/miscutil/lib/errorlib.py
+++ b/modules/miscutil/lib/errorlib.py
@@ -37,7 +37,8 @@ from invenio.config import CFG_SITE_LANG, CFG_LOGDIR, \
     CFG_SITE_ADMIN_EMAIL_EXCEPTIONS, \
     CFG_ERRORLIB_RESET_EXCEPTION_NOTIFICATION_COUNTER_AFTER, \
     CFG_PROPAGATE_EXCEPTIONS, \
-    CFG_ERRORLIB_SENTRY_URI
+    CFG_ERRORLIB_SENTRY_URI, \
+    CFG_VERSION
 from invenio.urlutils import wash_url_argument
 from invenio.messages import wash_language, gettext_set_language
 from invenio.dateutils import convert_datestruct_to_datetext
@@ -387,7 +388,31 @@ def register_exception(stream='error',
     if CFG_ERRORLIB_SENTRY_URI:
         from raven import Client
         client = Client(CFG_ERRORLIB_SENTRY_URI)
-        client.captureException()
+        try:
+            if req:
+                from invenio.webuser import collect_user_info
+                user_info = collect_user_info(req)
+                client.user_context({'id': user_info['uid'],
+                                    'is_anonymous': user_info['guest'] == '1',
+                                    'is_authenticated': user_info['guest'] == '0',
+                                    'email': user_info['email'],
+                                    'group': user_info['group'],
+                                    'nickname': user_info['nickname']})
+                client.http_context({'url': req.full_uri,
+                                    'remote_ip': user_info['remote_ip'],
+                                    'agent': user_info['agent'],
+                                    'referer': user_info['referer'],
+                                    'method': req.method,
+                                    'query_string': req.args,
+                                    'headers': dict(req.headers_in),
+                                    'https': req.is_https(),
+                                    'env': req.environ})
+                client.extra_context(user_info)
+            filename = _get_filename_and_line(sys.exc_info())[0]
+            client.tags_context({'filename': filename}, {'version', CFG_VERSION})
+            client.captureException()
+        finally:
+            client.context.clear()
 
     if CFG_PROPAGATE_EXCEPTIONS:
         raise

--- a/modules/webstyle/lib/webinterface_handler_wsgi.py
+++ b/modules/webstyle/lib/webinterface_handler_wsgi.py
@@ -247,6 +247,12 @@ class SimulatedModPythonRequest(object):
     def get_uri(self):
         return self.__environ['PATH_INFO']
 
+    def get_full_uri(self):
+        if self.is_https():
+            return CFG_SITE_SECURE_URL + self.get_unparsed_uri()
+        else:
+            return CFG_SITE_URL + self.get_unparsed_uri()
+
     def get_headers_in(self):
         return self.__headers_in
 
@@ -431,9 +437,14 @@ class SimulatedModPythonRequest(object):
         assert not self.__tainted, "The original WSGI environment is tainted since at least req.write or req.form has been used."
         return self.__environ, self.__start_response
 
+    def get_environ(self):
+        return self.__environ
+
+    environ = property(get_environ)
     content_type = property(get_content_type, set_content_type)
     unparsed_uri = property(get_unparsed_uri)
     uri = property(get_uri)
+    full_uri = property(get_full_uri)
     headers_in = property(get_headers_in)
     subprocess_env = property(get_subprocess_env)
     args = property(get_args)


### PR DESCRIPTION
- Introduces support for HTTP, and user context in sentry, by
  exploiting information provided in req object when available.
  (closes #1960)

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
