### PR TITLE
search: fix for search typeahead configuration

### DIFF
--- a/invenio/base/static/js/settings.js
+++ b/invenio/base/static/js/settings.js
@@ -47,6 +47,7 @@ require.config({
     "jasmine-html": "vendors/jasmine/lib/jasmine-core/jasmine-html",
     "jasmine-ajax": "vendors/jasmine-ajax/lib/mock-ajax",
     "jasmine-boot": "js/jasmine/boot",
+    "searchtypeahead-configuration": "js/search/default_typeahead_configuration",
   },
   shim: {
     jquery: {

--- a/invenio/modules/search/bundles.py
+++ b/invenio/modules/search/bundles.py
@@ -23,7 +23,6 @@ from invenio.ext.assets import Bundle, RequireJSFilter
 from invenio.base.bundles import jquery as _j, invenio as _i
 
 js = Bundle(
-    'js/search/default_typeahead_configuration.js',
     'js/search/init.js',
     filters=RequireJSFilter(exclude=[_j, _i]),
     output="search.js",

--- a/invenio/modules/search/static/js/search/default_typeahead_configuration.js
+++ b/invenio/modules/search/static/js/search/default_typeahead_configuration.js
@@ -18,78 +18,82 @@
  */
 
 /**
-* Generates configuration of invenio syntax for search field typeahead
-*
-* @method getInvenioParserConf
-* @param {Array of strings} Contains values of possible query type
-*  keywords as 'author', 'abstract' etc.
-*/
-function getDefaultParserConf(area_keywords) {
+  * Generates configuration of invenio syntax for search field typeahead
+  *
+  * @method getInvenioParserConf
+  * @param {Array of strings} Contains values of possible query type
+  *  keywords as 'author', 'abstract' etc.
+  */
+define([], function() {
+  return function (area_keywords) {
 
-  var get_next_word_type = function(previous_word_type, word_types) {
-    // returns the next type according to syntax order
+    var get_next_word_type = function(previous_word_type, word_types) {
+      // returns the next type according to syntax order
 
-    // the case when this is the first word
-    if (previous_word_type == undefined)
-      return [word_types.QUERY_TYPE, word_types.NOT];
+      // the case when this is the first word
+      if (previous_word_type == undefined)
+        return [word_types.QUERY_TYPE, word_types.NOT];
 
-    if (previous_word_type == word_types.QUERY_TYPE)
-      return word_types.QUERY_VALUE;
+      if (previous_word_type == word_types.QUERY_TYPE)
+        return word_types.QUERY_VALUE;
 
-    if (previous_word_type == word_types.QUERY_VALUE)
-      return [word_types.QUERY_TYPE, word_types.LOGICAL_EXP, word_types.NOT]
+      if (previous_word_type == word_types.QUERY_VALUE)
+        return [word_types.QUERY_TYPE, word_types.LOGICAL_EXP, word_types.NOT]
 
-    if (previous_word_type == word_types.LOGICAL_EXP)
-      return [word_types.QUERY_TYPE, word_types.NOT];
+      if (previous_word_type == word_types.LOGICAL_EXP)
+        return [word_types.QUERY_TYPE, word_types.NOT];
 
-    if (previous_word_type == word_types.NOT)
-      return word_types.QUERY_TYPE;
-  }
+      if (previous_word_type == word_types.NOT)
+        return word_types.QUERY_TYPE;
+    }
 
-  function endsWithColon(str, char_roles, start_idx, end_idx) {
-    return str[end_idx] == ':';
-  }
+    function endsWithColon(str, char_roles, start_idx, end_idx) {
+      return str[end_idx] == ':';
+    }
 
-  function notStartsNorEndsWithColon(str, char_roles, start_idx, end_idx) {
-    return !endsWithColon(str, char_roles, start_idx, end_idx)
-      && !(start_idx > 0 && str[start_idx - 1] == ':');
-  }
+    function notStartsNorEndsWithColon(str, char_roles, start_idx, end_idx) {
+      return !endsWithColon(str, char_roles, start_idx, end_idx)
+        && !(start_idx > 0 && str[start_idx - 1] == ':');
+    }
 
-  return {
-    keywords: {
-      SEARCH: {
-        LOGICAL_EXP: {
-          min_length: 1,
-          values: ['AND', 'OR'],
-          detection_condition: notStartsNorEndsWithColon,
-          autocomplete_suffix: ' '
+    var invenio_syntax = {
+      keywords: {
+        SEARCH: {
+          LOGICAL_EXP: {
+            min_length: 1,
+            values: ['AND', 'OR'],
+            detection_condition: notStartsNorEndsWithColon,
+            autocomplete_suffix: ' '
+          },
+          NOT: {
+            min_length: 1,
+            values: ['NOT'],
+            detection_condition: notStartsNorEndsWithColon,
+            autocomplete_suffix: ' '
+          }
         },
-        NOT: {
-          min_length: 1,
-          values: ['NOT'],
-          detection_condition: notStartsNorEndsWithColon,
-          autocomplete_suffix: ' '
+        ORDER: {
+          QUERY_TYPE: {
+            min_length: 1,
+            detection_condition: endsWithColon,
+            values: area_keywords,
+            autocomplete_suffix: ':'
+          },
+          QUERY_VALUE: {
+            min_length: 3,
+            terminating_separators: [' ']
+          }
         }
       },
-      ORDER: {
-        QUERY_TYPE: {
-          min_length: 1,
-          detection_condition: endsWithColon,
-          values: area_keywords,
-          autocomplete_suffix: ':'
-        },
-        QUERY_VALUE: {
-          min_length: 3,
-          terminating_separators: [' ']
-        }
-      }
-    },
-    get_next_word_type: get_next_word_type,
-    value_type_interpretation: {
-      author: 'exactauthor'
-    },
-    separators: [' ', ':', '(', ')']
-  };
+      get_next_word_type: get_next_word_type,
+      value_type_interpretation: {
+        author: 'exactauthor'
+      },
+      separators: [' ', ':', '(', ')']
+    };
 
-
-}
+    return {
+      invenio: invenio_syntax,
+    };
+  }
+});

--- a/invenio/modules/search/static/js/search/form.js
+++ b/invenio/modules/search/static/js/search/form.js
@@ -18,7 +18,11 @@
  */
 
 
-define(['jquery', 'js/search/typeahead'], function($) {
+define([
+    'jquery',
+    'searchtypeahead-configuration',
+    'js/search/typeahead',
+], function($, getParserConf, Bloodhound) {
     "use strict";
 
     $("form[name=search]").submit(function() {
@@ -345,9 +349,7 @@ define(['jquery', 'js/search/typeahead'], function($) {
 
         $('form[name=search] input[name=p]').searchTypeahead({
           value_hints_url: form.hintsUrl,
-          options_sets: {
-            invenio: getDefaultParserConf(areaKeywords)
-          },
+          options_sets: getParserConf(areaKeywords),
           default_set: form.defaultSet
         })
     }


### PR DESCRIPTION
It is about configurable parser in the search field which got broken at https://github.com/inveniosoftware/invenio/commit/3ed48581607a534319c0b1624a20b84016c4a649 because it deleted `searchfield_typeahead_configuration` block
