### PR TITLE
sqlalchemy: fix default integer constructor

### DIFF
--- a/invenio/ext/sqlalchemy/types/__init__.py
+++ b/invenio/ext/sqlalchemy/types/__init__.py
@@ -19,10 +19,17 @@
 
 """Implement various custom column types."""
 
-from .encrypted import Encrypted
+from .encrypted import Encrypted, AESEngine
 from .guid import GUID
 from .marshal_binary import MarshalBinary
 from .pickle_binary import PickleBinary
+from .legacyinteger import LegacyInteger
+from .legacymediuminteger import LegacyMediumInteger
+from .legacysmallinteger import LegacySmallInteger
+from .legacytinyinteger import LegacyTinyInteger
+from .legacybiginteger import LegacyBigInteger
 
 
-__all__ = ('Encrypted', 'GUID', 'MarshalBinary', 'PickleBinary')
+__all__ = ('Encrypted', 'GUID', 'MarshalBinary', 'PickleBinary',
+           'LegacyInteger', 'LegacyMediumInteger', 'LegacySmallInteger',
+           'LegacyTinyInteger', 'LegacyBigInteger', 'AESEngine')

--- a/invenio/ext/sqlalchemy/types/encrypted.py
+++ b/invenio/ext/sqlalchemy/types/encrypted.py
@@ -76,7 +76,8 @@ class Encrypted(TypeDecorator):
     def __init__(self, key, **kwargs):
         """Initialization.
 
-        :param key: [String] a given key for encryption/decryption
+        :param key: :class:`~sqlalchemy.types.String`
+            a given key for encryption/decryption
         """
         super(Encrypted, self).__init__(**kwargs)
         # produce a 32-bytes key
@@ -85,7 +86,8 @@ class Encrypted(TypeDecorator):
     def process_bind_param(self, value, dialect):
         """Encrypt a value on the way in.
 
-        :param value: [String] the value to be encrypted
+        :param value: :class:`~sqlalchemy.types.String`
+            the value to be encrypted
         """
         return self.encr_decr_engine.encrypt(self.cipher, value)
 

--- a/invenio/ext/sqlalchemy/types/guid.py
+++ b/invenio/ext/sqlalchemy/types/guid.py
@@ -28,8 +28,9 @@ class GUID(TypeDecorator):
 
     """Platform-independent GUID type.
 
-    Uses Postgresql's `UUID` type, otherwise uses
-    `CHAR(32)`, storing as stringified hex values.
+    Uses Postgresql's :class:`~sqlalchemy.dialects.postgresql.UUID`
+    type, otherwise uses :class:`~sqlalchemy.types.CHAR` (32),
+    storing as stringified hex values.
     """
 
     impl = CHAR

--- a/invenio/ext/sqlalchemy/types/legacybiginteger.py
+++ b/invenio/ext/sqlalchemy/types/legacybiginteger.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2011, 2012, 2013, 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 515 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Platform-independent BigInteger type."""
+
+from sqlalchemy.types import TypeDecorator, BigInteger
+from sqlalchemy.dialects.mysql import BIGINT
+
+
+class LegacyBigInteger(TypeDecorator):
+
+    """Platform-independent BigInteger type.
+
+    Uses MySQL's :class:`~sqlalchemy.dialects.mysql.BIGINT` type, otherwise
+    uses SQLAlchemy definition of :class:`~sqlalchemy.types.BigInteger`.
+    """
+
+    impl = BigInteger
+
+    def __init__(self, display_width=15, unsigned=False, **kwargs):
+        """Reserve special arguments only for MySQL Platform."""
+        self.display_width = display_width
+        self.unsigned = unsigned
+        super(LegacyBigInteger, self).__init__(**kwargs)
+
+    def load_dialect_impl(self, dialect):
+        """Load dialect dependent implementation."""
+        if dialect.name == 'mysql':
+            return dialect.type_descriptor(BIGINT(self.display_width,
+                                                  unsigned=self.unsigned))
+        else:
+            return dialect.type_descriptor(BigInteger)

--- a/invenio/ext/sqlalchemy/types/legacyinteger.py
+++ b/invenio/ext/sqlalchemy/types/legacyinteger.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2011, 2012, 2013, 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Platform-independent Integer type."""
+
+from sqlalchemy.types import TypeDecorator, Integer
+from sqlalchemy.dialects.mysql import INTEGER
+
+
+class LegacyInteger(TypeDecorator):
+
+    """Platform-independent Integer type.
+
+    Uses MySQL's :class:`~sqlalchemy.dialects.mysql.INTEGER` type, otherwise
+    uses SQLAlchemy definition of :class:`~sqlalchemy.types.Integer`.
+    """
+
+    impl = Integer
+
+    def __init__(self, display_width=15, unsigned=False, **kwargs):
+        """Reserve special arguments only for MySQL Platform."""
+        self.display_width = display_width
+        self.unsigned = unsigned
+        super(LegacyInteger, self).__init__(**kwargs)
+
+    def load_dialect_impl(self, dialect):
+        """Load dialect dependent implementation."""
+        if dialect.name == 'mysql':
+            return dialect.type_descriptor(INTEGER(self.display_width,
+                                                   unsigned=self.unsigned))
+        else:
+            return dialect.type_descriptor(Integer)

--- a/invenio/ext/sqlalchemy/types/legacymediuminteger.py
+++ b/invenio/ext/sqlalchemy/types/legacymediuminteger.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2011, 2012, 2013, 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Platform-independent MediumInteger type."""
+
+from sqlalchemy.types import Integer, TypeDecorator
+from sqlalchemy.dialects.mysql import MEDIUMINT
+
+
+class LegacyMediumInteger(TypeDecorator):
+
+    """Platform-independent MediumInteger type.
+
+    Uses MySQL's :class:`~sqlalchemy.dialects.mysql.MEDIUMINT` type, otherwise
+    uses SQLAlchemy definition of :class:`~sqlalchemy.types.Integer`.
+    """
+
+    impl = Integer
+
+    def __init__(self, display_width=9, unsigned=False, **kwargs):
+        """Reserve special arguments only for MySQL Platform."""
+        self.display_width = display_width
+        self.unsigned = unsigned
+        super(LegacyMediumInteger, self).__init__(**kwargs)
+
+    def load_dialect_impl(self, dialect):
+        """Load dialect dependent implementation."""
+        if dialect.name == 'mysql':
+            return dialect.type_descriptor(MEDIUMINT(self.display_width,
+                                                     unsigned=self.unsigned))
+        else:
+            return dialect.type_descriptor(Integer)

--- a/invenio/ext/sqlalchemy/types/legacysmallinteger.py
+++ b/invenio/ext/sqlalchemy/types/legacysmallinteger.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2011, 2012, 2013, 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 55 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Platform-independent SmallInteger type."""
+
+from sqlalchemy.types import SmallInteger
+from sqlalchemy.dialects.mysql import SMALLINT
+from . import LegacyInteger
+
+
+class LegacySmallInteger(LegacyInteger):
+
+    """Platform-independent SmallInteger type.
+
+    Uses MySQL's :class:`~sqlalchemy.dialects.mysql.SMALLINT` type, otherwise
+    uses SQLAlchemy definition of :class:`~sqlalchemy.types.SmallInteger`.
+    """
+
+    impl = SmallInteger
+
+    def __init__(self, display_width=5, unsigned=False, zerofill=True,
+                 **kwargs):
+        """Reserve special arguments only for MySQL Platform."""
+        self.zerofill = zerofill
+        super(LegacySmallInteger, self).__init__(
+            display_width, unsigned, **kwargs)
+
+    def load_dialect_impl(self, dialect):
+        """Load dialect dependent implementation."""
+        if dialect.name == 'mysql':
+            return dialect.type_descriptor(SMALLINT(self.display_width,
+                                                    unsigned=self.unsigned,
+                                                    zerofill=self.zerofill))
+        else:
+            return dialect.type_descriptor(SmallInteger)

--- a/invenio/ext/sqlalchemy/types/legacytinyinteger.py
+++ b/invenio/ext/sqlalchemy/types/legacytinyinteger.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2011, 2012, 2013, 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 52 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Platform-independent TinyInteger type."""
+
+from sqlalchemy.types import Integer, TypeDecorator
+from sqlalchemy.dialects.mysql import TINYINT
+
+
+class LegacyTinyInteger(TypeDecorator):
+
+    """Platform-independent TinyInteger type.
+
+    Uses MySQL's :class:`~sqlalchemy.dialects.mysql.TINYINT` type, otherwise
+    uses SQLAlchemy definition of :class:`~sqlalchemy.types.Integer`.
+    """
+
+    impl = Integer
+
+    def __init__(self, display_width=2, unsigned=False, **kwargs):
+        """Reserve special arguments only for MySQL Platform."""
+        self.display_width = display_width
+        self.unsigned = unsigned
+        super(LegacyTinyInteger, self).__init__(**kwargs)
+
+    def load_dialect_impl(self, dialect):
+        """Load dialect dependent implementation."""
+        if dialect.name == 'mysql':
+            return dialect.type_descriptor(TINYINT(self.display_width,
+                                                   unsigned=self.unsigned))
+        else:
+            return dialect.type_descriptor(Integer)


### PR DESCRIPTION
- Addresses issue with default constructor on types that do not
  accept arguments in SQLAlchemy>=0.9. (closes #1776)

Signed-off-by: Leonardo Rossi leonardo.r@cern.ch
