### PR TITLE
deposit: plupload filter option addition

### DIFF
--- a/invenio/modules/deposit/static/js/deposit/plupload.js
+++ b/invenio/modules/deposit/static/js/deposit/plupload.js
@@ -57,7 +57,8 @@ define(function(require, exports, module) {
           $upload_stop = this.$element.find('.upload-stop'),
           $upload_speed = this.$element.find('.upload-speed'),
           $upload_filetable = this.$element.find('.upload-filetable'),
-          $upload_filelist = this.$element.find('.upload-filelist');
+          $upload_filelist = this.$element.find('.upload-filelist'),
+          $upload_errors = this.$element.find('.upload-errors');
 
       var had_error = false;
 


### PR DESCRIPTION
- Adds filters to plupload settings in order, for example, to limit
  the mime types allowed.
- Fixes missing error div selector.

Signed-off-by: Javier Martin Montull javier.martin.montull@cern.ch
