### PR TITLE
WebSearch: fix number of printed records

### DIFF
--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -4510,6 +4510,9 @@ def print_records(req, recIDs, jrec=1, rg=CFG_WEBSEARCH_DEF_RECORDS_IN_GROUPS, f
 
         #req.write("%s:%d-%d" % (recIDs, irec_min, irec_max))
 
+        if len(recIDs) > rg and rg != -9999:
+            recIDs = slice_records(recIDs, jrec, rg)
+
         if format.startswith('x'):
 
             # print header if needed


### PR DESCRIPTION
* Fixes the number of records printed when a ranking methond is
  used.

Co-authored-by: Nikolaos Kasioumis <nikolaos.kasioumis@cern.ch>
Signed-off-by: Ludmila Marian <ludmila.marian@gmail.com>