### PR TITLE
OAIHarvest: fix oai harvesting for name space qualified xml

### DIFF
--- a/modules/oaiharvest/lib/oai_harvest_getter.py
+++ b/modules/oaiharvest/lib/oai_harvest_getter.py
@@ -118,7 +118,9 @@ def OAI_Session(server, script, http_param_dict , method="POST", output="",
         else:
             sys.stdout.write(harvested_data)
 
-        rt_obj = re.search('<resumptionToken.*>(.+)</resumptionToken>',
+        # FIXME We should NOT use regular expressions to parse XML. This works
+        # for the time being to escape namespaces.
+        rt_obj = re.search('<.*resumptionToken.*>(.+)</.*resumptionToken.*>',
             harvested_data, re.DOTALL)
         if rt_obj is not None and rt_obj != "":
             http_param_dict = http_param_resume(http_param_dict, rt_obj.group(1))

--- a/modules/oaiharvest/lib/oai_harvest_getter.py
+++ b/modules/oaiharvest/lib/oai_harvest_getter.py
@@ -102,8 +102,10 @@ def OAI_Session(server, script, http_param_dict , method="POST", output="",
                                      http_request_parameters(http_param_dict, method), method,
                                      secure, user, password, cert_file, key_file)
         if output:
-            # Write results to a file specified by 'output'
-            if harvested_data.lower().find('<'+http_param_dict['verb'].lower()) > -1:
+            # Write results to a file specified by 'output', once we have any
+            # records retrieved. Thus we check for an "noRecordsMatch" error
+            # before continuation.
+            if harvested_data.lower().find('<error code="noRecordsMatch">'.lower()) == -1:
                 output_fd, output_filename = tempfile.mkstemp(suffix="_%07d.harvested" % (i,), \
                                                               prefix=output_name, dir=output_path)
                 os.write(output_fd, harvested_data)


### PR DESCRIPTION
OpenAIRE exposes the XML files with full name spaces. This breaks invenios harvesting routines which rely on regexp matching of the returned answers. 

Two issues arise:
1. `oai_harvest_getter.py` checks, if any records are returned by searching for a `<ListRecords>` line. This fails, if this line reads `<oai:ListRecords>` instead. The _fix_ uses the `noRecordsMatch` error return in OAI in case no records match the harvesting criteria. (cf. http://www.openarchives.org/OAI/openarchivesprotocol.html#ErrorConditions)
2. `oai_harvest_utils.py` uses a function to dedupe returned records by means of their OAI-ID. This also lives on regexping. In the OpenAIRE usecase this results in completely invalid XML, as only the first `len(<ListRecords>)` chars of the header get written at all (`header_index_end = data.find("<ListRecords>") + len("<ListRecords>")`. Secondly, all subsequent regexps fail, as they never match due to the namespace qualifier. The latter can in principle be arbitrary. The _fix_ introduces `lxml.etree` parsing of the document to extract the OAI-IDs by means of `XPath` statements. Additionally, only thos records get written to the result file that were not already done. Searching for records is also implemented by `XPath`, building of the final element uses `lxml` factories.

Combined they should address and fix #2300 also for harvesting from OpenAIRE.

@jalavik and @kaplun for review. Backported code 1.1 maint is available as well.