### PR TITLE
WIP WebSearch: partial SRU protocol support

### DIFF
--- a/modules/bibformat/lib/bibformat_utils.py
+++ b/modules/bibformat/lib/bibformat_utils.py
@@ -224,7 +224,10 @@ def record_get_xml(recID, format='xm', decompress=zlib.decompress,
         out += "   </header>\n"
         out += "   <metadata>\n"
 
-    if format.startswith("xm") or format == "marcxml":
+    if format == "marcxml_sru":
+        out += "  <record>\n"
+
+    if format.startswith("xm") or format == "marcxml" or format == "marcxml_sru":
         res = None
         if on_the_fly is False:
             # look for cached format existence:
@@ -238,7 +241,7 @@ def record_get_xml(recID, format='xm', decompress=zlib.decompress,
             # record 'recID' is not formatted in 'format' -- they are
             # not in "bibfmt" table; so fetch all the data from
             # "bibXXx" tables:
-            if format == "marcxml":
+            if format == "marcxml" or format == "marcxml_sru":
                 out += """    <record xmlns="http://www.loc.gov/MARC21/slim">\n"""
                 out += "        <controlfield tag=\"001\">%d</controlfield>\n" % int(recID)
             elif format.startswith("xm"):
@@ -355,6 +358,8 @@ def record_get_xml(recID, format='xm', decompress=zlib.decompress,
     # print record closing tags, if needed:
     if format == "marcxml" or format == "oai_dc":
         out += "   </metadata>\n"
+        out += "  </record>\n"
+    elif format == "marcxml_sru":
         out += "  </record>\n"
 
     return out

--- a/modules/websearch/lib/websearch_templates.py
+++ b/modules/websearch/lib/websearch_templates.py
@@ -77,7 +77,7 @@ from invenio.search_engine_config import CFG_WEBSEARCH_ENABLED_SEARCH_INTERFACES
 from invenio.dbquery import run_sql, CFG_DATABASE_NAME
 from invenio.messages import gettext_set_language
 from invenio.urlutils import make_canonical_urlargd, drop_default_urlargd, create_html_link, create_url
-from invenio.htmlutils import nmtoken_from_string
+from invenio.htmlutils import nmtoken_from_string, encode_for_xml
 from invenio.webinterface_handler import wash_urlargd
 from invenio.bibrank_citation_searcher import get_cited_by_count
 from invenio.webuser import session_param_get
@@ -5122,12 +5122,12 @@ class Template:
                     <databaseInfo>
                       <title>%s</title>
                       <description lang="en" primary="true">%s</description>
-                    </databaseInfo>""" % (self.sru_protocol_version,
-                                        site_sru_url,
-                                        site_port,
-                                        CFG_DATABASE_NAME,
-                                        CFG_SITE_NAME,
-                                        CFG_SITE_NAME)
+                    </databaseInfo>""" % (encode_for_xml(sel.sru_protocol_version),
+                                          encode_for_xml(site_sru_url),
+                                          encode_for_xml(site_port),
+                                          encode_for_xml(CFG_DATABASE_NAME),
+                                          encode_for_xml(CFG_SITE_NAME),
+                                          encode_for_xml(CFG_SITE_NAME))
 
         out += """<indexInfo>
                       <set identifier="info:srw/cql-context-set/1/cql-v1.1" name="cql"/>
@@ -5136,7 +5136,7 @@ class Template:
         res = run_sql("""SELECT id, name, description FROM idxINDEX""")
         if res:
             for id, name, description in res:
-                out += """<index id="%d"><title>%s</title><map><name set="dc">%s</name></map></index>""" % (id, name, description)
+                out += """<index id="%d"><title>%s</title><map><name set="dc">%s</name></map></index>""" % (encode_for_xml(id, quote=True), encode_for_xml(name), encode_for_xml(description))
 
         out += """</indexInfo>
         <schemaInfo>
@@ -5168,7 +5168,7 @@ class Template:
             <zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/">
             <zs:version>%s</zs:version>
             <zs:numberOfRecords>%d</zs:numberOfRecords>""" % \
-            (self.sru_protocol_version, params['number_of_records'])
+            (encode_for_xml(self.sru_protocol_version), params['number_of_records'])
         return out
 
     def tmpl_sru_search_retrieve_epilogue(self):

--- a/modules/webstyle/lib/webinterface_layout.py
+++ b/modules/webstyle/lib/webinterface_layout.py
@@ -104,6 +104,12 @@ except:
     WebInterfaceRSSFeedServicePages = WebInterfaceDumbPages
 
 try:
+    from invenio.websearch_webinterface import WebInterfaceSRUServicePages
+except:
+    register_exception(alert_admin=True, subject='EMERGENCY')
+    WebInterfaceSRUServicePages = WebInterfaceDumpPages
+
+try:
     from invenio.websearch_webinterface import WebInterfaceUnAPIPages
 except:
     register_exception(alert_admin=True, subject='EMERGENCY')
@@ -352,6 +358,7 @@ class WebInterfaceInvenio(WebInterfaceSearchInterfacePages):
                    ('getfile.py', 'getfile'),
                    'submit',
                    'rss',
+                   'sru',
                    'stats',
                    'journal',
                    'help',
@@ -392,6 +399,7 @@ class WebInterfaceInvenio(WebInterfaceSearchInterfacePages):
         error = WebInterfaceErrorPages()
         oai2d = WebInterfaceDisabledPages()
         rss = WebInterfaceRSSFeedServicePages()
+        sru = WebInterfaceDisabledPages()
         stats = WebInterfaceDisabledPages()
         journal = WebInterfaceDisabledPages()
         help = WebInterfaceDocumentationPages()
@@ -424,6 +432,7 @@ class WebInterfaceInvenio(WebInterfaceSearchInterfacePages):
         error = WebInterfaceErrorPages()
         oai2d = WebInterfaceOAIProviderPages()
         rss = WebInterfaceRSSFeedServicePages()
+        sru = WebInterfaceSRUServicePages()
         stats = WebInterfaceStatsPages()
         journal = WebInterfaceJournalPages()
         help = WebInterfaceDocumentationPages()


### PR DESCRIPTION
* Implements partial support to SRU protocol as described in
  <http://www.loc.gov/standards/sru/index.html>.
  (addresses #1153)

* Operations Search/Retrieve and Explain are supported but operation
  Scan and CQL language are not supported.

* Example URL: /sru?operation=searchRetrieve&version=1.2&query=Model

Signed-off-by: Vangelis Banos <vbanos@gmail.com>