### PR TITLE
search: quick fix for queries with leading space

### DIFF
--- a/invenio/modules/search/views/search.py
+++ b/invenio/modules/search/views/search.py
@@ -439,6 +439,10 @@ def search(collection, p, of, so, rm):
     argd = argd_orig = wash_search_urlargd(request.args)
     argd['of'] = 'id'
 
+    # fix for queries like `/search?p=+ellis`
+    if 'p' in argd:
+        argd['p'] = argd['p'].strip()
+
     # update search arguments with the search user preferences
     if 'rg' not in request.values and current_user.get('rg'):
         argd['rg'] = int(current_user.get('rg'))


### PR DESCRIPTION
Strips leading/trailing white space from `p` argument to `/search`. This quick-fixes queries like `/search?p=+ellis` that were otherwise leading to "Showing records 1 to 0 out of 0 results" situations.
