### PR TITLE
jsonalchemy: fix problem with reserved names

### DIFF
--- a/invenio/modules/jsonalchemy/jsonext/parsers/legacy_parser.py
+++ b/invenio/modules/jsonalchemy/jsonext/parsers/legacy_parser.py
@@ -70,7 +70,7 @@ class LegacyParser(DecoratorOnEvalBaseExtensionParser):
             {'100'   : ['authors[0]'],
              '100__' : ['authors[0]'],
              '100__%': ['authors[0]'],
-             '100__a': ['auhtors[0].full_name'],
+             '100__a': ['authors[0].full_name'],
              .......
             }
         """
@@ -92,7 +92,7 @@ class LegacyParser(DecoratorOnEvalBaseExtensionParser):
                     inner_source_format] = {}
 
             for field_legacy_rule in legacy_rule:
-                #Allow string and tuple in the config file
+                # Allow string and tuple in the config file
                 legacy_fields = (field_legacy_rule[0], ) \
                     if isinstance(field_legacy_rule[0], six.string_types) \
                     else field_legacy_rule[0]

--- a/invenio/modules/jsonalchemy/jsonext/producers/json_for_marc.py
+++ b/invenio/modules/jsonalchemy/jsonext/producers/json_for_marc.py
@@ -142,11 +142,16 @@ def produce(self, fields=None):
                                 tmp_dict[marc_tag] = value[subfield]
                             except:
                                 try:
-                                    tmp_dict[marc_tag] = try_to_eval(subfield,
-                                                                     functions(
-                                                                         self.additional_info.namespace),
-                                                                     value=value,
-                                                                     self=self)
+                                    # Evaluate only non keyword values.
+                                    if subfield in __builtins__:
+                                        raise ImportError
+                                    tmp_dict[marc_tag] = try_to_eval(
+                                        subfield,
+                                        functions(
+                                            self.additional_info.namespace
+                                        ),
+                                        value=value,
+                                        self=self)
                                 except ImportError:
                                     pass
                                 except Exception as e:

--- a/invenio/modules/jsonalchemy/testsuite/fields/fields.cfg
+++ b/invenio/modules/jsonalchemy/testsuite/fields/fields.cfg
@@ -286,6 +286,16 @@ test_json_for_marc:
     producer:
         json_for_marc(), {"980__a": "'test_me_'+value"}
 
+thesis:
+    creator:
+        @legacy((("502", "502__", "502__%"), ""),
+                ("502__b", "type"),
+                ("502__c", "university"),
+                ("502__d", "date"))
+        marc, "502__", {'type': value['b'], 'university': value['c'], 'date': value['d']}
+    producer:
+        json_for_marc(), {"502__b": "type", "502__c": "str('University of Fictive Science')", "502__d": "date"}
+
 @extend
 dummy:
     derived:

--- a/invenio/modules/jsonalchemy/testsuite/fields/title.cfg
+++ b/invenio/modules/jsonalchemy/testsuite/fields/title.cfg
@@ -40,6 +40,7 @@ title:
 title_title:
     creator:
          marc, "245__", { 'title':value['a'], 'foo':'bar'}
+
 title_parallel:
     creator:
         @legacy(("246_1a", "title"),


### PR DESCRIPTION
- Addresses issue when `try_to_eval` function was evaluating missing
  subfields to existing global Python functions.  (closes #2593)

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
