### PR TITLE
BibIndex: tag.recjsonvalue NOT NULL

### DIFF
--- a/modules/miscutil/lib/upgrades/invenio_2014_09_09_tag_recjsonvalue_not_null.py
+++ b/modules/miscutil/lib/upgrades/invenio_2014_09_09_tag_recjsonvalue_not_null.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2014 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+import warnings
+from invenio.dbquery import run_sql
+from invenio.textutils import wait_for_user
+
+depends_on = ['invenio_2014_08_13_tag_recjsonvalue']
+
+
+def info():
+    """Upgrade recipe information."""
+    return "tag.recjson_value NOT NULL"
+
+
+def do_upgrade():
+    """Upgrade recipe procedure."""
+    run_sql(
+        "ALTER TABLE tag CHANGE COLUMN recjson_value recjson_value text NOT NULL;")
+
+
+def estimate():
+    """Upgrade recipe time estimate."""
+    return 1

--- a/modules/miscutil/sql/tabcreate.sql
+++ b/modules/miscutil/sql/tabcreate.sql
@@ -3510,7 +3510,7 @@ CREATE TABLE IF NOT EXISTS tag (
   id mediumint(9) unsigned NOT NULL auto_increment,
   name varchar(255) NOT NULL,
   value varchar(6) default '',
-  recjson_value text,
+  recjson_value text NOT NULL,
   PRIMARY KEY  (id)
 ) ENGINE=MyISAM;
 
@@ -5041,5 +5041,6 @@ INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2013_12_05_new_index_doi
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_03_13_new_index_filename',NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_08_12_format_code_varchar20',NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_08_13_tag_recjsonvalue',NOW());
+INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_09_09_tag_recjsonvalue_not_null',NOW());
 
 -- end of file


### PR DESCRIPTION
* Complements upgrade recipe invenio_2014_08_13_tag_recjsonvalue by
  adding the further property NOT NULL to the tag.recjsonvalue column
  definition.
  (closes #1947)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>