### PR TITLE
search: loading of Bloodhound using requirejs

### DIFF
--- a/invenio/base/static/js/build.js
+++ b/invenio/base/static/js/build.js
@@ -48,6 +48,6 @@
         'jqueryui-timepicker/jqueryui-sliderAccess': {deps: ['jquery']},
         'jqueryui-timepicker/jqueryui-timepicker-addon': {deps: ['jquery', 'ui/slider']},
         'jqueryui-timepicker/i18n/jquery-ui-timepicker-addon-i18n': {deps: ['jqueryui-timepicker/jquery-ui-timepicker-addon']},
-        typeahead: {deps: ['jquery']},
+        typeahead: {deps: ['jquery'], exports: 'Bloodhound'},
     }
 })

--- a/invenio/base/static/js/settings.js
+++ b/invenio/base/static/js/settings.js
@@ -36,6 +36,6 @@ require.config({
         'jqueryui-timepicker/jquery-ui-sliderAccess': {deps: ['jquery']},
         'jqueryui-timepicker/jquery-ui-timepicker-addon': {deps: ['jquery', 'ui/slider']},
         'jqueryui-timepicker/i18n/jquery-ui-timepicker-addon-i18n': {deps: ['jqueryui-timepicker/jquery-ui-timepicker-addon']},
-        typeahead: {deps: ['jquery']},
+        typeahead: {deps: ['jquery'], exports: 'Bloodhound'},
     }
 })

--- a/invenio/modules/search/static/js/search/typeahead.js
+++ b/invenio/modules/search/static/js/search/typeahead.js
@@ -150,7 +150,7 @@ define([
   'jquery',
   'js/search/search_parser',
   'typeahead', // $.fn.typeahead()
-], function($, SearchParser) {
+], function($, SearchParser, Bloodhound) {
   "use strict";
 
   function SearchTypeahead(element, options) {


### PR DESCRIPTION
Twitter's typeahead exports also Bloodhound their data fetching engine. It is a missing part of the current configuration. However everything works in the current pu because loading of 'typeahead' dependency stores `Bloodhound` class in the global namespace anyway. This PR makes possible loading Bloodhound in a proper requirejs way.

I haven't modify here the deposit module because it uses custom data fetching.
