### PR TITLE
installation: dependency links renovation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   - "sudo /usr/sbin/make-ssl-cert generate-default-snakeoil /etc/apache2/ssl/apache.pem"
   - "travis_retry pip install -r requirements.txt --quiet"
   - "travis_retry pip install -r .travis-$REQUIREMENTS-requirements.txt --allow-all-external --quiet"
-  - "travis_retry pip install -e .[docs] --quiet"
+  - "travis_retry pip install -e .[docs] --quiet --process-dependency-links"
   - "python setup.py compile_catalog"
   - "inveniomanage config create secret-key"
   - "inveniomanage config set CFG_EMAIL_BACKEND flask.ext.email.backends.console.Mail"

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -216,7 +216,7 @@ Installing Invenio.
 .. code-block:: console
 
     (invenio)$ cdvirtualenv src/invenio
-    (invenio)$ pip install -r requirements.txt
+    (invenio)$ pip install --process-dependency-links -e .[development]
 
 Some modules may require specific dependencies listed as ``extras``. Pick the
 ones you need. E.g. to add `images` support, we can do as follow:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
--e git+git://github.com/lnielsen-cern/dictdiffer.git#egg=dictdiffer
+-e git+git://github.com/inveniosoftware/dictdiffer.git#egg=dictdiffer
 -e git+https://github.com/mrjoes/flask-admin#egg=Flask-Admin
--e git+https://github.com/mitsuhiko/flask-sqlalchemy#egg=Flask-SQLAlchemy-dev
 # requires numpy before it can be installed
 #-e svn://svn.code.sf.net/p/gnuplot-py/code/trunk#egg=gnuplot-py
--e git+git://github.com/romanchyla/workflow.git@e41299579501704b1486c72cc2509a9f82e63ea6#egg=workflow
-
--e .[development]
+-e git+git://github.com/inveniosoftware/workflow.git@e41299579501704b1486c72cc2509a9f82e63ea6#egg=workflow

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,11 @@ class _install_lib(install_lib):
         self.run_command('compile_catalog')
         install_lib.run(self)
 
+dependency_links = [
+    "git+git://github.com/inveniosoftware/dictdiffer.git#egg=dictdiffer",
+    "git+git://github.com/mrjoes/flask-admin.git#egg=Flask-Admin-1.0.9.dev0",
+    "git+git://github.com/inveniosoftware/workflow.git@e41299579501704b1486c72cc2509a9f82e63ea6#egg=workflow",
+]
 
 install_requires = [
     "alembic>=0.6.6",
@@ -82,7 +87,7 @@ install_requires = [
     "Flask-RESTful>=0.2.12",
     "Flask-Script>=2.0.5",
     # Development version is used, will switch to >=2.0 once released.
-    "Flask-SQLAlchemy>1.9",
+    "Flask-SQLAlchemy>=2.0",
     "Flask-WTF>=0.9.5",
     "fs>=0.4",
     "intbitset>=2.0",
@@ -274,6 +279,7 @@ setup(
         ]
     },
     install_requires=install_requires,
+    dependency_links=dependency_links,
     extras_require=extras_require,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
- Prepares `setup.py` for Invenio v2.0 release for pip<1.6.
  (addresses #1797)
- NOTE use `pip install --process-dependency-links -e .`

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
