### PR TITLE
DocExtract: several improvements

### DIFF
--- a/modules/docextract/etc/report-numbers.kb
+++ b/modules/docextract/etc/report-numbers.kb
@@ -181,6 +181,8 @@ CMS CR                 ---CMS-CR
 CMS NOTE               ---CMS-NOTE
 CMS EXO                ---CMS-EXO
 LHCB                   ---LHCB
+LHCB JOURNAL           ---LHCB-JOURNAL
+LHCB ANA               ---LHCB-ANA
 SN ATLAS               ---SN-ATLAS
 PAS SUSY               ---CMS-PAS-SUS
 CMS PAS EXO            ---CMS-PAS-EXO
@@ -303,3 +305,9 @@ ANL HEP TR   ---ANL-HEP-TR
 ANTARES SOFT  ---ANTARES-SOFT
 ANTARES PHYS  ---ANTARES-Phys
 ANTARES OPMO  ---ANTARES-Opmo
+
+
+*****LIGO*****
+< Tyy9999 00 a>
+
+LIGO---LIGO

--- a/modules/docextract/lib/docextract_pdf.py
+++ b/modules/docextract/lib/docextract_pdf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -29,6 +29,7 @@ for and the characters that should be used to replace them.
 replace in plain-text.
 """
 
+import os
 import re
 import subprocess
 
@@ -475,6 +476,9 @@ def convert_PDF_to_plaintext(fpath, keep_layout=False):
     @return: (list) of unicode strings (contents of the PDF file translated
     into plaintext; each string is a line in the document.)
     """
+    if not os.path.isfile(CFG_PATH_PDFTOTEXT):
+        raise Exception('Missing pdftotext executable')
+
     if keep_layout:
         layout_option = "-layout"
     else:

--- a/modules/docextract/lib/docextract_regression_tests.py
+++ b/modules/docextract/lib/docextract_regression_tests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2012 CERN.
+## Copyright (C) 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -37,7 +37,8 @@ if CFG_INSPIRE_SITE:
   <datafield tag="999" ind1="C" ind2="5">
     <subfield code="o">2</subfield>
     <subfield code="h">C. L. Sarazin, X-Ray Emission</subfield>
-    <subfield code="m">from Clusters of Galaxies (Cambridge University Press, Cambridge 1988)</subfield>
+    <subfield code="m">from Clusters of Galaxies (Cambridge University Press, Cambridge)</subfield>
+    <subfield code="y">1988</subfield>
   </datafield>
   <datafield tag="999" ind1="C" ind2="5">
     <subfield code="o">3</subfield>
@@ -100,7 +101,8 @@ else:
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">2</subfield>
       <subfield code="h">C. L. Sarazin, X-Ray Emission</subfield>
-      <subfield code="m">from Clusters of Galaxies (Cambridge University Press, Cambridge 1988)</subfield>
+      <subfield code="m">from Clusters of Galaxies (Cambridge University Press, Cambridge)</subfield>
+      <subfield code="y">1988</subfield>
    </datafield>
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">3</subfield>

--- a/modules/docextract/lib/docextract_task.py
+++ b/modules/docextract/lib/docextract_task.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2011, 2012 CERN.
+## Copyright (C) 2011, 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -19,41 +19,31 @@
 
 """Generic Framework for extracting metadata from records using bibsched"""
 
-import traceback
-
 from datetime import datetime
 from itertools import chain
 from invenio.bibtask import task_get_option, write_message, \
                             task_sleep_now_if_required, \
                             task_update_progress
 from invenio.dbquery import run_sql
-from invenio.search_engine import get_record
 from invenio.search_engine import get_collection_reclist
-from invenio.refextract_api import get_pdf_doc
-from invenio.bibrecord import record_get_field_instances, \
-                              field_get_subfield_values
 
 
 def task_run_core_wrapper(name, core_func, extra_vars=None, post_process=None):
     def fun():
-        try:
-            return task_run_core(name, core_func,
-                                 extra_vars=extra_vars,
-                                 post_process=post_process)
-        except Exception:
-            # Remove extra '\n'
-            write_message(traceback.format_exc()[:-1])
-            raise
+        return task_run_core(name,
+                             core_func,
+                             extra_vars=extra_vars,
+                             post_process=post_process)
     return fun
 
 
 def fetch_last_updated(name):
-    select_sql = "SELECT last_recid, last_updated FROM xtrJOB" \
-        " WHERE name = %s LIMIT 1"
+    select_sql = """SELECT last_recid, last_updated FROM xtrJOB
+                    WHERE name = %s LIMIT 1"""
     row = run_sql(select_sql, (name,))
     if not row:
-        sql = "INSERT INTO xtrJOB (name, last_updated, last_recid) " \
-            "VALUES (%s, '1970-01-01', 0)"
+        sql = """INSERT INTO xtrJOB (name, last_updated, last_recid)
+                 VALUES (%s, '1970-01-01', 0)"""
         run_sql(sql, (name,))
         row = run_sql(select_sql, (name,))
 
@@ -65,33 +55,30 @@ def fetch_last_updated(name):
 
 
 def store_last_updated(recid, creation_date, name):
-    sql = "UPDATE xtrJOB SET last_recid = %s WHERE name=%s AND last_recid < %s"
-    run_sql(sql, (recid, name, recid))
-    sql = "UPDATE xtrJOB SET last_updated = %s " \
-                "WHERE name=%s AND last_updated < %s"
-    iso_date = creation_date.isoformat()
-    run_sql(sql, (iso_date, name, iso_date))
+    if recid is not None:
+        sql = "UPDATE xtrJOB SET last_recid = %s WHERE name=%s AND last_recid < %s"
+        run_sql(sql, (recid, name, recid))
+    if creation_date is not None:
+        sql = """UPDATE xtrJOB SET last_updated = %s
+                 WHERE name=%s AND last_updated < %s"""
+        iso_date = creation_date.isoformat()
+        run_sql(sql, (iso_date, name, iso_date))
 
 
 def fetch_concerned_records(name):
     task_update_progress("Fetching record ids")
 
-    last_recid, last_date = fetch_last_updated(name)
+    dummy, last_date = fetch_last_updated(name)
 
     if task_get_option('new'):
         # Fetch all records inserted since last run
-        sql = "SELECT `id`, `creation_date` FROM `bibrec` " \
-            "WHERE `creation_date` >= %s " \
-            "AND `id` > %s " \
-            "ORDER BY `creation_date`"
-        records = run_sql(sql, (last_date.isoformat(), last_recid))
-    elif task_get_option('modified'):
-        # Fetch all records inserted since last run
-        sql = "SELECT `id`, `modification_date` FROM `bibrec` " \
-            "WHERE `modification_date` >= %s " \
-            "AND `id` > %s " \
-            "ORDER BY `modification_date`"
-        records = run_sql(sql, (last_date.isoformat(), last_recid))
+        sql = """SELECT `id_bibrec`, `cd` FROM `bibdocfsinfo`
+                 INNER JOIN `bibrec_bibdoc`
+                 ON `bibdocfsinfo`.`id_bibdoc` = `bibrec_bibdoc`.`id_bibdoc`
+                 WHERE `cd` > %s
+                 AND format IN ('.pdf', '.PDF', '.pdf;pdfa', '.PDF;pdfa')
+                 ORDER BY `cd`"""
+        records = run_sql(sql, [last_date.isoformat()])
     else:
         given_recids = task_get_option('recids')
         for collection in task_get_option('collections'):
@@ -99,50 +86,15 @@ def fetch_concerned_records(name):
 
         if given_recids:
             format_strings = ','.join(['%s'] * len(given_recids))
-            records = run_sql("SELECT `id`, NULL FROM `bibrec` " \
-                "WHERE `id` IN (%s) ORDER BY `id`" % format_strings,
-                    list(given_recids))
+            records = run_sql("""SELECT `id`, NULL FROM `bibrec`
+                                 WHERE `id` IN (%s)
+                                 ORDER BY `id`""" % format_strings,
+                              list(given_recids))
         else:
             records = []
 
     task_update_progress("Done fetching record ids")
 
-    return records
-
-
-def fetch_concerned_arxiv_records(name):
-    task_update_progress("Fetching arxiv record ids")
-
-    dummy, last_date = fetch_last_updated(name)
-
-    # Fetch all records inserted since last run
-    sql = "SELECT `id`, `modification_date` FROM `bibrec` " \
-        "WHERE `modification_date` >= %s " \
-        "AND `creation_date` > NOW() - INTERVAL 7 DAY " \
-        "ORDER BY `modification_date`" \
-        "LIMIT 5000"
-    records = run_sql(sql, [last_date.isoformat()])
-
-    def check_arxiv(recid):
-        record = get_record(recid)
-
-        for report_tag in record_get_field_instances(record, "037"):
-            for category in field_get_subfield_values(report_tag, 'a'):
-                if category.startswith('arXiv'):
-                    return True
-        return False
-
-    def check_pdf_date(recid):
-        doc = get_pdf_doc(recid)
-        if doc:
-            return doc.md > last_date
-        return False
-
-    records = [(r, mod_date) for r, mod_date in records if check_arxiv(r)]
-    records = [(r, mod_date) for r, mod_date in records if check_pdf_date(r)]
-    write_message("recids %s" % repr([(r, mod_date.isoformat()) \
-                                               for r, mod_date in records]))
-    task_update_progress("Done fetching arxiv record ids")
     return records
 
 
@@ -156,7 +108,7 @@ def process_records(name, records, func, extra_vars):
         write_message(msg)
         func(recid, **extra_vars)
         if date:
-            store_last_updated(recid, date, name)
+            store_last_updated(None, date, name)
         count += 1
 
 
@@ -171,12 +123,6 @@ def task_run_core(name, func, extra_vars=None, post_process=None):
 
     records = fetch_concerned_records(name)
     process_records(name, records, func, extra_vars)
-
-    if task_get_option('arxiv'):
-        extra_vars['_arxiv'] = True
-        arxiv_name = "%s:arxiv" % name
-        records = fetch_concerned_arxiv_records(arxiv_name)
-        process_records(arxiv_name, records, func, extra_vars)
 
     if post_process:
         post_process(**extra_vars)

--- a/modules/docextract/lib/refextract_api.py
+++ b/modules/docextract/lib/refextract_api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -25,7 +25,6 @@ present here can be considered private by the invenio modules.
 
 
 import os
-import sys
 
 from urllib import urlretrieve
 from tempfile import mkstemp
@@ -117,7 +116,9 @@ def extract_references_from_file(path, recid=None):
         docbody, dummy = get_plaintext_document_body(path, keep_layout=True)
         reflines, dummy, dummy = extract_references_from_fulltext(docbody)
 
-    return parse_references(reflines, recid=recid)
+    references = parse_references(reflines, recid=recid)
+    references['999C6'][0].add_subfield('v', os.path.basename(path))
+    return references
 
 
 def extract_references_from_string_xml(source,
@@ -332,7 +333,11 @@ def search_from_reference(text):
     return field, pattern.encode('utf-8')
 
 
-def check_record_for_refextract(recid):
+def record_can_extract_refs(recid):
+    return not bool(get_fieldvalues(recid, '999C5_'))
+
+
+def record_can_overwrite_refs(recid):
     if get_fieldvalues(recid, '999C6v'):
         # References extracted by refextract
         if get_fieldvalues(recid, '999C59'):

--- a/modules/docextract/lib/refextract_config.py
+++ b/modules/docextract/lib/refextract_config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2010, 2011 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2010, 2011, 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -24,7 +24,7 @@ from invenio.config import CFG_VERSION, CFG_ETCDIR
 
 # pylint: disable=C0301
 
-CFG_REFEXTRACT_VERSION_NUM = '1.5.40'
+CFG_REFEXTRACT_VERSION_NUM = '1.5.44'
 # Version number:
 CFG_REFEXTRACT_VERSION = "Invenio/%s refextract/%s" \
                                     % (CFG_VERSION, CFG_REFEXTRACT_VERSION_NUM)
@@ -53,6 +53,7 @@ CFG_REFEXTRACT_FIELDS = {
     'misc': 'm',
     'linemarker': 'o',
     'doi': 'a',
+    'hdl': 'a',
     'reportnumber': 'r',
     'journal': 's',
     'url': 'u',
@@ -71,7 +72,7 @@ CFG_REFEXTRACT_IND1_REFERENCE            = "C"    # ref field ind1
 CFG_REFEXTRACT_IND2_REFERENCE            = "5"    # ref field ind2
 
 ## refextract statistics fields:
-CFG_REFEXTRACT_TAG_ID_EXTRACTION_STATS     = "999C6" # ref-stats tag
+CFG_REFEXTRACT_TAG_ID_EXTRACTION_STATS = "999C6"  # ref-stats tag
 
 CFG_REFEXTRACT_SUBFIELD_EXTRACTION_STATS   = "a"   # ref-stats subfield
 CFG_REFEXTRACT_SUBFIELD_EXTRACTION_TIME    = "t"   # ref-stats time subfield

--- a/modules/docextract/lib/refextract_engine.py
+++ b/modules/docextract/lib/refextract_engine.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -59,7 +59,10 @@ from invenio.refextract_re import (get_reference_line_numeration_marker_patterns
                                    re_tagged_citation,
                                    re_numeration_no_ibid_txt,
                                    re_roman_numbers,
-                                   re_recognised_numeration_for_title_plus_series)
+                                   re_recognised_numeration_for_title_plus_series,
+                                   remove_year,
+                                   re_year_in_misc_txt,
+                                   re_hdl)
 
 
 description = """
@@ -466,11 +469,21 @@ def add_year_elements(splitted_citations):
                                                               and 'year' in el:
                 year = el['year']
                 break
+
+        if not year:
+            for el in citation:
+                m = re_year_in_misc_txt.search(el['misc_txt'])
+                if m:
+                    year = m.group(0)
+
         if year:
             citation.append({'type': 'YEAR',
                              'year': year,
                              'misc_txt': '',
                             })
+            for el in citation:
+                if year in el['misc_txt']:
+                    el['misc_txt'] = remove_year(el['misc_txt'], year)
 
     return splitted_citations
 
@@ -552,6 +565,46 @@ def add_recid_elements(splitted_citations):
                 break
 
 
+def arxiv_urls_to_report_numbers(citation_elements):
+    arxiv_url_prefix = 'http://arxiv.org/abs/'
+    for el in citation_elements:
+        if el['type'] == 'URL' and el['url_string'].startswith(arxiv_url_prefix):
+            el['type'] = 'REPORTNUMBER'
+            el['report_num'] = el['url_string'].replace(arxiv_url_prefix, 'arXiv:')
+
+
+def look_for_hdl(citation_elements):
+    """Looks for handle identifiers in the misc txt of the citation elements
+
+       When finding an hdl, creates a new HDL element.
+       @param citation_elements: (list) elements to process
+    """
+    for el in list(citation_elements):
+        matched_hdl = re_hdl.finditer(el['misc_txt'])
+        for match in reversed(list(matched_hdl)):
+            hdl_el = {'type': 'HDL',
+                      'hdl_id': match.group('hdl_id'),
+                      'misc_txt': el['misc_txt'][match.end():]}
+            el['misc_txt'] = el['misc_txt'][0:match.start()]
+            citation_elements.insert(citation_elements.index(el)+1, hdl_el)
+
+
+def look_for_hdl_urls(citation_elements):
+    """Looks for handle identifiers that have already been identified as urls
+
+       When finding an hdl, creates a new HDL element.
+       @param citation_elements: (list) elements to process
+    """
+    for el in citation_elements:
+        if el['type'] == 'URL':
+            match = re_hdl.match(el['url_string'])
+            if match:
+                el['type'] = 'HDL'
+                el['hdl_id'] = match.group('hdl_id')
+                del el['url_desc']
+                del el['url_string']
+
+
 ## End of elements transformations
 
 
@@ -604,23 +657,26 @@ def parse_reference_line(ref_line, kbs, bad_titles_count={}):
     format_hep(citation_elements)
     remove_b_for_nucl_phys(citation_elements)
     mangle_volume(citation_elements)
+    arxiv_urls_to_report_numbers(citation_elements)
+    look_for_hdl(citation_elements)
+    look_for_hdl_urls(citation_elements)
     associate_recids(citation_elements)
 
     # Split the reference in multiple ones if needed
     splitted_citations = split_citations(citation_elements)
 
-    # Look for books in misc field
-    look_for_undetected_books(splitted_citations, kbs)
     # Look for implied ibids
     look_for_implied_ibids(splitted_citations)
+    # Find year
+    add_year_elements(splitted_citations)
+    # Look for books in misc field
+    look_for_undetected_books(splitted_citations, kbs)
     # Associate recids to the newly added ibids/books
     associate_recids_catchup(splitted_citations)
     # Remove references with only misc text
     # splitted_citations = remove_invalid_references(splitted_citations)
     # Merge references with only misc text
     # splitted_citations = merge_invalid_references(splitted_citations)
-    # Find year
-    add_year_elements(splitted_citations)
     # Remove duplicate authors
     remove_duplicated_authors(splitted_citations)
     # Remove duplicate DOIs
@@ -633,6 +689,16 @@ def parse_reference_line(ref_line, kbs, bad_titles_count={}):
     return splitted_citations, line_marker, counts, bad_titles_count
 
 
+def year_from_citation(citation):
+    citation_year = None
+
+    for el in citation:
+        if el['type'] == 'YEAR':
+            citation_year = el['year']
+            break
+
+    return citation_year
+
 
 def look_for_undetected_books(splitted_citations, kbs):
     for citation in splitted_citations:
@@ -643,43 +709,46 @@ def look_for_undetected_books(splitted_citations, kbs):
 def search_for_book_in_misc(citation, kbs):
     """Searches for books in the misc_txt field if the citation is not recognized as anything like a journal, book, etc.
     """
+    citation_year = year_from_citation(citation)
     for citation_element in citation:
-        if citation_element['type'] == 'MISC':
-            write_message('* Unknown citation found. Searching for book title in: %s' % citation_element['misc_txt'], verbose=9)
-            for title in kbs['books']:
-                startIndex = find_substring_ignore_special_chars(citation_element['misc_txt'], title)
-                if startIndex != -1:
-                    line = kbs['books'][title.upper()]
-                    book_year = line[2].strip(';')
-                    book_authors = line[0]
-                    book_found = False
-                    if citation_element['misc_txt'].find(book_year) != -1:
-                        # For now consider the citation as valid, we are using
-                        # an exact search, we don't need to check the authors
-                        # However, the code below will be useful if we decide
-                        # to introduce fuzzy matching.
-                        book_found = True
+        write_message('* Searching for book title in: %s' % citation_element['misc_txt'], verbose=9)
+        for title in kbs['books']:
+            startIndex = find_substring_ignore_special_chars(citation_element['misc_txt'], title)
+            if startIndex != -1:
+                line = kbs['books'][title.upper()]
+                book_year = line[2].strip(';')
+                book_authors = line[0]
+                book_found = False
+                if citation_year == book_year:
+                    # For now consider the citation as valid, we are using
+                    # an exact search, we don't need to check the authors
+                    # However, the code below will be useful if we decide
+                    # to introduce fuzzy matching.
+                    book_found = True
 
-                        for author in get_possible_author_names(citation):
-                            if find_substring_ignore_special_chars(book_authors, author) != -1:
-                                book_found = True
+                    for author in get_possible_author_names(citation):
+                        if find_substring_ignore_special_chars(book_authors, author) != -1:
+                            book_found = True
 
-                        for author in re.findall('[a-zA-Z]{4,}', book_authors):
-                            if find_substring_ignore_special_chars(citation_element['misc_txt'], author) != -1:
-                                book_found = True
+                    for author in re.findall('[a-zA-Z]{4,}', book_authors):
+                        if find_substring_ignore_special_chars(citation_element['misc_txt'], author) != -1:
+                            book_found = True
 
-                        if book_found is True:
-                            write_message('* Book found: %s' % title, verbose=9)
-                            book_element = {'type': 'BOOK',
-                                            'misc_txt': '',
-                                            'authors': book_authors,
-                                            'title': line[1],
-                                            'year': book_year}
-                            citation.append(book_element)
-                            citation_element['misc_txt'] = cut_substring_with_special_chars(citation_element['misc_txt'], title, startIndex)
-                            return True
+                    if book_found:
+                        write_message('* Book found: %s' % title, verbose=9)
+                        book_element = {'type': 'BOOK',
+                                        'misc_txt': '',
+                                        'authors': book_authors,
+                                        'title': line[1],
+                                        'year': book_year}
+                        citation.append(book_element)
+                        citation_element['misc_txt'] = cut_substring_with_special_chars(citation_element['misc_txt'], title, startIndex)
+                        # Remove year from misc txt
+                        citation_element['misc_txt'] = remove_year(citation_element['misc_txt'], book_year)
+                        return True
 
-            write_message('  * Book not found!', verbose=9)
+        write_message('  * Book not found!', verbose=9)
+
     return False
 
 def get_possible_author_names(citation):
@@ -691,11 +760,12 @@ def get_possible_author_names(citation):
 def find_substring_ignore_special_chars(s, substr):
     s = s.upper()
     substr = substr.upper()
-    clean_s, subs_in_s = re.subn('[^A-Z0-9]', '', s)
-    clean_substr, subs_in_substr = re.subn('[^A-Z0-9]', '', substr)
+    clean_s, dummy_subs_in_s = re.subn('[^A-Z0-9]', '', s)
+    clean_substr, dummy_subs_in_substr = re.subn('[^A-Z0-9]', '', substr)
     startIndex = clean_s.find(clean_substr)
     if startIndex != -1:
         i = 0
+        real_index = 0
         re_alphanum = re.compile('[A-Z0-9]')
         for real_index, char in enumerate(s):
             if re_alphanum.match(char):
@@ -720,7 +790,7 @@ def cut_substring_with_special_chars(s, sub, startIndex):
         #end of substrin reached?
         if subPosition >= len(clean_sub):
             #include everything till a space, open bracket or a normal character
-            counter += len(re.split('[ [{(a-zA-Z0-9]',s[startIndex+counter:],1)[0])
+            counter += len(re.split('[ [{(a-zA-Z0-9]', s[startIndex+counter:], 1)[0])
 
             return s[0:startIndex].strip()+ ' ' +s[startIndex+counter:].strip()
 
@@ -1150,8 +1220,8 @@ def parse_tagged_reference_line(line_marker,
         # Increment the stats counters:
         count_misc += 1
         identified_citation_element = {
-            'type'       : "MISC",
-            'misc_txt'   : "%s" % cur_misc_txt,
+            'type'    : "MISC",
+            'misc_txt': cur_misc_txt,
         }
         citation_elements.append(identified_citation_element)
 

--- a/modules/docextract/lib/refextract_find.py
+++ b/modules/docextract/lib/refextract_find.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -62,28 +62,33 @@ def find_reference_section(docbody):
     title_patterns = get_reference_section_title_patterns()
 
     # Try to find refs section title:
-    for reversed_index, line in enumerate(reversed(docbody)):
-        title_match = regex_match_list(line, title_patterns)
-        if title_match:
-            title = title_match.group('title')
-            index = len(docbody) - 1 - reversed_index
-            temp_ref_details, found_title = find_numeration(docbody[index:index+6], title)
-            if temp_ref_details:
-                if ref_details and 'title' in ref_details \
-                               and ref_details['title'] \
-                               and not temp_ref_details['title']:
-                    continue
-                if ref_details and 'marker' in ref_details \
-                               and ref_details['marker'] \
-                               and not temp_ref_details['marker']:
-                    continue
+    for title_pattern in title_patterns:
+        # Look for title pattern in docbody
+        for reversed_index, line in enumerate(reversed(docbody)):
+            title_match = title_pattern.match(line)
+            if title_match:
+                title = title_match.group('title')
+                index = len(docbody) - 1 - reversed_index
+                temp_ref_details, found_title = find_numeration(docbody[index:index+6], title)
+                if temp_ref_details:
+                    if ref_details and 'title' in ref_details \
+                                   and ref_details['title'] \
+                                   and not temp_ref_details['title']:
+                        continue
+                    if ref_details and 'marker' in ref_details \
+                                   and ref_details['marker'] \
+                                   and not temp_ref_details['marker']:
+                        continue
 
-                ref_details = temp_ref_details
-                ref_details['start_line'] = index
-                ref_details['title_string'] = title
+                    ref_details = temp_ref_details
+                    ref_details['start_line'] = index
+                    ref_details['title_string'] = title
 
-            if found_title:
-                break
+                if found_title:
+                    break
+
+        if ref_details:
+            break
 
     return ref_details
 
@@ -492,7 +497,7 @@ def get_reference_section_beginning(fulltext):
     if sect_start:
         write_message('* title %r' % sect_start['title_string'], verbose=3)
         write_message('* marker %r' % sect_start['marker'], verbose=3)
-        write_message('* title_marker_same_line %s' \
+        write_message('* title_marker_same_line %s'
             % sect_start['title_marker_same_line'], verbose=3)
     else:
         write_message('* could not find references section', verbose=3)

--- a/modules/docextract/lib/refextract_kbs.py
+++ b/modules/docextract/lib/refextract_kbs.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -306,7 +306,7 @@ def build_reportnum_kb(fpath):
             for classification in preprint_classifications:
                 search_pattern_str = ur'(?:^|[^a-zA-Z0-9\/\.\-])([\[\(]?(?P<categ>' \
                                      + classification[0].strip() + u')' \
-                                     + numeration_regexp + u'[\]\)]?)'
+                                     + numeration_regexp + ur'[\]\)]?)'
 
                 re_search_pattern = re.compile(search_pattern_str,
                                                  re.UNICODE)

--- a/modules/docextract/lib/refextract_re.py
+++ b/modules/docextract/lib/refextract_re.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -369,7 +369,7 @@ re_tagged_numeration_near_line_start = \
 
 re_ibid = re.compile(ur'(-|\b)?IBID(EM)?\.?', re.UNICODE)
 
-re_series_from_numeration = re.compile(ur'^([A-Z])\s*[,\s:-]?\s*\d+', re.UNICODE)
+re_series_from_numeration = re.compile(ur'^([A-Za-z])\s*[,\s:-]?\s*\d+', re.UNICODE)
 re_series_from_numeration_after_volume = re.compile(ur'^\d+\s*[,\s:-]?\s*([A-Z])', re.UNICODE)
 
 # Obtain the series character from the standardised title text
@@ -637,6 +637,11 @@ re_doi = (re.compile(ur"""
     [\w\-_:;\(\)/<>])                       # any character excluding a full stop
     """, re.VERBOSE))
 
+## Pattern used to locate HDL (handle identifiers)
+re_hdl = re.compile(ur"""([hH][dD][lL]:
+                          |https?://hdl\.handle\.net/)
+                         (?P<hdl_id>\S+/\S+)""", re.UNICODE|re.VERBOSE)
+
 
 def _create_regex_pattern_add_optional_spaces_to_word_characters(word):
     """Add the regex special characters (\s*) to allow optional spaces between
@@ -661,26 +666,26 @@ def get_reference_section_title_patterns():
     """
     patterns = []
     titles = [u'references',
-              u'references.',
               u'r\u00C9f\u00E9rences',
               u'r\u00C9f\u00C9rences',
-              u'reference',
-              u'refs',
-              u'r\u00E9f\u00E9rence',
-              u'r\u00C9f\u00C9rence',
               u'r\xb4ef\xb4erences',
-              u'r\u00E9fs',
-              u'r\u00C9fs',
               u'bibliography',
               u'bibliographie',
+              u'literaturverzeichnis',
               u'citations',
-              u'literaturverzeichnis']
+              u'refs',
+              u'publications'
+              u'r\u00E9fs',
+              u'r\u00C9fs',
+              u'reference',
+              u'r\u00E9f\u00E9rence',
+              u'r\u00C9f\u00C9rence']
     sect_marker = u'^\s*([\[\-\{\(])?\s*' \
                   u'((\w|\d){1,5}([\.\-\,](\w|\d){1,5})?\s*' \
                   u'[\.\-\}\)\]]\s*)?' \
                   u'(?P<title>'
     sect_marker1 = u'^(\d){1,3}\s*(?P<title>'
-    line_end = ur'(\s*s\s*e\s*c\s*t\s*i\s*o\s*n\s*)?)([\)\}\]])?' \
+    line_end = ur'(\s*s\s*e\s*c\s*t\s*i\s*o\s*n\s*)?)\.?([\)\}\]])?' \
         ur'($|\s*[\[\{\(\<]\s*[1a-z]\s*[\}\)\>\]]|\:$)'
 
     for t in titles:
@@ -851,3 +856,17 @@ re_arxiv_notation = re.compile(ur"""
 # et. al. before J. /// means J is a journal
 
 re_num = re.compile(ur'(\d+)')
+
+
+re_year_in_misc_txt = re.compile(ur"(?:^|(?<!\d))(?:19|20)\d{2}(?:(?!\d)|$)")
+
+
+def remove_year(s, year=None):
+    if year:
+        year_pattern = re.escape(year)
+    else:
+        year_pattern = ur"(?:19|20)\d{2}"
+    s = re.sub(ur'\[\s*%s\s*\]' % year_pattern, '', s)
+    s = re.sub(ur'\(\s*%s\s*\)' % year_pattern, '', s)
+    s = re.sub(ur'\s*%s\s*' % year_pattern, '', s)
+    return s

--- a/modules/docextract/lib/refextract_record.py
+++ b/modules/docextract/lib/refextract_record.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2013 CERN.
+## Copyright (C) 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -106,14 +106,14 @@ def build_references(citations):
 
     Transform the reference elements into marc xml
     """
-        # Now, run the method which will take as input:
-        # 1. A list of lists of dictionaries, where each dictionary is a piece
-        # of citation information corresponding to a tag in the citation.
-        # 2. The line marker for this entire citation line (mulitple citation
-        # 'finds' inside a single citation will use the same marker value)
-        # The resulting xml line will be a properly marked up form of the
-        # citation. It will take into account authors to try and split up
-        # references which should be read as two SEPARATE ones.
+    # Now, run the method which will take as input:
+    # 1. A list of lists of dictionaries, where each dictionary is a piece
+    # of citation information corresponding to a tag in the citation.
+    # 2. The line marker for this entire citation line (mulitple citation
+    # 'finds' inside a single citation will use the same marker value)
+    # The resulting xml line will be a properly marked up form of the
+    # citation. It will take into account authors to try and split up
+    # references which should be read as two SEPARATE ones.
     return [c for citation_elements in citations
               for elements in citation_elements['elements']
               for c in build_reference_fields(elements,
@@ -155,15 +155,15 @@ def build_reference_fields(citation_elements, line_marker, inspire_format=None):
     if inspire_format is None:
         inspire_format = CFG_INSPIRE_SITE
 
-    ## Begin the datafield element
+    # Begin the datafield element
     current_field = create_reference_field(line_marker)
 
     reference_fields = [current_field]
 
     for element in citation_elements:
-        ## Before going onto checking 'what' the next element is, handle misc text and semi-colons
-        ## Multiple misc text subfields will be compressed later
-        ## This will also be the only part of the code that deals with MISC tag_typed elements
+        # Before going onto checking 'what' the next element is, handle misc text and semi-colons
+        # Multiple misc text subfields will be compressed later
+        # This will also be the only part of the code that deals with MISC tag_typed elements
         misc_txt = element['misc_txt']
         if misc_txt.strip("., [](){}"):
             misc_txt = misc_txt.lstrip('])} ,.').rstrip('[({ ,.')
@@ -190,7 +190,10 @@ def build_reference_fields(citation_elements, line_marker, inspire_format=None):
 
         # DOI
         elif element['type'] == "DOI":
-            add_subfield(current_field, 'doi', element['doi_string'])
+            add_subfield(current_field, 'doi', 'doi:' + element['doi_string'])
+        # HDL
+        elif element['type'] == "HDL":
+            add_subfield(current_field, 'hdl', 'hdl:' + element['hdl_id'])
 
         # AUTHOR
         elif element['type'] == "AUTH":

--- a/modules/docextract/lib/refextract_regression_tests.py
+++ b/modules/docextract/lib/refextract_regression_tests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2010, 2011, 2013 CERN.
+## Copyright (C) 2010, 2011, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -25,12 +25,15 @@ They are intended to make sure there is no regression in references parsing.
 """
 
 from invenio.testutils import InvenioTestCase
-import re
+from mock import patch
 
+from invenio import bibupload
+from invenio.search_engine_utils import get_fieldvalues
 from invenio.testutils import make_test_suite, run_test_suite, InvenioXmlTestCase
 from invenio.refextract_engine import parse_references
 from invenio.docextract_utils import setup_loggers
 from invenio.refextract_text import wash_and_repair_reference_line
+from invenio.config import CFG_ETCDIR
 from invenio import refextract_kbs
 from invenio import refextract_record
 
@@ -165,12 +168,32 @@ class RefextractInvenioTest(InvenioXmlTestCase):
         _reference_test(self, ref_line, u"""<record>
    <datafield ind1="C" ind2="5" tag="999">
        <subfield code="o">1</subfield>
-       <subfield code="t">Electrical breakdown in gases</subfield>
        <subfield code="y">1973</subfield>
+       <subfield code="t">Electrical breakdown in gases</subfield>
        <subfield code="0">34</subfield>
    </datafield>
 </record>
 """)
+
+    def test_ligo_report_number(self):
+        """Checks that LIGO report numbers are recognized"""
+        ref_line = u"""[2] LIGO-T950132-00-R; LIGO-T940063-00-R; LIGO-T060303-00-D"""
+        _reference_test(self, ref_line, u"""<record>
+   <datafield ind1="C" ind2="5" tag="999">
+       <subfield code="o">2</subfield>
+       <subfield code="r">LIGO-T950132-00-R</subfield>
+   </datafield>
+   <datafield ind1="C" ind2="5" tag="999">
+       <subfield code="o">2</subfield>
+       <subfield code="r">LIGO-T940063-00-R</subfield>
+   </datafield>
+   <datafield ind1="C" ind2="5" tag="999">
+       <subfield code="o">2</subfield>
+       <subfield code="r">LIGO-T060303-00-D</subfield>
+   </datafield>
+</record>
+""")
+
 
 class RefextractTest(InvenioXmlTestCase):
     """Testing output of refextract"""
@@ -181,7 +204,8 @@ class RefextractTest(InvenioXmlTestCase):
 
         self.inspire = True
         self.kb_books = [
-            ('Griffiths, David', 'Introduction to elementary particles', '2008')
+            ('Griffiths, David', 'Introduction to elementary particles', '2008'),
+            ('Kosyakov, B.P.', 'Introduction to the classical theory of particles and fields', '2007'),
         ]
         self.kb_journals = [
             ("PHYSICAL REVIEW SPECIAL TOPICS ACCELERATORS AND BEAMS", "Phys.Rev.ST Accel.Beams"),
@@ -435,8 +459,42 @@ class RefextractTest(InvenioXmlTestCase):
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">10</subfield>
       <subfield code="h">R. Penrose and W. Rindler</subfield>
+      <subfield code="y">1986</subfield>
    </datafield>
 </record>""")
+
+    def test_book2(self):
+        """book with authors and title and year
+
+        This book was not detected, this tests makes sure the bug does not
+        appear again."""
+        ref_line = u"""[6] B. P. Kosyakov, Introduction to the classical theory of particles and fields, (Springer Verlag, 2007)."""
+        _reference_test(self, ref_line, u"""<record>
+   <datafield tag="999" ind1="C" ind2="5">
+      <subfield code="o">6</subfield>
+      <subfield code="h">B. P. Kosyakov</subfield>
+      <subfield code="p">Springer</subfield>
+      <subfield code="y">2007</subfield>
+      <subfield code="t">Introduction to the classical theory of particles and fields</subfield>
+   </datafield>
+</record>""")
+
+    def test_book_year_removed(self):
+        """check that the year is removed from the misc field
+
+        This book was not detected, this tests makes sure the bug does not
+        appear again."""
+        ref_line = u"""[6] B. P. Kosyakov, Introduction to the classical theory of particles and fields, (Springer Verlag, 2007)."""
+        _reference_test(self, ref_line, u"""<record>
+   <datafield tag="999" ind1="C" ind2="5">
+      <subfield code="o">6</subfield>
+      <subfield code="h">B. P. Kosyakov</subfield>
+      <subfield code="p">Springer</subfield>
+      <subfield code="m">Verlag,)</subfield>
+      <subfield code="y">2007</subfield>
+      <subfield code="t">Introduction to the classical theory of particles and fields</subfield>
+   </datafield>
+</record>""", ignore_misc=False)
 
     def test_hep_combined(self):
         ref_line = u"""[11] R. Britto-Pacumio, A. Strominger and A. Volovich, JHEP 9911:013 (1999); hep-th/9905210; blah hep-th/9905211; blah hep-ph/9711200"""
@@ -575,6 +633,7 @@ class RefextractTest(InvenioXmlTestCase):
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">20</subfield>
       <subfield code="h">M. Duff, B. Nilsson and C. Pope</subfield>
+      <subfield code="y">1986</subfield>
    </datafield>
 </record>""")
 
@@ -636,6 +695,7 @@ class RefextractTest(InvenioXmlTestCase):
       <subfield code="o">25</subfield>
       <subfield code="h">C. Fefferman and C. Graham</subfield>
       <subfield code="t">Conformal Invariants</subfield>
+      <subfield code="y">1985</subfield>
    </datafield>
 </record>""")
 
@@ -1071,6 +1131,7 @@ class RefextractTest(InvenioXmlTestCase):
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">46</subfield>
       <subfield code="h">E. Schrodinger</subfield>
+      <subfield code="y">1931</subfield>
    </datafield>
 </record>""")
 
@@ -1097,7 +1158,7 @@ class RefextractTest(InvenioXmlTestCase):
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">48</subfield>
       <subfield code="h">O.O. Vaneeva, R.O. Popovych and C. Sophocleous</subfield>
-      <subfield code="a">10.1007/s10440-008-9280-9</subfield>
+      <subfield code="a">doi:10.1007/s10440-008-9280-9</subfield>
       <subfield code="r">arXiv:0708.3457</subfield>
    </datafield>
 </record>""")
@@ -1107,7 +1168,7 @@ class RefextractTest(InvenioXmlTestCase):
         _reference_test(self, ref_line, u"""<record>
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">1</subfield>
-      <subfield code="a">10.1175/1520-0442(2000)013&lt;2671:TAORTT&gt;2.0.CO;2</subfield>
+      <subfield code="a">doi:10.1175/1520-0442(2000)013&lt;2671:TAORTT&gt;2.0.CO;2</subfield>
    </datafield>
 </record>""")
 
@@ -1117,7 +1178,8 @@ class RefextractTest(InvenioXmlTestCase):
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">49</subfield>
       <subfield code="h">M. I. Trofimov, N. De Filippis and E. A. Smolenskii</subfield>
-      <subfield code="a">10.1007/s11172-006-0105-6</subfield>
+      <subfield code="a">doi:10.1007/s11172-006-0105-6</subfield>
+      <subfield code="y">2005</subfield>
    </datafield>
 </record>""")
 
@@ -1128,10 +1190,12 @@ class RefextractTest(InvenioXmlTestCase):
       <subfield code="o">50</subfield>
       <subfield code="h">M. Gell-Mann, P. Ramon ans R. Slansky</subfield>
       <subfield code="p">North-Holland</subfield>
+      <subfield code="y">1979</subfield>
    </datafield>
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">50</subfield>
       <subfield code="h">T. Yanagida</subfield>
+      <subfield code="y">1979</subfield>
    </datafield>
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">50</subfield>
@@ -1178,6 +1242,7 @@ class RefextractTest(InvenioXmlTestCase):
       <subfield code="h">Hush, D.R., R.Leighton, and B.G. Horne</subfield>
       <subfield code="t">Progress in supervised Neural Netw. What's new since Lippmann?</subfield>
       <subfield code="p">IEEE</subfield>
+      <subfield code="y">1993</subfield>
    </datafield>
 </record>""")
 
@@ -1301,6 +1366,7 @@ class RefextractTest(InvenioXmlTestCase):
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">63</subfield>
       <subfield code="h">Z. Guzik and R. Jacobsson</subfield>
+      <subfield code="y">2005</subfield>
    </datafield>
 </record>""")
 
@@ -1540,6 +1606,7 @@ Rev. D 80 034030 1-25"""
       <subfield code="c">ATLAS Collaboration</subfield>
       <subfield code="u">http://cdsweb.cern.ch/record/1266235/files/ATLAS-COM-CONF-2010-031.pdf</subfield>
       <subfield code="r">ATLAS-CONF-2010-031</subfield>
+      <subfield code="y">2010</subfield>
    </datafield>
 </record>""")
 
@@ -1619,6 +1686,7 @@ Rev. D 80 034030 1-25"""
       <subfield code="h">S. Calatroni, H. Neupert, and M. Taborelli</subfield>
       <subfield code="t">Fatigue testing of materials by UV pulsed laser irradiation</subfield>
       <subfield code="r">CERN-CLIC-Note-615</subfield>
+      <subfield code="y">2004</subfield>
    </datafield>
 </record>""")
 
@@ -1630,6 +1698,7 @@ Rev. D 80 034030 1-25"""
       <subfield code="h">H. Braun, R. Corsini, J. P. Delahaye, A. de Roeck, S. Dbert, A. Ferrari, G. Geschonke, A. Grudiev, C. Hauviller, B. Jeanneret, E. Jensen, T. Lefvre, Y. Papaphilippou, G. Riddone, L. Rinolfi, W. D. Schlatter, H. Schmickler, D. Schulte, I. Syratchev, M. Taborelli, F. Tecker, R. Toms, S. Weisz, and W. Wuensch</subfield>
       <subfield code="t">CLIC 2008 parameters</subfield>
       <subfield code="r">CERN-CLIC-Note-764</subfield>
+      <subfield code="y">2008</subfield>
    </datafield>
 </record>""")
 
@@ -1688,6 +1757,7 @@ Rev. D 80 034030 1-25"""
       <subfield code="o">5</subfield>
       <subfield code="h">I. J. Aitchison and A. J. Hey</subfield>
       <subfield code="p">CRC Pr.</subfield>
+      <subfield code="y">2003</subfield>
    </datafield>
 </record>""")
 
@@ -1698,6 +1768,7 @@ Rev. D 80 034030 1-25"""
       <subfield code="o">48</subfield>
       <subfield code="h">D. Adams, S. Asai, D. Cavalli, M. D\xfchrssen, K. Edmonds, S. Elles, M. Fehling, U. Felzmann, L. Gladilin, L. Helary, M. Hohlfeld, S. Horvat, K. Jakobs, M. Kaneda, G. Kirsch, S. Kuehn, J. F. Marchand, C. Pizio, X. Portell, D. Rebuzzi, E. Schmidt, A. Shibata, I. Vivarelli, S. Winkelmann, and S. Yamamoto</subfield>
       <subfield code="r">ATL-PHYS-INT-2009-110</subfield>
+      <subfield code="y">2009</subfield>
    </datafield>
 </record>""")
 
@@ -1769,6 +1840,7 @@ Rev. D 80 034030 1-25"""
       <subfield code="o">15</subfield>
       <subfield code="h">(E. Berger (eds.))</subfield>
       <subfield code="p">World Scientific</subfield>
+      <subfield code="y">1992</subfield>
    </datafield>
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">15</subfield>
@@ -1803,7 +1875,8 @@ Rev. D 80 034030 1-25"""
    </datafield>
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">15</subfield>
-      <subfield code="m">Proceedings of the 1990 Summer Study on High Energy Physics</subfield>
+      <subfield code="m">Proceedings of theSummer Study on High Energy Physics</subfield>
+      <subfield code="y">1990</subfield>
    </datafield>
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">15</subfield>
@@ -1886,13 +1959,15 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
       <subfield code="o">39</subfield>
       <subfield code="h">M. Sisti</subfield>
       <subfield code="c">CUORE Collaboration</subfield>
-      <subfield code="m">J. Phys. Conf. Ser. 203 (2010)012069</subfield>
+      <subfield code="m">J. Phys. Conf. Ser. 203 012069</subfield>
+      <subfield code="y">2010</subfield>
    </datafield>
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">39</subfield>
       <subfield code="h">F. Bellini, C. Bucci, S. Capelli, O. Cremonesi, L. Gironi, M. Martinez, M. Pavanand C. Tomei et al.</subfield>
-      <subfield code="m">Astropart. Phys. 33 (2010) 169</subfield>
+      <subfield code="m">Astropart. Phys. 33  169</subfield>
       <subfield code="r">arXiv:0912.0452 [physics.ins-det]</subfield>
+      <subfield code="y">2010</subfield>
    </datafield>
 </record>""", ignore_misc=False)
 
@@ -1987,6 +2062,7 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
       <subfield code="o">20</subfield>
       <subfield code="h">G. Duckeck</subfield>
       <subfield code="t">ATLAS computing: Technical design report</subfield>
+      <subfield code="y">1988</subfield>
    </datafield>
 </record>""")
 
@@ -1997,6 +2073,7 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
       <subfield code="o">22</subfield>
       <subfield code="h">B. Crowell</subfield>
       <subfield code="i">0-9704670-3-6</subfield>
+      <subfield code="y">2009</subfield>
    </datafield>
 </record>""")
 
@@ -2008,6 +2085,7 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
       <subfield code="h">D. E. Gray</subfield>
       <subfield code="p">McGraw-Hill</subfield>
       <subfield code="i">9780070014855</subfield>
+      <subfield code="y">1972</subfield>
    </datafield>
 </record>""")
 
@@ -2171,7 +2249,6 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
    </datafield>
 </record>""")
 
-
     def test_complex_author(self):
         ref_line = u"""[39] Michael E. Peskin, Michael E. Peskin and Michael E. Peskin “An Introduction To Quantum Field Theory,” Westview Press, 1995."""
         _reference_test(self, ref_line, u"""<record>
@@ -2179,6 +2256,7 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
       <subfield code="o">39</subfield>
       <subfield code="h">Michael E. Peskin, Michael E. Peskin and Michael E. Peskin</subfield>
       <subfield code="t">An Introduction To Quantum Field Theory</subfield>
+      <subfield code="y">1995</subfield>
    </datafield>
 </record>""")
 
@@ -2189,6 +2267,7 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
       <subfield code="o">39</subfield>
       <subfield code="h">Dan V. Schroeder, Dan V. Schroeder and Dan V. Schroeder</subfield>
       <subfield code="t">An Introduction To Quantum Field Theory</subfield>
+      <subfield code="y">1995</subfield>
    </datafield>
 </record>""")
 
@@ -2199,6 +2278,7 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
       <subfield code="o">39</subfield>
       <subfield code="h">Michael E. Peskin and Dan V. Schroeder</subfield>
       <subfield code="t">An Introduction To Quantum Field Theory</subfield>
+      <subfield code="y">1995</subfield>
    </datafield>
 </record>""")
 
@@ -2369,6 +2449,7 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
       <subfield code="o">12</subfield>
       <subfield code="h">C. T. Hill and E. H. Simmons</subfield>
       <subfield code="r">hep-ph/0203079</subfield>
+      <subfield code="y">2003</subfield>
    </datafield>
 </record>""")
 
@@ -2421,6 +2502,24 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
    </datafield>
 </record>""")
 
+    def test_dash_dash_report_number(self):
+        ref_line = u"""[6] ATL--PHYS-INT-2009-110"""
+        _reference_test(self, ref_line, u"""<record>
+   <datafield tag="999" ind1="C" ind2="5">
+      <subfield code="o">6</subfield>
+      <subfield code="r">ATL-PHYS-INT-2009-110</subfield>
+   </datafield>
+</record>""")
+
+    def test_dash_dash_num_report_number(self):
+        ref_line = u"""[6] ATL-PHYS-INT-2009--110"""
+        _reference_test(self, ref_line, u"""<record>
+   <datafield tag="999" ind1="C" ind2="5">
+      <subfield code="o">6</subfield>
+      <subfield code="r">ATL-PHYS-INT-2009-110</subfield>
+   </datafield>
+</record>""")
+
     def test_only_journal(self):
         ref_line = u"""[6] Phys. Rev.D, 41 (1990) 83"""
         _reference_test(self, ref_line, u"""<record>
@@ -2436,7 +2535,7 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
         _reference_test(self, ref_line, u"""<record>
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">6</subfield>
-      <subfield code="a">10.1007/s10440-008-9280-9</subfield>
+      <subfield code="a">doi:10.1007/s10440-008-9280-9</subfield>
    </datafield>
 </record>""")
 
@@ -2452,6 +2551,7 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
       <subfield code="o">1</subfield>
       <subfield code="h">D. Adams, S. Asai, D. Cavalli, K. Edmonds</subfield>
       <subfield code="r">ATL-PHYS-INT-2009-110</subfield>
+      <subfield code="y">2009</subfield>
    </datafield>
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">2</subfield>
@@ -2512,6 +2612,7 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
       <subfield code="o">21</subfield>
       <subfield code="h">R. Barlow</subfield>
       <subfield code="r">physics/0401042</subfield>
+      <subfield code="y">2003</subfield>
    </datafield>
 </record>""")
 
@@ -2705,7 +2806,8 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">44</subfield>
       <subfield code="h">R. Baier et al.</subfield>
-      <subfield code="m">Invalid. Hello. Lett. B 345 (1995)</subfield>
+      <subfield code="m">Invalid. Hello. Lett. B 345</subfield>
+      <subfield code="y">1995</subfield>
    </datafield>
 </record>""", ignore_misc=False)
 
@@ -2759,6 +2861,7 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
         _reference_test(self, ref_line, u"""<record>
    <datafield tag="999" ind1="C" ind2="5">
       <subfield code="o">14</subfield>
+      <subfield code="y">2012</subfield>
    </datafield>
 </record>""")
 
@@ -2789,6 +2892,7 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
       <subfield code="o">35</subfield>
       <subfield code="h">G. I. Egri, Z. Fodor, C. Hoelbling, S. D. Katz, D. N\xf3gr\xe1di, et al.</subfield>
       <subfield code="r">hep-lat/0611022</subfield>
+      <subfield code="y">2007</subfield>
    </datafield>
 </record>""")
 
@@ -2822,7 +2926,7 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
         _reference_test(self, ref_line, u"""<record>
    <datafield ind1="C" ind2="5" tag="999">
        <subfield code="o">1</subfield>
-       <subfield code="a">10.1007/s10440-008-9280-9</subfield>
+       <subfield code="a">doi:10.1007/s10440-008-9280-9</subfield>
    </datafield>
 </record>""")
 
@@ -2873,14 +2977,107 @@ and C. Tomei et al., Astropart. Phys. 33 (2010) 169 [arXiv:0912.0452 [physics.in
    </datafield>
 </record>""")
 
+    def test_hdl_url(self):
+        """Checks hdl url recognition"""
+        ref_line = u"""[2] http://hdl.handle.net/1201/99999 """
+        _reference_test(self, ref_line, u"""<record>
+   <datafield ind1="C" ind2="5" tag="999">
+       <subfield code="o">2</subfield>
+       <subfield code="a">hdl:1201/99999</subfield>
+   </datafield>
+</record>""")
+
+    def test_hdl(self):
+        """Checks hdl recognition"""
+        ref_line = u"""[2] before hdl:1201/99999 after"""
+        _reference_test(self, ref_line, u"""<record>
+   <datafield ind1="C" ind2="5" tag="999">
+       <subfield code="o">2</subfield>
+       <subfield code="a">hdl:1201/99999</subfield>
+   </datafield>
+</record>""")
+
+    def test_journal_lowercase(self):
+        """Checks journal with lower case volume letter"""
+        ref_line = u"""[2] phys.rev. d90 064027"""
+        _reference_test(self, ref_line, u"""<record>
+   <datafield ind1="C" ind2="5" tag="999">
+       <subfield code="o">2</subfield>
+       <subfield code="s">Phys.Rev.,D90,064027</subfield>
+   </datafield>
+</record>""")
+
 
 class TaskTest(InvenioTestCase):
     def setUp(self):
         setup_loggers(verbosity=0)
+        self.recid = 20
 
     def test_task_run_core(self):
         from invenio.refextract_task import task_run_core
         task_run_core(1, [])
+
+    def test_overwrite(self):
+        from invenio.refextract_task import extract_one, NotSafeForExtraction
+        def mocked_look_for_fulltext(recid):
+            return "%s/docextract/example.pdf" % CFG_ETCDIR
+        with patch('invenio.refextract_api.look_for_fulltext', mocked_look_for_fulltext):
+            results = []
+            try:
+                extract_one(self.recid, results)
+            except NotSafeForExtraction:
+                pass
+            else:
+                self.assertEqual(len(results), 1)
+                self.assertTrue(results[0]['999C5'])
+
+
+class TaskRecordWithRefsTest(InvenioTestCase):
+    def setUp(self):
+        """Setup record needed for tests
+
+        We setup the record with id=self.recid to have a single dummy
+        reference."""
+        setup_loggers(verbosity=0)
+        self.recid = 20
+        self.bibupload_xml = """<record>
+            <controlfield tag="001">%s</controlfield>
+            <datafield tag="999" ind1="C" ind2="5">
+                <subfield code="m">This is a dummy reference</subfield>
+            </datafield>
+        </record>""" % self.recid
+        recs = bibupload.xml_marc_to_records(self.bibupload_xml)
+        status, dummy, err = bibupload.bibupload(recs[0], opt_mode='correct')
+        assert status == 0, err.strip()
+        assert len(get_fieldvalues(self.recid, '999C5m')) == 1
+
+    def tearDown(self):
+        """Helper function that restores self.recid MARCXML"""
+        recs = bibupload.xml_marc_to_records(self.bibupload_xml)
+        bibupload.bibupload(recs[0], opt_mode='delete')
+
+    def test_no_overwrite(self):
+        from invenio.refextract_task import extract_one, NotSafeForExtraction
+        try:
+            extract_one(self.recid, [])
+        except NotSafeForExtraction:
+            pass
+        else:
+            self.fail()
+
+    def test_overwrite(self):
+        from invenio.refextract_task import extract_one, NotSafeForExtraction
+        def mocked_look_for_fulltext(recid):
+            return "%s/docextract/example.pdf" % CFG_ETCDIR
+        with patch('invenio.refextract_api.look_for_fulltext', mocked_look_for_fulltext):
+            results = []
+            try:
+                extract_one(self.recid, results, overwrite=True)
+            except NotSafeForExtraction:
+                pass
+            else:
+                self.assertEqual(len(results), 1)
+                self.assertTrue(results[0]['999C5'])
 
 TEST_SUITE = make_test_suite(RefextractTest)
 if __name__ == '__main__':

--- a/modules/docextract/lib/refextract_tag.py
+++ b/modules/docextract/lib/refextract_tag.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -545,7 +545,7 @@ def extract_series_from_volume(volume):
     for p in patterns:
         match = p.search(volume)
         if match:
-            return match.group(1)
+            return match.group(1).upper()
     return None
 
 

--- a/modules/docextract/lib/refextract_task.py
+++ b/modules/docextract/lib/refextract_task.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2011 CERN.
+## Copyright (C) 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -29,7 +29,7 @@ from datetime import datetime, timedelta
 from tempfile import mkstemp
 
 from invenio.bibtask import task_init, task_set_option, \
-                            task_get_option, write_message
+                            task_get_option
 from invenio.config import CFG_VERSION, \
                            CFG_SITE_SECURE_URL, \
                            CFG_REFEXTRACT_TICKET_QUEUE, \
@@ -41,17 +41,22 @@ from invenio.search_engine import perform_request_search
 from invenio.refextract_cli import HELP_MESSAGE, DESCRIPTION
 from invenio.refextract_api import extract_references_from_record, \
                                    FullTextNotAvailable, \
-                                   check_record_for_refextract
+                                   record_can_extract_refs, \
+                                   record_can_overwrite_refs
 from invenio.refextract_config import CFG_REFEXTRACT_FILENAME
 from invenio.bibtask import task_low_level_submission
 from invenio.docextract_task import task_run_core_wrapper, \
                                     split_ids
-from invenio.docextract_utils import setup_loggers
+from invenio.docextract_utils import setup_loggers, write_message
 from invenio.docextract_record import print_records
 from invenio.bibedit_utils import get_bibrecord
 from invenio.bibrecord import record_get_field_instances, \
                               field_get_subfield_values
 from invenio.bibcatalog import BIBCATALOG_SYSTEM
+
+
+class NotSafeForExtraction(Exception):
+    pass
 
 
 def check_options():
@@ -60,10 +65,8 @@ def check_options():
     values. It must return False if there are errors in the options.
     """
     if not task_get_option('new') \
-            and not task_get_option('modified') \
             and not task_get_option('recids') \
-            and not task_get_option('collections') \
-            and not task_get_option('arxiv'):
+            and not task_get_option('collections'):
         print >>sys.stderr, 'Error: No records specified, you need' \
             ' to specify which files to run on'
         return False
@@ -81,31 +84,18 @@ def cb_parse_option(key, value, opts, args):
     if key in ('-a', '--new'):
         task_set_option('new', True)
         task_set_option('no-overwrite', True)
-    elif key in ('-m', '--modified'):
-        task_set_option('modified', True)
-        task_set_option('no-overwrite', True)
     elif key == '--inspire':
         msg = """The --inspire option does not exist anymore.
 Please set the config variable CFG_INSPIRE_SITE instead."""
         raise StandardError(msg)
-    elif key in ('--kb-reports', ):
-        task_set_option('kb-reports', value)
-    elif key in ('--kb-journals', ):
-        task_set_option('kb-journals', value)
-    elif key in ('--kb-journals-re', ):
-        task_set_option('kb-journals-re', value)
-    elif key in ('--kb-authors', ):
-        task_set_option('kb-authors', value)
-    elif key in ('--kb-books', ):
-        task_set_option('kb-books', value)
-    elif key in ('--kb-conferences', ):
-        task_set_option('kb-conferences', value)
     elif key in ('--create-ticket', ):
         task_set_option('create-ticket', True)
     elif key in ('--no-overwrite', ):
-        task_set_option('no-overwrite', True)
-    elif key in ('--arxiv'):
-        task_set_option('arxiv', True)
+        msg = """The --no-overwrite option does not exist anymore.
+This option is set by default. Please use --overwrite to overwrite references."""
+        raise StandardError(msg)
+    elif key in ('--overwrite', ):
+        task_set_option('overwrite', True)
     elif key in ('-c', '--collections'):
         collections = task_get_option('collections')
         if not collections:
@@ -164,9 +154,9 @@ def _create_ticket(recid, bibcatalog_system, queue):
                     write_message("arXiv paper", verbose=1)
                     return
 
-        # Only create tickets for HEP
+        # Only create tickets for CORE papers
         if not in_core:
-            write_message("not in hep", verbose=1)
+            write_message("not in core papers", verbose=1)
             return
 
         # Do not create tickets for old records
@@ -176,12 +166,6 @@ def _create_ticket(recid, bibcatalog_system, queue):
             return
 
         for report_tag in record_get_field_instances(record, "037"):
-            for category in field_get_subfield_values(report_tag, 'c'):
-                if category.startswith('astro-ph'):
-                    write_message("astro-ph", verbose=1)
-                    # We do not curate astro-ph
-                    return
-
             for report_number in field_get_subfield_values(report_tag, 'a'):
                 subject += " " + report_number
                 break
@@ -194,33 +178,39 @@ def _create_ticket(recid, bibcatalog_system, queue):
                                     recordid=recid)
 
 
-def task_run_core(recid, records, bibcatalog_system=None, _arxiv=False):
+def task_run_core(recid, records, bibcatalog_system=None):
     setup_loggers(None, use_bibtask=True)
-
-    if _arxiv:
-        overwrite = True
-    else:
-        overwrite = not task_get_option('no-overwrite')
-
     try:
-        record = extract_references_from_record(recid)
-        msg = "Extracted references for %s" % recid
-        safe_to_extract = True
-        if overwrite:
-            write_message("%s (overwrite)" % msg)
-        else:
-            write_message(msg)
-            if not check_record_for_refextract(recid):
-                write_message('Record not safe for re-extraction, skipping')
-                safe_to_extract = False
-
-        if safe_to_extract:
-            records.append(record)
-            # Create a RT ticket if necessary
-            if task_get_option('new') or task_get_option('create-ticket'):
-                create_ticket(recid, bibcatalog_system)
+        extract_one(recid=recid,
+                    records=records,
+                    overwrite=task_get_option('overwrite'),
+                    create_a_ticket=task_get_option('new') or task_get_option('create-ticket'),
+                    bibcatalog_system=bibcatalog_system)
     except FullTextNotAvailable:
         write_message("No full text available for %s" % recid)
+    except NotSafeForExtraction:
+        write_message('Record not safe for re-extraction, skipping')
+
+
+def extract_one(recid, records, overwrite=False, bibcatalog_system=None,
+                create_a_ticket=False):
+    msg = "Extracting references for %s" % recid
+    if overwrite:
+        write_message("%s (overwrite)" % msg)
+        safe_to_extract = record_can_overwrite_refs(recid)
+    else:
+        write_message(msg)
+        safe_to_extract = record_can_extract_refs(recid)
+
+    if safe_to_extract:
+        record = extract_references_from_record(recid)
+        records.append(record)
+        # Create a RT ticket if necessary
+        if create_a_ticket:
+            create_ticket(recid, bibcatalog_system)
+    else:
+        raise NotSafeForExtraction()
+
 
 
 def cb_submit_bibupload(bibcatalog_system=None, records=None):
@@ -230,9 +220,8 @@ def cb_submit_bibupload(bibcatalog_system=None, records=None):
         # Save new record to file
         temp_fd, temp_path = mkstemp(prefix=CFG_REFEXTRACT_FILENAME,
                                      dir=CFG_TMPSHAREDDIR)
-        temp_file = os.fdopen(temp_fd, 'w')
-        temp_file.write(references_xml)
-        temp_file.close()
+        with os.fdopen(temp_fd, 'w') as temp_file:
+            temp_file.write(references_xml)
 
         # Update record
         task_low_level_submission('bibupload', 'refextract', '-c', temp_path)
@@ -249,44 +238,36 @@ def main():
         help_specific_usage=HELP_MESSAGE + """
 
   Scheduled (daemon) options:
-  -a, --new          Run on all newly inserted records.
-  -m, --modified     Run on all newly modified records.
-  -r, --recids       Record id for extraction.
+  -a, --new          Run on all newly inserted pdfs.
+  -i, --id           Record id for extraction.
   -c, --collections  Entire Collection for extraction.
-  --arxiv            All arxiv modified records within last week
 
   Special (daemon) options:
   --create-ticket    Create a RT ticket for record references
 
   Examples:
    (run a daemon job)
-      refextract -a
+      refextract --new
    (run on a set of records)
-      refextract --recids 1,2 -r 3
+      refextract --id 1,2 -i 3
    (run on a collection)
       refextract --collections "Reports"
    (run as standalone)
-      refextract -o /home/chayward/refs.xml /home/chayward/thesis.pdf
+      docextract -o /home/chayward/refs.xml /home/chayward/thesis.pdf
 
 """,
         version="Invenio v%s" % CFG_VERSION,
-        specific_params=("hVv:x:r:c:nai:f:",
+        specific_params=("hVv:x:c:r:nai:f:",
                             ["help",
                              "version",
                              "verbose=",
-                             "inspire",
-                             "kb-journals=",
-                             "kb-journals-re=",
-                             "kb-report-numbers=",
-                             "kb-authors=",
-                             "kb-books=",
-                             "recids=",
                              "id=",
+                             "recids=",
                              "collections=",
                              "new",
-                             "modified",
+                             "inspire",
+                             "overwrite",
                              "no-overwrite",
-                             "arxiv",
                              "create-ticket"]),
         task_submit_elaborate_specific_parameter_fnc=cb_parse_option,
         task_submit_check_options_fnc=check_options,

--- a/modules/pdfchecker/lib/arxiv_pdf_checker.py
+++ b/modules/pdfchecker/lib/arxiv_pdf_checker.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2011 CERN.
+## Copyright (C) 2011, 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -38,7 +38,7 @@ from invenio.shellutils import split_cli_ids_arg
 from invenio.dbquery import run_sql
 from invenio.bibtask import task_low_level_submission
 from invenio.refextract_api import record_has_fulltext, \
-                                   check_record_for_refextract
+                                   record_can_extract_refs
 from invenio.bibtask import task_init, \
                             write_message, \
                             task_update_progress, \
@@ -354,11 +354,12 @@ def submit_refextract_task(recids):
     """Submit a refextract task if needed"""
     # First filter out recids we cannot safely extract references from
     # (mostly because they have been curated)
-    recids = [recid for recid in recids if check_record_for_refextract(recid)]
+    recids = [recid for recid in recids if not record_can_extract_refs(recid)]
 
     if recids:
         recids_str = ','.join(str(recid) for recid in recids)
-        task_low_level_submission('refextract', NAME, '-i', recids_str)
+        task_low_level_submission('refextract', NAME, '-i', recids_str,
+                                  '--overwrite')
 
 
 def fetch_updated_arxiv_records(date):


### PR DESCRIPTION
* Accepts Publications as reference section.

* Refactors book handling and search.
  (closes #959)

* Daemon extracts all added pdfs.

* Correctly handles PDF/A files.

* Adds LIGO and LHCP report numbers to the kb.

* Adds the filename of the extracted files in the 999C6f field.

* Converts arxiv urls to report numbers

* Adds support for hdl identifiers.

* Sets a priority on which title form is the most important.
  References will be given priority over anything else while Reference
  will rank last with Bibliography in between.
  That means that if "Bibliography" is found in the text, we assume it is
  the reference section and we don't look for a section titles "Reference".

* Improves error message when pdftotext is missing.

Signed-off-by: Alessio Deiana <alessio.deiana@cern.ch>
Tested-by: Samuele Kaplun <samuele.kaplun@cern.ch>