### PR TITLE
jasmine: initial release

### DIFF
--- a/invenio/base/config.py
+++ b/invenio/base/config.py
@@ -52,6 +52,7 @@ EXTENSIONS = [
     'invenio.ext.collect',
     'invenio.ext.restful',
     'invenio.ext.menu',
+    'invenio.ext.jasmine',  # after assets
     'flask.ext.breadcrumbs:Breadcrumbs',
     'invenio.modules.deposit.url_converters',
 ]

--- a/invenio/ext/jasmine/__init__.py
+++ b/invenio/ext/jasmine/__init__.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Jasmine test runner extension.
+
+1. Ensure ``TESTING`` configuration variable is set to ``True``.
+2. Reinstall assets (with ``TESTING = True``).
+
+   .. code-block:: console
+
+        (invenio)$ cdvirtualenv src/invenio-demosite
+        (invenio)$ inveniomanage bower -i bower-base.json > bower.json
+        (invenio)$ bower install
+        (invenio)$ inveniomanage collect
+        (invenio)$ inveniomanage assets build
+
+3. Run tests by loading http://localhost:4000/jasmine/specrunner in your
+   browser.
+
+Missing features
+----------------
+
+* Console test runner (likely we will use Karma test runner).
+* CI integration.
+
+
+FlightJS tests
+---------------
+
+Following is an example of a very simple FlightJS component which is normally
+added in your Invenio module under ``static/js/**/*.js``:
+
+.. code-block:: javascript
+
+    // invenio/modules/*/static/js/mycomponent.js
+    define(function(require) {
+        'use strict';
+
+        var defineComponent = require('flight/lib/component');
+
+        return defineComponent(mycomponent);
+
+        function mycomponent() {
+            this.attributes({
+                myattr: 'somevalue',
+            });
+
+            // ...
+
+            this.after('initialize', function() {
+                // ...
+            });
+        }
+    });
+
+To test above FlightJS component, create a spec file in
+``testsuite/js/**/*.spec.js``:
+
+.. code-block:: javascript
+
+    // invenio/modules/*/testsuite/js/mycomponent.spec.js
+    'use strict';
+
+    describeComponent('js/mycomponent', function() {
+        // Initialize the component and attach it to the DOM
+        beforeEach(function() {
+            this.setupComponent();
+        });
+
+        it('should be defined', function() {
+            expect(this.component).toBeDefined();
+        });
+    });
+
+See https://github.com/flightjs/jasmine-flight for further examples how to test
+FlightJS components.
+
+HOWTO
+-----
+
+Mock AJAX request
+~~~~~~~~~~~~~~~~~
+
+.. code-block: javascript
+
+    'use strict';
+
+    describeComponent('js/mycomponent', function() {
+
+        // Initialize the component and attach it to the DOM
+        beforeEach(function() {
+            jasmine.Ajax.install();
+            this.setupComponent();
+        });
+
+        afterEach(function() {
+            jasmine.Ajax.uninstall();
+        });
+
+        it('should make ajax request', function() {
+            // trigger some event that makes an AJAX request ...
+
+            // Retrieve most recent request.
+            var request = jasmine.Ajax.requests.mostRecent();
+            expect(request.url).toBe('/foo/bar');
+            expect(request.method).toBe('GET');
+
+            // Fake response from server.
+            request.response({
+                status: 200,
+                responseText: 'somevalue'
+            })
+        });
+    });
+
+See http://jasmine.github.io/2.0/ajax.html for further information.
+
+"""
+
+from __future__ import absolute_import
+
+from .views import blueprint
+from . import bundles
+from ..assets.registry import bundles as bundles_registry
+
+
+def setup_app(app):
+    """Initialize Jasmine extensions."""
+    if app.testing:
+        # Register blueprint
+        app.register_blueprint(blueprint)
+
+        # Register bundles
+        with app.app_context():
+            bundles_registry.register((bundles, bundles.jasmine_js))
+            bundles_registry.register((bundles, bundles.jasmine_styles))

--- a/invenio/ext/jasmine/bundles.py
+++ b/invenio/ext/jasmine/bundles.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Bundles for Jasmine test runner."""
+
+from invenio.ext.assets import Bundle
+
+jasmine_js = Bundle(
+    # es5-shim is needed by PhantomJS
+    'vendors/es5-shim/es5-shim.js',
+    'vendors/es5-shim/es5-sham.js',
+    'vendors/jasmine/lib/jasmine-core/jasmine.js',
+    'vendors/jasmine/lib/jasmine-core/jasmine-html.js',
+    'js/jasmine/boot.js',
+    'vendors/jquery/dist/jquery.js',
+    'vendors/jasmine-jquery/lib/jasmine-jquery.js',
+    'vendors/jasmine-flight/lib/jasmine-flight.js',
+    'vendors/jasmine-ajax/lib/mock-ajax.js',
+    output="jasmine.js",
+    # Must be included prior to RequireJS
+    weight=-1,
+    bower={
+        "jasmine": ">=2",
+        "jasmine-jquery": ">=2",
+        "jasmine-flight": ">=3",
+        "jasmine-ajax": ">=2",
+    }
+)
+
+jasmine_styles = Bundle(
+    'vendors/jasmine/lib/jasmine-core/jasmine.css',
+    weight=-1,
+    output='jasmine.css'
+)

--- a/invenio/ext/jasmine/registry.py
+++ b/invenio/ext/jasmine/registry.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Registry for Jasmine spec files."""
+
+import os
+import re
+from werkzeug.utils import import_string
+from flask.ext.registry import RegistryProxy
+from invenio.ext.registry import DictModuleAutoDiscoverySubRegistry
+
+
+class JasmineSpecsAutoDiscoveryRegistry(DictModuleAutoDiscoverySubRegistry):
+
+    """Registry for Jasmine spec files.
+
+    Looks into /testsuite/js/*.spec.js in each module.
+    """
+
+    pattern = re.compile(".+\.spec.js")
+    specs_folder = 'js'
+
+    def __init__(self, *args, **kwargs):
+        """Initialize registry."""
+        super(JasmineSpecsAutoDiscoveryRegistry, self).__init__(
+            'testsuite', **kwargs
+        )
+
+    def keygetter(self, key, original_value, new_value):
+        """No key mapping."""
+        return key
+
+    def _walk_dir(self, pkg, base, root):
+        """Recursively register *.spec.js files."""
+        for root, dirs, files in os.walk(root):
+            for name in files:
+                if JasmineSpecsAutoDiscoveryRegistry.pattern.match(name):
+                    specfilename = os.path.join(root, name)
+                    specpath = "{0}/{1}".format(
+                        pkg,
+                        specfilename[len(base)+1:]
+                    )
+                    self.register(specfilename, key=specpath)
+            for name in dirs:
+                self._walk_dir(pkg, base, os.path.join(root, name))
+
+    def _discover_module(self, pkg):
+        """Load list of files from resource directory."""
+        import_str = pkg + '.' + self.module_name
+
+        try:
+            module = import_string(import_str, silent=self.silent)
+            if module is not None:
+                for p in module.__path__:
+                    specsfolder = os.path.join(p, self.specs_folder)
+                    if os.path.isdir(specsfolder):
+                        self._walk_dir(pkg, specsfolder, specsfolder)
+        except ImportError as e:  # pylint: disable=C0103
+            self._handle_importerror(e, pkg, import_str)
+        except SyntaxError as e:
+            self._handle_syntaxerror(e, pkg, import_str)
+
+
+specs = RegistryProxy("jasmine.specs", JasmineSpecsAutoDiscoveryRegistry)

--- a/invenio/ext/jasmine/static/js/jasmine/boot.js
+++ b/invenio/ext/jasmine/static/js/jasmine/boot.js
@@ -1,0 +1,216 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2014 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * Invenio is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Invenio; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ */
+/*
+Copyright (c) 2008-2013 Pivotal Labs
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+/**
+ Starting with version 2.0, this file "boots" Jasmine, performing all of the necessary initialization before executing the loaded environment and all of a project's specs. This file should be loaded after `jasmine.js`, but before any project source files or spec files are loaded. Thus this file can also be used to customize Jasmine for a project.
+
+ If a project is using Jasmine via the standalone distribution, this file can be customized directly. If a project is using Jasmine via the [Ruby gem][jasmine-gem], this file can be copied into the support directory via `jasmine copy_boot_js`. Other environments (e.g., Python) will have different mechanisms.
+
+ The location of `boot.js` can be specified and/or overridden in `jasmine.yml`.
+
+ [jasmine-gem]: http://github.com/pivotal/jasmine-gem
+ */
+
+(function() {
+
+  /**
+   * ## Require &amp; Instantiate
+   *
+   * Require Jasmine's core files. Specifically, this requires and attaches all of Jasmine's code to the `jasmine` reference.
+   */
+  window.jasmine = jasmineRequire.core(jasmineRequire);
+
+  /**
+   * Since this is being run in a browser and the results should populate to an HTML page, require the HTML-specific Jasmine code, injecting the same reference.
+   */
+  jasmineRequire.html(jasmine);
+
+  /**
+   * Create the Jasmine environment. This is used to run all specs in a project.
+   */
+  var env = jasmine.getEnv();
+
+  /**
+   * ## The Global Interface
+   *
+   * Build up the functions that will be exposed as the Jasmine public interface. A project can customize, rename or alias any of these functions as desired, provided the implementation remains unchanged.
+   */
+  var jasmineInterface = {
+    describe: function(description, specDefinitions) {
+      return env.describe(description, specDefinitions);
+    },
+
+    xdescribe: function(description, specDefinitions) {
+      return env.xdescribe(description, specDefinitions);
+    },
+
+    it: function(desc, func) {
+      return env.it(desc, func);
+    },
+
+    xit: function(desc, func) {
+      return env.xit(desc, func);
+    },
+
+    beforeEach: function(beforeEachFunction) {
+      return env.beforeEach(beforeEachFunction);
+    },
+
+    afterEach: function(afterEachFunction) {
+      return env.afterEach(afterEachFunction);
+    },
+
+    expect: function(actual) {
+      return env.expect(actual);
+    },
+
+    pending: function() {
+      return env.pending();
+    },
+
+    spyOn: function(obj, methodName) {
+      return env.spyOn(obj, methodName);
+    },
+
+    jsApiReporter: new jasmine.JsApiReporter({
+      timer: new jasmine.Timer()
+    })
+  };
+
+  /**
+   * Add all of the Jasmine global/public interface to the proper global, so a project can use the public interface directly. For example, calling `describe` in specs instead of `jasmine.getEnv().describe`.
+   */
+  if (typeof window == "undefined" && typeof exports == "object") {
+    extend(exports, jasmineInterface);
+  } else {
+    extend(window, jasmineInterface);
+  }
+
+  /**
+   * Expose the interface for adding custom equality testers.
+   */
+  jasmine.addCustomEqualityTester = function(tester) {
+    env.addCustomEqualityTester(tester);
+  };
+
+  /**
+   * Expose the interface for adding custom expectation matchers
+   */
+  jasmine.addMatchers = function(matchers) {
+    return env.addMatchers(matchers);
+  };
+
+  /**
+   * Expose the mock interface for the JavaScript timeout functions
+   */
+  jasmine.clock = function() {
+    return env.clock;
+  };
+
+  /**
+   * ## Runner Parameters
+   *
+   * More browser specific code - wrap the query string in an object and to allow for getting/setting parameters from the runner user interface.
+   */
+
+  var queryString = new jasmine.QueryString({
+    getWindowLocation: function() { return window.location; }
+  });
+
+  var catchingExceptions = queryString.getParam("catch");
+  env.catchExceptions(typeof catchingExceptions === "undefined" ? true : catchingExceptions);
+
+  /**
+   * ## Reporters
+   * The `HtmlReporter` builds all of the HTML UI for the runner page. This reporter paints the dots, stars, and x's for specs, as well as all spec names and all failures (if any).
+   */
+  var htmlReporter = new jasmine.HtmlReporter({
+    env: env,
+    onRaiseExceptionsClick: function() { queryString.setParam("catch", !env.catchingExceptions()); },
+    getContainer: function() { return document.body; },
+    createElement: function() { return document.createElement.apply(document, arguments); },
+    createTextNode: function() { return document.createTextNode.apply(document, arguments); },
+    timer: new jasmine.Timer()
+  });
+
+  /**
+   * The `jsApiReporter` also receives spec results, and is used by any environment that needs to extract the results  from JavaScript.
+   */
+  env.addReporter(jasmineInterface.jsApiReporter);
+  env.addReporter(htmlReporter);
+
+  /**
+   * Filter which specs will be run by matching the start of the full name against the `spec` query param.
+   */
+  var specFilter = new jasmine.HtmlSpecFilter({
+    filterString: function() { return queryString.getParam("spec"); }
+  });
+
+  env.specFilter = function(spec) {
+    return specFilter.matches(spec.getFullName());
+  };
+
+  /**
+   * Setting up timing functions to be able to be overridden. Certain browsers (Safari, IE 8, phantomjs) require this hack.
+   */
+  window.setTimeout = window.setTimeout;
+  window.setInterval = window.setInterval;
+  window.clearTimeout = window.clearTimeout;
+  window.clearInterval = window.clearInterval;
+
+  /**
+   * ## Execution
+   *
+   * Only on demand execution.
+   */
+  window.executeTests = function() {
+    htmlReporter.initialize();
+    env.execute();
+  };
+
+  /**
+   * Helper function for readability above.
+   */
+  function extend(destination, source) {
+    for (var property in source) destination[property] = source[property];
+    return destination;
+  }
+
+}());

--- a/invenio/ext/jasmine/templates/jasmine/specrunner.html
+++ b/invenio/ext/jasmine/templates/jasmine/specrunner.html
@@ -1,0 +1,19 @@
+{#
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+-#}
+{%- extends "jasmine/specrunner_base.html" -%}

--- a/invenio/ext/jasmine/templates/jasmine/specrunner_base.html
+++ b/invenio/ext/jasmine/templates/jasmine/specrunner_base.html
@@ -1,0 +1,44 @@
+{#
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+-#}
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Jasmine Spec Runner</title>
+    {% bundle "jasmine.js", "require.js", "jasmine.css" %}
+    {%- include "base/stylesheets.html" %}
+    {% include "base/scripts.html" %}
+    <script type="text/javascript">
+    // Test files are loaded using RequireJS. Each test file in turns uses RequireJS
+    // to load the JS files they test.
+    require(
+        [{% for m in modules %}'{{m}}'{%if not loop.last %}, {% endif %}{% endfor %}],
+        function () {
+            // Jasmine runs tests on window.onload() by default, thus before
+            // require.js has had a chance to load them. Thus we use a custom
+            // boot.js file which renames window.onload to window.executeTests and
+            // calls the executeTests() once the test modules have been loaded.
+            window.executeTests();
+        }
+    )
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/invenio/ext/jasmine/views.py
+++ b/invenio/ext/jasmine/views.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Views for Jasmine test runner."""
+
+from flask import Blueprint, render_template, send_file, abort, url_for
+from .registry import specs
+
+blueprint = Blueprint(
+    'jasmine',
+    __name__,
+    url_prefix='/jasmine',
+    static_folder='static',
+    template_folder='templates',
+)
+
+
+@blueprint.route('/specrunner/', methods=['GET'])
+def specrunner():
+    """Render Jasmine test runner page."""
+    modules = [url_for('jasmine.spec', specpath=x) for x in specs.keys()]
+    modules.sort()
+    return render_template('jasmine/specrunner.html', modules=modules)
+
+
+@blueprint.route('/spec/<path:specpath>', methods=['GET'])
+def spec(specpath):
+    """Send a single spec file."""
+    if specpath not in specs:
+        abort(404)
+
+    return send_file(
+        specs[specpath],
+        mimetype="application/javascript",
+        conditional=False,
+        add_etags=False,
+    )


### PR DESCRIPTION
- Adds Jasmine test runner to execute JavaScript unit tests.
- NOTE Test runner is only enabled when TESTING=True and requires a
  bower reinstall and assets rebuild. Please see
  `invenio/ext/jasmine/__init__.py` for details.

Signed-off-by: Lars Holm Nielsen lars.holm.nielsen@cern.ch
