### PR TITLE
installation: disable SSLv3 in Apache config

### DIFF
--- a/invenio/base/templates/invenio-apache-vhost-ssl.conf.tpl
+++ b/invenio/base/templates/invenio-apache-vhost-ssl.conf.tpl
@@ -24,7 +24,7 @@
 ServerSignature Off
 ServerTokens Prod
 TraceEnable off
-SSLProtocol all -SSLv2
+SSLProtocol all -SSLv2 -SSLv3
 SSLCipherSuite HIGH:MEDIUM:!ADH
 {{ '#' if not listen_directive_needed }}{{ 'Listen ' + vhost_site_url_port}}
 NameVirtualHost {{ vhost_ip_address }}:{{ vhost_site_url_port }}


### PR DESCRIPTION
- Disables SSLv3.0 due to known vulnerability.  (closes #2515)

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
