### PR TITLE
deposit: datetime picker library modification

### DIFF
--- a/invenio/base/static/js/settings.js
+++ b/invenio/base/static/js/settings.js
@@ -33,6 +33,8 @@ require.config({
     "jquery-caret": "vendors/jquery.caret/dist/jquery.caret-1.5.2",
     "jquery-tokeninput": "vendors/jquery-tokeninput/src/jquery.tokeninput",
     "jquery-jeditable": "vendors/jquery.jeditable/index",
+    "moment": "vendors/moment/moment",
+    "bootstrap-datetimepicker": "vendors/eonasdan-bootstrap-datetimepicker/src/js/bootstrap-datetimepicker",
     bootstrap: "vendors/bootstrap/dist/js/bootstrap",
   },
   shim: {
@@ -72,6 +74,10 @@ require.config({
     },
     bootstrap: {
       deps: ["jquery"]
+    },
+    "bootstrap-datetimepicker": {
+      deps: ["jquery", "bootstrap", "moment"],
+      exports: "$.fn.datetimepicker"
     },
   }
 })

--- a/invenio/modules/deposit/bundles.py
+++ b/invenio/modules/deposit/bundles.py
@@ -32,12 +32,14 @@ js = Bundle(
     bower={
         "plupload": "latest",
         "ckeditor": "latest",
-        "flight": "latest"
+        "flight": "latest",
+        "eonasdan-bootstrap-datetimepicker": "latest",
     }
 )
 
 styles = Bundle(
     "css/deposit/form.css",
+    "vendors/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.css",
     output="deposit.css",
     filters="cleancss",
     weight=51

--- a/invenio/modules/deposit/static/js/deposit/form.js
+++ b/invenio/modules/deposit/static/js/deposit/form.js
@@ -41,8 +41,8 @@ define(function(require, exports, module) {
     require('./dynamic_field_list')
     // provides $.fn.sortable
     require('ui/sortable')
-    // provides $.fn.datepicker
-    require('ui/datepicker')
+    // provides $.fn.datetimepicker
+    require('bootstrap-datetimepicker')
     // provides $.fn.typeahead
     require('typeahead')
 
@@ -56,7 +56,10 @@ define(function(require, exports, module) {
         save_all_url: "",
         complete_url: "",
         autocomplete_url: "",
-        datepicker_options: {dateFormat: "yy-mm-dd"},
+        datepicker_options: {
+          format: "YYYY-MM-DD",
+          pickTime: false,
+        },
 
         // Selectors
         datepickerSelector: '.datepicker',
@@ -781,7 +784,7 @@ define(function(require, exports, module) {
       $(e.target).css("overflow", "visible");
     })
     // Initialize jquery_plugins
-    $(this.attr.datepickerSelector).datepicker(this.attr.datepicker_options);
+    $(this.attr.datepickerSelector).datetimepicker(this.attr.datepicker_options);
   });
 
   }

--- a/invenio/modules/deposit/templates/deposit/run_base.html
+++ b/invenio/modules/deposit/templates/deposit/run_base.html
@@ -95,7 +95,10 @@ require(["jquery", "js/deposit/form", "js/deposit/plupload"], function($, form) 
         complete_url: complete_url,
         autocomplete_url: autocomplete_url,
         datepicker_element: '.datepicker',
-        datepicker_options: {dateFormat: "yy-mm-dd"}
+        datepicker_options: {
+          format: 'YYYY-MM-DD',
+          pickTime: false,
+        }
       });
 
       $('.pluploader').pluploadWidget({


### PR DESCRIPTION
- Changes the datetime picker library from the jQuery UI to
  bootstrap-datetimepicker.
- Increases the consistency with the Bootstrap design.
- NOTE introduces new JS library
  https://github.com/Eonasdan/bootstrap-datetimepicker.

Signed-off-by: Pedro Gaudêncio pedro.gaudencio@cern.ch
Co-authored-by: Georgios Kokosioulis georgios.kokosioulis@cern.ch
Co-authored-by: Javier Martin Montull javier.martin.montull@cern.ch
