### PR TITLE
legacy: indexer recjson none value fix

### DIFF
--- a/invenio/legacy/bibindex/engine_utils.py
+++ b/invenio/legacy/bibindex/engine_utils.py
@@ -25,6 +25,8 @@
 import re
 import sys
 
+from invenio.base.helpers import utf8ifier
+
 from invenio.legacy.dbquery import run_sql, \
     DatabaseError
 from invenio.legacy.bibsched.bibtask import write_message
@@ -312,7 +314,8 @@ def get_field_tags(field, tagtype="marc"):
         res = run_sql(query, (field,))
         values = []
         for row in res:
-            values.extend(row[0].split(","))
+            if row[0] is not None:
+                values.extend(row[0].split(","))
         return values
 
 
@@ -550,4 +553,4 @@ def get_values_recursively(subfield, phrases):
         for s in _get_values(subfield):
             get_values_recursively(s, phrases)
     elif subfield is not None:
-        phrases.append(str(subfield))
+        phrases.append(utf8ifier(subfield))


### PR DESCRIPTION
- Prevents BibIndex to crash when indexing `recjson` values.
  (closes #2285)

Signed-off-by: Esteban J. G. Gabancho esteban.gabancho@gmail.com
