### PR TITLE
authors: initial release

### DIFF
--- a/invenio/base/config.py
+++ b/invenio/base/config.py
@@ -63,12 +63,13 @@ PACKAGES = [
 ]
 
 PACKAGES_EXCLUDE = [
-    'invenio.modules.archiver',
     'invenio.modules.annotations',
+    'invenio.modules.archiver',
+    'invenio.modules.authors',
     'invenio.modules.communities',
-    'invenio.modules.pages',
     'invenio.modules.linkbacks',
     'invenio.modules.multimedia',
+    'invenio.modules.pages',
 ]
 
 LEGACY_WEBINTERFACE_EXCLUDE = [

--- a/invenio/modules/accounts/models.py
+++ b/invenio/modules/accounts/models.py
@@ -55,6 +55,7 @@ class User(db.Model):
         return "%s <%s>" % (self.nickname, self.email)
 
     __tablename__ = 'user'
+    __mapper_args__ = {'confirm_deleted_rows': False}
     id = db.Column(db.Integer(15, unsigned=True), primary_key=True,
                    autoincrement=True)
     email = db.Column(db.String(255), nullable=False, server_default='',

--- a/invenio/modules/authors/__init__.py
+++ b/invenio/modules/authors/__init__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+"""Authors module.
+
+    This module is work in progress. To enable it, remove the entry from
+    PACKAGE_EXCLUDED in invenio.base.config.
+"""
+
+from warnings import warn
+
+#TODO Remove this warning when authors module is stable.
+warn("This module is 'work in progress' and thus unstable.", ImportWarning)

--- a/invenio/modules/authors/api.py
+++ b/invenio/modules/authors/api.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2013, 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Author API."""

--- a/invenio/modules/authors/config.py
+++ b/invenio/modules/authors/config.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Default configuration of the authors module."""

--- a/invenio/modules/authors/errors.py
+++ b/invenio/modules/authors/errors.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Exceptions raised by Author API."""
+
+
+class AuthorsError(Exception):
+
+    """General author exception.
+
+    All author-related exceptions should inherit from this class.
+    """
+
+
+class SignatureExistsError(AuthorsError):
+
+    """Should be raised when a signature already exists."""

--- a/invenio/modules/authors/models.py
+++ b/invenio/modules/authors/models.py
@@ -1,0 +1,320 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2011, 2012, 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Authors data models."""
+
+from sqlalchemy.orm.exc import MultipleResultsFound
+
+from invenio.ext.sqlalchemy import db, utils
+from invenio.modules.accounts.models import User
+from invenio.modules.records.models import Record
+from invenio.modules.records.api import get_record
+
+from .errors import SignatureExistsError
+
+# The 'authors_citation' table is an association table of publications.
+# An 'authors_publication' cites an other 'authors_publication'.
+Citation = db.Table('authors_citation', db.metadata,
+                    db.Column('citer', db.Integer(15, unsigned=True),
+                              db.ForeignKey('authors_publication.id')),
+                    db.Column('cited', db.Integer(15, unsigned=True),
+                              db.ForeignKey('authors_publication.id')))
+
+
+class Publication(db.Model):
+
+    """Model representing a publication entity.
+
+    Each publication is associated to an Invenio bibrec (record),
+    may have authors and may contain references to other publications.
+    Finally, each publication may have citations by other publications.
+    """
+
+    __tablename__ = 'authors_publication'
+
+    # When deleting a number of signatures, it should not be expected
+    # by the mapper that the same number of publications should be
+    # deleted, as many signatures can be associated with a publication.
+    # This disables the default behaviour of the mapper to show a
+    # warning.
+    __mapper_args__ = {'confirm_deleted_rows': False}
+
+    id = db.Column(db.Integer(15, unsigned=True), primary_key=True,
+                   autoincrement=True, nullable=False)
+    """Id of the publication (required)."""
+
+    id_bibrec = db.Column(db.MediumInteger(8, unsigned=True),
+                          db.ForeignKey(Record.id), nullable=False)
+    """Id of the associated Invenio bibrec (required)."""
+
+    authors = db.relationship('Author', secondary='authors_signature',
+                              secondaryjoin="""and_(
+                                  Signature.id_author == Author.id,
+                                  Signature.attribution.in_(
+                                      ('unknown', 'verified')))""")
+    """Authors of the publication."""
+
+    references = db.relationship('Publication', secondary='authors_citation',
+                                 primaryjoin=Citation.c.cited == id,
+                                 secondaryjoin=Citation.c.citer == id,
+                                 backref='citations')
+    """Publications that this publication cites.
+           Other direction: publications that cite this publication."""
+
+    @property
+    def record(self):
+        """Get the Invenio record in JSON format.
+
+        :return: an instance of a record in JSON format
+        """
+        return get_record(self.id_bibrec)
+
+    def __repr__(self):
+        """Return a printable representation of a Publication."""
+        return 'Publication(id=%s)' % self.id
+
+    @utils.session_manager
+    def delete(self):
+        """Delete a publication and the associated signatures.
+
+        Note: This is the mandatory way to delete a publication when
+        using database engines that do not support 'ON DELETE' clauses
+        (e.g. MyISAM of MySQL).
+        """
+        sigs = Signature.query.filter(Signature.publication == self).all()
+        for s in sigs:
+            db.session.delete(s)
+
+        db.session.delete(self)
+
+
+class Author(db.Model):
+
+    """Model representing an author entity.
+
+    Each author may be associated to an Invenio author bibrec (record),
+    an Invenio user and may have publications. Moreover,
+    an author may have fellow coauthors and citations (based on his
+    publications).
+    """
+
+    __tablename__ = 'authors_author'
+
+    # When deleting a number of signatures, it should not be expected
+    # by the mapper that the same number of authors should be deleted,
+    # as many signatures can be associated with a publication. This
+    # disables the default behaviour of the mapper to show a warning.
+    __mapper_args__ = {'confirm_deleted_rows': False}
+
+    id = db.Column(db.Integer(15, unsigned=True), primary_key=True,
+                   autoincrement=True, nullable=False)
+    """Id of the author (required)."""
+
+    id_bibrec = db.Column(db.MediumInteger(8, unsigned=True),
+                          db.ForeignKey(Record.id))
+    """Id of the associated Invenio author bibrec."""
+
+    id_user = db.Column(db.Integer(15, unsigned=True), db.ForeignKey(User.id))
+    """Id of the associated Invenio user."""
+
+    user = db.relationship('User', backref=db.backref("author", uselist=False))
+    """Invenio user associated with this author."""
+    publications = db.relationship('Publication',
+                                   secondary='authors_signature',
+                                   secondaryjoin="""and_(
+                                    Signature.id_publication == Publication.id,
+                                    Signature.attribution.in_(
+                                     ('unknown', 'verified')))""")
+    """Publications of the author."""
+
+    @property
+    def record(self):
+        """Get the Invenio author record in JSON format.
+
+        :return: an instance of an author record in JSON format
+        """
+        return get_record(self.id_bibrec)
+
+    @property
+    def coauthors(self):
+        """Get the the authors co-writing this author's publications.
+
+        :return: Author objects
+        """
+        return (coauthor for publication in self.publications
+                for coauthor in publication.authors if coauthor != self)
+
+    @property
+    def citations(self):
+        """Get the citations of this author's publications.
+
+        :return: Publication objects
+        """
+        return (citation for publication in self.publications
+                for citation in publication.citations)
+
+    def __repr__(self):
+        """Return a printable representation of an Author."""
+        return 'Author(id=%s)' % self.id
+
+    @utils.session_manager
+    def delete(self):
+        """Delete an author and modify the associated signatures.
+
+        When deleting an author, the author field in the associated
+        signatures should be set to None.
+
+        Note: This is the mandatory way to delete a publication when
+        using database engines that do not support 'ON DELETE' clauses
+        (e.g. MyISAM of MySQL).
+        """
+        for s in Signature.query.filter(Signature.author == self).all():
+            s.author = None
+            db.session.add(s)
+        db.session.commit()
+
+        db.session.delete(self)
+
+
+class Signature(db.Model):
+
+    """Represents a signature of an author on a publication.
+
+    A signature is the event when an author "signs" a publication.
+    For example, "author A has written publication P" is a valid
+    signature.
+
+    Each signature has a unique id, an author and a publication.
+    Additionally, each signature is associated to a curator and a JSON
+    field representing raw metadata from the corresponding publication.
+
+    Finally, each signature has an attribution field which represents
+    a certainty level: a signature may be either attributed
+    automatically (default), verified by a curator or rejected by a
+    curator.
+    """
+
+    __tablename__ = 'authors_signature'
+    __mapper_args__ = {'confirm_deleted_rows': False}
+
+    id = db.Column(db.Integer(15, unsigned=True), primary_key=True,
+                   autoincrement=True, nullable=False)
+    """Id of the signature (required)."""
+
+    id_author = db.Column(db.Integer(15, unsigned=True),
+                          db.ForeignKey(Author.id, ondelete="SET NULL"))
+    """Id of the associated author."""
+
+    id_publication = db.Column(db.Integer(15, unsigned=True),
+                               db.ForeignKey(Publication.id), nullable=False)
+    """Id of the associated publication."""
+
+    id_curator = db.Column(db.Integer(15, unsigned=True),
+                           db.ForeignKey(User.id))
+    """Id of the last curator (User) of this signature."""
+
+    raw_metadata = db.Column(db.JSON, default=None)
+    """Raw metadata of the record in JSON format."""
+
+    attribution = db.Column(db.Enum('unknown', 'rejected', 'verified',
+                                    name='authors_attribution'),
+                            default='unknown')
+    """Attribution may be "unknown" (default), "verified", "rejected."""
+
+    author = db.relationship('Author', backref='signatures')
+    """Author who signs."""
+
+    publication = db.relationship('Publication', backref='signatures')
+    """Publication signed."""
+
+    curator = db.relationship('User')
+    """User who last curated this signature
+           (disambiguation algorithm if None)"""
+
+    def __repr__(self):
+        """Return a printable representation of a Signature."""
+        return 'Signature(id=%s)' % self.id
+
+    @utils.session_manager
+    def claim(self, curator):
+        """Claim that the signature is a true event.
+
+        :param curator: the User who verifies the truth
+        """
+        self.curator = curator
+        self.attribution = 'verified'
+        db.session.add(self)
+
+    @utils.session_manager
+    def disclaim(self, curator):
+        """Disclaim that the signature is a true event.
+
+        :param curator: the User who verifies the falseness
+        """
+        self.curator = curator
+        self.attribution = 'rejected'
+        db.session.add(self)
+
+    @utils.session_manager
+    def move(self, author, curator=None):
+        """Modify the author in the signature.
+
+        The attribution of the signature is not altered.
+
+        :param author: the Author to move the signature to
+        :param curator: the User who performs the move (optional)
+        """
+        self.curator = curator
+        self.author = author
+        db.session.add(self)
+
+    @staticmethod
+    @utils.session_manager
+    def reassign(author, curator, signature):
+        """Reassign a signature to a different author.
+
+        The current author of a signature rejects the signature. Then,
+        a new signature is created and claimed for the given author.
+
+        :param author: the Author to reassign the signature to
+        :param curator: the User who performs the reassignment
+        :param signature: the signature to reassign
+
+        :raise SignatureExistsError: the given author already has
+                                     the given signature.
+        """
+        try:
+            sig = Signature.query.filter_by(publication=signature.publication,
+                                            author=author).scalar()
+            if sig:
+                raise SignatureExistsError(
+                    "Cannot reassign signature {signature} to author {author} "
+                    "for publication {signature.publication}. The author "
+                    "already has a signature for this publication."
+                    .format(signature=signature, author=author))
+            signature.disclaim(curator)
+            new_signature = Signature(publication=signature.publication,
+                                      author=author)
+            new_signature.claim(curator)
+        except MultipleResultsFound as e:
+            # This should not happen.
+            raise e
+
+
+__all__ = ('Publication', 'Author', 'Signature', 'Citation')

--- a/invenio/modules/authors/tasks.py
+++ b/invenio/modules/authors/tasks.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Author tasks."""

--- a/invenio/modules/authors/testsuite/__init__.py
+++ b/invenio/modules/authors/testsuite/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2011, 2012, 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+"""Authors tests."""

--- a/invenio/modules/authors/testsuite/test_authors_models.py
+++ b/invenio/modules/authors/testsuite/test_authors_models.py
@@ -1,0 +1,341 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2011, 2012, 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Tests for Authors Models."""
+from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
+
+from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
+
+
+class AuthorModelsTestCase(InvenioTestCase):
+
+    """Base class for author model tests."""
+
+    def setUp(self):
+        """Basic setup for tests."""
+        self.import_context()
+        self._dummy_record = self.Record()
+        self.db.session.add(self._dummy_record)
+        self.db.session.commit()
+
+        self._user = self.User(password='test')
+        self._publications = [self.Publication(id_bibrec=self._dummy_record.id)
+                              for _ in range(0, 3)]
+        self._authors = [self.Author() for _ in range(0, 3)]
+
+        map(self._publications[0].authors.append, self._authors[0:2])
+        map(self._publications[1].authors.append, self._authors[1:3])
+        self._publications[2].authors.append(self._authors[0])
+        self._publications[0].references.append(self._publications[1])
+
+        self.db.session.add(self._user)
+        map(self.db.session.add, self._authors)
+        map(self.db.session.add, self._publications)
+        self.db.session.commit()
+
+    def tearDown(self):
+        """Basic teardown for tests."""
+        for author in self._authors:
+            author.delete()
+
+        for publication in self._publications:
+            publication.delete()
+
+        self.db.session.delete(self._dummy_record)
+        self.db.session.delete(self._user)
+        self.db.session.commit()
+
+    def import_context(self):
+        """Import the Invenio classes here to make sure the testing
+           context is valid."""
+        from invenio.ext.sqlalchemy import db
+        from invenio.modules.authors import models
+        from invenio.modules.accounts.models import User
+        from invenio.modules.records.models import Record
+        from invenio.modules.authors.errors import SignatureExistsError
+
+        self.db = db
+        self.Author = models.Author
+        self.Publication = models.Publication
+        self.Signature = models.Signature
+        self.User = User
+        self.SignatureExistsError = SignatureExistsError
+        self.Record = Record
+
+
+class AuthorsModelsBasicTestCase(AuthorModelsTestCase):
+
+    """Basic models tests."""
+
+    def test_publication_has_author(self):
+        """Publications should have authors assigned automatically."""
+        pub_authors = self._publications[0].authors
+
+        self.assertEqual(set(pub_authors), {self._authors[0],
+                                            self._authors[1]})
+
+    def test_author_has_publication(self):
+        """Authors should have publications assigned automatically."""
+        author_pubs = self._authors[0].publications
+
+        self.assertEqual(set(author_pubs),
+                         {self._publications[0], self._publications[2]})
+
+        author_pubs = self._authors[1].publications
+
+        self.assertEqual(set(author_pubs),
+                         {self._publications[0], self._publications[1]})
+
+    def test_references_and_citations(self):
+        """The references of a paper should be the citations of the
+           referenced paper."""
+        self.assertEqual(self._publications[0].references,
+                         [self._publications[1]])
+
+        self.assertEqual(self._publications[1].citations,
+                         [self._publications[0]])
+
+    def test_coauthors(self):
+        """Test for author.coauthors."""
+        self.assertEqual(tuple(self._authors[0].coauthors),
+                         (self._authors[1],))
+
+    def test_author_citations(self):
+        """Test for author.citations."""
+        self.assertEqual(tuple(self._authors[2].citations),
+                         (self._publications[0],))
+
+    def test_author_user_one_to_one_relationship(self):
+        """The author should be connected to one user only.
+           The access of the author associated to the user should
+           be possible."""
+        self._authors[0].user = self._user
+        self.db.session.add(self._authors[0])
+        self.db.session.commit()
+        self.assertEqual(self._authors[0].user, self._user)
+        self.assertEqual(self._user.author, self._authors[0])
+
+        self._authors[1].user = self._user
+        self.db.session.add(self._authors[1])
+        self.db.session.commit()
+        self.assertFalse(self._authors[0].user)
+        self.assertEqual(self._authors[1].user, self._user)
+        self.assertEqual(self._user.author, self._authors[1])
+
+
+class TestAuthorsModelsCleanup(AuthorModelsTestCase):
+
+    """Models tests testing the deletion of models and side-effects."""
+
+    def setUp(self):
+        """Additional setup for claiming tests."""
+        self.import_context()
+        self._dummy_record = self.Record()
+        self.db.session.add(self._dummy_record)
+        self.db.session.commit()
+
+        self._publications = [self.Publication(id_bibrec=self._dummy_record.id)
+                              for _ in range(0, 3)]
+        self._author = self.Author()
+        self._user = self.User(password='test')
+        self._author.user = self._user
+
+        map(self._author.publications.append, self._publications)
+        self.db.session.add(self._author)
+        map(self.db.session.add, self._publications)
+        self.db.session.add(self._user)
+        self.db.session.commit()
+
+    def tearDown(self):
+        """Additional teardown for claiming tests."""
+        try:
+            self._author.delete()
+        except AttributeError:
+            pass
+        for publication in self._publications:
+            try:
+                publication.delete()
+            except AttributeError:
+                pass
+        self.db.session.delete(self._dummy_record)
+        self.db.session.delete(self._user)
+        self.db.session.commit()
+
+    def test_author_deletion(self):
+        """When an author is deleted, the respective signatures should
+           have NULL as author. The publications should be there"""
+        sigs = self.Signature.query.filter(
+            self.Signature.author == self._author).all()
+        self._author.delete()
+
+        self.assertEqual([None] * 3, [sig.author for sig in sigs])
+        self.assertTrue(self._user)
+
+    def test_publication_deletion(self):
+        """When a publication is deleted the respective signatures should be
+           deleted"""
+        self._publications[0].delete()
+        deleted_pub = self._publications[0]
+
+        self.assertFalse(self.Signature.query.filter(
+            self.Signature.publication == deleted_pub).all())
+
+    def test_signature_deletion(self):
+        """When a signature is deleted, neither the publication or
+           the author should be deleted. However, the link between
+           the publication and the author should disappear."""
+        pub1 = self._publications[0]
+        sign1 = self.Signature.query.filter(
+            self.Signature.publication == pub1).all()[0]
+        self.db.session.delete(sign1)
+        self.db.session.commit()
+
+        author = self._author
+        publication = self._publications[0]
+
+        self.assertTrue(author)
+        self.assertTrue(publication)
+        self.assertEqual(set(author.publications), set(self._publications[1:]))
+
+    def test_user_deletion(self):
+        """When a user gets deleted, the author should stay intact."""
+        self.db.session.delete(self._user)
+        self.assertTrue(self._author)
+
+
+class TestAuthorsModelsClaims(AuthorModelsTestCase):
+
+    """Tests for the claiming operations of signatures"""
+
+    def setUp(self):
+        """Additional setup for claiming tests."""
+        super(TestAuthorsModelsClaims, self).setUp()
+        pub_2 = self._publications[1]
+        self._authors[0].publications.append(pub_2)
+        self.db.session.add(self._authors[0])
+        self.db.session.commit()
+
+    def tearDown(self):
+        """Additional teardown for claiming tests."""
+        self.db.session.commit()
+        super(TestAuthorsModelsClaims, self).tearDown()
+
+    def _get_signature(self, author, publication):
+        """Get signature for author and publication.
+
+        Fails test if no or many signatures are found.
+        """
+        sig_query = self.Signature.query.filter(
+            self.db.and_(self.Signature.author == author,
+                         self.Signature.publication == publication))
+        try:
+            sig = sig_query.one()
+        except NoResultFound:
+            self.fail('No signature found for author: %s and publication %s' %
+                      (author, publication))
+        except MultipleResultsFound:
+            self.fail("""Multiple signatures found for author: %s and
+            publication %s. In the context of the test this is wrong.""" %
+                      (author, publication))
+        return sig
+
+    def test_signature_claim(self):
+        """When a signature is claimed, the attribution status is set
+           to 'verified' and the user claiming becomes the curator."""
+        sig = self._get_signature(self._authors[0],
+                                  self._publications[1])
+        sig_id = sig.id
+        sig.claim(self._user)
+        self.assertEqual(sig.author, self.Signature.query.get(sig_id).author)
+        self.assertEqual(self._user,
+                         self.Signature.query.get(sig_id).curator)
+        self.assertEqual(self.Signature.query.get(sig_id).attribution,
+                         'verified')
+
+    def test_signature_disclaim(self):
+        """When a signature is disclaimed, the attribution status
+           is set to verified and the user disclaiming becomes the
+           curator."""
+        sig = self._get_signature(self._authors[0],
+                                  self._publications[1])
+        sig_id = sig.id
+        pubs_before = len(sig.author.publications)
+        sig.disclaim(self._user)
+        self.assertEqual(pubs_before, len(sig.author.publications) + 1)
+        self.assertEqual(sig.author, self.Signature.query.get(sig_id).author)
+        self.assertEqual(self._user,
+                         self.Signature.query.get(sig_id).curator)
+        self.assertEqual(self.Signature.query.get(sig_id).attribution,
+                         'rejected')
+        self.assertFalse(self._publications[1]
+                         in self._authors[0].publications)
+        self.assertFalse(self._authors[0] in self._publications[1].authors)
+
+    def test_signature_move(self):
+        """No attribution should be altered.
+           Only the author and the curator should be modified."""
+        sig = self._get_signature(self._authors[0],
+                                  self._publications[1])
+        sig_len_before = self.db.session.query(self.Signature).count()
+        sig.move(self._authors[1])
+        sig_len_after = self.db.session.query(self.Signature).count()
+
+        self.assertFalse(self._publications[1]
+                         in self._authors[0].publications)
+
+        self.assertTrue(self._publications[1]
+                        in self._authors[1].publications)
+
+        self.assertEqual(sig_len_before, sig_len_after)
+
+    def test_signature_reassignment(self):
+        """A new signature should be created.
+           The old signature should have an attribution of 'rejected'
+           and the new signature should have an attribution of 'verified'."""
+        sig = self._get_signature(self._authors[0], self._publications[2])
+        sig_len_before = self.db.session.query(self.Signature).count()
+        self.Signature.reassign(self._authors[2], self._user, sig)
+        sig_len_after = self.db.session.query(self.Signature).count()
+        self.assertEqual(sig_len_before + 1, sig_len_after)
+        self.assertEqual(sig.attribution, 'rejected')
+        one_sig = self.Signature.query.filter_by(
+            publication=self._publications[2], author=self._authors[2]).one()
+        self.assertTrue(one_sig)
+        self.assertEqual(one_sig.attribution, 'verified')
+
+    def test_signature_reassignment_already_assigned(self):
+        """A Signature cannot be reassigned to an author who already
+           owns this signature. A SignatureExistsError should be
+           raised."""
+        sig = self._get_signature(self._authors[0], self._publications[1])
+        try:
+            with self.assertRaises(self.SignatureExistsError):
+                self.Signature.reassign(self._authors[0], self._user, sig)
+        except AssertionError:
+            self.fail("""SignatureExistsError was not raised,
+                when trying to associate a second signature to
+                the same pair of self.Author and Publications""")
+
+
+TEST_SUITE = make_test_suite(AuthorsModelsBasicTestCase,
+                             TestAuthorsModelsCleanup,
+                             TestAuthorsModelsClaims)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
- Initial module structure.
- Introduces SQLAlchemy models for Publication, Author and Signature.
- Introduces claiming operations on signatures.
- Adds citation association table.
- Tests for models.

Signed-off-by: Artem Tsikiridis artem.tsikiridis@cern.ch
Co-authored-by: Gilles Louppe gilles.louppe@cern.ch
Co-authored-by: Mateusz Susik mateusz.susik@cern.ch
Co-authored-by: Evangelos Tzemis evangelos.tzemis@cern.ch
