### PR TITLE
xmlmarclint: import fix

### DIFF
--- a/invenio/legacy/bibrecord/scripts/xmlmarclint.py
+++ b/invenio/legacy/bibrecord/scripts/xmlmarclint.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013 CERN.
+## Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -17,26 +17,28 @@
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-from __future__ import print_function
-
 """
 XML MARC lint - check your XML MARC files.
 """
 
-__revision__ = "$Id$"
+from __future__ import print_function
 
 import getopt
 import string
-import sys
 
-from invenio.legacy.bibrecord import create_records, print_recs, concat
+from invenio.legacy.bibrecord import (
+    create_records,
+    print_recs
+)
 
 
 def main():
+    """Execute script."""
+    import sys
+
     cmdusage = """Usage: %s [options] <marcxmlfile>
     General options:
       -h, --help            Print this help.
-      -V, --version         Print version information.
       -v, --verbose=LEVEL   Verbose level (from 0 to 9, default 0).
     Description: checks the validity of MARCXML file.
     """ % (sys.argv[0])
@@ -46,16 +48,14 @@ def main():
     listofrecs = []
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hVv:", ["help", "version", "verbose="])
+        opts, args = getopt.getopt(
+            sys.argv[1:], "hv:", ["help", "verbose="])
     except getopt.GetoptError:
         print(cmdusage)
         sys.exit(2)
 
     for opt in opts:
-        if opt[0] in ("-V","--version"):
-            print(__revision__)
-            sys.exit(0)
-        elif opt[0] in ("-h","--help"):
+        if opt[0] in ("-h", "--help"):
             sys.stderr.write(cmdusage)
             sys.exit(0)
         elif opt[0] in ("-v", "--verbose"):
@@ -72,15 +72,15 @@ def main():
         sys.exit(0)
 
     try:
-        xmltext = open(xmlfile,'r').read()
+        xmltext = open(xmlfile, 'r').read()
     except IOError:
         print("[ERROR] File %s not found." % xmlfile)
         import sys
         sys.exit(1)
 
     listofrecs = create_records(xmltext, 0, 1)
-    badr = filter((lambda x: x[1]==0), listofrecs)
-    badrecords = map((lambda x:x[0]), badr)
+    badr = filter((lambda x: x[1] == 0), listofrecs)
+    badrecords = map((lambda x: x[0]), badr)
 
     s = ''
     errors = []
@@ -91,14 +91,15 @@ def main():
 
     if verbose:
         if verbose <= 3:
-            errors.extend(map((lambda x:x[2]), listofrecs))
+            errors.extend(map((lambda x: x[2]), listofrecs))
         else:
             s = print_recs(badrecords)
-            errors.extend(map((lambda x:x[2]), listofrecs))
+            errors.extend(map((lambda x: x[2]), listofrecs))
     else:
         if badrecords:
-            print("[ERROR] Bad records detected.  For more information, increase verbosity.")
-            print("\n[INFO] You may also want to run `xmllint %s' to help " \
+            print(
+                "[ERROR] Bad records detected.  For more information, increase verbosity.")
+            print("\n[INFO] You may also want to run `xmllint %s' to help "
                   "localise errors in the input file." % xmlfile)
             sys.exit(1)
 
@@ -109,6 +110,6 @@ def main():
             print(s)
         for error in errors:
             print("[ERROR]", error)
-        print("[INFO] You may also want to run `xmllint %s' to help " \
+        print("[INFO] You may also want to run `xmllint %s' to help "
               "localise errors in the input file." % xmlfile)
         sys.exit(1)


### PR DESCRIPTION
## Before:

The tool `xmlmarclint` is broken, _for some reason_ (as `sys` is indeed imported):

```
$ xmlmarclint /some/filepath
Traceback (most recent call last):
  File "/home/jlavik/envs/pu/bin/xmlmarclint", line 9, in <module>
    load_entry_point('Invenio==1.9999.2.dev20140807133158', 'console_scripts', 'xmlmarclint')()
  File "/home/jlavik/envs/pu/src/invenio/invenio/legacy/bibrecord/scripts/xmlmarclint.py", line 42, in main
    """ % (sys.argv[0])
UnboundLocalError: local variable 'sys' referenced before assignment
```
## After:

It works.
