### PR TITLE
record_editor: fix javascript on /record/edit

### DIFF
--- a/invenio/base/static/js/build.js
+++ b/invenio/base/static/js/build.js
@@ -36,6 +36,7 @@
         'ui': 'vendors/jquery-ui/ui',
         'jqueryui-timepicker': 'vendors/jqueryui-timepicker-addon/dist',
         'jquery-form': 'vendors/jquery-form/jquery.form',
+	'jquery-ui': 'vendors/jquery-ui/jquery-ui.min',
         hgn: 'vendors/requirejs-hogan-plugin/hgn',
         hogan: 'vendors/hogan/web/builds/3.0.2/hogan-3.0.2.amd',
         text: 'vendors/requirejs-hogan-plugin/text'

--- a/invenio/base/static/js/init.js
+++ b/invenio/base/static/js/init.js
@@ -17,7 +17,7 @@
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
  */
 
-require(['jquery', 'jquery-form'], function($) {
+require(['jquery', 'jquery-form', 'jquery-ui'], function($) {
     // loading all the jQuery modules for the not require.js ready scripts
     // everywhere.
 })

--- a/invenio/base/static/js/settings.js
+++ b/invenio/base/static/js/settings.js
@@ -24,6 +24,7 @@ require.config({
         'ui': 'vendors/jquery-ui/ui',
         'jqueryui-timepicker': 'vendors/jqueryui-timepicker-addon/dist',
         'jquery-form': 'vendors/jquery-form/jquery.form',
+	'jquery-ui': 'vendors/jquery-ui/jquery-ui.min',
         hgn: 'vendors/requirejs-hogan-plugin/hgn',
         hogan: 'vendors/hogan/web/builds/3.0.2/hogan-3.0.2.amd',
         text: 'vendors/requirejs-hogan-plugin/text'

--- a/invenio/base/templates/page_base.html
+++ b/invenio/base/templates/page_base.html
@@ -81,16 +81,15 @@
   {%- endblock head_apple_icons %}
   {%- endblock head_links %}
 
-  {%- block header %}
-    {{- metaheaderadd | safe }}
-    {%- block metaheader %}{% endblock metaheader %}
-  {%- endblock header %}
-
   {%- block _top_assets %}
     {%- block global_stylesheets %}
       {%- include "base/stylesheets.html" %}
     {%- endblock %}
   {%- endblock %}
+  {%- block header %}
+    {{- metaheaderadd | safe }}
+    {%- block metaheader %}{% endblock metaheader %}
+  {%- endblock header %}
   {%- block css %}{% endblock %}
   {%- endblock head %}
 </head>

--- a/invenio/legacy/bibedit/engine.py
+++ b/invenio/legacy/bibedit/engine.py
@@ -270,7 +270,6 @@ def perform_request_init(uid, ln, req, lastupdated):
             "</script>\n"
     # Add scripts (the ordering is NOT irrelevant).
     scripts = [
-        'vendors/jquery-ui/jquery-ui.min.js',
         'vendors/jquery.jeditable/index.js',
         'vendors/jquery.hotkeys/jquery.hotkeys.js',
         'vendors/json2/json2.js'
@@ -1747,7 +1746,6 @@ def perform_request_init_template_interface():
 
     # Add scripts (the ordering is NOT irrelevant).
     scripts = [
-        'vendors/jquery-ui/jquery-ui.min.js',
         'vendors/json2/json2.js'
     ]
     bibedit_scripts = ['display.js', 'template_interface.js']


### PR DESCRIPTION
Patch along the lines of #1901 to fix #2143.
- configures a `jquery-ui` asset containing `jquery-ui.min.js` and makes it part of the `jquery` bundle
- removes explicit `jquery-ui.min.js` loading in `legacy/bibedit/engine.py`
- reorders `header` and `_top_assets` blocks in `page_base.html` (**again?!**)

Makes the `jquery` bundle even bigger (half a megabyte now). It's just a dirty fix, not a nice solution :(.
