### PR TITLE
deposit: fix for sort function for authors

### DIFF
--- a/invenio/modules/deposit/static/js/deposit/dynamic_field_list.js
+++ b/invenio/modules/deposit/static/js/deposit/dynamic_field_list.js
@@ -65,11 +65,15 @@ define(function(require, exports, module) {
      */
     init: function () {
 
+      var that = this;
+
       // Make list sortable
       if (this.options.sortable) {
         var sortable_options = {
           items: "." + this.options.element_css_class,
-          update: this.sort_element,
+          update: function(e, ui) {
+            that.sort_element(e, ui);
+          }
         };
 
         if (this.$element.find("." + this.options.sort_cssclass).length !== 0) {


### PR DESCRIPTION
- Fixes invalid `this` pointer in a function passed as a parameter
  of sortable plugin.

Signed-off-by: Kamil Neczaj kamil.neczaj@cern.ch
