### PR TITLE
workflows: always save current object

### DIFF
--- a/invenio/modules/workflows/tasks/marcxml_tasks.py
+++ b/invenio/modules/workflows/tasks/marcxml_tasks.py
@@ -150,7 +150,6 @@ def convert_record(stylesheet="oaidc2marcxml.xsl"):
         except Exception as e:
             msg = "Could not convert record: %s\n%s" % \
                   (str(e), traceback.format_exc())
-            obj.extra_data["_error_msg"] = msg
             raise WorkflowError("Error: %s" % (msg,),
                                 id_workflow=eng.uuid,
                                 id_object=obj.id)


### PR DESCRIPTION
- Adds missing saving points of BibWorkflowObjects in the workflow
  engine when using engine execution manipulation functions such
  as `continueNextToken()`, `jumpTokenBack()`, `jumpTokenForward()`.
- Removes duplicate setting of error_msg.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
