### PR TITLE
BibField: CFG_BIBFORMAT_HIDDEN_RECJSON_FIELDS

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -225,7 +225,7 @@ CFG_ERRORLIB_RESET_EXCEPTION_NOTIFICATION_COUNTER_AFTER = 14400
 
 ## CFG_ERRORLIB_SENTRY_URI -- optionally, if you use Sentry for logging.
 ## Sentry notifies you when your users experience errors.
-## Enables logging of exceptions in invenio to given Sentry server. 
+## Enables logging of exceptions in invenio to given Sentry server.
 CFG_ERRORLIB_SENTRY_URI =
 
 ## CFG_CERN_SITE -- do we want to enable CERN-specific code?
@@ -1946,6 +1946,10 @@ CFG_BIBCATALOG_SYSTEM_RT_DEFAULT_PWD =
 ## CFG_BIBFORMAT_HIDDEN_TAGS -- comma-separated list of MARC tags that
 ## are not shown to users not having cataloging authorizations.
 CFG_BIBFORMAT_HIDDEN_TAGS = 595
+
+## CFG_BIBFORMAT_HIDDEN_RECJSON_FIELDS -- comma-separated list of MARC tags that
+## are not shown to users not having cataloging authorizations.
+CFG_BIBFORMAT_HIDDEN_RECJSON_FIELDS = internal_notes,__meta_metadata__
 
 ## CFG_BIBFORMAT_HIDDEN_FILE_FORMATS -- comma-separated list of file formats
 ## that are not shown explicitly to user not having cataloging authorizations.

--- a/modules/bibfield/lib/bibfield.py
+++ b/modules/bibfield/lib/bibfield.py
@@ -88,7 +88,7 @@ def create_records(blob, master_format='marc', verbose=0, **additional_info):
     return [create_record(record_blob, master_format, verbose=verbose, **additional_info) for record_blob in record_blods]
 
 
-def get_record(recid, reset_cache=False, fields=()):
+def get_record(recid, reset_cache=False):
     """
     Record factory, it retrieves the record from bibfmt table if it is there,
     if not, or reset_cache is set to True, it searches for the appropriate
@@ -130,9 +130,4 @@ def get_record(recid, reset_cache=False, fields=()):
         run_sql("REPLACE INTO bibfmt(id_bibrec, format, last_updated, value) VALUES (%s, 'recjson', NOW(), %s)",
                 (recid, msgpack.dumps(record.dumps())))
 
-    if fields:
-        chunk = SmartDict()
-        for key in fields:
-            chunk[key] = record.get(key)
-        record = chunk
     return record

--- a/modules/bibfield/lib/bibfield_regression_tests.py
+++ b/modules/bibfield/lib/bibfield_regression_tests.py
@@ -86,15 +86,6 @@ class BibFieldRecordFieldValuesTest(InvenioTestCase):
         self.assertEqual(4, record['number_of_citations'])
 
 
-    def test_get_record_using_field_filter(self):
-        """BibField - get record filtering fields"""
-        authors = get_record(12, fields=('authors',))
-        self.assertEquals(len(authors['authors']), 19)
-        mainauthor_title = get_record(12, fields=('authors[0]', 'title'))
-        self.assertTrue('authors[0].full_name' in mainauthor_title)
-        self.assertTrue('title' in mainauthor_title)
-
-
 class BibFieldCreateRecordTests(InvenioTestCase):
     """
     Bibfield - demo file parsing test

--- a/modules/miscutil/lib/inveniocfg.py
+++ b/modules/miscutil/lib/inveniocfg.py
@@ -221,6 +221,7 @@ You may want to customise your invenio-local.conf configuration accordingly."""
                        'CFG_WEBSEARCH_USE_MATHJAX_FOR_FORMATS',
                        'CFG_BIBUPLOAD_STRONG_TAGS',
                        'CFG_BIBFORMAT_HIDDEN_TAGS',
+                       'CFG_BIBFORMAT_HIDDEN_RECJSON_FIELDS',
                        'CFG_BIBSCHED_GC_TASKS_TO_REMOVE',
                        'CFG_BIBSCHED_GC_TASKS_TO_ARCHIVE',
                        'CFG_BIBUPLOAD_FFT_ALLOWED_LOCAL_PATHS',

--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -75,6 +75,7 @@ from invenio.config import \
      CFG_SITE_NAME, \
      CFG_LOGDIR, \
      CFG_BIBFORMAT_HIDDEN_TAGS, \
+     CFG_BIBFORMAT_HIDDEN_RECJSON_FIELDS, \
      CFG_SITE_URL, \
      CFG_ACCESS_CONTROL_LEVEL_ACCOUNTS, \
      CFG_SOLR_URL, \
@@ -4932,14 +4933,28 @@ def print_record(recID, format='hb', ot='', ln=CFG_SITE_LANG, decompress=zlib.de
     if format == 'recstruct':
         return get_record(recID)
 
-    if format.startswith('recjson'):
+    #check from user information if the user has the right to see hidden fields/tags in the
+    #records as well
+    can_see_hidden = False
+    if user_info:
+        can_see_hidden = user_info.get('precached_canseehiddenmarctags', False)
+
+    if format == 'recjson':
         import json
         from invenio.bibfield import get_record as get_recjson
-        if ot:
-            ot = list(set(ot) - set(CFG_BIBFORMAT_HIDDEN_TAGS))
-            return json.dumps(dict(get_recjson(recID, fields=ot)))
-        else:
-            return json.dumps(get_recjson(recID).dumps())
+        from invenio.bibfield_utils import SmartDict
+        recjson = get_recjson(recID)
+        record = SmartDict()
+        keys = ot or recjson.keys()
+        for key in keys:
+            if key == 'bibdocs':
+                continue
+            if not can_see_hidden and key in CFG_BIBFORMAT_HIDDEN_RECJSON_FIELDS:
+                continue
+            record[key] = recjson.get(key)
+        # skipkeys is True to skip e.g. the bibdocs key, which is a non
+        # primitive object.
+        return json.dumps(dict(record), skipkeys=True)
 
     _ = gettext_set_language(ln)
 
@@ -4952,19 +4967,9 @@ def print_record(recID, format='hb', ot='', ln=CFG_SITE_LANG, decompress=zlib.de
     else:
         display_claim_this_paper = False
 
-
-
-
-    #check from user information if the user has the right to see hidden fields/tags in the
-    #records as well
-    can_see_hidden = False
-    if user_info:
-        can_see_hidden = user_info.get('precached_canseehiddenmarctags', False)
-
     can_edit_record = False
     if check_user_can_edit_record(user_info, recID):
         can_edit_record = True
-
 
     out = ""
 
@@ -5028,9 +5033,12 @@ def print_record(recID, format='hb', ot='', ln=CFG_SITE_LANG, decompress=zlib.de
             out += "%s" % decompress(res[0][0])
         elif ot:
             # field-filtered output was asked for; print only some fields
+            record = get_record(recID)
             if not can_see_hidden:
+                for tag in CFG_BIBFORMAT_HIDDEN_TAGS:
+                    del record[tag]
                 ot = list(set(ot) - set(CFG_BIBFORMAT_HIDDEN_TAGS))
-            out += record_xml_output(get_record(recID), ot)
+            out += record_xml_output(record, ot)
         else:
             # record 'recID' is not formatted in 'format' or we ask
             # for field-filtered output -- they are not in "bibfmt"


### PR DESCRIPTION
* Introduces ad-interim new config variable
  CFG_BIBFORMAT_HIDDEN_RECJSON_FIELDS to list which recjson fields
  need to be not exposed via public interfaces.
  (addresses #2197)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>