### PR TITLE
base: fix dangerous demosite populate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ before_script:
   - "sudo apachectl configtest && sudo service apache2 restart || echo 'Apache failed ...'"
   - "inveniomanage database init --yes-i-know || echo ':('"
   - "inveniomanage database create --quiet || echo ':('"
-#  - "inveniomanage demosite populate"
+#  - "inveniomanage demosite populate --yes-i-know"
 
 script:
   - "sphinx-build -qnNW docs docs/_build/html"

--- a/invenio/base/scripts/demosite.py
+++ b/invenio/base/scripts/demosite.py
@@ -60,9 +60,17 @@ option_packages = manager.option('-p', '--packages', dest='packages',
 @option_file
 @option_jobid
 @option_extrainfo
+@option_yes_i_know
 def populate(packages=[], default_data=True, files=None,
-             job_id=0, extra_info=None):
+             job_id=0, extra_info=None, yes_i_know=False):
     """Load demo records.  Useful for testing purposes."""
+    from invenio.utils.text import wrap_text_in_a_box, wait_for_user
+
+    ## Step 0: confirm deletion
+    wait_for_user(wrap_text_in_a_box(
+        "WARNING: You are going to override data in tables!"
+    ))
+
     if not default_data:
         print('>>> Default data has been skiped (--no-data).')
         return


### PR DESCRIPTION
- NOTE `inveniomanage demosite populate` asks for user confirmation or `--yes-i-know` argument.  (closes #2294)

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
