### PR TITLE
BibCheck: allow filtering by subfield contents

### DIFF
--- a/modules/bibcheck/lib/bibcheck_plugins_unit_tests.py
+++ b/modules/bibcheck/lib/bibcheck_plugins_unit_tests.py
@@ -46,6 +46,13 @@ MOCK_RECORD = {
     '340': [([('a', 'FI\xc3\x28LM')], ' ', ' ', '', 7)], # Invalid utf-8
     '595': [([('a', ' Press')], ' ', ' ', '', 7)], # Leading spaces
     '653': [([('a', 'LEP')], '1', ' ', '', 7)],
+    '695': [([('a', 'gravitation: nonlocal'), ('2', 'INSPIRE')], ' ', ' ', '', 7)],
+    '696': [([('2', 'INSPIRE'), ('a', 'gravitation: nonlocal')], ' ', ' ', '', 7)],
+    '697': [([('2', 'author'), ('a', 'gravitation')], ' ', ' ', '', 7)],
+    '698': [([('a', 'gravitation: nonlocal'), ('a', 'propagator'), ('2', 'INSPIRE'), ('a', 'singularity')], ' ', ' ', '', 7)],
+    '699': [([('2', 'INSPIRE'), ('a', 'gravitation')], ' ', ' ', '', 7),
+            ([('2', 'INSPIRE'), ('a', 'antigravitation')], ' ', ' ', '', 7)
+            ],
     '856': [([('f', 'neil.calder@cern.ch')], '0', ' ', '', 7)],
     '994': [([('u', 'http://httpstat.us/200')], '4', ' ', '', 7)], # Url that works
     '995': [([('u', 'www.google.com/favicon.ico')], '4', ' ', '', 7)],  # url without protocol

--- a/modules/bibcheck/lib/bibcheck_unit_tests.py
+++ b/modules/bibcheck/lib/bibcheck_unit_tests.py
@@ -174,6 +174,35 @@ class BibCheckAmendableRecordTest(InvenioTestCase):
             set(self.record.iterfields(["1%%%%%"]))
         )
         self.assertEqual(
+            set([(("695__a", 0, 0, 1), "gravitation: nonlocal")]),
+            set(self.record.iterfields(["695__a"],
+                                       subfield_filter=('2', 'INSPIRE')))
+        )
+        self.assertEqual(
+            set([(("696__a", 0, 1, 0), "gravitation: nonlocal")]),
+            set(self.record.iterfields(["696__a"],
+                                       subfield_filter=('2', 'INSPIRE')))
+        )
+        self.assertEqual(
+            set(),
+            set(self.record.iterfields(["697__a"],
+                                       subfield_filter=('2', 'INSPIRE')))
+        )
+        self.assertEqual(
+            set([(("698__a", 0, 0, 2), "gravitation: nonlocal"),
+                 (("698__a", 0, 1, 2), "propagator"),
+                 (("698__a", 0, 3, 2), "singularity")
+                 ]),
+            set(self.record.iterfields(["698__a"],
+                                       subfield_filter=('2', 'INSPIRE')))
+        )
+        self.assertEqual(
+            set([(("699__a", 0, 1, 0), "gravitation"),
+                 (("699__a", 1, 1, 0), "antigravitation")]),
+            set(self.record.iterfields(["699__a"],
+                                       subfield_filter=('2', 'INSPIRE')))
+        )
+        self.assertEqual(
             set([(("9944_u", 0, 0), self.record["994"][0][0][0][1]),
             (("9954_u", 0, 0), self.record["995"][0][0][0][1]),
             (("9964_u", 0, 0), self.record["996"][0][0][0][1]),


### PR DESCRIPTION
* Add optional argument `subfield_filter` to `iterfields()` method that
  accepts a (code, value) pair. If a code is passed then only fields
  matching this pair will be yielded.

Co-Authored-By: Kirsten Sachs <kirsten.sachs@desy.de>