### PR TITLE
WebSearch: stemming and '*'

### DIFF
--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -2511,8 +2511,16 @@ def search_unit_in_bibwords(word, f, decompress=zlib.decompress, wl=0):
         if stemming_language:
             word0 = lower_index_term(word0)
             word1 = lower_index_term(word1)
-            word0 = stem(word0, stemming_language)
-            word1 = stem(word1, stemming_language)
+            # We remove trailing truncation character before stemming
+            if word0.endswith('%'):
+                word0 = stem(word0[:-1], stemming_language) + '%'
+            else:
+                word0 = stem(word0, stemming_language)
+            if word1.endswith('%'):
+                word1 = stem(word1[:-1], stemming_language) + '%'
+            else:
+                word1 = stem(word1, stemming_language)
+
         word0_washed = wash_index_term(word0)
         word1_washed = wash_index_term(word1)
         if f.endswith('count'):
@@ -2536,7 +2544,11 @@ def search_unit_in_bibwords(word, f, decompress=zlib.decompress, wl=0):
             word = re_word.sub('', word)
         if stemming_language:
             word = lower_index_term(word)
-            word = stem(word, stemming_language)
+            # We remove trailing truncation character before stemming
+            if word.endswith('%'):
+                word = stem(word[:-1], stemming_language) + '%'
+            else:
+                word = stem(word, stemming_language)
         if word.find('%') >= 0: # do we have wildcard in the word?
             if f == 'journal':
                 # FIXME: quick hack for the journal index


### PR DESCRIPTION
- When a trailing '_' is used in a search over an index for which
  stemming is enabled, removes first the trailing '_', applies
  stemming and readds the trailing '*'.
  (closes #2468)

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
