### PR TITLE
deposit: fix PlUpload in IE9

### DIFF
--- a/invenio/base/templates/page_base.html
+++ b/invenio/base/templates/page_base.html
@@ -35,6 +35,7 @@
   {%- block head %}
   {%- block head_meta %}
   <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title>{{ title+' - ' if title }}{{ config.CFG_SITE_NAME_INTL[g.ln] }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   {%- if description %}<meta name="description" content="{{ description }}" />{% endif %}

--- a/invenio/modules/deposit/static/js/deposit/plupload.js
+++ b/invenio/modules/deposit/static/js/deposit/plupload.js
@@ -438,7 +438,7 @@ define(function(require, exports, module) {
 
   $.fn.pluploadWidget.defaults = {
     files: null,
-    runtimes: 'html5',
+    runtimes: 'html5,html4',
     chunksize: '10mb',
     unique_names : true,
     browse_button : 'pickfiles',


### PR DESCRIPTION
- Enables html4 runtime in PlUpload.
-  Force IE9 standard mode.

Signed-off-by: Adrian Pawel Baran adrian.pawel.baran@cern.ch
