### PR TITLE
formatter: display record with no record id

### DIFF
--- a/invenio/modules/formatter/template_context_functions/tfn_get_back_to_search_links.py
+++ b/invenio/modules/formatter/template_context_functions/tfn_get_back_to_search_links.py
@@ -36,7 +36,8 @@ def template_context_function(recID):
     :type recID: string
     :return: html output
     """
-
+    if recID is None:
+        return ""
     # this variable is set to zero so nothing is displayed
     if not cfg['CFG_WEBSEARCH_PREV_NEXT_HIT_LIMIT']:
         return ""

--- a/invenio/modules/formatter/templates/format/record/Default_HTML_detailed.tpl
+++ b/invenio/modules/formatter/templates/format/record/Default_HTML_detailed.tpl
@@ -51,8 +51,6 @@
     {{ bfe_appears_in_collections(bfo, prefix="<p style='margin-left: 10px;'><em>The record appears in these collections:</em><br />", suffix="</p>") }}
 
     {# WebTags #}
-    {{ tfn_webtag_record_tags(record['recid'], current_user.get_id())|prefix('<hr />') }}
-    {% if record.get('recid') is not None %}
-        {{ tfn_get_back_to_search_links(record['recid'])|wrap(prefix='<div class="pull-right linksbox">', suffix='</div>') }}
-    {% endif %}
+    {{ tfn_webtag_record_tags(record.get('recid'), current_user.get_id())|prefix('<hr />') }}
+    {{ tfn_get_back_to_search_links(record.get('recid'))|wrap(prefix='<div class="pull-right linksbox">', suffix='</div>') }}
 {% endblock %}


### PR DESCRIPTION
Getting the check more specific had a very weird result, I guess on Wednesday my browser was loading a cached version of the page and I couldn't notice it. This error message showed today:  TemplateAssertionError: no test named 'None'.

It also changed the behavior of the template when the record had  a 'recid'
before:
![screenshot from 2014-09-12 15 27 25](https://cloud.githubusercontent.com/assets/4313776/4250480/ea726cf6-3a83-11e4-9041-d9d06add3aa8.png)

after:
![screenshot from 2014-09-12 15 28 47](https://cloud.githubusercontent.com/assets/4313776/4250496/14aa3cba-3a84-11e4-9848-3d756b6dba58.png)
