### PR TITLE
records: lazy type introduction in MarcXML export

### DIFF
--- a/invenio/modules/records/api.py
+++ b/invenio/modules/records/api.py
@@ -20,6 +20,7 @@
 """Record API."""
 
 import six
+from speaklater import is_lazy_string
 
 from flask import current_app
 from sqlalchemy import or_
@@ -180,8 +181,9 @@ class Record(SmartJson):
             ind1 = ''
             ind2 = ''
             for key, value in six.iteritems(marc_dict):
-                if isinstance(value, six.string_types) or \
-                        not isinstance(value, Iterable):
+                if (isinstance(value, six.string_types)
+                     or not isinstance(value, Iterable)
+                     or is_lazy_string(value)):
                     value = [value]
                 for v in value:
                     if v is None:


### PR DESCRIPTION
**Idea:**
Check if the string is a lazy string and convert it into a list in order not to be split in letters while exporting to MarcXML.

**Problem:**
As an example, this is the languages list we have in a form to generate a select field:

```
languages = [("en", _("English")),
             ("fre", _("French")),
             ("ger", _("German")),
             ("dut", _("Dutch")),
             ("ita", _("Italian")),
             ("spa", _("Spanish")),
             ("por", _("Portuguese")),
             ("gre", _("Greek")),
             ("slo", _("Slovak")),
             ("cze", _("Czech")),
             ("hun", _("Hungarian")),
             ("pol", _("Polish")),
             ("nor", _("Norwegian")),
             ("swe", _("Swedish")),
             ("fin", _("Finnish")),
             ("rus", _("Russian")),
             ("oth", _("Other"))]
```

It uses `_` from `invenio.base.i18n`. What happens when we generate MarcXML from it is:

```
> from invenio.modules.deposit.models import Deposition
> d = Deposition.get(20)
> s = d.get_latest_sip(sealed=True)
> s.metadata['language']

lu'English'

> print s.package

<record>
    <controlfield tag="001">340</controlfield>
    <datafield tag="041" ind1="" ind2="">
        <subfield code="a">E</subfield>
        <subfield code="a">n</subfield>
        <subfield code="a">g</subfield>
        <subfield code="a">l</subfield>
        <subfield code="a">i</subfield>
        <subfield code="a">s</subfield>
        <subfield code="a">h</subfield>
    </datafield>
    <datafield tag="245" ind1="" ind2="">
        <subfield code="a">title</subfield>
    </datafield>
    <datafield tag="980" ind1="" ind2="">
        <subfield code="a">HEP</subfield>
    </datafield>
</record>
```

This would be the correct MarcXML:

```
> print s.package

<record>
    <controlfield tag="001">340</controlfield>
    <datafield tag="041" ind1="" ind2="">
        <subfield code="a">English</subfield>
    </datafield>
    <datafield tag="245" ind1="" ind2="">
        <subfield code="a">title</subfield>
    </datafield>
    <datafield tag="980" ind1="" ind2="">
        <subfield code="a">HEP</subfield>
    </datafield>
</record>
```

To contextualize, `s.package` is the MarcXML generated by [`legacy_export_as_marc()`](https://github.com/inveniosoftware/invenio/blob/pu/invenio/modules/records/api.py#L165) prior to the record upload. In this case, it breaks specifically the language field as if it had several languages, when in fact only has "English". This happens because the string isn't `six.string_types` nor an `Iterable`, it's a lazy string type and that case is not covered by the conditions.

**Proposal:**
Since we're working with translated strings in the forms, the proposal is to include that check in the conditions to make the `value` in the current `marc_dict` a list (`[value]`).
