### PR TITLE
general: WTForms 2 compatibility fixes

### DIFF
--- a/invenio/modules/accounts/forms.py
+++ b/invenio/modules/accounts/forms.py
@@ -19,7 +19,10 @@
 
 """WebAccount Forms"""
 
-from wtforms.validators import Required
+try:
+    from wtforms.validators import Required
+except ImportError:
+    from wtforms.validators import DataRequired as Required
 from flask.ext.login import current_user
 from flask.ext.wtf import Form, validators
 from wtforms.fields import SubmitField, BooleanField, TextField, \

--- a/invenio/modules/deposit/fields/__init__.py
+++ b/invenio/modules/deposit/fields/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2012, 2013 CERN.
+## Copyright (C) 2012, 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -17,7 +17,10 @@
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-from wtforms.fields.core import _unset_value
+try:
+    from wtforms.fields.core import _unset_value
+except ImportError:
+    from wtforms.utils import unset_value as _unset_value
 
 from .abstract import *
 from .author import *

--- a/invenio/modules/search/admin.py
+++ b/invenio/modules/search/admin.py
@@ -20,7 +20,11 @@
 """Flask-Admin page to configure facets sets per collection."""
 
 from wtforms.fields import SelectField, IntegerField
-from wtforms.validators import ValidationError, Required
+from wtforms.validators import ValidationError
+try:
+    from wtforms.validators import Required
+except ImportError:
+    from wtforms.validators import DataRequired as Required
 
 from invenio.ext.admin.views import ModelView
 from invenio.ext.sqlalchemy import db


### PR DESCRIPTION
- Support for _WTForms_ in _Flask-Admin_ is coming thanks to (mrjoes/flask-admin#676). I have tested deposit Article form and basic functionality seems to work.
- If you have custom forms in the overlay plea read [what's new](https://wtforms.readthedocs.org/en/wtforms2/whats_new.html) first (cc @lnielsen-cern, @jalavik, @jmartinm, @egabancho).
#### How to install

``` console
$ pip install -e git+https://github.com/arsgeografica/flask-admin@f836bf46ba9a2c8c709cd7d47cdc92e13a56efa5#egg=Flask-Admin
$ pip install --upgrade wtforms
```
