### PR TITLE
oauth2server: missing access token in test case

### DIFF
--- a/invenio/modules/oauth2server/testsuite/test_provider.py
+++ b/invenio/modules/oauth2server/testsuite/test_provider.py
@@ -519,6 +519,7 @@ class OAuth2ProviderTestCase(InvenioTestCase):
         # Access token is not valid for this scope
         r = self.client.get(
             '/oauth/info/',
+            query_string="access_token=%s" % self.personal_token.access_token,
             base_url=cfg['CFG_SITE_SECURE_URL']
         )
         self.assertStatus(r, 401)


### PR DESCRIPTION
- Fixes missing access token in test case. (closes #2166)

Signed-off-by: Lars Holm Nielsen lars.holm.nielsen@cern.ch
