### PR TITLE
base: bundle less filename correction

### DIFF
--- a/invenio/base/bundles.py
+++ b/invenio/base/bundles.py
@@ -136,7 +136,7 @@ invenio = Bundle(
 #  - LESS_RUN_IN_DEBUG is False
 #
 lessjs = Bundle(
-    "vendors/less/dist/less-1.7.0.js",
+    "vendors/less/dist/less.js",
     output="less.js",
     filters="uglifyjs",
     weight=0,


### PR DESCRIPTION
- Corrects the less JS bundle filename to avoid causing a file
  not found error for this file while building assets.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
