### PR TITLE
BibMerge: `perform_request_init` added CFG_SITE_RECORD as script data

### DIFF
--- a/modules/bibmerge/lib/bibmerge_engine.py
+++ b/modules/bibmerge/lib/bibmerge_engine.py
@@ -25,7 +25,7 @@ import re
 
 from invenio.config import \
      CFG_BIBUPLOAD_INTERNAL_DOI_PATTERN, \
-     CFG_BIBEDIT_INTERNAL_DOI_PROTECTION_LEVEL
+     CFG_BIBEDIT_INTERNAL_DOI_PROTECTION_LEVEL, CFG_SITE_RECORD
 from invenio.bibmerge_merger import merge_field_group, replace_field, \
                                     add_field, delete_field, merge_field, \
                                     add_subfield, replace_subfield, \
@@ -55,6 +55,15 @@ def perform_request_init():
     errors   = []
     warnings = []
     body = ''
+
+    # Add script data.
+
+    data = {'gSITE_RECORD': '"' + CFG_SITE_RECORD + '"'}
+
+    body += '<script type="text/javascript">\n'
+    for key in data:
+        body += '    var %s = %s;\n' % (key, data[key])
+    body += '    </script>\n'
 
     # Build page structure and control panel.
     body += bibmerge_templates.controlpanel()


### PR DESCRIPTION
The lack of this javascript variable produced an error when trying to edit master or slave record.