### PR TITLE
base: jquery-multifile source update

### DIFF
--- a/invenio/base/bundles.py
+++ b/invenio/base/bundles.py
@@ -107,8 +107,7 @@ jquery = Bundle(
         "jquery.jeditable": "http://invenio-software.org/download/jquery/"
                             "v1.5/js/jquery.jeditable.mini.js",
         "jquery-migrate": "latest",  # orphan
-        "jquery-multifile": "svn+http://jquery-multifile-plugin.googlecode.com"
-                            "/svn/",  # orphan
+        "jquery-multifile": "https://github.com/fyneworks/multifile",
         "jquery-tablesorter": "http://invenio-software.org/download/jquery/"
                               "jquery.tablesorter.20111208.zip",  # orphan
         "jquery-tokeninput": "latest",


### PR DESCRIPTION
- Moves jquery-multifile source to Github to avoid error on
  installation.

Signed-off-by: Javier Martin Montull javier.martin.montull@cern.ch
