### PR TITLE
principal: raise 401 on authorization failure

### DIFF
--- a/invenio/ext/principal/__init__.py
+++ b/invenio/ext/principal/__init__.py
@@ -54,7 +54,7 @@ class AccAuthorizeActionPermission(Permission):
 
 
 def permission_required(action, **kwargs):
-    return AccAuthorizeActionPermission(action, **kwargs).require()
+    return AccAuthorizeActionPermission(action, **kwargs).require(http_exception=401)
 
 
 def setup_app(app):


### PR DESCRIPTION
Instead of giving 500 Internal Server Error. A template is shown to the user about authorization failure.

The template however is a bit "funky":

![Funk!](http://dl.dropbox.com/u/19162117/Selection_007.png)
