### PR TITLE
workflows: Holding Pen file serving fix

### DIFF
--- a/invenio/modules/workflows/views/holdingpen.py
+++ b/invenio/modules/workflows/views/holdingpen.py
@@ -217,8 +217,8 @@ def get_file_from_task_result(object_id=None, filename=None):
     task_results = bwobject.get_tasks_results()
     if filename in task_results and task_results[filename]:
         fileinfo = task_results[filename][0].get("result", dict())
-        directory = os.path.split(fileinfo.get("full_path", ""))[0]
-        return send_from_directory(directory, filename)
+        directory, actual_filename = os.path.split(fileinfo.get("full_path", ""))
+        return send_from_directory(directory, actual_filename)
 
 
 @blueprint.route('/restart_record', methods=['GET', 'POST'])


### PR DESCRIPTION
- Fixes the file serving used in Holding Pen details pages
  to also serve files that were automatically prefixed with
  uuid's.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
