### PR TITLE
workflows: correspond object state names with docs

### DIFF
--- a/invenio/base/utils.py
+++ b/invenio/base/utils.py
@@ -17,7 +17,11 @@
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""Implement various utils."""
+"""Implement various utils.
+
+Utilities that could potentially exist in separate packages should be placed in
+this file.
+"""
 
 from flask import has_app_context, current_app
 from werkzeug.utils import import_string, find_modules
@@ -211,3 +215,25 @@ if sys.hexversion >= 0x2070000:
     captureWarnings = logging.captureWarnings
 else:
     captureWarnings = _captureWarnings
+
+# https://mail.python.org/pipermail/python-ideas/2011-January/008958.html
+class staticproperty(object):
+
+    """Property decorator for static methods."""
+
+    def __init__(self, function):
+        self._function = function
+
+    def __get__(self, instance, owner):
+        return self._function()
+
+
+class classproperty(object):
+
+    """Property decorator for class methods."""
+
+    def __init__(self, function):
+        self._function = function
+
+    def __get__(self, instance, owner):
+        return self._function(owner)

--- a/invenio/ext/logging/__init__.py
+++ b/invenio/ext/logging/__init__.py
@@ -163,7 +163,11 @@ Issue a pending deprecation warning (silent by default):
 
 from __future__ import absolute_import
 
+import warnings
+
 import logging
+from functools import wraps
+
 from .wrappers import register_exception, get_pretty_traceback
 
 
@@ -174,5 +178,21 @@ def setup_app(app):
         logger = logging.getLogger('py.warnings')
         logger.addHandler(logging.StreamHandler())
         logger.setLevel(logging.WARNING)
+
+
+# Improved version of http://code.activestate.com/recipes/391367-deprecated/
+def deprecated(message, category=DeprecationWarning):
+    def wrap(func):
+        """Decorator which can be used to mark functions as deprecated.
+
+        :param message: text to include in the warning
+        :param category: warning category
+        """
+        @wraps(func)
+        def new_func(*args, **kwargs):
+            warnings.warn(message, category, stacklevel=3)
+            return func(*args, **kwargs)
+        return new_func
+    return wrap
 
 __all__ = ('register_exception', 'get_pretty_traceback')

--- a/invenio/modules/deposit/models.py
+++ b/invenio/modules/deposit/models.py
@@ -458,7 +458,7 @@ class DepositionType(object):
         # Only reinitialize if really needed (i.e. you can only
         # reinitialize a fully completed workflow).
         wo = deposition.workflow_object
-        if wo.version == ObjectVersion.FINAL and \
+        if wo.version == ObjectVersion.COMPLETED and \
            wo.workflow.status == WorkflowStatus.COMPLETED:
 
             wo.version = ObjectVersion.INITIAL
@@ -471,13 +471,13 @@ class DepositionType(object):
     def stop_workflow(cls, deposition):
         # Only stop workflow if really needed
         wo = deposition.workflow_object
-        if wo.version != ObjectVersion.FINAL and \
+        if wo.version != ObjectVersion.COMPLETED and \
            wo.workflow.status != WorkflowStatus.COMPLETED:
 
             # Only workflows which has been fully completed once before
             # can be stopped
             if deposition.has_sip():
-                wo.version = ObjectVersion.FINAL
+                wo.version = ObjectVersion.COMPLETED
                 wo.workflow.status = WorkflowStatus.COMPLETED
 
                 # Clear all drafts

--- a/invenio/modules/workflows/__init__.py
+++ b/invenio/modules/workflows/__init__.py
@@ -187,8 +187,8 @@ we get 4 objects back as each object passed have a snapshot created.
     before the workflow started. These are created to allow for objects to
     be easily restarted in the workflow with the initial data intact.
 
-You can also query the engine instance to only give you the completed, halted
-or initial objects.
+You can also query the engine instance to only give you the objects which are in
+a certain state.
 
 .. code-block:: python
 
@@ -198,9 +198,23 @@ or initial objects.
 
     len(eng.completed_objects)  # outputs: 0
 
+    len(eng.running_objects)  # outputs: 0
+
+    len(eng.waiting_objects)  # outputs: 0
+
+    len(eng.error_objects)  # outputs: 0
+
 (`eng.completed_objects` is empty because both objects passed is halted.)
 
-For example, to retrieve the data from the first object, you can use
+This output is actually representative of snapshots of the objects, not the
+objects themselves. The _default_ snapshotting behaviour is also evident here:
+There is one snapshot taken in the beginning of the execution and one
+when the object reaches one of the other states. A snapshot can only be in a
+single state.
+
+No object will ever be in the `running` state under usual operation.
+
+Moreover, to retrieve the data from the first object, you can use
 `get_data()` as with single objects:
 
 .. code-block:: python

--- a/invenio/modules/workflows/engine.py
+++ b/invenio/modules/workflows/engine.py
@@ -192,32 +192,42 @@ class BibWorkflowEngine(GenericWorkflowEngine):
         """Return the objects associated with this workflow."""
         return self.db_obj.objects
 
-    @property
-    def final_objects(self):
-        """Return the objects associated with this workflow."""
+    def objects_of_statuses(self, statuses):
         results = []
         for obj in self.db_obj.objects:
-            if obj.version in [ObjectVersion.FINAL]:
+            if obj.version in statuses:
                 results.append(obj)
         return results
+
+    @property
+    def completed_objects(self):
+        """Return completed objects."""
+        return self.objects_of_statuses([ObjectVersion.FINAL])
 
     @property
     def halted_objects(self):
-        """Return the objects associated with this workflow."""
-        results = []
-        for obj in self.db_obj.objects:
-            if obj.version in [ObjectVersion.HALTED]:
-                results.append(obj)
-        return results
+        """Return halted objects."""
+        return self.objects_of_statuses([ObjectVersion.HALTED])
 
     @property
     def running_objects(self):
-        """Return the objects associated with this workflow."""
-        results = []
-        for obj in self.db_obj.objects:
-            if obj.version in [ObjectVersion.RUNNING]:
-                results.append(obj)
-        return results
+        """Return running objects."""
+        return self.objects_of_statuses([ObjectVersion.RUNNING])
+
+    @property
+    def initial_objects(self):
+        """Return initial objects."""
+        return self.objects_of_statuses([ObjectVersion.INITIAL])
+
+    @property
+    def waiting_objects(self):
+        """Return waiting objects."""
+        return self.objects_of_statuses([ObjectVersion.WAITING])
+
+    @property
+    def error_objects(self):
+        """Return error objects."""
+        return self.objects_of_statuses([ObjectVersion.ERROR])
 
     def __getstate__(self):
         """Pickling needed functions."""

--- a/invenio/modules/workflows/engine.py
+++ b/invenio/modules/workflows/engine.py
@@ -202,7 +202,7 @@ class BibWorkflowEngine(GenericWorkflowEngine):
     @property
     def completed_objects(self):
         """Return completed objects."""
-        return self.objects_of_statuses([ObjectVersion.FINAL])
+        return self.objects_of_statuses([ObjectVersion.COMPLETED])
 
     @property
     def halted_objects(self):
@@ -293,7 +293,7 @@ BibWorkflowEngine
             filter(BibWorkflowObject.id_workflow == self.uuid).\
             filter(BibWorkflowObject.version.in_(
                 [ObjectVersion.INITIAL,
-                 ObjectVersion.FINAL]
+                 ObjectVersion.COMPLETED]
             )).group_by(BibWorkflowObject.version).all()
         return len(res) == 2 and res[0] == res[1]
 
@@ -434,7 +434,7 @@ BibWorkflowEngine
                     obj.log.debug(msg)
 
                     # Processing for the object is stopped!
-                    obj.save(version=ObjectVersion.FINAL)
+                    obj.save(version=ObjectVersion.COMPLETED)
                     self.increase_counter_finished()
                     break
                 except JumpTokenBack as step:
@@ -447,7 +447,7 @@ BibWorkflowEngine
                     i[1] = [0]  # reset the callbacks pointer
 
                     # This object is skipped for some reason. So we're done
-                    obj.save(version=ObjectVersion.FINAL)
+                    obj.save(version=ObjectVersion.COMPLETED)
                     self.increase_counter_finished()
                 except JumpTokenForward as step:
                     if step.args[0] < 0:
@@ -458,7 +458,7 @@ BibWorkflowEngine
                     i[1] = [0]  # reset the callbacks pointer
 
                     # This object is skipped for some reason. So we're done
-                    obj.save(version=ObjectVersion.FINAL)
+                    obj.save(version=ObjectVersion.COMPLETED)
                     self.increase_counter_finished()
                 except ContinueNextToken:
                     self.log.debug('Stop processing for this object, '
@@ -466,7 +466,7 @@ BibWorkflowEngine
                     i[1] = [0]  # reset the callbacks pointer
 
                     # This object is skipped for some reason. So we're done
-                    obj.save(version=ObjectVersion.FINAL)
+                    obj.save(version=ObjectVersion.COMPLETED)
                     self.increase_counter_finished()
                     continue
                 except (HaltProcessing, WorkflowHalt) as e:
@@ -501,7 +501,7 @@ BibWorkflowEngine
                             id_object=self.getCurrObjId(),
                         )
             # We save each object once it is fully run through
-            obj.save(version=ObjectVersion.FINAL)
+            obj.save(version=ObjectVersion.COMPLETED)
             self.increase_counter_finished()
             i[1] = [0]  # reset the callbacks pointer
         self.after_processing(objects, self)

--- a/invenio/modules/workflows/models.py
+++ b/invenio/modules/workflows/models.py
@@ -30,6 +30,8 @@ from sqlalchemy.orm.exc import NoResultFound
 from invenio.ext.sqlalchemy import db
 from invenio.ext.sqlalchemy.utils import session_manager
 from invenio.base.globals import cfg
+from invenio.base.utils import classproperty
+from invenio.ext.logging import deprecated
 
 from .logger import get_logger, BibWorkflowLogHandler
 
@@ -39,13 +41,19 @@ class ObjectVersion(object):
     """Specify the different versions possible."""
 
     INITIAL = 0
-    FINAL = 1
+    COMPLETED = 1
     HALTED = 2
     RUNNING = 3
     WAITING = 4
     ERROR = 5
     MAPPING = {"New": 0, "Done": 1, "Need action": 2,
                "In process": 3, "Waiting": 4, "Error": 5}
+
+    @classproperty
+    @deprecated("Please use ObjectVersion.COMPLETED "
+                "instead of ObjectVersion.FINAL")
+    def FINAL(cls):
+        return cls.COMPLETED
 
 
 def get_default_data():

--- a/invenio/modules/workflows/testsuite/test_workflows.py
+++ b/invenio/modules/workflows/testsuite/test_workflows.py
@@ -187,7 +187,7 @@ distances from it.
         self.assertEqual(38, test_object.get_data())
         self.assertEqual(None, test_object.id_parent)
         self.assertEqual(WorkflowStatus.COMPLETED, engine.status)
-        self.assertEqual(ObjectVersion.FINAL, test_object.version)
+        self.assertEqual(ObjectVersion.COMPLETED, test_object.version)
 
     def test_object_creation_halt(self):
         """Test status of object before/after workflow.
@@ -249,7 +249,7 @@ distances from it.
             for my_object_b in engine.getObjects():
                 engine = continue_oid(my_object_b[1].id, "restart_task")
         self.assertEqual(0, test_object.get_data())
-        self.assertEqual(ObjectVersion.FINAL, test_object.version)
+        self.assertEqual(ObjectVersion.COMPLETED, test_object.version)
         self.assertEqual(WorkflowStatus.COMPLETED, engine.status)
 
     def test_workflow_object_creation(self):
@@ -281,7 +281,7 @@ distances from it.
         self.assertEqual(ObjectVersion.INITIAL, initial_object.version)
         self.assertEqual(initial_data, initial_object.get_data())
         self.assertEqual(final_data, test_object.get_data())
-        self.assertEqual(ObjectVersion.FINAL, test_object.version)
+        self.assertEqual(ObjectVersion.COMPLETED, test_object.version)
 
     def test_workflow_object_creation_simple(self):
         """Test to see if the right snapshots or object versions are created."""
@@ -310,7 +310,7 @@ distances from it.
         # There should only be 2 objects (initial, final)
         self.assertEqual(2, len(all_objects))
         self.assertEqual(test_object.id_parent, initial_object.id)
-        self.assertEqual(ObjectVersion.FINAL, initial_object.version)
+        self.assertEqual(ObjectVersion.COMPLETED, initial_object.version)
         self.assertEqual(final_data, initial_object.get_data())
         self.assertEqual(initial_data, test_object.get_data())
         self.assertEqual(ObjectVersion.INITIAL, test_object.version)
@@ -407,7 +407,7 @@ distances from it.
         workflow = continue_oid(current.id,
                                 module_name="unit_tests")
         self.assertEqual(WorkflowStatus.COMPLETED, workflow.status)
-        self.assertEqual(ObjectVersion.FINAL, current.version)
+        self.assertEqual(ObjectVersion.COMPLETED, current.version)
 
     def test_workflow_for_finished_object(self):
         """Test starting workflow with finished object given."""
@@ -425,7 +425,7 @@ distances from it.
                          module_name="unit_tests")
 
         self.assertEqual(WorkflowStatus.COMPLETED, workflow.status)
-        self.assertEqual(ObjectVersion.FINAL, current.version)
+        self.assertEqual(ObjectVersion.COMPLETED, current.version)
         self.assertEqual(38, current.get_data())
 
         previous = BibWorkflowObject.query.get(current.id)
@@ -435,7 +435,7 @@ distances from it.
                            module_name="unit_tests")
 
         self.assertEqual(WorkflowStatus.COMPLETED, workflow_2.status)
-        self.assertEqual(ObjectVersion.FINAL, previous.version)
+        self.assertEqual(ObjectVersion.COMPLETED, previous.version)
         self.assertEqual(56, previous.get_data())
 
     def test_logging_for_workflow_objects_without_workflow(self):
@@ -543,14 +543,14 @@ distances from it.
         continue_oid(oid=obj_halted.id, module_name="unit_tests")
 
         self.assertEqual(19, obj_halted.get_data())
-        self.assertEqual(ObjectVersion.FINAL, obj_halted.version)
+        self.assertEqual(ObjectVersion.COMPLETED, obj_halted.version)
 
         # Let's do that last task again, shall we?
         continue_oid(oid=obj_halted.id, start_point="restart_prev",
                      module_name="unit_tests")
 
         self.assertEqual(37, obj_halted.get_data())
-        self.assertEqual(ObjectVersion.FINAL, obj_halted.version)
+        self.assertEqual(ObjectVersion.COMPLETED, obj_halted.version)
 
     def test_restart_workflow(self):
         """Test restarting workflow for given workflow id."""
@@ -701,7 +701,7 @@ class TestWorkflowTasks(WorkflowTasksTestCase):
         self.assertEqual("gte9", test_object.get_extra_data()["test"])
 
         workflow = continue_oid(test_object.id)
-        self.assertEqual(ObjectVersion.FINAL, test_object.version)
+        self.assertEqual(ObjectVersion.COMPLETED, test_object.version)
         self.assertEqual(WorkflowStatus.COMPLETED, workflow.status)
 
     def test_workflow_without_workflow_object_saved(self):

--- a/invenio/modules/workflows/views/holdingpen.py
+++ b/invenio/modules/workflows/views/holdingpen.py
@@ -61,7 +61,7 @@ HOLDINGPEN_WORKFLOW_STATES = {
     ObjectVersion.HALTED: {'message': _('Need Action'), 'class': 'danger'},
     ObjectVersion.WAITING: {'message': _('Waiting'), 'class': 'warning'},
     ObjectVersion.ERROR: {'message': _('Error'), 'class': 'danger'},
-    ObjectVersion.FINAL: {'message': _('Done'), 'class': 'success'},
+    ObjectVersion.COMPLETED: {'message': _('Done'), 'class': 'success'},
     ObjectVersion.INITIAL: {'message': _('New'), 'class': 'info'},
     ObjectVersion.RUNNING: {'message': _('In process'), 'class': 'warning'}
 }

--- a/invenio/modules/workflows/worker_engine.py
+++ b/invenio/modules/workflows/worker_engine.py
@@ -155,7 +155,7 @@ def get_workflow_object_instances(data, engine):
             if data_object.id:
                 data_object.log.debug("Existing workflow object found for "
                                       "this object. Saving a snapshot.")
-                if data_object.version == ObjectVersion.FINAL:
+                if data_object.version == ObjectVersion.COMPLETED:
                     data_object.version = ObjectVersion.INITIAL
                 workflow_objects.append(
                     generate_snapshot(data_object, engine)


### PR DESCRIPTION
* Fix reference to `completed_objects` in the documentation (was:
  `final_objects` in code).

* Expose all other states via the `BibWorkflowEngine` interface and
  expand documentation.