### PR TITLE
docs: missing mkdir command addition

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -174,6 +174,7 @@ branch.
 
 .. code-block:: console
 
+    $ mkdir -p $HOME/src
     $ cd $HOME/src/
     $ export BRANCH=pu
     $ git clone --branch $BRANCH git://github.com/inveniosoftware/invenio.git


### PR DESCRIPTION
Before change, following the docs leads to: 

```
cd $HOME/src/
-bash: cd: /home/dev/src/: No such file or directory
```
