### PR TITLE
Connector: Fix Register membership test operator

### DIFF
--- a/invenio/utils/connector.py
+++ b/invenio/utils/connector.py
@@ -473,9 +473,6 @@ class Record(dict):
         else:
             return datafields
 
-    def __contains__(self, item):
-        return dict.__contains__(item)
-
     def __repr__(self):
         return "Record(" + dict.__repr__(self) + ")"
 


### PR DESCRIPTION
I just removed the `__contains__` method because it is breaking membership tests that were working before since `has_key` was used instead. I believe it's not necessary as, if implemented correctly, the behavior would be the same as of  `dict.__contains__`. 
