### PR TITLE
accounts: fix for permanent login support

### DIFF
--- a/invenio/ext/login/__init__.py
+++ b/invenio/ext/login/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2012, 2013, 2014 CERN.
+## Copyright (C) 2012, 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -22,7 +22,7 @@
 import urllib
 
 from .legacy_user import UserInfo
-from flask import request, flash, g, url_for, redirect
+from flask import request, flash, g, url_for, redirect, session
 from flask.ext.login import (
     LoginManager,
     current_user,
@@ -93,7 +93,7 @@ def login_redirect(referer=None):
 
 
 def authenticate(nickname_or_email=None, password=None,
-                 login_method='Local'):
+                 login_method='Local', remember=False):
     """
     Find user identified by given information and login method.
 
@@ -129,8 +129,9 @@ def authenticate(nickname_or_email=None, password=None,
         flash(_("You have not yet confirmed the email address for the \
             '%(login_method)s' authentication method.",
               login_method=login_method), 'warning')
-
-    return login_user(user.id)
+    if remember:
+        session.permanent = True
+    return login_user(user.id, remember=remember)
 
 
 def setup_app(app):

--- a/invenio/modules/accounts/views/accounts.py
+++ b/invenio/modules/accounts/views/accounts.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2012, 2013 CERN.
+## Copyright (C) 2012, 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -57,12 +57,12 @@ blueprint = Blueprint('webaccount', __name__, url_prefix="/youraccount",
                  'password': (unicode, None),
                  'login_method': (wash_login_method, 'Local'),
                  'action': (unicode, ''),
-                 'remember_me': (bool, False),
+                 'remember': (bool, False),
                  'referer': (unicode, None)})
 @register_breadcrumb(blueprint, '.login', _('Login'))
 @ssl_required
 def login(nickname=None, password=None, login_method=None, action='',
-          remember_me=False, referer=None):
+          remember=False, referer=None):
     if cfg.get('CFG_ACCESS_CONTROL_LEVEL_SITE') > 0:
         return abort(401)  # page is not authorized
 
@@ -82,7 +82,8 @@ def login(nickname=None, password=None, login_method=None, action='',
     if request.method == "POST":
         try:
             if login_method == 'Local' and form.validate_on_submit() and \
-               authenticate(nickname, password, login_method=login_method):
+               authenticate(nickname, password, login_method=login_method,
+                            remember=remember):
                 flash(
                     _("You are logged in as %(nick)s.", nick=nickname),
                     "success"

--- a/invenio/modules/oauthclient/config.py
+++ b/invenio/modules/oauthclient/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2014 CERN.
+## Copyright (C) 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -62,6 +62,7 @@ keys:
 - ``authorized_handler`` - Import path to authorized callback handler.
 - ``disconnect_handler`` - Import path to disconnect callback handler.
 - ``signup_handler`` - A dictionary of import path to sign up callback handler.
+- ``remember`` - Boolean indicating if the session should be permament.
 
 .. code-block:: python
 
@@ -78,6 +79,7 @@ keys:
                 view="...",
             ),
             params=dict(...),
+            remember=True
             )
         )
     )

--- a/invenio/modules/oauthclient/handlers.py
+++ b/invenio/modules/oauthclient/handlers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2014 CERN.
+## Copyright (C) 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -214,7 +214,8 @@ def authorized_signup_handler(resp, remote, *args, **kwargs):
 
         # Authenticate user
         if not oauth_authenticate(remote.consumer_key, user,
-                                  require_existing_link=False):
+                                  require_existing_link=False,
+                                  remember=cfg['OAUTHCLIENT_REMOTE_APPS'][remote.name].get('remember', False)):
             return current_app.login_manager.unauthorized()
 
         # Link account
@@ -286,7 +287,8 @@ def signup_handler(remote, *args, **kwargs):
 
         # Authenticate the user
         if not oauth_authenticate(remote.consumer_key, user,
-                                  require_existing_link=False):
+                                  require_existing_link=False,
+                                  remember=cfg['OAUTHCLIENT_REMOTE_APPS'][remote.name].get('remember', False)):
             return current_app.login_manager.unauthorized()
 
         # Link account and set session data

--- a/invenio/modules/oauthclient/utils.py
+++ b/invenio/modules/oauthclient/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2014 CERN.
+## Copyright (C) 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -47,10 +47,11 @@ def oauth_get_user(client_id, account_info=None, access_token=None):
     return None
 
 
-def oauth_authenticate(client_id, userinfo, require_existing_link=False):
+def oauth_authenticate(client_id, userinfo, require_existing_link=False,
+                       remember=False):
     """ Authenticate an oauth authorized callback. """
     # Authenticate via the access token (access token used to get user_id)
-    if userinfo and authenticate(userinfo['email']):
+    if userinfo and authenticate(userinfo['email'], remember=remember):
         if require_existing_link:
             account = RemoteAccount.get(userinfo.get_id(), client_id)
             if account is None:

--- a/invenio/utils/washers.py
+++ b/invenio/utils/washers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ## This file is part of Invenio.
-## Copyright (C) 2012, 2013, 2014 CERN.
+## Copyright (C) 2012, 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -85,7 +85,7 @@ def wash_urlargd(form, content):
 
         # Since we got here, 'value' is sure to be a single symbol,
         # not a list kind of structure anymore.
-        if dst_type in (int, float, long):
+        if dst_type in (int, float, long, bool):
             try:
                 result[k] = dst_type(value)
             except:


### PR DESCRIPTION
* Sets session.permanent when then user marks 'remember me'.

* Allows configuration of oauth login to set if session should
  be permanent.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>