### PR TITLE
oaiharvester: record splitting improvement

### DIFF
--- a/invenio/legacy/oaiharvest/utils.py
+++ b/invenio/legacy/oaiharvest/utils.py
@@ -287,55 +287,6 @@ Logs :
     return subject, text
 
 
-def record_extraction_from_file(path):
-    """
-    Get an harvested file, and transform each record as if
-    it was another independent harvested document.
-
-    :param path: is the path of the file harvested
-    :return : return a table of records encapsulated with markup of the
-              document designated by path
-
-    *This function much FASTER (3-5 TIMES) than using regex.*
-    """
-
-    #Will contains all the records
-    list_of_records = []
-    temporary_record = ""
-    footer = ""
-    #will contains the header of the file ie: all lines before the first record
-    header = ""
-    step = 0
-    for line in open(path, 'r+'):
-        # Extraction of the header
-        if step == 0:
-            if not line.startswith("<record>"):
-                header += line
-            else:
-                step = 1
-                temporary_record = line
-        elif step == 1:
-            if line.startswith("</ListRecords>") or line.startswith("</GetRecord>"):
-                step = 2
-                footer = line
-            elif line.startswith("<record>"):
-                temporary_record = line
-            elif line.startswith("</record>"):
-                temporary_record += line
-                list_of_records.append(temporary_record)
-            else:
-                temporary_record += line
-        elif step == 2:
-            footer += line
-
-    #Reassembling of the records and the footer and header
-
-    for i in range(0, len(list_of_records)):
-        list_of_records[i] = header + list_of_records[i] + footer
-
-    return list_of_records
-
-
 def harvest_step(obj, harvestpath):
     """
     Performs the entire harvesting step.

--- a/invenio/modules/oaiharvester/tasks/harvesting.py
+++ b/invenio/modules/oaiharvester/tasks/harvesting.py
@@ -54,6 +54,8 @@ def filtering_oai_pmh_identifier(obj, eng):
     :param obj: BibworkflowObject being processed
     :param eng: BibWorkflowEngine processing the object
     """
+    from ..utils import identifier_extraction_from_string
+
     if "oaiharvest" not in eng.extra_data:
         eng.extra_data["oaiharvest"] = {}
     if "identifiers" not in eng.extra_data["oaiharvest"]:
@@ -64,12 +66,9 @@ def filtering_oai_pmh_identifier(obj, eng):
     else:
         obj_data_list = obj.data
     for record in obj_data_list:
-        delimiter_start = "<identifier>"
-        delimiter_end = "</identifier>"
-        identifier = record[
-            record.index(delimiter_start) +
-            len(delimiter_start):record.index(delimiter_end)
-        ]
+        identifier = (identifier_extraction_from_string(record) or
+                      identifier_extraction_from_string(record, oai_namespace="") or
+                      "")
         if identifier in eng.extra_data["oaiharvest"]["identifiers"]:
             return False
         else:
@@ -186,7 +185,7 @@ def harvest_records(obj, eng):
 
 def get_records_from_file(path=None):
     """Allow to retrieve the records from a file."""
-    from invenio.legacy.oaiharvest.utils import record_extraction_from_file
+    from ..utils import record_extraction_from_file
 
     @wraps(get_records_from_file)
     def _get_records_from_file(obj, eng):

--- a/invenio/modules/oaiharvester/testsuite/test_utils.py
+++ b/invenio/modules/oaiharvester/testsuite/test_utils.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Test for workflow tasks used by OAI harvester."""
+
+import os
+import tempfile
+
+from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
+
+
+class OAIHarvesterUtils(InvenioTestCase):
+
+    """Class to test the OAI XML utils tasks."""
+
+    def test_identifier_extraction(self):
+        """Test extracting identifier from OAI XML."""
+        from invenio.modules.oaiharvester.utils import identifier_extraction_from_string
+        xml_sample = ("<record><test></test>"
+                      "<identifier>identifier1</identifier></record>")
+        self.assertEqual(identifier_extraction_from_string(xml_sample, oai_namespace=""),
+                         "identifier1")
+
+    def test_identifier_extraction_with_namespace(self):
+        """Test extracting identifier from OAI XML."""
+        from invenio.modules.oaiharvester.utils import identifier_extraction_from_string
+        xml_sample = ("<OAI-PMH xmlns='http://www.openarchives.org/OAI/2.0/'>"
+                      "<record><test></test>"
+                      "<identifier>identifier1</identifier></record>"
+                      "</OAI-PMH>")
+        self.assertEqual(identifier_extraction_from_string(xml_sample),
+                         "identifier1")
+
+    def test_records_extraction_without_namespace(self):
+        """Test extracting records from OAI XML without a namespace."""
+        from invenio.modules.oaiharvester.utils import record_extraction_from_string
+        xml_sample = """
+        <OAI-PMH>
+        <responseDate>2014-11-05T09:32:51Z</responseDate>
+        <request verb="GetRecord" identifier="oai:arXiv.org:0804.2273" metadataPrefix="arXiv">http://export.arxiv.org/oai2</request>
+        <GetRecord>
+        <record>
+        <header>
+         <identifier>oai:arXiv.org:0804.2273</identifier>
+         <datestamp>2008-04-16</datestamp>
+         <setSpec>cs</setSpec>
+        </header>
+        <metadata>
+         <arXiv>
+         <id>0804.2273</id><created>2008-04-14</created><authors><author><keyname>Lagoze</keyname><forenames>Carl</forenames></author><author><keyname>Van de Sompel</keyname><forenames>Herbert</forenames></author><author><keyname>Nelson</keyname><forenames>Michael L.</forenames></author><author><keyname>Warner</keyname><forenames>Simeon</forenames></author><author><keyname>Sanderson</keyname><forenames>Robert</forenames></author><author><keyname>Johnston</keyname><forenames>Pete</forenames></author></authors><title>Object Re-Use &amp; Exchange: A Resource-Centric Approach</title><categories>cs.DL cs.NI</categories><acm-class>C.2.3</acm-class><license>http://creativecommons.org/licenses/by/3.0/</license><abstract>  The OAI Object Reuse and Exchange (OAI-ORE) framework recasts the
+        repository-centric notion of digital object to a bounded aggregation of Web
+        resources. In this manner, digital library content is more integrated with the
+        Web architecture, and thereby more accessible to Web applications and clients.
+        This generalized notion of an aggregation that is independent of repository
+        containment conforms more closely with notions in eScience and eScholarship,
+        where content is distributed across multiple services and databases. We provide
+        a motivation for the OAI-ORE project, review previous interoperability efforts,
+        describe draft ORE specifications and report on promising results from early
+        experimentation that illustrate improved interoperability and reuse of digital
+        objects.
+        </abstract></arXiv>
+        </metadata>
+        </record>
+        </GetRecord>
+        </OAI-PMH>
+        """
+        self.assertEqual(len(record_extraction_from_string(xml_sample, oai_namespace="")),
+                         1)
+
+    def test_records_extraction_with_namespace_getrecord(self):
+        """Test extracting records from OAI XML with GetRecord."""
+        from invenio.modules.oaiharvester.utils import record_extraction_from_string
+        xml_sample = """
+        <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+        <responseDate>2014-11-05T09:32:51Z</responseDate>
+        <request verb="GetRecord" identifier="oai:arXiv.org:0804.2273" metadataPrefix="arXiv">http://export.arxiv.org/oai2</request>
+        <GetRecord>
+        <record>
+        <header>
+         <identifier>oai:arXiv.org:0804.2273</identifier>
+         <datestamp>2008-04-16</datestamp>
+         <setSpec>cs</setSpec>
+        </header>
+        <metadata>
+         <arXiv xmlns="http://arxiv.org/OAI/arXiv/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://arxiv.org/OAI/arXiv/ http://arxiv.org/OAI/arXiv.xsd">
+         <id>0804.2273</id><created>2008-04-14</created><authors><author><keyname>Lagoze</keyname><forenames>Carl</forenames></author><author><keyname>Van de Sompel</keyname><forenames>Herbert</forenames></author><author><keyname>Nelson</keyname><forenames>Michael L.</forenames></author><author><keyname>Warner</keyname><forenames>Simeon</forenames></author><author><keyname>Sanderson</keyname><forenames>Robert</forenames></author><author><keyname>Johnston</keyname><forenames>Pete</forenames></author></authors><title>Object Re-Use &amp; Exchange: A Resource-Centric Approach</title><categories>cs.DL cs.NI</categories><acm-class>C.2.3</acm-class><license>http://creativecommons.org/licenses/by/3.0/</license><abstract>  The OAI Object Reuse and Exchange (OAI-ORE) framework recasts the
+        repository-centric notion of digital object to a bounded aggregation of Web
+        resources. In this manner, digital library content is more integrated with the
+        Web architecture, and thereby more accessible to Web applications and clients.
+        This generalized notion of an aggregation that is independent of repository
+        containment conforms more closely with notions in eScience and eScholarship,
+        where content is distributed across multiple services and databases. We provide
+        a motivation for the OAI-ORE project, review previous interoperability efforts,
+        describe draft ORE specifications and report on promising results from early
+        experimentation that illustrate improved interoperability and reuse of digital
+        objects.
+        </abstract></arXiv>
+        </metadata>
+        </record>
+        </GetRecord>
+        </OAI-PMH>
+        """
+        self.assertEqual(len(record_extraction_from_string(xml_sample)),
+                         1)
+
+    def test_records_extraction_with_namespace_listrecords(self):
+        """Test extracting records from OAI XML with ListRecords."""
+        from invenio.modules.oaiharvester.utils import record_extraction_from_string
+        xml_sample = """
+        <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+        <responseDate>2014-11-05T09:30:08Z</responseDate><request from="2014-05-01" verb="ListRecords" set="INSPIRE:Conferences" metadataPrefix="marcxml" until="2014-05-02">http://inspirehep.net/oai2d</request><ListRecords>
+        <record><header><identifier>oai:inspirehep.net:972855</identifier><datestamp>2014-05-02T12:22:51Z</datestamp><setSpec>INSPIRE:Conferences</setSpec></header><metadata><marc:record xmlns:marc="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd" type="Bibliographic">
+             <marc:leader>00000coc  2200000uu 4500</marc:leader>
+          <marc:controlfield tag="001">972855</marc:controlfield>
+          <marc:controlfield tag="005">20140502142251.0</marc:controlfield>
+          <marc:datafield tag="111" ind1=" " ind2=" ">
+            <marc:subfield code="a">2000 IEEE Nuclear and Space Radiation Effects Conference</marc:subfield>
+            <marc:subfield code="c">Reno, Nevada</marc:subfield>
+            <marc:subfield code="d">24-28 Jul 2000</marc:subfield>
+            <marc:subfield code="e">NSREC 2000</marc:subfield>
+            <marc:subfield code="g">C00-07-24.3</marc:subfield>
+            <marc:subfield code="x">2000-07-24</marc:subfield>
+          </marc:datafield>
+        </marc:record>
+        </metadata></record><record><header><identifier>oai:inspirehep.net:974318</identifier><datestamp>2014-05-02T12:22:47Z</datestamp><setSpec>INSPIRE:Conferences</setSpec></header><metadata><marc:record xmlns:marc="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd" type="Bibliographic">
+             <marc:leader>00000coc  2200000uu 4500</marc:leader>
+          <marc:controlfield tag="001">974318</marc:controlfield>
+          <marc:controlfield tag="005">20140502142246.0</marc:controlfield>
+          <marc:datafield tag="111" ind1=" " ind2=" ">
+            <marc:subfield code="a">2002 IEEE Nuclear and Space Radiation Effects Conference</marc:subfield>
+            <marc:subfield code="c">Phoenix, Arizona</marc:subfield>
+            <marc:subfield code="d">15-19 Jul 2002</marc:subfield>
+            <marc:subfield code="e">NSREC 2002</marc:subfield>
+            <marc:subfield code="g">C02-07-15.3</marc:subfield>
+            <marc:subfield code="x">2002-07-15</marc:subfield>
+          </marc:datafield>
+        </marc:record>
+        </metadata></record></ListRecords>
+        </OAI-PMH>
+        """
+        self.assertEqual(len(record_extraction_from_string(xml_sample)),
+                         2)
+
+    def test_records_extraction_from_file(self):
+        """Test extracting records from OAI XML."""
+        from invenio.modules.oaiharvester.utils import record_extraction_from_file
+        xml_sample = """
+        <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+        <responseDate>2014-11-05T09:32:51Z</responseDate>
+        <request verb="GetRecord" identifier="oai:arXiv.org:0804.2273" metadataPrefix="arXiv">http://export.arxiv.org/oai2</request>
+        <GetRecord>
+        <record>
+        <header>
+         <identifier>oai:arXiv.org:0804.2273</identifier>
+         <datestamp>2008-04-16</datestamp>
+         <setSpec>cs</setSpec>
+        </header>
+        <metadata>
+         <arXiv xmlns="http://arxiv.org/OAI/arXiv/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://arxiv.org/OAI/arXiv/ http://arxiv.org/OAI/arXiv.xsd">
+         <id>0804.2273</id><created>2008-04-14</created><authors><author><keyname>Lagoze</keyname><forenames>Carl</forenames></author><author><keyname>Van de Sompel</keyname><forenames>Herbert</forenames></author><author><keyname>Nelson</keyname><forenames>Michael L.</forenames></author><author><keyname>Warner</keyname><forenames>Simeon</forenames></author><author><keyname>Sanderson</keyname><forenames>Robert</forenames></author><author><keyname>Johnston</keyname><forenames>Pete</forenames></author></authors><title>Object Re-Use &amp; Exchange: A Resource-Centric Approach</title><categories>cs.DL cs.NI</categories><acm-class>C.2.3</acm-class><license>http://creativecommons.org/licenses/by/3.0/</license><abstract>  The OAI Object Reuse and Exchange (OAI-ORE) framework recasts the
+        repository-centric notion of digital object to a bounded aggregation of Web
+        resources. In this manner, digital library content is more integrated with the
+        Web architecture, and thereby more accessible to Web applications and clients.
+        This generalized notion of an aggregation that is independent of repository
+        containment conforms more closely with notions in eScience and eScholarship,
+        where content is distributed across multiple services and databases. We provide
+        a motivation for the OAI-ORE project, review previous interoperability efforts,
+        describe draft ORE specifications and report on promising results from early
+        experimentation that illustrate improved interoperability and reuse of digital
+        objects.
+        </abstract></arXiv>
+        </metadata>
+        </record>
+        </GetRecord>
+        </OAI-PMH>
+        """
+        fd_tmp, path_tmp = tempfile.mkstemp()
+        os.write(fd_tmp, xml_sample)
+        os.close(fd_tmp)
+
+        self.assertEqual(len(record_extraction_from_file(path_tmp)), 1)
+
+
+TEST_SUITE = make_test_suite(OAIHarvesterUtils)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)

--- a/invenio/modules/oaiharvester/utils.py
+++ b/invenio/modules/oaiharvester/utils.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""OAI harvest utils."""
+
+from lxml import etree
+
+
+def record_extraction_from_file(path, oai_namespace="{http://www.openarchives.org/OAI/2.0/}"):
+    """Given a harvested file return a list of every record incl. headers.
+
+    :param path: is the path of the file harvested
+    :type path: str
+
+    :return: return a list of XML records as string
+    :rtype: str
+    """
+    list_of_records = []
+    with open(path) as xml_file:
+        list_of_records = record_extraction_from_string(xml_file.read(), oai_namespace)
+    return list_of_records
+
+
+def record_extraction_from_string(xml_string, oai_namespace="{http://www.openarchives.org/OAI/2.0/}"):
+    """Given a OAI-PMH XML return a list of every record incl. headers.
+
+    :param xml_string: OAI-PMH XML
+    :type xml_string: str
+
+    :return: return a list of XML records as string
+    :rtype: str
+    """
+    root = etree.fromstring(xml_string)
+    headers = []
+    headers.extend(root.findall(".//{0}responseDate".format(oai_namespace)))
+    headers.extend(root.findall(".//{0}request".format(oai_namespace)))
+
+    records = root.findall(".//{0}record".format(oai_namespace))
+
+    list_of_records = []
+    for record in records:
+        wrapper = etree.Element("{0}OAI-PMH".format(oai_namespace))
+        for header in headers:
+            wrapper.append(header)
+        wrapper.append(record)
+        list_of_records.append(etree.tostring(wrapper))
+    return list_of_records
+
+
+def identifier_extraction_from_string(xml_string, oai_namespace="{http://www.openarchives.org/OAI/2.0/}"):
+    """Given a OAI-PMH XML string return the OAI identifier.
+
+    :param xml_string: OAI-PMH XML
+    :type xml_string: str
+
+    :return: OAI identifier
+    :rtype: str
+    """
+    root = etree.fromstring(xml_string)
+    node = root.find(".//{0}identifier".format(oai_namespace))
+    if node is not None:
+        return node.text


### PR DESCRIPTION
- Improves the splitting of records from OAI-PMH requests to also
  handle the case of MARCXML from other Invenio instances.
- Defers the splitting logic to a XML parser and moves some utility
  functions to a new utils file in the new module structure.
- Adds tests for these utility functions.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
