### PR TITLE
knowledge: fix get_kbr_values returned value

### DIFF
--- a/invenio/modules/knowledge/api.py
+++ b/invenio/modules/knowledge/api.py
@@ -502,7 +502,7 @@ def get_kbr_values(kb_name, searchkey="", searchvalue="", searchtype='s',
             kb = get_kb_by_name(kb_name)
     except NoResultFound:
         return []
-    return kb.get_kbr_values(searchkey, searchvalue, searchtype)
+    return list(kb.get_kbr_values(searchkey, searchvalue, searchtype))
 
 
 def get_kbr_items(kb_name, searchkey="", searchvalue="", searchtype='s'):


### PR DESCRIPTION
- Fixes the returned value of get_kbr_values:
  list of one element list instead of list of elements.

Signed-off-by: Leonardo Rossi leonardo.r@cern.ch
