### PR TITLE
babel: do not merge NullTranslations

### DIFF
--- a/invenio/ext/babel/errors.py
+++ b/invenio/ext/babel/errors.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Custom errors for Babel extension."""
+
+
+class NoCompiledTranslationError(Exception):
+
+    """Raised when no compiled *.mo translations are found."""


### PR DESCRIPTION
Our homegrown Babel function `get_translation` throws an `AttributeError` when the code tries to `merge` a `NullTranslations` object.

I was seeing this when missing the compiled translations (*.mo) after installing Invenio via overlay. The practical solution was to just compile the translations with `pybabel compile` on the site-packages folder of Invenio.

Dunno if this is the right approach though.. @jirikuncar 
