### PR TITLE
OAIRepository: OAI-PMH handler advertised

### DIFF
--- a/modules/oairepository/doc/admin/oairepository-admin-guide.webdoc
+++ b/modules/oairepository/doc/admin/oairepository-admin-guide.webdoc
@@ -128,3 +128,13 @@ $ oairepositoryupdater -d
 <p>
 
 Please see also invenio.conf for more fine configurations of the OAI Repository.
+
+<a name="2.2.2"></a><h4>2.2.2 OAI-PMH handler</h4>
+<p>OAI harvester wishing to harvest records exposed by the current instance will have to access the OAI-PMH handler available at:
+<blockquote>
+<pre>
+<CFG_SITE_URL>/oai2d
+</pre>
+</blockquote>
+E.g. visit <a href="<CFG_SITE_URL>/oai2d?verb=Identify" target="_blank"><CFG_SITE_URL>/oai2d?verb=Identify</a> in order to receive the OAI-PMH identification of this Invenio instance.
+</p>


### PR DESCRIPTION
- Officially advertises the location of the OAI-PMH handler implemented
  by the OAIRepository module.
  (closes #1027)

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
