### PR TITLE
mixer: dump database fixes

### DIFF
--- a/invenio/base/scripts/database.py
+++ b/invenio/base/scripts/database.py
@@ -251,6 +251,12 @@ def create(default_data=True, quiet=False):
 
 
 @manager.command
+def dump():
+    """Export all the tables, similar to `dbdump`."""
+    print('>>> Dumping the DataBase.')
+
+
+@manager.command
 def diff():
     """Diff database against SQLAlchemy models."""
     try:

--- a/invenio/ext/fixtures/__init__.py
+++ b/invenio/ext/fixtures/__init__.py
@@ -54,10 +54,16 @@ def load_fixtures(sender, yes_i_know=False, drop=True, **kwargs):
     db.session.commit()
 
 
+def fixture_dump(sender, **kwargs):
+    """Dump fixtures."""
+    print('ERROR: This feature is not implemented inside fixtures.')
+
+
 def setup_app(app):
     """Set up the extension for the given app."""
     # Subscribe to database post create command
     from invenio.base import signals
-    from invenio.base.scripts.database import create, recreate
+    from invenio.base.scripts.database import create, recreate, dump
     signals.post_command.connect(load_fixtures, sender=create)
     signals.post_command.connect(load_fixtures, sender=recreate)
+    signals.post_command.connect(fixture_dump, sender=dump)


### PR DESCRIPTION
- Adds new command `inveniomanage database dump` to allow dumping the
  content of the database using the mixer.
- Fixes imports and trailing white spaces on json dump.

Signed-off-by: Esteban J. G. Gabancho esteban.gabancho@gmail.com
