### PR TITLE
general: no INSERT delayed usage

### DIFF
--- a/modules/bibdocfile/lib/bibdocfile.py
+++ b/modules/bibdocfile/lib/bibdocfile.py
@@ -2150,7 +2150,7 @@ class BibDoc(object):
         run_sql('DELETE FROM bibrec_bibdoc WHERE id_bibdoc=%s', (self.id, ))
         run_sql('DELETE FROM bibdoc_bibdoc WHERE id_bibdoc1=%s OR id_bibdoc2=%s', (self.id, self.id))
         run_sql('DELETE FROM bibdoc WHERE id=%s', (self.id, ))
-        run_sql('INSERT DELAYED INTO hstDOCUMENT(action, id_bibdoc, doctimestamp) VALUES("EXPUNGE", %s, NOW())', (self.id, ))
+        run_sql('INSERT INTO hstDOCUMENT(action, id_bibdoc, doctimestamp) VALUES("EXPUNGE", %s, NOW())', (self.id, ))
         run_sql('DELETE FROM bibdocfsinfo WHERE id_bibdoc=%s', (self.id, ))
         del self._docfiles
         del self.id
@@ -2685,9 +2685,9 @@ class BibDoc(object):
             """Log an action into the bibdoclog table."""
             try:
                 if timestamp:
-                    run_sql('INSERT DELAYED INTO hstDOCUMENT(action, id_bibdoc, docname, docformat, docversion, docsize, docchecksum, doctimestamp) VALUES(%s, %s, %s, %s, %s, %s, %s, %s)', (action, docid, docname, docformat, version, size, checksum, timestamp))
+                    run_sql('INSERT INTO hstDOCUMENT(action, id_bibdoc, docname, docformat, docversion, docsize, docchecksum, doctimestamp) VALUES(%s, %s, %s, %s, %s, %s, %s, %s)', (action, docid, docname, docformat, version, size, checksum, timestamp))
                 else:
-                    run_sql('INSERT DELAYED INTO hstDOCUMENT(action, id_bibdoc, docname, docformat, docversion, docsize, docchecksum, doctimestamp) VALUES(%s, %s, %s, %s, %s, %s, %s, NOW())', (action, docid, docname, docformat, version, size, checksum))
+                    run_sql('INSERT INTO hstDOCUMENT(action, id_bibdoc, docname, docformat, docversion, docsize, docchecksum, doctimestamp) VALUES(%s, %s, %s, %s, %s, %s, %s, NOW())', (action, docid, docname, docformat, version, size, checksum))
             except DatabaseError:
                 register_exception()
 
@@ -2856,7 +2856,7 @@ class BibDoc(object):
         docformat = docformat.upper()
         if not version:
             version = self.get_latest_version()
-        return run_sql("INSERT DELAYED INTO rnkDOWNLOADS "
+        return run_sql("INSERT INTO rnkDOWNLOADS "
             "(id_bibrec,id_bibdoc,file_version,file_format,"
             "id_user,client_host,download_time) VALUES "
             "(%s,%s,%s,%s,%s,INET_ATON(%s),NOW())",

--- a/modules/bibformat/lib/bibformat_dblayer.py
+++ b/modules/bibformat/lib/bibformat_dblayer.py
@@ -480,10 +480,9 @@ def save_preformatted_record(recID, of, res, needs_2nd_pass=False,
                              low_priority=False, compress=zlib.compress):
     start_date = time.strftime('%Y-%m-%d %H:%M:%S')
     formatted_record = compress(res)
+    sql_str = ""
     if low_priority:
         sql_str = " LOW_PRIORITY"
-    else:
-        sql_str = " DELAYED"
     run_sql("""INSERT%s INTO bibfmt
                (id_bibrec, format, last_updated, value, needs_2nd_pass)
                VALUES (%%s, %%s, %%s, %%s, %%s)

--- a/modules/bibrank/lib/bibrank_downloads_similarity.py
+++ b/modules/bibrank/lib/bibrank_downloads_similarity.py
@@ -55,7 +55,7 @@ def register_page_view_event(recid, uid, client_ip_address):
         # do not register access if we are in read-only access control
         # site mode:
         return []
-    return run_sql("INSERT DELAYED INTO rnkPAGEVIEWS " \
+    return run_sql("INSERT INTO rnkPAGEVIEWS " \
                    " (id_bibrec,id_user,client_host,view_time) " \
                    " VALUES (%s,%s,INET_ATON(%s),NOW())", \
                    (recid, uid, client_ip_address))

--- a/modules/webcomment/lib/webcomment.py
+++ b/modules/webcomment/lib/webcomment.py
@@ -2062,7 +2062,7 @@ def toggle_comment_visibility(uid, comid, collapse, recid):
         params = (comid,)
         res = run_sql(query, params)
         if res:
-            query = """INSERT DELAYED IGNORE INTO cmtCOLLAPSED (id_bibrec, id_cmtRECORDCOMMENT, id_user)
+            query = """INSERT IGNORE INTO cmtCOLLAPSED (id_bibrec, id_cmtRECORDCOMMENT, id_user)
                               VALUES (%s, %s, %s)"""
             params = (res[0][0], comid, uid)
             run_sql(query, params)


### PR DESCRIPTION
* No longer uses INSERT DELAYED, since, beginning with MySQL 5.5.7,
  INSERT DELAYED is always handled as a simple INSERT (that is,
  without the DELAYED option) whenever the value of binlog_format is
  STATEMENT or MIXED. (In the latter case, the statement no longer
  triggers a switch to row-based logging, and so is logged using the
  statement-based format.)
  (closes #2268)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>
Reported-by: Thorsten Schwander <thorsten.schwander@gmail.com>