### PR TITLE
WebSearch: no headers for deleted records

### DIFF
--- a/modules/websearch/lib/websearch_templates.py
+++ b/modules/websearch/lib/websearch_templates.py
@@ -570,6 +570,11 @@ class Template:
 
         _ = gettext_set_language(ln)
 
+        from invenio.search_engine import record_exists
+
+        if record_exists(recid) < 1:
+            return ('', '', '')
+
         title = get_fieldvalues(recid, "245__a") or \
                 get_fieldvalues(recid, "111__a")
 


### PR DESCRIPTION
- Avoids populating title/description/keyword HTML headers for
  deleted records.
  (closes #1682)

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
