### PR TITLE
OAIHarvest: fix identifier parsing

### DIFF
--- a/modules/oaiharvest/lib/Makefile.am
+++ b/modules/oaiharvest/lib/Makefile.am
@@ -25,7 +25,8 @@ pylib_DATA = oai_harvest_getter.py \
              oai_harvest_daemon.py \
              oai_harvest_config.py \
              oai_harvest_utils.py \
-             oai_harvest_web_tests.py
+             oai_harvest_web_tests.py \
+             oai_harvest_unit_tests.py
 
 EXTRA_DIST = $(pylib_DATA)
 

--- a/modules/oaiharvest/lib/oai_harvest_daemon.py
+++ b/modules/oaiharvest/lib/oai_harvest_daemon.py
@@ -1406,6 +1406,7 @@ def get_dates(dates):
 
 
 def get_identifier_names(identifier):
+    """Return list of identifiers from a comma-separated string."""
     if identifier:
         # Let's see if the user had a comma-separated list of OAI ids.
         stripped_idents = []
@@ -1416,9 +1417,6 @@ def get_identifier_names(identifier):
                 elif "arXiv" in ident:
                     # New style arXiv ID
                     ident = ident.replace("arXiv", "oai:arXiv.org")
-                elif "/" in ident:
-                    # Old style arXiv ID?
-                    ident = "%s%s" % ("oai:arXiv.org:", ident)
             stripped_idents.append(ident.strip())
         return stripped_idents
 

--- a/modules/oaiharvest/lib/oai_harvest_unit_tests.py
+++ b/modules/oaiharvest/lib/oai_harvest_unit_tests.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Unit tests for the OAI harvester."""
+
+from invenio.testutils import (
+    InvenioTestCase,
+    make_test_suite,
+    run_test_suite,
+)
+
+
+class TestOAIUtils(InvenioTestCase):
+
+    """Test for OAI utility functions."""
+
+    def test_identifier_filter(self):
+        """oaiharvest - testing identifier filter."""
+        from invenio.oai_harvest_daemon import get_identifier_names
+        self.assertEqual(get_identifier_names("oai:mysite.com:1234"),
+                         ["oai:mysite.com:1234"])
+        self.assertEqual(get_identifier_names("oai:mysite.com:1234, oai:example.com:2134"),
+                         ["oai:mysite.com:1234", "oai:example.com:2134"])
+        self.assertEqual(get_identifier_names("oai:mysite.com:1234/testing, oai:example.com:record/1234"),
+                         ["oai:mysite.com:1234/testing", "oai:example.com:record/1234"])
+
+    def test_identifier_filter_special_arXiv(self):
+        """oaiharvest - testing identifier filter for arXiv."""
+        from invenio.oai_harvest_daemon import get_identifier_names
+        self.assertEqual(get_identifier_names("oai:arxiv.org:1234.1245"),
+                         ["oai:arXiv.org:1234.1245"])
+        self.assertEqual(get_identifier_names("oai:arXiv.org:1234.1245, arXiv:1234.1245"),
+                         ["oai:arXiv.org:1234.1245", "oai:arXiv.org:1234.1245"])
+        self.assertEqual(get_identifier_names("oai:arXiv.org:1234.12452"),
+                         ["oai:arXiv.org:1234.12452"])
+
+
+TEST_SUITE = make_test_suite(TestOAIUtils)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
I screwed up something in the OAI harvest deamon in regards to one-shot harvesting of identifiers. Basically anything with a `/` got an arXiv prefix. :-1:  

Here I am trying to fix my mistake (by simply dropping the old arXiv ID support) and hoping to recover my honour by adding tests. :dancer: 

Thanks @switowski for reporting it.