### PR TITLE
celery: deprecated celeryd replacement

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -512,7 +512,7 @@ which must be running alongside with the web server.
 
     # launch celery
     $ workon invenio
-    (invenio)$ celeryd -E -A invenio.celery.celery --workdir=$VIRTUAL_ENV
+    (invenio)$ celery worker -E -A invenio.celery.celery --workdir=$VIRTUAL_ENV
 
     # in a new terminal
     $ workon invenio

--- a/Procfile-elasticsearch
+++ b/Procfile-elasticsearch
@@ -1,5 +1,5 @@
 web: inveniomanage runserver
 cache: redis-server
-worker: celeryd -E -A invenio.celery.celery --loglevel=INFO --workdir=$VIRTUAL_ENV
+worker: celery worker -E -A invenio.celery.celery --loglevel=INFO --workdir=$VIRTUAL_ENV
 workermon: flower --broker=redis://localhost:6379/1
 indexer: elasticsearch -D es.config=invenio/ext/elasticsearch/config/elasticsearch.yml


### PR DESCRIPTION
- As of the celery version 3.1, `celeryd` is deprecated in favour of
  `celery worker`. It will be completely removed with the 3.2 version.

Signed-off-by: Daniel Lovasko daniel.lovasko@cern.ch
