### PR TITLE
installation: Flask-Admin>=1.0.9

### DIFF
--- a/.travis-devel-requirements.txt
+++ b/.travis-devel-requirements.txt
@@ -3,7 +3,7 @@
 -e git+git://github.com/mitsuhiko/itsdangerous.git#egg=itsdangerous
 -e git+git://github.com/jek/blinker.git#egg=blinker
 -e git+git://github.com/mitsuhiko/flask.git#egg=flask
--e git+git://github.com/mrjoes/flask-admin.git#egg=Flask-Admin-1.0.9.dev0
+-e git+git://github.com/mrjoes/flask-admin.git#egg=Flask-Admin
 -e git+git://github.com/lepture/flask-wtf.git#egg=Flask-WTF
 
 -e git+git://github.com/inveniosoftware/dictdiffer.git#egg=dictdiffer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
--e git+git://github.com/mrjoes/flask-admin.git#egg=Flask-Admin-1.0.9.dev0
 # requires numpy before it can be installed
 #-e svn://svn.code.sf.net/p/gnuplot-py/code/trunk#egg=gnuplot-py

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,6 @@ class _install_lib(install_lib):
         self.run_command('compile_catalog')
         install_lib.run(self)
 
-dependency_links = [
-    "git+git://github.com/mrjoes/flask-admin.git#egg=Flask-Admin-1.0.9.dev0",
-]
-
 install_requires = [
     "alembic>=0.6.6",
     "Babel>=1.3",
@@ -70,8 +66,7 @@ install_requires = [
     "feedparser>=5.1",
     "fixture>=1.5",
     "Flask>=0.10.1",
-    # Development version is used, will switch to >=1.0.9 once released.
-    "Flask-Admin>=1.0.9.dev0",
+    "Flask-Admin>=1.0.9",
     "Flask-Assets>=0.10",
     "Flask-Babel>=0.9",
     "Flask-Breadcrumbs>=0.2",
@@ -285,7 +280,6 @@ setup(
         ]
     },
     install_requires=install_requires,
-    dependency_links=dependency_links,
     extras_require=extras_require,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
- Uses official released version of Flask-Admin>=1.0.9.  (closes #1797)

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
