### PR TITLE
elasticsearch: fix for arguments of signal receivers

### DIFF
--- a/invenio/ext/elasticsearch/__init__.py
+++ b/invenio/ext/elasticsearch/__init__.py
@@ -818,7 +818,7 @@ def index_collections(sender, collections):
     return index_collections.delay(sender, [])
 
 
-def drop_index(sender, yes_i_know, default_data=None):
+def drop_index(sender, *args, **kwargs):
     """
     Remove the elasticsearch index.
 
@@ -829,7 +829,7 @@ def drop_index(sender, yes_i_know, default_data=None):
     es.delete_index()
 
 
-def create_index(sender, yes_i_know=False, default_data=None):
+def create_index(sender, *args, **kwargs):
     """
     Create the elasticsearch index.
 


### PR DESCRIPTION
Signed-off-by: Johnny Mariéthoz Johnny.Mariethoz@rero.ch

Add "args" and "quiet" arguments to functions.
