### PR TITLE
base: test records loading

### DIFF
--- a/invenio/base/scripts/demosite.py
+++ b/invenio/base/scripts/demosite.py
@@ -25,6 +25,7 @@ import os
 import pkg_resources
 import sys
 
+from invenio.base.globals import cfg
 from invenio.ext.script import Manager
 
 manager = Manager(usage=__doc__)
@@ -72,9 +73,12 @@ def populate(packages=[], default_data=True, files=None,
     db.session.execute("TRUNCATE schTASK")
     db.session.commit()
     if files is None:
-        files = [pkg_resources.resource_filename(
-            'invenio',
-            os.path.join('testsuite', 'data', 'demo_record_marc_data.xml'))]
+        if cfg.get('BASE_DEMOSITE_RECORDS_FIXTURE'):
+            files = cfg.get('BASE_DEMOSITE_RECORDS_FIXTURE', [])
+        else:
+            files = [pkg_resources.resource_filename('invenio',
+                     os.path.join('testsuite', 'data',
+                                  'demo_record_marc_data.xml'))]
 
     # upload demo site files:
     bibupload_flags = '-i'


### PR DESCRIPTION
- Enables inveniomanage demosite populate with custom xml.
- NOTE: Before populating DB with demo records from custom xml
  please make sure that BASE_DEMOSITE_RECORDS_FIXTURE
  is set to list containing proper filenames

Signed-off-by: Adrian Pawel Baran adrian.pawel.baran@cern.ch
