### PR TITLE
base: fix for padding on to of a flask-admin page

### DIFF
--- a/invenio/base/static/css/admin.css
+++ b/invenio/base/static/css/admin.css
@@ -2,10 +2,6 @@
 
    Copied over from flask_admin.
 */
-body
-{
-    padding-top: 60px;
-}
 
 /* Form customizations */
 form.icon {


### PR DESCRIPTION
Fixes such a white strip on to of admin pages:

![padding](https://cloud.githubusercontent.com/assets/4245137/4134123/4cec905a-3368-11e4-82d8-f5743899c3e5.png)

The white strip affects demosite too.
