### PR TITLE
travis: minimal requirements testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ services:
 
 language: python
 
+env:
+  - REQUIREMENTS=lowest
+  - REQUIREMENTS=devel
+
 python:
 # FIXME: the build times out on Python 2.6 (inveniosoftware/invenio#1789)
 #  - "2.6"
@@ -35,6 +39,8 @@ python:
 before_install:
   - "sudo add-apt-repository -y ppa:chris-lea/node.js"
   - "sudo apt-get update"
+  - "python requirements.py > .travis-lowest-requirements.txt"
+  - "touch .travis-devel-requirements.txt"
 
 install:
   - "sudo apt-get -qy install apache2 libapache2-mod-wsgi ssl-cert poppler-utils git subversion nodejs --fix-missing"
@@ -43,7 +49,9 @@ install:
   - "sudo a2enmod rewrite"
   - "sudo mkdir /etc/apache2/ssl"
   - "sudo /usr/sbin/make-ssl-cert generate-default-snakeoil /etc/apache2/ssl/apache.pem"
-  - "travis_retry pip install -r requirements-docs.txt --quiet"
+  - "travis_retry pip install -r requirements.txt --quiet"
+  - "travis_retry pip install -r .travis-$REQUIREMENTS-requirements.txt --allow-all-external --quiet"
+  - "travis_retry pip install -e .[docs] --quiet"
   - "python setup.py compile_catalog"
   - "inveniomanage config create secret-key"
   - "inveniomanage config set CFG_EMAIL_BACKEND flask.ext.email.backends.console.Mail"

--- a/requirements.py
+++ b/requirements.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+## This file is part of Invenio.
+## Copyright (C) 2013, 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Generate minimal requirements from setup.py."""
+
+from __future__ import print_function
+
+import mock
+import pkg_resources
+import setuptools
+import sys
+
+
+if __name__ == '__main__':
+    with mock.patch.object(setuptools, 'setup') as mock_setup:
+        import setup  # pylint: disable=F401
+
+    # called arguments are in `mock_setup.call_args`
+    args, kwargs = mock_setup.call_args
+    install_requires = kwargs.get('install_requires', [])
+
+    for pkg in pkg_resources.parse_requirements(install_requires):
+        if len(pkg.specs):
+            if pkg.specs[0][0] == '>=':
+                print("{0.project_name}=={0.specs[0][1]}".format(pkg))
+            elif pkg.specs[0][0] == '>':
+                print(
+                    "{0.project_name} specify exact minimal version using "
+                    "'>=' instead of '>'.".format(pkg), file=sys.stderr)

--- a/setup.py
+++ b/setup.py
@@ -54,19 +54,19 @@ class _install_lib(install_lib):
 
 
 install_requires = [
-    "alembic>=0.6",
+    "alembic>=0.6.6",
     "Babel>=1.3",
     "BeautifulSoup>=3.2.1",
     "BeautifulSoup4>=4.3.2",
-    "celery>=3.1",
+    "celery>=3.1.8",
     # Cerberus>=0.7.1 api changes and is not yet supported
     "Cerberus>=0.7,<0.7.1",
     "dictdiffer>=0.0.3",
     "feedparser>=5.1",
     "fixture>=1.5",
-    "Flask>=0.10",
+    "Flask>=0.10.1",
     # Development version is used, will switch to >=1.0.9 once released.
-    "Flask-Admin>1.0.8",
+    "Flask-Admin>=1.0.9.dev0",
     "Flask-Assets>=0.10",
     "Flask-Babel>=0.9",
     "Flask-Breadcrumbs>=0.1",
@@ -76,7 +76,7 @@ install_requires = [
     "Flask-Gravatar>=0.4",
     "Flask-Login>=0.2.7",
     "Flask-Menu>=0.1",
-    "Flask-OAuthlib>=0.6.0,<0.7", # quick fix for issue #2158
+    "Flask-OAuthlib>=0.6.0,<0.7",  # quick fix for issue #2158
     "Flask-Principal>=0.4",
     "Flask-Registry>=0.2",
     "Flask-RESTful>=0.2.12",
@@ -86,7 +86,7 @@ install_requires = [
     "Flask-WTF>=0.9.5",
     "fs>=0.4",
     "intbitset>=2.0",
-    "jellyfish>=0.3",
+    "jellyfish>=0.3.2",
     "Jinja2>=2.7",
     "libmagic>=1.0",
     "lxml>=3.3",
@@ -109,7 +109,7 @@ install_requires = [
     "raven>=5.0.0",
     "rdflib>=4.1.2",
     "redis==2.8.0",  # Is it explicitly required?
-    "reportlab>=3.1,<3.2",
+    "reportlab>=3.1.8,<3.2",
     "requests>=2.3,<2.4",
     "six>=1.7.2",
     "Sphinx",


### PR DESCRIPTION
- Adds script for minimal requirements generation from `setup.py`.
  (addresses #2044)

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
