### PR TITLE
search:fix query string in add-to-search functionality

### DIFF
--- a/invenio/modules/search/static/js/search/form.js
+++ b/invenio/modules/search/static/js/search/form.js
@@ -192,9 +192,13 @@ define(['jquery', 'js/search/typeahead'], function($) {
                 jvol = $('#journal-vol').val(),
                 jpage = $('#journal-page').val()
 
-            if (author !== '') { query.push('author:' + author) }
+            if (author !== '') { query.push('author:' + '\"' + author + '\"') }
             if (title !== '') { query.push('title:' + title) }
-            if (rn !== '') { query.push('reportnumber:' + rn) }
+            if (rn !== '') { 
+                var rnArray = rn.match(/(\S+)/g);
+                var rnQueryString = "reportnumber:" + rnArray.join(' reportnumber:');
+                query.push(rnQueryString); 
+            }
             if (aff !== '') { query.push('affiliation:' + aff) }
             if (cn !== '') { query.push('collaboration:' + cn) }
             if (k !== '') { query.push('keyword:' + k) }


### PR DESCRIPTION
- Splits terms in Report Number field (addresses #2252)
- Adds double quotes around author filed value(closes #2251)

Signed-off-by: Adrian Pawel Baran adrian.pawel.baran@cern.ch
