### PR TITLE
knowledge: migrate sql interface to sqlalchemy

### DIFF
--- a/invenio/modules/knowledge/dblayer.py
+++ b/invenio/modules/knowledge/dblayer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2009, 2010, 2011, 2013 CERN.
+## Copyright (C) 2009, 2010, 2011, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -23,26 +23,27 @@ Database access related functions for BibKnowledge.
 
 __revision__ = "$Id$"
 
-
-from invenio.legacy.dbquery import run_sql
+from invenio.ext.sqlalchemy import db
 from invenio.utils.memoise import Memoise
+from .models import KnwKB, KnwKBRVAL, KnwKBDDEF
+from invenio.modules.search.models import Collection
+
 
 def get_kbs_info(kbtypeparam="", searchkbname=""):
     """Returns all kbs as list of dictionaries {id, name, description, kbtype}
        If the KB is dynamic, the dynamic kb key are added in the dict.
     """
     out = []
-    query = "SELECT id, name, description, kbtype FROM knwKB ORDER BY name"
-    res = run_sql(query)
+    res = KnwKB.query.order_by(KnwKB.name).all()
+
     for row in res:
-        doappend = 1 # by default
-        kbid = row[0]
-        name = row[1]
-        description = row[2]
-        kbtype = row[3]
+        doappend = 1  # by default
+        kbid = row.id
+        name = row.name
+        kbtype = row.kbtype
         dynres = {}
         if kbtype == 'd':
-            #get the dynamic config
+            # get the dynamic config
             dynres = get_kb_dyn_config(kbid)
         if kbtypeparam:
             doappend = 0
@@ -53,159 +54,164 @@ def get_kbs_info(kbtypeparam="", searchkbname=""):
             if (name == searchkbname):
                 doappend = 1
         if doappend:
-            mydict = {'id':kbid, 'name':name,
-                      'description':description,
-                      'kbtype':kbtype}
+            mydict = row.to_dict()
             mydict.update(dynres)
             out.append(mydict)
     return out
 
 
 def get_all_kb_names():
-    """Returns all knowledge base names
-       @return list of names
+    """
+    Returns all knowledge base names.
+
+    :return list of names
     """
     out = []
-    res = run_sql("""SELECT name FROM knwKB""")
+    res = KnwKB.query.all()
     for row in res:
-        out.append(row[0])
+        out.append(row.name)
     return out
 
 
-
 def get_kb_id(kb_name):
-    """Returns the id of the kb with given name"""
-    res = run_sql("""SELECT id FROM knwKB WHERE name LIKE %s""",
-                  (kb_name,))
-    if len(res) > 0:
-        return res[0][0]
-    else:
-        return None
+    """
+    Returns the id of the kb with given name.
+
+    :raises: :exc:`~sqlalchemy.orm.exc.NoResultFound` in case not exist.
+
+    :return integer
+    """
+    kb = KnwKB.query.filter_by(name=kb_name).first()
+    return kb.id if kb is not None else None
+
 
 get_kb_id_memoised = Memoise(get_kb_id)
 
+
 def get_kb_name(kb_id):
-    """Returns the name of the kb with given id
-    @param kb_id the id
-    @return string
     """
-    res = run_sql("""SELECT name FROM knwKB WHERE id=%s""",
-                  (kb_id,))
-    if len(res) > 0:
-        return res[0][0]
-    else:
-        return None
+    Returns the name of the kb with given id.
+
+    :param kb_id the id
+
+    :raises: :exc:`~sqlalchemy.orm.exc.NoResultFound` in case not exist.
+
+    :return string
+    """
+    return KnwKB.query.filter_by(id=kb_id).one().name
+
 
 def get_kb_type(kb_id):
-    """Returns the type of the kb with given id
-    @param kb_id knowledge base id
-    @return kb_type
     """
-    res = run_sql("""SELECT kbtype FROM knwKB WHERE id=%s""",
-                  (kb_id,))
-    if len(res) > 0:
-        return res[0][0]
-    else:
-        return None
+    Returns the type of the kb with given id.
+
+    :param kb_id knowledge base id
+
+    :return kb_type
+    """
+    return KnwKB.query.filter_by(id=kb_id).one().kbtype
+
 
 def get_kb_mappings(kb_name="", sortby="to", keylike="", valuelike="", match_type="s"):
-    """Returns a list of all mappings from the given kb, ordered by key
-    @param kb_name knowledge base name. if "", return all
-    @param sortby the sorting criteria ('from' or 'to')
-    @keylike return only entries where key matches this
-    @valuelike return only entries where value matches this
+    """
+    Returns a list of all mappings from the given kb, ordered by key.
+
+    :param kb_name knowledge base name. if "", return all
+
+    :param sortby the sorting criteria ('from' or 'to')
+
+    :keylike return only entries where key matches this
+
+    :valuelike return only entries where value matches this
     """
     out = []
-    k_id = get_kb_id(kb_name)
 
     if len(keylike) > 0:
         if match_type == "s":
             keylike = "%"+keylike+"%"
     else:
         keylike = '%'
+
     if len(valuelike) > 0:
         if match_type == "s":
             valuelike = "%"+valuelike+"%"
     else:
         valuelike = '%'
-    if not kb_name:
-        res = run_sql("""SELECT m.id, m.m_key, m.m_value, m.id_knwKB,
-                         k.name
-                   FROM knwKBRVAL m, knwKB k
-                   where m_key like %s
-                   and m_value like %s
-                   and m.id_knwKB = k.id""", (keylike, valuelike))
-    else:
-        res = run_sql("""SELECT m.id, m.m_key, m.m_value, m.id_knwKB,
-                         k.name
-               FROM knwKBRVAL m, knwKB k
-               WHERE id_knwKB=%s
-               and m.id_knwKB = k.id
-               and m_key like %s
-               and m_value like %s""", (k_id, keylike, valuelike))
-    #sort res
-    lres = list(res)
+
+    query = db.session.query(KnwKBRVAL).join(KnwKB).filter(
+        KnwKBRVAL.m_key.like(keylike),
+        KnwKBRVAL.m_value.like(valuelike))
+
+    if kb_name:
+        query.filter(KnwKB.name == kb_name)
+
     if sortby == "from":
-        lres.sort(lambda x, y:cmp(x[1], y[1]))
+        query = query.order_by(KnwKBRVAL.m_key)
     else:
-        lres.sort(lambda x, y:cmp(x[2], y[2]))
-    for row in lres:
-        out.append({'id':row[0], 'key':row[1],
-                     'value': row[2],
-                     'kbid': row[3], 'kbname': row[4]})
+        query = query.order_by(KnwKBRVAL.m_value)
+
+    res = query.all()
+
+    for row in res:
+        out.append(row.to_dict())
     return out
+
 
 def get_kb_dyn_config(kb_id):
     """
     Returns a dictionary of 'field'=> y, 'expression'=> z
     for a knowledge base of type 'd'. The dictionary may have coll_id, collection.
-    @param kb_id the id
-    @return dict
+
+    :param kb_id the id
+
+    :return dict
     """
-    res = run_sql("""SELECT output_tag, search_expression, id_collection
-               FROM knwKBDDEF where
-               id_knwKB = %s""", (kb_id, ))
-    mydict = {}
-    for row in res:
-        mydict['field'] = row[0]
-        mydict['expression'] = row[1]
-        mydict['coll_id'] = row[2]
-    #put a collection field if collection exists..
-    if 'coll_id' in mydict:
-        c_id =  mydict['coll_id']
-        res = run_sql("""SELECT name from collection where id = %s""", (c_id,))
-        if res:
-            mydict['collection'] = res[0][0]
-    return mydict
+    dyn_config = KnwKBDDEF.query.filter_by(id_knwKB=kb_id).first()
+    if dyn_config is None:
+        return {}
+    else:
+        return dyn_config.to_dict()
+
 
 def save_kb_dyn_config(kb_id, field, expression, collection=""):
-    """Saves a dynamic knowledge base configuration
+    """
+    Saves a dynamic knowledge base configuration.
 
-    @param kb_id the id
-    @param field the field where values are extracted
-    @param expression ..using this expression
-    @param collection ..in a certain collection (default is all)
+    :param kb_id the id
+
+    :param field the field where values are extracted
+
+    :param expression ..using this expression
+
+    :param collection ..in a certain collection (default is all)
     """
     #check that collection exists
     coll_id = None
     if collection:
-        res = run_sql("""SELECT id from collection where name = %s""", (collection,))
-        if res:
-            coll_id = res[0][0]
-    run_sql("""DELETE FROM knwKBDDEF where id_knwKB = %s""", (kb_id, ))
-    run_sql("""INSERT INTO knwKBDDEF (id_knwKB, output_tag, search_expression, id_collection)
-               VALUES (%s,%s,%s,%s)""", (kb_id, field, expression, coll_id))
+        coll_id = Collection.query.filter_by(name=collection).first()
+
+    KnwKBDDEF.query.filter_by(id_knwKB=kb_id).delete()
+
+    knwKBDDEF = KnwKBDDEF(id_knwKB=kb_id, output_tag=field, search_expression=expression, id_collection=coll_id)
+
+    db.session.add(knwKBDDEF)
+    db.session.commit()
+
     return ""
 
-def get_kb_description(kb_name):
-    """Returns the description of the given kb
 
-    @param kb_id the id
-    @return string
+def get_kb_description(kb_name):
     """
-    k_id = get_kb_id(kb_name)
-    res = run_sql("""SELECT description FROM knwKB WHERE id=%s""", (k_id,))
-    return res[0][0]
+    Returns the description of the given kb.
+
+    :param kb_id the id
+
+    :raises: :exc:`~sqlalchemy.orm.exc.NoResultFound` in case not exist.
+
+    :return string
+    """
+    return KnwKB.query.filter_by(name=kb_name).one().description
+
 
 def add_kb(kb_name, kb_description, kb_type=None):
     """
@@ -214,12 +220,13 @@ def add_kb(kb_name, kb_description, kb_type=None):
 
     If name already exists replace old value
 
-    @param kb_name the name of the kb to create
-    @param kb_description a description for the kb
-    @return the id of the newly created kb
-    """
+    :param kb_name the name of the kb to create
 
-    kb_db = 'w' #the typical written_as - change_to
+    :param kb_description a description for the kb
+
+    :return the id of the newly created kb
+    """
+    kb_db = 'w'  # the typical written_as - change_to
     if not kb_type:
         pass
     else:
@@ -227,157 +234,202 @@ def add_kb(kb_name, kb_description, kb_type=None):
             kb_db = 't'
         if kb_type == 'dynamic':
             kb_db = 'd'
-    run_sql("""REPLACE INTO knwKB (name, description, kbtype)
-                VALUES (%s,%s,%s)""", (kb_name, kb_description, kb_db))
-    return get_kb_id(kb_name)
+
+    knwKB = KnwKB.query.filter_by(name=kb_name).first()
+
+    if(knwKB is None):
+        knwKB = KnwKB(name=kb_name, description=kb_description, kbtype=kb_db)
+        db.session.add(knwKB)
+        db.session.commit()
+    else:
+        update_kb(kb_name, kb_name, kb_description, kb_type)
+
+    return knwKB.id
+
 
 def delete_kb(kb_name):
-    """Deletes the given kb"""
+    """Deletes the given kb."""
     k_id = get_kb_id(kb_name)
-    run_sql("""DELETE FROM knwKBRVAL WHERE id_knwKB = %s""", (k_id,))
-    run_sql("""DELETE FROM knwKB WHERE id = %s""", (k_id,))
-    #finally, delete from COLL table
-    run_sql("""DELETE FROM knwKBDDEF where id_knwKB = %s""", (k_id,))
+    if k_id is None:
+        return
+    KnwKBRVAL.query.filter_by(id_knwKB=k_id).delete()
+    KnwKB.query.filter_by(id=k_id).delete()
+    KnwKBDDEF.query.filter_by(id_knwKB=k_id).delete()
+    db.session.commit()
     return True
 
 
 def kb_exists(kb_name):
-    """Returns True if a kb with the given name exists"""
-    rows = run_sql("""SELECT id FROM knwKB WHERE name = %s""",
-                   (kb_name,))
-    if len(rows) > 0:
+    """Returns True if a kb with the given name exists."""
+    if KnwKB.query.filter_by(name=kb_name).first():
         return True
     else:
         return False
 
-def update_kb(kb_name, new_name, new_description=''):
-    """Updates given kb with new name and (optionally) new description"""
-    k_id = get_kb_id(kb_name)
-    run_sql("""UPDATE knwKB
-                  SET name = %s , description = %s
-                WHERE id = %s""", (new_name, new_description, k_id))
-    return True
+
+def update_kb(kb_name, new_name, new_description='', kbtype=None):
+    """Updates given kb with new name and (optionally) new description."""
+    kb = KnwKB.query.filter_by(name=kb_name).one()
+    kb.name = new_name
+    kb.description = new_description
+    kb.kbtype = kbtype
+    try:
+        db.session.merge(kb)
+    except:
+        # FIXME add re-raise exception
+        db.session.rollback()
+        return False
+    finally:
+        db.session.commit()
+        return True
+
 
 def add_kb_mapping(kb_name, key, value):
-    """Adds new mapping key->value in given kb"""
-    k_id = get_kb_id(kb_name)
-    run_sql("""REPLACE INTO knwKBRVAL (m_key, m_value, id_knwKB)
-                VALUES (%s, %s, %s)""", (key, value, k_id))
-    return True
+    """Adds new mapping key->value in given kb."""
+    knwKB = KnwKB.query.filter_by(name=kb_name).first()
+    kbrval = KnwKBRVAL.query.filter_by(m_key=key, id_knwKB=knwKB.id if knwKB else 0).first()
+    ret = True
+    if(kbrval is None):
+        kbrval = KnwKBRVAL(m_key=key, m_value=value,
+                           id_knwKB=knwKB.id if knwKB else None,
+                           kb=knwKB)
+        try:
+            db.session.merge(kbrval)
+        except:
+            # FIXME add re-raise exception
+            db.session.rollback()
+            ret = False
+        finally:
+            db.session.commit()
+    else:
+        kbrval.m_key = key
+        kbrval.m_value = value
+        kbrval.id_knwKB = knwKB.id if knwKB else 0
+        kbrval.kb = knwKB
+        try:
+            db.session.add(kbrval)
+        except:
+            # FIXME add re-raise exception
+            db.session.rollback()
+            ret = False
+        finally:
+            db.session.commit()
+
+    return ret
+
 
 def remove_kb_mapping(kb_name, key):
-    """Removes mapping with given key from given kb"""
+    """Removes mapping with given key from given kb."""
     k_id = get_kb_id(kb_name)
-    run_sql("""DELETE FROM knwKBRVAL
-                WHERE m_key = %s AND id_knwKB = %s""",
-            (key, k_id))
+    KnwKBRVAL.query.filter_by(m_key=key, id_knwKB=k_id).delete()
     return True
 
+
 def kb_mapping_exists(kb_name, key):
-    """Returns true if the mapping with given key exists in the given kb"""
+    """Returns true if the mapping with given key exists in the given kb."""
     if kb_exists(kb_name):
         k_id = get_kb_id(kb_name)
-        rows = run_sql("""SELECT id FROM knwKBRVAL
-                           WHERE m_key = %s
-                             AND id_knwKB = %s""", (key, k_id))
-        if len(rows) > 0:
-            return True
+        return True if KnwKBRVAL.query.filter(KnwKBRVAL.m_key.like(key), KnwKBRVAL.id_knwKB.like(k_id)).first() is not None else False
     return False
 
+
 def kb_key_rules(key):
+    # FIXME rewrite docs
     """Returns a list of 4-tuples that have a key->value mapping in some KB
-       The format of the tuples is [kb_id, kb_name,key,value] """
-    res = run_sql("""SELECT f.id, f.name, m.m_key, m.m_value
-                     from knwKBRVAL as m JOIN
-                     knwKB as f on
-                     m.id_knwKB=f.id WHERE
-                     m.m_key = %s""", (key, ))
-    return res
+       The format of the tuples is [kb_id, kb_name,key,value]."""
+    return KnwKBRVAL.query.filter_by(m_key=key).all()
+
 
 def kb_value_rules(value):
+    # FIXME rewrite docs
     """Returns a list of 4-tuples that have a key->value mapping in some KB
-       The format of the tuples is [kb_id, kb_name,key,value] """
-    res = run_sql("""SELECT f.id, f.name, m.m_key, m.m_value from
-                     knwKBRVAL as m JOIN
-                     knwKB as f on
-                     m.id_knwKB=f.id WHERE
-                     m.m_value = %s""", (value, ))
-    return res
+       The format of the tuples is [kb_id, kb_name,key,value]."""
+    return KnwKBRVAL.query.filter_by(m_value=value).all()
+
 
 def get_kb_mapping_value(kb_name, key):
+    # FIXME rewrite docs
     """
     Returns a value of the given key from the given kb.
     If mapping not found, returns None #'default'
 
-    @param kb_name the name of a knowledge base
-    @param key the key to look for
-    #@param default a default value to return if mapping is not found
+    :param kb_name the name of a knowledge base
+    :param key the key to look for
+    #:param default a default value to return if mapping is not found
     """
     k_id = get_kb_id(kb_name)
-    res = run_sql("""SELECT m_value FROM knwKBRVAL
-                      WHERE m_key LIKE %s
-                        AND id_knwKB = %s LIMIT 1""",
-                  (key, k_id))
-    if len(res) > 0:
-        return res[0][0]
-    else:
-        return None # default
+    kval = KnwKBRVAL.query.filter_by(m_key=key, id_knwKB=k_id).first()
+    return kval.m_value if kval is not None else None
+
 
 def update_kb_mapping(kb_name, key, new_key, new_value):
+    # FIXME rewrite docs
     """Updates the mapping given by key with new key and value"""
     k_id = get_kb_id(kb_name)
-    run_sql("""UPDATE knwKBRVAL
-                  SET m_key = %s , m_value = %s
-                WHERE m_key = %s AND id_knwKB = %s""",
-            (new_key, new_value, key, k_id))
+    kval = KnwKBRVAL.query.filter_by(m_key=key, id_knwKB=k_id).one()
+    kval.m_key = new_key
+    kval.m_value = new_value
+    kval.id_knwKB = k_id
+    try:
+        db.session.merge(kval)
+    except:
+        db.session.rollback()
+        # FIXME add re-raise exception
+    finally:
+        db.session.commit()
     return True
 
-#the following functions should be used by a higher level API
+# the following functions should be used by a higher level API
+
 
 def get_kba_values(kb_name, searchname="", searchtype="s"):
     """Returns the "authority file" type of list of values for a
        given knowledge base.
-       @param kb_name the name of the knowledge base
-       @param searchname search by this..
-       @param searchtype s=substring, e=exact, sw=startswith
+       :param kb_name the name of the knowledge base
+       :param searchname search by this..
+       :param searchtype s=substring, e=exact, sw=startswith
     """
     k_id = get_kb_id(kb_name)
     if searchtype == 's' and searchname:
         searchname = '%'+searchname+'%'
-    if searchtype == 'sw' and searchname: #startswith
+    if searchtype == 'sw' and searchname:  # startswith
         searchname = searchname+'%'
 
     if not searchname:
         searchname = '%'
-    res = run_sql("""SELECT m_value FROM knwKBRVAL
-                      WHERE m_value LIKE %s
-                        AND id_knwKB = %s""",
-                  (searchname, k_id))
-    return res
+
+    vals = []
+    kvals = KnwKBRVAL.query.filter(KnwKBRVAL.id_knwKB.like(k_id), KnwKBRVAL.m_value.like(searchname)).all()
+    for kval in kvals:
+        vals.append(kval.m_value)
+    return vals
+
 
 def get_kbr_keys(kb_name, searchkey="", searchvalue="", searchtype='s'):
     """Returns keys from a knowledge base
-       @param kb_name the name of the knowledge base
-       @param searchkey search using this key
-       @param searchvalue search using this value
-       @param searchtype s=substring, e=exact, sw=startswith
+       :param kb_name the name of the knowledge base
+       :param searchkey search using this key
+       :param searchvalue search using this value
+       :param searchtype s=substring, e=exact, sw=startswith
     """
     k_id = get_kb_id(kb_name)
     if searchtype == 's' and searchkey:
         searchkey = '%'+searchkey+'%'
     if searchtype == 's' and searchvalue:
         searchvalue = '%'+searchvalue+'%'
-    if searchtype == 'sw' and searchvalue: #startswith
+    if searchtype == 'sw' and searchvalue:  # startswith
         searchvalue = searchvalue+'%'
     if not searchvalue:
         searchvalue = '%'
     if not searchkey:
         searchkey = '%'
-    return run_sql("""SELECT m_key FROM knwKBRVAL
-                      WHERE m_value LIKE %s
-                      AND m_key LIKE %s
-                        AND id_knwKB = %s""",
-                  (searchvalue, searchkey, k_id))
+
+    keys = []
+    kkeys = KnwKBRVAL.query.filter(KnwKBRVAL.id_knwKB.like(k_id), KnwKBRVAL.m_key.like(searchkey)).all()
+    for kkey in kkeys:
+        keys.append(kkey.m_key)
+    return keys
+
 
 def get_kbr_values(kb_name, searchkey="%", searchvalue="", searchtype='s', use_memoise=False):
     """Returns values from a knowledge base
@@ -387,64 +439,64 @@ def get_kbr_values(kb_name, searchkey="%", searchvalue="", searchtype='s', use_m
        but if it is empty for exact, it matches nothing.
        If searchvalue is unspecified or empty, it matches anything in all cases.
 
-       @param kb_name the name of the knowledge base
-       @param searchkey search using this key
-       @param searchvalue search using this value
-       @param searchtype s=substring, e=exact, sw=startswith
-       @param use_memoise: can we memoise while doing lookups?
-       @type use_memoise: bool
-       @return a list of values
+       :param kb_name the name of the knowledge base
+       :param searchkey search using this key
+       :param searchvalue search using this value
+       :param searchtype s=substring, e=exact, sw=startswith
+       :param use_memoise: can we memoise while doing lookups?
+       :type use_memoise: bool
+       :return a list of values
     """
     if use_memoise:
         k_id = get_kb_id_memoised(kb_name)
     else:
         k_id = get_kb_id(kb_name)
+    if k_id is None:
+        return []
+    if searchkey is None:
+        searchkey = '%'
     if searchtype == 's':
         searchkey = '%'+searchkey+'%'
     if searchtype == 's' and searchvalue:
         searchvalue = '%'+searchvalue+'%'
-    if searchtype == 'sw' and searchvalue: #startswith
+    if searchtype == 'sw' and searchvalue:  # startswith
         searchvalue = searchvalue+'%'
     if not searchvalue:
         searchvalue = '%'
-    return run_sql("""SELECT m_value FROM knwKBRVAL
-                      WHERE m_value LIKE %s
-                      AND m_key LIKE %s
-                        AND id_knwKB = %s""",
-                  (searchvalue, searchkey, k_id))
+
+    vals = []
+    kvals = KnwKBRVAL.query.filter(KnwKBRVAL.id_knwKB.like(k_id), KnwKBRVAL.m_value.like(searchvalue), KnwKBRVAL.m_key.like(searchkey)).all()
+    for kval in kvals:
+        vals.append(kval.m_value)
+    return vals
+
 
 get_kbr_values_memoised = Memoise(get_kbr_values)
 
+
 def get_kbr_items(kb_name, searchkey="", searchvalue="", searchtype='s'):
     """Returns dicts of 'key' and 'value' from a knowledge base
-       @param kb_name the name of the knowledge base
-       @param searchkey search using this key
-       @param searchvalue search using this value
-       @param searchtype s=substring, e=exact, sw=startswith
-       @return a list of dictionaries [{'key'=>x, 'value'=>y},..]
+       :param kb_name the name of the knowledge base
+       :param searchkey search using this key
+       :param searchvalue search using this value
+       :param searchtype s=substring, e=exact, sw=startswith
+       :return a list of dictionaries [{'key'=>x, 'value'=>y},..]
     """
     k_id = get_kb_id(kb_name)
     if searchtype == 's' and searchkey:
         searchkey = '%'+searchkey+'%'
     if searchtype == 's' and searchvalue:
         searchvalue = '%'+searchvalue+'%'
-    if searchtype == 'sw' and searchvalue: #startswith
+    if searchtype == 'sw' and searchvalue:  # startswith
         searchvalue = searchvalue+'%'
     if not searchvalue:
         searchvalue = '%'
     if not searchkey:
         searchkey = '%'
-    res = []
-    rows = run_sql("""SELECT m_key, m_value FROM knwKBRVAL
-                      WHERE m_value LIKE %s
-                      AND m_key LIKE %s
-                        AND id_knwKB = %s""",
-                  (searchvalue, searchkey, k_id))
-    for row in rows:
-        mdict = {}
-        m_key = row[0]
-        m_value = row[1]
-        mdict['key'] = m_key
-        mdict['value'] = m_value
-        res.append(mdict)
-    return res
+
+    vals = []
+    kvals = KnwKBRVAL.query.filter(KnwKBRVAL.id_knwKB.like(k_id), KnwKBRVAL.m_value.like(searchvalue), KnwKBRVAL.m_key.like(searchkey)).all()
+    for kval in kvals:
+        vals.append({'key': kval.m_key, 'value': kval.m_value})
+
+    return vals

--- a/invenio/modules/knowledge/models.py
+++ b/invenio/modules/knowledge/models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#
+##
 ## This file is part of Invenio.
 ## Copyright (C) 2011, 2012, 2014 CERN.
 ##
@@ -38,6 +38,12 @@ class KnwKB(db.Model):
     description = db.Column(db.Text, nullable=True)
     kbtype = db.Column(db.Char(1), nullable=True)
 
+    def to_dict(self):
+        """ Return a dict representation of KnwKB."""
+        return {'id': self.id, 'name': self.name,
+                'description': self.description,
+                'kbtype': self.kbtype}
+
 
 class KnwKBDDEF(db.Model):
 
@@ -54,6 +60,13 @@ class KnwKBDDEF(db.Model):
     kb = db.relationship(KnwKB, backref='kbdefs')
     collection = db.relationship(Collection, backref='kbdefs')
 
+    def to_dict(self):
+        """ Return a dict representation of KnwKBDDEF."""
+        return {'field': self.output_tag,
+                'expression': self.search_expression,
+                'coll_id': self.id_collection,
+                'collection': self.collection.name if self.collection else None}
+
 
 class KnwKBRVAL(db.Model):
 
@@ -69,6 +82,12 @@ class KnwKBRVAL(db.Model):
                          nullable=False, server_default='0')
     kb = db.relationship(KnwKB, backref='kbrvals')
 
+    def to_dict(self):
+        """ Return a dict representation of KnwKBRVAL."""
+        return {'id': self.id, 'key': self.m_key,
+                'value': self.m_value,
+                'kbid': self.kb.id if self.kb else None,
+                'kbname': self.kb.name if self.kb else None}
 
 __all__ = ('KnwKB',
            'KnwKBDDEF',


### PR DESCRIPTION
- Replaces run_sql queries with SQLAchemy query.

Signed-off-by: Leonardo Rossi leonardo.r@cern.ch
