### PR TITLE
deposit: FileUploadField validation fixes

### DIFF
--- a/invenio/modules/deposit/validation_utils.py
+++ b/invenio/modules/deposit/validation_utils.py
@@ -78,8 +78,12 @@ class RequiredIf(object):
 
     def __call__(self, form, field):
         try:
+            from invenio.modules.deposit.fields.file_upload import FileUploadField
             other_field = getattr(form, self.other_field_name)
-            other_val = other_field.data
+            if isinstance(other_field, FileUploadField):
+                other_val = form.files
+            else:
+                other_val = other_field.data
             for v in self.values:
                 # Check if field value is required
                 if (callable(v) and v(other_val)) or (other_val == v):


### PR DESCRIPTION
[[continue](https://github.com/jirikuncar/invenio/pull/312/files#r20167198)] @jirikuncar, I could add the `form.files` to `field.data` in `pre_validation()`, but

```
> json.dumps(form.files)
*** TypeError: {"checksum": "f164caa95a9825b34366392c921486e4", "size": 56629, "id": "a97b2e4e-f349-4c1b-8571-b8e54ed18a17", "name": "file.pdf"} is not JSON serializable
```

Since actually we don't want to save the `DepositionFile` objects from `form.files` in the `field.data` but simply validate them, we could just add that exception there. A different approach could be handle `field.data` in the `FileUploadField` as a bool and assign T/F depending whether there are files or not (and change the validator afterwards)... But I'm not sure about this last one.
