### PR TITLE
sqlalchemy: fix PostgreSQL test connection

### DIFF
--- a/invenio/base/scripts/database.py
+++ b/invenio/base/scripts/database.py
@@ -102,7 +102,7 @@ def drop(yes_i_know=False, quiet=False):
     from sqlalchemy import event
     from invenio.utils.date import get_time_estimator
     from invenio.utils.text import wrap_text_in_a_box, wait_for_user
-    from invenio.legacy.inveniocfg import test_db_connection
+    from invenio.ext.sqlalchemy.utils import test_sqla_connection, test_sqla_utf8_chain
     from invenio.ext.sqlalchemy import db, models
     from invenio.legacy.bibdocfile.api import _make_base_dir
     from invenio.modules.jsonalchemy.wrappers import StorageEngine
@@ -113,7 +113,8 @@ def drop(yes_i_know=False, quiet=False):
         "data on filesystem!"))
 
     ## Step 1: test database connection
-    test_db_connection()
+    test_sqla_connection()
+    test_sqla_utf8_chain()
     list(models)
 
     ## Step 2: disable foreign key checks
@@ -188,17 +189,12 @@ def create(default_data=True, quiet=False):
 
     from sqlalchemy import event
     from invenio.utils.date import get_time_estimator
-    from invenio.legacy.inveniocfg import test_db_connection
+    from invenio.ext.sqlalchemy.utils import test_sqla_connection, test_sqla_utf8_chain
     from invenio.ext.sqlalchemy import db, models
     from invenio.modules.jsonalchemy.wrappers import StorageEngine
 
-    try:
-        test_db_connection()
-    except Exception as e:
-        from invenio.ext.logging.wrappers import get_traceback
-        print('Cannot connect with the db:', e.message)
-        print(get_traceback())
-        return
+    test_sqla_connection()
+    test_sqla_utf8_chain()
 
     list(models)
 

--- a/invenio/ext/sqlalchemy/utils.py
+++ b/invenio/ext/sqlalchemy/utils.py
@@ -29,9 +29,15 @@ For example, session_manager used to handle commit/rollback:
                 db.session.add(self)
 """
 
-import sqlalchemy
+from __future__ import print_function
+
 import base64
+import os
+import sqlalchemy
+import sys
+
 from intbitset import intbitset
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import class_mapper, properties
 
 
@@ -51,7 +57,7 @@ def get_model_type(ModelBase):
 
             elif isinstance(prop, properties.RelationshipProperty):
                 relationships.add(prop.key)
-                #set with _userGroup, and rest of relationships
+                # set with _userGroup, and rest of relationships
 
         for relationship in relationships:
             retval.append(synonyms[relationship])
@@ -67,8 +73,8 @@ def get_model_type(ModelBase):
                 return ''
 
         for c in self.__table__.columns:
-            #NOTE   This hack is not needed if you redefine types.TypeDecorator for
-            #       desired classes (Binary, LargeBinary, ...)
+            # NOTE This hack is not needed if you redefine types.TypeDecorator
+            # for desired classes (Binary, LargeBinary, ...)
 
             value = getattr(self, c.name)
             if value is None:
@@ -83,10 +89,10 @@ def get_model_type(ModelBase):
 
     def fromdict(self, args):
         """Update instance from dictionary."""
-        #NOTE Why not to do things simple ...
+        # NOTE Why not to do things simple ...
         self.__dict__.update(args)
 
-        #for c in self.__table__.columns:
+        # for c in self.__table__.columns:
         #    name = str(c).split('.')[1]
         #    try:
         #        d = args[name]
@@ -141,3 +147,88 @@ def session_manager(orig_func):
             raise
 
     return new_func
+
+
+def test_sqla_connection():
+    """Test connection with the database."""
+    print("Test connection... \t", end="")
+
+    try:
+        from sqlalchemy import inspect
+        from invenio.ext.sqlalchemy import db
+        inspector = inspect(db.engine)
+        inspector.get_table_names()
+    except OperationalError as err:
+        from invenio.utils.text import wrap_text_in_a_box
+        from invenio.config import CFG_DATABASE_HOST, \
+            CFG_DATABASE_PORT, CFG_DATABASE_NAME, CFG_DATABASE_USER, \
+            CFG_DATABASE_PASS
+        print(" [ERROR]")
+        print(wrap_text_in_a_box("""\
+DATABASE CONNECTIVITY ERROR:
+
+%(errmsg)s.\n
+
+Perhaps you need to set up database and connection rights?
+If yes, then please execute:
+
+console> inveniomanage database init --yes-i-know
+
+The values printed above were detected from your
+configuration. If they are not right, then please edit your
+invenio-local.conf file and rerun 'inveniocfg --update-all' first.
+
+
+If the problem is of different nature, then please inspect
+the above error message and fix the problem before continuing.""" % {
+            'errmsg': err.args[0],
+            'dbname': CFG_DATABASE_NAME,
+            'dbhost': CFG_DATABASE_HOST,
+            'dbport': CFG_DATABASE_PORT,
+            'dbuser': CFG_DATABASE_USER,
+            'dbpass': CFG_DATABASE_PASS,
+            'webhost': (CFG_DATABASE_HOST == 'localhost' and 'localhost' or
+                        os.popen('hostname -f', 'r').read().strip()),
+        }))
+        sys.exit(1)
+    print(" [OK]")
+
+
+def test_sqla_utf8_chain():
+    """Test insert and select of a UTF-8 string."""
+    from sqlalchemy import Table, Column
+    from sqlalchemy.types import CHAR, VARBINARY
+    from sqlalchemy.ext.declarative import declarative_base
+
+    from invenio.ext.sqlalchemy import db
+
+    print("Test UTF-8 support... \t", end="")
+
+    tmptable = "test__invenio__utf8"
+    beta_in_utf8 = "β"  # Greek beta in UTF-8 is 0xCEB2
+
+    Base = declarative_base()
+
+    table = Table(tmptable, Base.metadata,
+                  Column('x', CHAR(1)),
+                  Column('y', VARBINARY(2)))
+
+    if table.exists(bind=db.engine):
+        table.drop(bind=db.engine)
+
+    table.create(bind=db.engine)
+
+    db.engine.execute(table.insert(), x=beta_in_utf8, y=beta_in_utf8)
+    result = db.engine.execute(table.select().where(
+        table.c.x == beta_in_utf8).where(table.c.y == beta_in_utf8))
+
+    assert result.rowcount == 1
+
+    for row in result:
+        # Database is configured to always return Unicode.
+        assert row['x'] == beta_in_utf8.decode('utf-8')
+        assert row['y'] == beta_in_utf8
+
+    table.drop(bind=db.engine)
+
+    print(" [OK]")

--- a/invenio/legacy/dbquery_mysql.py
+++ b/invenio/legacy/dbquery_mysql.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+##
 ## This file is part of Invenio.
 ## Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
 ##
@@ -37,6 +39,7 @@ import os
 import string
 import time
 import re
+import sys
 
 from thread import get_ident
 from flask import current_app
@@ -531,3 +534,4 @@ def real_escape_string(unescaped_string, run_on_slave=False):
     connection_object = _db_login(dbhost)
     escaped_string = connection_object.escape_string(unescaped_string)
     return escaped_string
+

--- a/invenio/legacy/dbquery_postgresql.py
+++ b/invenio/legacy/dbquery_postgresql.py
@@ -140,6 +140,7 @@ def run_sql(sql, param=None, n=0, with_desc=False, with_dict=False, run_on_slave
             return cur.lastrowid
         return cur
 
+
 def run_sql_many(query, params, limit=None, run_on_slave=False):
     """Run SQL on the server with PARAM.
 
@@ -311,3 +312,4 @@ def real_escape_string(unescaped_string, run_on_slave=False):
     connection_object = db.engine.raw_connection()
     escaped_string = connection_object.escape(unescaped_string)
     return escaped_string
+


### PR DESCRIPTION
- Use a SQLAlchemy's independent query to test connection.
- Create a dialect depending procedure to initially test the db.

Signed-off-by: Leonardo Rossi leonardo.r@cern.ch
