### PR TITLE
documentation: fixes in install instructions

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -89,7 +89,7 @@ user. You will need the root password later on and we will refer to it as
 .. code-block:: console
 
     $ sudo yum install mysql-server
-    $ sudo service msyqld status
+    $ sudo service mysqld status
     mysqld is stopped
     $ sudo service mysqld start
     $ sudo mysql_secure_installation
@@ -339,7 +339,7 @@ the original files. As a developer you may want to have symbolic links instead.
 3.3. Development
 ~~~~~~~~~~~~~~~~
 
-Once you have everything installed you can create database and populate it
+Once you have everything installed, you can create the database and populate it
 with demo records.
 
 .. code-block:: console


### PR DESCRIPTION
This is a first pull request to get acquainted with the Invenio development cycle.  It fixes small typos that I noticed in the install instructions.

Besides this, it is worth noting that the instructions regarding nodejs and npm are no longer required in Ubuntu 14.04. In my case, everything went smoothly by simply installing the `nodejs`, `nodejs-legacy` and `npm` packages directly from the official Ubuntu repo. What version of Ubuntu do you officially support? 

Signed-off-by: Gilles Louppe g.louppe@gmail.com
