### PR TITLE
Docs: missing mkdir command addition

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -174,6 +174,7 @@ branch.
 
 .. code-block:: console
 
+    $ mkdir -p $HOME/src
     $ cd $HOME/src/
     $ export BRANCH=pu
     $ git clone --branch $BRANCH git://github.com/inveniosoftware/invenio.git


### PR DESCRIPTION
Docs: missing mkdir command addition
- Adds command `$ mkdir -p $HOME/src` to installation tutorial.

Reported-by: Kevin Bowrin kjbowrin@gmail.com
