### PR TITLE
workflows: clean engine calls

### DIFF
--- a/invenio/modules/workflows/tasks/marcxml_tasks.py
+++ b/invenio/modules/workflows/tasks/marcxml_tasks.py
@@ -30,7 +30,6 @@ from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from invenio.base.globals import cfg
 from invenio.base.wrappers import lazy_import
 from invenio.utils.shell import run_shell_command, Timeout
-from invenio.utils.plotextractor.converter import untar
 from invenio.modules.workflows.utils import convert_marcxml_to_bibfield
 
 bibtask = lazy_import("invenio.legacy.bibsched.bibtask")
@@ -584,6 +583,7 @@ def plot_extract(plotextractor_types):
     from invenio.utils.plotextractor.cli import (get_defaults, extract_captions,
                                                  extract_context)
     from invenio.utils.plotextractor.converter import convert_images
+    from invenio.utils.plotextractor.converter import untar
 
     def _plot_extract(obj, eng):
         """Perform the plotextraction step."""
@@ -755,6 +755,7 @@ def author_list(obj, eng):
     from invenio.legacy.bibrecord import create_records, record_xml_output
     from invenio.legacy.bibconvert.xslt_engine import convert
     from invenio.utils.plotextractor.cli import get_defaults
+    from invenio.utils.plotextractor.converter import untar
 
     identifiers = obj.data["system_number_external"]["value"]
     bibtask.task_sleep_now_if_required()

--- a/invenio/modules/workflows/tasks/workflows_tasks.py
+++ b/invenio/modules/workflows/tasks/workflows_tasks.py
@@ -371,8 +371,6 @@ def workflows_reviews(stop_if_error=False, clean=True):
     if a child workflow has crashed.
     :type stop_if_error: bool
     """
-    from invenio.modules.workflows.errors import WorkflowError
-
     def _workflows_reviews(obj, eng):
         if eng.extra_data["_nb_workflow"] == 0:
             raise WorkflowError("Nothing has been harvested ! Look into logs for errors !", eng.uuid, obj.id)

--- a/invenio/modules/workflows/testsuite/test_workflows_delayed.py
+++ b/invenio/modules/workflows/testsuite/test_workflows_delayed.py
@@ -96,7 +96,8 @@ class WorkflowDelayedTest(WorkflowTasksTestCase):
         from ..workers.worker_celery import (celery_run, celery_restart,
                                              celery_continue)
         from invenio.modules.workflows.utils import BibWorkflowObjectIdContainer
-        from invenio.modules.workflows.models import BibWorkflowObject
+        from invenio.modules.workflows.models import (BibWorkflowObject,
+                                                      get_default_extra_data)
 
         test_objectb = BibWorkflowObject()
         test_objectb.set_data(22)
@@ -128,15 +129,20 @@ class WorkflowDelayedTest(WorkflowTasksTestCase):
                        module_name="unit_tests"))
         self.assertEqual(5, test_object.get_data())
         self.assertEqual("lt9", test_object.get_extra_data()["test"])
+
+        engine._extra_data = get_default_extra_data()  # reset iterators
         celery_restart(engine.uuid)
         self.assertEqual(5, test_object.get_data())
         self.assertEqual("lt9", test_object.get_extra_data()["test"])
+
         celery_continue(test_object.id, "continue_next")
         self.assertEqual(6, test_object.get_data())
         self.assertEqual("lt9", test_object.get_extra_data()["test"])
+
         celery_continue(test_object.id, "continue_next")
         self.assertEqual(9, test_object.get_data())
         self.assertEqual("gte9", test_object.get_extra_data()["test"])
+
         celery_continue(test_object.id, "continue_next")
         self.assertEqual(15, test_object.get_data())
         self.assertEqual("gte9", test_object.get_extra_data()["test"])


### PR DESCRIPTION
- No longer generates another object snapshot when continuing a
  workflow causing many duplications in the database.
- The same workflow is re-used when continuing a workflow, as originally
  intended.
- Improves current workflow integration to be cleaner, using defined
  interfaces instead of updating closed variables.
- Adds new restart point, 'first', to re-start a workflow engine from
  first object and/or first task (callback).
- Cleans up obvious, unneeded comments.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
