### PR TITLE
assets: requirejs exclude option

### DIFF
--- a/invenio/base/bundles.py
+++ b/invenio/base/bundles.py
@@ -62,18 +62,11 @@
 
 import mimetypes
 
-from invenio.ext.assets import Bundle
+from invenio.ext.assets import Bundle, RequireJSFilter
 
 
 mimetypes.add_type("text/css", ".less")
 
-
-invenio = Bundle(
-    "js/invenio.js",
-    output="invenio.js",
-    filters="requirejs",
-    weight=90
-)
 
 styles = Bundle(
     "vendors/jquery-tokeninput/styles/token-input.css",
@@ -97,10 +90,6 @@ styles = Bundle(
     }
 )
 
-# FIXME
-#if config.CFG_WEBSTYLE_TEMPLATE_SKIN != "default":
-#    styles.contents.append("css/" + config.CFG_WEBSTYLE_TEMPLATE_SKIN + ".css")
-
 jquery = Bundle(
     "vendors/jquery/dist/jquery.js",
     "vendors/jquery.jeditable/index.js",
@@ -108,6 +97,7 @@ jquery = Bundle(
     "vendors/jquery.caret/dist/jquery.caret-1.5.2.js",
     "vendors/hogan/web/builds/3.0.2/hogan-3.0.2.js",
     "vendors/bootstrap/dist/js/bootstrap.js",
+    "vendors/typeahead.js/dist/typeahead.bundle.js",
     "js/bootstrap-select.js",
     "js/translate.js",
     "js/init.js",
@@ -140,6 +130,13 @@ jquery = Bundle(
         "uploadify": "latest"  # orphan
         #"bootstrap": "*", is set by invenio.css already.
     }
+)
+
+invenio = Bundle(
+    "js/invenio.js",
+    output="invenio.js",
+    filters=RequireJSFilter(exclude=[jquery]),
+    weight=90
 )
 
 # less.js is only used when the following configuration is set:

--- a/invenio/base/static/js/build.js
+++ b/invenio/base/static/js/build.js
@@ -26,10 +26,17 @@
             comments: false
         },
         compress: {
-            drop_console: true
+            drop_console: true,
+            sequences: true,
+            dead_code: true,
+            conditionals: true,
+            booleans: true,
+            unused: true,
+            if_return: true,
+            join_vars: true
         },
         warnings: true,
-        mangle: false
+        mangle: true
     },
     mainConfigFile: './settings.js',
 })

--- a/invenio/base/static/js/init.js
+++ b/invenio/base/static/js/init.js
@@ -17,7 +17,17 @@
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
  */
 
-require(['jquery', 'jquery-form', 'jquery-ui'], function($) {
+require([
+    'jquery',
+    'jquery-form',
+    'jquery-ui',
+    'ui/core',
+    'ui/mouse',
+    'ui/widget',
+    'ui/sortable',
+    'ui/datepicker',
+    'typeahead',
+    ], function() {
     // loading all the jQuery modules for the not require.js ready scripts
     // everywhere.
 })

--- a/invenio/ext/assets/__init__.py
+++ b/invenio/ext/assets/__init__.py
@@ -41,10 +41,11 @@ Additional extensions and functions for the `flask.ext.assets` module.
 from .commands import AssetsCommand, BowerCommand
 from .extensions import BundleExtension
 from .registry import bundles
-from .wrappers import Bundle
+from .wrappers import Bundle, RequireJSFilter
 
 
-__all__ = ("bower", "bundles", "command", "setup_app", "Bundle")
+__all__ = ("bower", "bundles", "command", "setup_app", "Bundle",
+           "RequireJSFilter")
 
 command = AssetsCommand()
 bower = BowerCommand()

--- a/invenio/modules/accounts/bundles.py
+++ b/invenio/modules/accounts/bundles.py
@@ -19,10 +19,9 @@
 
 """Accounts bundles."""
 
-from invenio.ext.assets import Bundle
+from invenio.ext.assets import Bundle, RequireJSFilter
 
-from invenio.base.bundles import styles as _styles
-
+from invenio.base.bundles import styles as _styles, jquery as _j, invenio as _i
 
 # The underscore makes it "hidden" for the bundle collector.
 _styles.contents += ("css/accounts/login.css",)
@@ -31,7 +30,7 @@ js = Bundle(
     "js/accounts/init.js",
     output="accounts.js",
     weight=80,
-    filters="requirejs",
+    filters=RequireJSFilter(exclude=[_j, _i]),
     bower={
         "jquery-ui": "~1.11"
     }

--- a/invenio/modules/deposit/bundles.py
+++ b/invenio/modules/deposit/bundles.py
@@ -19,15 +19,15 @@
 
 """Deposit bundles."""
 
-from invenio.ext.assets import Bundle
-
+from invenio.ext.assets import Bundle, RequireJSFilter
+from invenio.base.bundles import jquery as _j, invenio as _i
 
 js = Bundle(
     "vendors/plupload/js/moxie.js",
     "vendors/plupload/js/plupload.dev.js",
     "js/deposit/init.js",
     output="deposit.js",
-    filters="requirejs",
+    filters=RequireJSFilter(exclude=[_j, _i]),
     weight=51,
     bower={
         "plupload": "latest",

--- a/invenio/modules/messages/bundles.py
+++ b/invenio/modules/messages/bundles.py
@@ -19,9 +19,9 @@
 
 """Messages bundles."""
 
-from invenio.ext.assets import Bundle
+from invenio.ext.assets import Bundle, RequireJSFilter
 
-from invenio.base.bundles import styles as _styles
+from invenio.base.bundles import styles as _styles, jquery as _j, invenio as _i
 
 _styles.contents.append(
     "vendors/jqueryui-timepicker-addon/dist/jquery-ui-timepicker-addon.css"
@@ -31,7 +31,7 @@ js = Bundle(
     'js/messages/init.js',
     output='messages.js',
     weight=70,
-    filters='requirejs',
+    filters=RequireJSFilter(exclude=[_j, _i]),
     bower={
         "jquery-ui": "~1.11",
         "jqueryui-timepicker-addon": "latest"

--- a/invenio/modules/search/bundles.py
+++ b/invenio/modules/search/bundles.py
@@ -19,13 +19,14 @@
 
 """Search bundles."""
 
-from invenio.ext.assets import Bundle
+from invenio.ext.assets import Bundle, RequireJSFilter
+from invenio.base.bundles import jquery as _j, invenio as _i
 
 js = Bundle(
     'js/search/default_typeahead_configuration.js',
     'js/search/facet.js',
     'js/search/init.js',
-    filters="requirejs",
+    filters=RequireJSFilter(exclude=[_j, _i]),
     output="search.js",
     weight=50
 )
@@ -40,7 +41,7 @@ styles = Bundle(
 
 adminjs = Bundle(
     'js/admin/search/init.js',
-    filters="requirejs",
+    filters=RequireJSFilter(exclude=[_j, _i]),
     output="admin/search.js",
     weight=50,
     bower={


### PR DESCRIPTION
- Adds support for exclusion of files in RequireJS builds, to prevent
  files from being included multiple times. (closes #2411)

Signed-off-by: Lars Holm Nielsen lars.holm.nielsen@cern.ch
