### PR TITLE
RefExtract: avoid double encoding

### DIFF
--- a/invenio/legacy/refextract/linker.py
+++ b/invenio/legacy/refextract/linker.py
@@ -36,7 +36,7 @@ def config_cache(cache={}):
 def get_recids_matching_query(p, f, m='e'):
     """Return list of recIDs matching query for pattern and field."""
     config = config_cache()
-    recids = bibrank_search(p=p.encode('utf-8'), f=f, config=config, m=m)
+    recids = bibrank_search(p=p, f=f, config=config, m=m)
     return list(recids)
 
 


### PR DESCRIPTION
* Avoids encoding string twice when calling get_recids_matching_query()
  from BibRank in RefExtract.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>