### PR TITLE
WebStyle: goto regression test fixes

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -632,10 +632,10 @@ CFG_WEBSEARCH_PREV_NEXT_HIT_LIMIT = 1000
 CFG_WEBSEARCH_PREV_NEXT_HIT_FOR_GUESTS = 1
 
 ## CFG_WEBSEARCH_VIEWRESTRCOLL_POLICY -- when a record belongs to more than one
-## restricted collection, if the viewrestcoll policy is set to "ALL" (default)
+## restricted collection, if the viewrestcoll policy is set to "ALL"
 ## then the user must be authorized to all the restricted collections, in
 ## order to be granted access to the specific record. If the policy is set to
-## "ANY", then the user need to be authorized to only one of the collections
+## "ANY" (default), then the user need to be authorized to only one of the collections
 ## in order to be granted access to the specific record.
 CFG_WEBSEARCH_VIEWRESTRCOLL_POLICY = ANY
 

--- a/modules/webstyle/lib/goto_plugins/goto_plugin_latest_record.py
+++ b/modules/webstyle/lib/goto_plugins/goto_plugin_latest_record.py
@@ -1,21 +1,21 @@
 # -*- coding: utf-8 -*-
-##
-## This file is part of Invenio.
-## Copyright (C) 2012 CERN.
-##
-## Invenio is free software; you can redistribute it and/or
-## modify it under the terms of the GNU General Public License as
-## published by the Free Software Foundation; either version 2 of the
-## License, or (at your option) any later version.
-##
-## Invenio is distributed in the hope that it will be useful, but
-## WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Invenio; if not, write to the Free Software Foundation, Inc.,
-## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+# This file is part of Invenio.
+# Copyright (C) 2012, 2014 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """
 Demostrative PURL implementing a redirection to the very last record
@@ -25,6 +25,7 @@ Demostrative PURL implementing a redirection to the very last record
 from invenio.config import CFG_SITE_NAME, CFG_SITE_RECORD
 from invenio.search_engine import perform_request_search
 from invenio.bibdocfile import BibRecDocs, InvenioBibDocFileError
+
 
 def goto(cc=CFG_SITE_NAME, p='', f='', sf='date', so='d', docname='', format=''):
     """
@@ -53,7 +54,7 @@ def goto(cc=CFG_SITE_NAME, p='', f='', sf='date', so='d', docname='', format='')
             except InvenioBibDocFileError:
                 return url
             try:
-                bibdocfile = bibdoc.get_file(format=format)
+                bibdocfile = bibdoc.get_file(docformat=format)
                 return bibdocfile.get_url()
             except InvenioBibDocFileError:
                 return url


### PR DESCRIPTION
- Improves goto_engine related regression tests to take into account
  recent modification to the Atlantis Demo site, in particular
  with respect to restriction and file formats.
  (closes #1293)

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
