### PR TITLE
JSONAlchemy: any indicator support

### DIFF
--- a/invenio/modules/authors/recordext/fields/author_base.cfg
+++ b/invenio/modules/authors/recordext/fields/author_base.cfg
@@ -38,7 +38,7 @@ ids:
                   'required': True},
                   'value': {'type': 'string', 'required': True}}}}
     creator:
-        marc, "035__", {'type': value['9'], 'value': value['a']}
+        marc, "035..", {'type': value['9'], 'value': value['a']}
     producer:
         json_for_marc(), {"035__9": "type", "035__a": "value"}
 
@@ -65,7 +65,7 @@ name:
          'schema': {'last': {'type': 'string', 'empty': False},
                     'first': {'type': 'string', 'empty': False}}}}
     creator:
-        marc, "100__", {'last': util_split(value['a'], ', ', 0),
+        marc, "100..", {'last': util_split(value['a'], ', ', 0),
                         'first': util_split(value['a'], ', ', 1)}
     producer:
         json_for_marc(), {"100__a": "last + ', ' + first"}
@@ -80,6 +80,6 @@ publications_list:
         {'publications_list': {'type': 'list', 'force': True,
          'required': True}}
     creator:
-        marc, "900__", int(value["a"])
+        marc, "900..", int(value["a"])
     producer:
         json_for_marc(), {"900__a": ""}

--- a/invenio/modules/jsonalchemy/testsuite/fields/authors.cfg
+++ b/invenio/modules/jsonalchemy/testsuite/fields/authors.cfg
@@ -24,7 +24,7 @@ _first_author, creator:
                 ("100__h", "CCID"),
                 ("100__i", "INSPIRE_number"),
                 ("100__u", "first author affiliation", "affiliation"))
-        marc, "100__", { 'full_name':value['a'], 'first_name':util_split(value['a'],',',1), 'last_name':util_split(value['a'],',',0), 'relator_name':value['e'], 'CCID':value['h'], 'INSPIRE_number':value['i'], 'affiliation':value['u'] }
+        marc, "100..", { 'full_name':value['a'], 'first_name':util_split(value['a'],',',1), 'last_name':util_split(value['a'],',',0), 'relator_name':value['e'], 'CCID':value['h'], 'INSPIRE_number':value['i'], 'affiliation':value['u'] }
     producer:
         json_for_marc(), {"100__a": "full_name", "100__e": "relator_name", "100__h": "CCID", "100__i": "INSPIRE_number", "100__u": "affiliation"}
         json_for_dc(), {"dc:creator": "full_name"}
@@ -35,7 +35,7 @@ _additional_authors, contributor:
                 ("700__a", "additional author name", "full_name"),
                 ("700__u", "additional author affiliation", "affiliation"))
         @parse_first('_first_author')
-        marc, "700__", {'full_name': value['a'], 'first_name':util_split(value['a'],',',1), 'last_name':util_split(value['a'],',',0), 'relator_name':value['e'], 'CCID':value['h'], 'INSPIRE_number':value['i'], 'affiliation':value['u'] }
+        marc, "700..", {'full_name': value['a'], 'first_name':util_split(value['a'],',',1), 'last_name':util_split(value['a'],',',0), 'relator_name':value['e'], 'CCID':value['h'], 'INSPIRE_number':value['i'], 'affiliation':value['u'] }
     producer:
         json_for_marc(), {"700__a": "full_name", "700__e": "relator_name", "700__h": "CCID", "700__i": "INSPIRE_number", "700__u": "affiliation"}
         json_for_dc(), {"dc:contributor": "full_name"}

--- a/invenio/modules/jsonalchemy/testsuite/fields/fields.cfg
+++ b/invenio/modules/jsonalchemy/testsuite/fields/fields.cfg
@@ -49,7 +49,7 @@ abstract:
                 ("520__a", "abstract", "summary"),
                 ("520__b", "expansion"),
                 ("520__9", "number"))
-        marc, "520__", {'summary':value['a'], 'expansion':value['b'], 'number':value['9']}
+        marc, "520..", {'summary':value['a'], 'expansion':value['b'], 'number':value['9']}
     producer:
         json_for_marc(), {"520__a": "summary", "520__b": "expansion", "520__9": "number"}
         json_for_dc(), {"dc:description":"summary"}
@@ -61,7 +61,7 @@ collection:
                 ("980__a", "primary"),
                 ("980__b", "secondary"),
                 ("980__c", "deleted"))
-        marc, "980__", { 'primary':value['a'], 'secondary':value['b'], 'deleted':value['c'] }
+        marc, "980..", { 'primary':value['a'], 'secondary':value['b'], 'deleted':value['c'] }
     producer:
         json_for_marc(), {"980__a":"primary", "980__b":"secondary", "980__c":"deleted"}
 
@@ -70,7 +70,7 @@ doi:
     creator:
         @legacy((("024", "0247_", "0247_%"), ""),
                 ("0247_a", ""))
-        marc, "0247_", get_doi(value)
+        marc, "0247.", get_doi(value)
     producer:
         json_for_marc(), {'0247_2': 'str("DOI")', '0247_a': ''}
 
@@ -110,7 +110,7 @@ fft:
                         'format_moreinfo': value['u']
                        }
         @only_if_master_value((is_local_url(value['u']), ))
-        marc, "8564_", {'hots_name': value['a'],
+        marc, "8564.", {'hots_name': value['a'],
                         'access_number': value['b'],
                         'compression_information': value['c'],
                         'path':value['d'],
@@ -132,7 +132,7 @@ isbn:
         @legacy((("020", "020__", "020__%"), ""),
                 ("020__a", "isbn", "isbn"),
                 ("020__u", "medium"))
-        marc, "020__", {'isbn':value['a'], 'medium':value['u']}
+        marc, "020..", {'isbn':value['a'], 'medium':value['u']}
     producer:
         json_for_marc(), {"020__a": "isbn", "020__u": "medium"}
 
@@ -141,7 +141,7 @@ keywords:
         @legacy((("653", "6531_", "6531_%"), ""),
                 ("6531_a", "keyword", "term"),
                 ("6531_9", "institute"))
-        marc, "6531_", { 'term': value['a'], 'institute': value['9'] }
+        marc, "6531.", { 'term': value['a'], 'institute': value['9'] }
     producer:
         json_for_marc(), {"6531_a": "term", "6531_9": "institute"}
 
@@ -149,7 +149,7 @@ language:
     creator:
         @legacy((("041", "041__", "041__%"), ""),
                 ("041__a", ""))
-        marc, "041__", value['a']
+        marc, "041..", value['a']
     producer:
         json_for_marc(), {"041__a": ""}
         json_for_dc(), {"dc:language": ""}
@@ -158,7 +158,7 @@ primary_report_number:
     creator:
         @legacy((("037", "037__", "037__%"), ""),
                 ("037__a", "primary report number", ""), )
-        marc, "037__", value['a']
+        marc, "037..", value['a']
     producer:
         json_for_marc(), {"037__a": ""}
 
@@ -188,7 +188,7 @@ system_control_number:
         @legacy((("035", "035__", "035__%"), ""),
                 ("035__a", "system_control_number"),
                 ("035__9", "institute"))
-        marc, "035__", {'value': value['a'], 'canceled':value['z'], 'linkpage':value['6'], 'institute':value['9']}
+        marc, "035..", {'value': value['a'], 'canceled':value['z'], 'linkpage':value['6'], 'institute':value['9']}
     producer:
         json_for_marc(), {"035__a": "system_control_number", "035__9": "institute"}
 
@@ -198,7 +198,7 @@ system_number:
         @legacy((("970", "970__", "970__%"), ""),
                 ("970__a", "sysno"),
                 ("970__d", "recid"))
-        marc, "970__", {'value':value['a'], 'recid':value['d']}
+        marc, "970..", {'value':value['a'], 'recid':value['d']}
     producer:
         json_for_marc(), {"970__a": "sysno", "970__d": "recid"}
 
@@ -206,7 +206,7 @@ system_number:
 title:
     """Some useless documentation"""
     creator:
-        marc, "245__", value['foo']
+        marc, "245..", value['foo']
 
 url:
     creator:
@@ -226,7 +226,7 @@ url:
                 ("8564_y", "caption", "description"),
                 ("8564_z", "comment"))
         @only_if_master_value((not is_local_url(value['u']), ))
-        marc, "8564_", {'host_name': value['a'],
+        marc, "8564.", {'host_name': value['a'],
                         'access_number': value['b'],
                         'compression_information': value['c'],
                         'path':value['d'],
@@ -282,7 +282,7 @@ test_json_for_marc:
     schema:
         {'test_json_for_marc': {'type': 'list', 'force': True}}
     creator:
-        marc, "980__", value['a']
+        marc, "980..", value['a']
     producer:
         json_for_marc(), {"980__a": "'test_me_'+value"}
 
@@ -292,7 +292,7 @@ thesis:
                 ("502__b", "type"),
                 ("502__c", "university"),
                 ("502__d", "date"))
-        marc, "502__", {'type': value['b'], 'university': value['c'], 'date': value['d']}
+        marc, "502..", {'type': value['b'], 'university': value['c'], 'date': value['d']}
     producer:
         json_for_marc(), {"502__b": "type", "502__c": "str('University of Fictive Science')", "502__d": "date"}
 

--- a/invenio/modules/jsonalchemy/testsuite/fields/oldvalue.cfg
+++ b/invenio/modules/jsonalchemy/testsuite/fields/oldvalue.cfg
@@ -24,7 +24,7 @@ dates:
                     'death': {'type': 'integer', 'nullable': True}}}}
     creator:
         @only_if_master_value(value["d"])
-        marc, "100__", {'birth': int_util_split(value['d'], '-', 0),
+        marc, "100..", {'birth': int_util_split(value['d'], '-', 0),
                         'death': int_util_split(value['d'], '-', 1)}
     producer:
         json_for_marc(), {"100__d": "birth + '-' + death"}

--- a/invenio/modules/records/testsuite/fields/atlantis.cfg
+++ b/invenio/modules/records/testsuite/fields/atlantis.cfg
@@ -61,7 +61,7 @@ abstract:
                 ("520__a", "abstract", "summary"),
                 ("520__b", "expansion"),
                 ("520__9", "number"))
-        marc, "520__", {'summary':value['a'], 'expansion':value['b'], 'number':value['9']}
+        marc, "520..", {'summary':value['a'], 'expansion':value['b'], 'number':value['9']}
     producer:
         json_for_marc(), {"520__a": "summary", "520__b": "expansion", "520__9": "number"}
         json_for_dc(), {"dc:description": "summary"}
@@ -71,7 +71,7 @@ abstract_french:
         @legacy((("590", "590__", "590__%"), ""),
                 ("590__a", "summary"),
                 ("590__b", "expansion"))
-        marc, "590__", {'summary':value['a'], 'expansion':value['b']}
+        marc, "590..", {'summary':value['a'], 'expansion':value['b']}
     producer:
         json_for_marc(), {"590__a": "sumary", "590__b": "expansion"}
 
@@ -81,7 +81,7 @@ accelerator_experiment:
                 ("693__a", "accelerator"),
                 ("693__e", "experiment"),
                 ("693__f", "facility"))
-        marc, "693__", {'accelerator':value['a'], 'experiment':value['e'], 'facility':value['f']}
+        marc, "693..", {'accelerator':value['a'], 'experiment':value['e'], 'facility':value['f']}
     producer:
         json_for_marc(), {"693__a": "accelerator", "693__b": "experiment", "693__f": "facility"}
 
@@ -92,7 +92,7 @@ action_note:
                 ("583__c", "time"),
                 ("583__i", "email"),
                 ("583__z", "note"))
-        marc, "583__", {'action':value['a'], 'time':value['c'], 'email':value['i'], 'note':value['z']}
+        marc, "583..", {'action':value['a'], 'time':value['c'], 'email':value['i'], 'note':value['z']}
     producer:
         json_for_marc(), {"583__a": "action", "583__c": "time", "583__i": "email", "583__z": "note"}
 
@@ -109,7 +109,7 @@ address:
                 ("270__p", "contact"),
                 ("270__s", "suffix"),
                 ("270__9", "telex"))
-        marc, "270__", {'address':value['a'], 'city':value['b'], 'country':value['d'], 'pc':value['e'], 'telephone':value['k'], 'fax':value['l'], 'email':value['m'], 'contact':value['p'], 'suffix':value['s'], 'telex':value['9']}
+        marc, "270..", {'address':value['a'], 'city':value['b'], 'country':value['d'], 'pc':value['e'], 'telephone':value['k'], 'fax':value['l'], 'email':value['m'], 'contact':value['p'], 'suffix':value['s'], 'telex':value['9']}
     producer:
         json_for_marc(),  {"270__a":"address", "270__b":"city", "270__d":"country", "270__e":"pc", "270__k":"telephone", "270__l":"fax", "270__m":"email", "270__p":"contact", "270__s":"suffix", "270__9":"telex"}
 
@@ -123,7 +123,7 @@ affiliation:
     creator:
         @legacy((("901", "901__", "901__%"), ""),
                 ("901__u", ""))
-        marc, "901__", value['u']
+        marc, "901..", value['u']
     producer:
         json_for_marc(), {"901__u": ""}
 
@@ -149,7 +149,7 @@ aleph_linking_page:
                 ("962__i", "issue_link"),
                 ("962__k", "pages"),
                 ("962__t", "base"))
-        marc, "962__", {'type':value['a'], 'sysno':value['b'], 'library':value['l'], 'down_link':value['n'], 'up_link':value['n'], 'volume_link':value['y'], 'part_link':value['p'], 'issue_link':value['i'], 'pages':value['k'], 'base':value['t']}
+        marc, "962..", {'type':value['a'], 'sysno':value['b'], 'library':value['l'], 'down_link':value['n'], 'up_link':value['n'], 'volume_link':value['y'], 'part_link':value['p'], 'issue_link':value['i'], 'pages':value['k'], 'base':value['t']}
     producer:
         json_for_marc(), {"962__a":"type", "962__b":"sysno", "962__l":"library", "962__n":"down_link", "962__m":"up_link", "962__y":"volume_link", "962__p":"part_link", "962__i":"issue_link", "962__k":"pages", "962__t":"base"}
 
@@ -161,7 +161,7 @@ _first_author, first_author, creator:
                 ("100__h", "CCID"),
                 ("100__i", "INSPIRE_number"),
                 ("100__u", "first author affiliation", "affiliation"))
-        marc, "100__", { 'full_name':value['a'], 'first_name':util_split(value['a'],',',1), 'last_name':util_split(value['a'],',',0), 'relator_name':value['e'], 'CCID':value['h'], 'INSPIRE_number':value['i'], 'affiliation':value['u'] }
+        marc, "100..", { 'full_name':value['a'], 'first_name':util_split(value['a'],',',1), 'last_name':util_split(value['a'],',',0), 'relator_name':value['e'], 'CCID':value['h'], 'INSPIRE_number':value['i'], 'affiliation':value['u'] }
     producer:
         json_for_marc(), {"100__a": "full_name", "100__e": "relator_name", "100__h": "CCID", "100__i": "INSPIRE_number", "100__u": "affiliation"}
         json_for_dc(), {"dc:creator": "full_name"}
@@ -174,7 +174,7 @@ _additional_authors, additional_authors, contributor:
                 ("700__a", "additional author name", "full_name"),
                 ("700__u", "additional author affiliation", "affiliation"))
         @parse_first('_first_author')
-        marc, "700__", {'full_name': value['a'], 'first_name':util_split(value['a'],',',1), 'last_name':util_split(value['a'],',',0), 'relator_name':value['e'], 'CCID':value['h'], 'INSPIRE_number':value['i'], 'affiliation':value['u'] }
+        marc, "700..", {'full_name': value['a'], 'first_name':util_split(value['a'],',',1), 'last_name':util_split(value['a'],',',0), 'relator_name':value['e'], 'CCID':value['h'], 'INSPIRE_number':value['i'], 'affiliation':value['u'] }
     producer:
         json_for_marc(), {"700__a": "full_name", "700__e": "relator_name", "700__h": "CCID", "700__i": "INSPIRE_number", "700__u": "affiliation"}
         json_for_dc(), {"dc:contributor": "full_name"}
@@ -192,14 +192,14 @@ author_archive:
     creator:
         @legacy((("720", "720__", "720__%"), ""),
                 ("720__a", ""))
-        marc, "720__", value['a']
+        marc, "720..", value['a']
     producer:
         json_for_marc(), {"720__a": ""}
 base:
     creator:
         @legacy((("960", "960__", "960__%"), ""),
                 ("960__a", ""))
-        marc, "960__", value['a']
+        marc, "960..", value['a']
     producer:
         json_for_marc(), {"960__a": ""}
 
@@ -213,7 +213,7 @@ cataloguer_info:
                 ("961__l", "library"),
                 ("961__h", "hour"),
                 ("961__x", "creation_date"))
-        marc, "961__", {'cataloguer':value['a'], 'level':value['b'], 'modification_date':value['c'], 'library':value['l'], 'hour':value['h'], 'creation_date':value['x']}
+        marc, "961..", {'cataloguer':value['a'], 'level':value['b'], 'modification_date':value['c'], 'library':value['l'], 'hour':value['h'], 'creation_date':value['x']}
     producer:
         json_for_marc(),  {"961__a": "cataloguer", "961__b": "level", "961__c": "modification_date", "961__l": "library", "961__h": "hour", "961__x": "creation_date"}
 
@@ -225,7 +225,7 @@ classification_terms:
         @legacy((("694", "694__", "694__%"), ""),
                 ("694__a", "term"),
                 ("694__9", "institute"))
-        marc, "694__", {'term':value['a'], 'institute':value['9']}
+        marc, "694..", {'term':value['a'], 'institute':value['9']}
     producer:
         json_for_marc(),  {"694__a": "term", "694__9": "institute"}
 
@@ -235,7 +235,7 @@ cern_bookshop_statistics:
                 ("599__a", "number_of_books_bought"),
                 ("599__b", "number_of_books_sold"),
                 ("599__c", "relation"))
-        marc, "599__", {'number_of_books_bought':value['a'], 'number_of_books_sold':value['b'], 'relation':value['c']}
+        marc, "599..", {'number_of_books_bought':value['a'], 'number_of_books_sold':value['b'], 'relation':value['c']}
     producer:
         json_for_marc(),  {"599__a":"number_of_books_bought", "599__b":"number_of_books_sold", "599__c":"relation"}
 
@@ -244,7 +244,7 @@ code_designation:
         @legacy((("033", "033__", "033__%"), ""),
                 ("030__a", "coden", "coden"),
                 ("030__9", "source"))
-        marc, "030__", {'coden':value['a'], 'source':value['9']}
+        marc, "030..", {'coden':value['a'], 'source':value['9']}
     producer:
         json_for_marc(), {"030__a":"coden", "030__9":"source"}
 
@@ -257,7 +257,7 @@ collections:
                 ("980__a", "primary"),
                 ("980__b", "secondary"),
                 ("980__c", "deleted"))
-        marc, "980__", { 'primary':value['a'], 'secondary':value['b'], 'deleted':value['c'] }
+        marc, "980..", { 'primary':value['a'], 'secondary':value['b'], 'deleted':value['c'] }
     producer:
         json_for_marc(), {"980__a":"primary", "980__b":"secondary", "980__c":"deleted"}
 
@@ -265,7 +265,7 @@ comment:
     creator:
         @legacy((("500", "500__", "500__%"), ""),
                 ("500__a", "comment", ""))
-        marc, "500__", value['a']
+        marc, "500..", value['a']
     producer:
         json_for_marc(), {"500__a": ""}
 
@@ -275,7 +275,7 @@ content_type:
     creator:
         @legacy((("336", "336__", "336__%"), ""),
                 ("336__a", ""))
-        marc, "336__", value['a']
+        marc, "336..", value['a']
     producer:
         json_for_marc(), {"336__a": ""}
 
@@ -284,7 +284,7 @@ copyright:
     creator:
         @legacy((("598", "598__", "598__%"), ""),
                 ("598__a", ""))
-        marc, "598__", value['a']
+        marc, "598..", value['a']
     producer:
         json_for_marc(), {"580__a": ""}
 
@@ -295,7 +295,7 @@ _first_corporate_name, first_corporate_name:
                 ("110__a", "name"),
                 ("110__b", "subordinate_unit"),
                 ("110__g", "collaboration"))
-        marc, "110__", {'name':value['a'], 'subordinate_unit':value['b'], 'collaboration':value['g']}
+        marc, "110..", {'name':value['a'], 'subordinate_unit':value['b'], 'collaboration':value['g']}
     producer:
         json_for_marc(), {"110__a":"name", "110__b":"subordinate_unit", "110__":"collaboration"}
 
@@ -308,7 +308,7 @@ _additional_corporate_names, additional_corporate_names:
                 ("710__a", "name"),
                 ("710__b", "subordinate_unit"),
                 ("710__g", "collaboration", "collaboration"))
-        marc, "710__", {'name':value['a'], 'subordinate_unit':value['b'], 'collaboration':value['g']}
+        marc, "710..", {'name':value['a'], 'subordinate_unit':value['b'], 'collaboration':value['g']}
     producer:
         json_for_marc(), {"710__a":"name", "710__b":"subordinate_unit", "710__":"collaboration"}
 
@@ -324,7 +324,7 @@ cumulative_index:
     creator:
         @legacy((("555", "555__", "555__%"), ""),
                 ("555__a", ""))
-        marc, "555__", value['a']
+        marc, "555..", value['a']
     producer:
         json_for_marc(), {"555__a": ""}
 
@@ -332,7 +332,7 @@ current_publication_frequency:
     creator:
         @legacy((("310", "310__", "310__%"), ""),
                 ("310__a", ""))
-        marc, "310__", value['a']
+        marc, "310..", value['a']
     producer:
         json_for_marc(), {"310__a": ""}
 
@@ -340,7 +340,7 @@ publishing_country:
     creator:
         @legacy((("044", "044__", "044__%"), ""),
                 ("044__a", ""))
-        marc, "044__", value['a']
+        marc, "044..", value['a']
     producer:
         json_for_marc(), {"044__a": ""}
 
@@ -353,7 +353,7 @@ copyright_status:
                 ("542__e", "holder_contact"),
                 ("542__f", "statement"),
                 ("542__3", "materials"),)
-        marc, "542__", {'holder':value['d'], 'date':value['g'], 'url':value['u'], 'holder_contact':value['e'], 'statement':value['f'], 'materials':value['3']}
+        marc, "542..", {'holder':value['d'], 'date':value['g'], 'url':value['u'], 'holder_contact':value['e'], 'statement':value['f'], 'materials':value['3']}
     producer:
         json_for_marc(), {"542__d": "holder", "542__g": "date", "542__u": "url", "542__e": "holder_contact", "542__f": "statement", "542__3": "materials"}
 
@@ -362,7 +362,7 @@ dewey_decimal_classification_number:
     creator:
         @legacy((("082", "082__", "082__%"), ""),
                 ("082__a", ""))
-        marc, "082__", value['a']
+        marc, "082..", value['a']
     producer:
         json_for_marc(), {"082__a": ""}
 
@@ -372,7 +372,7 @@ dissertation_note:
                 ("502__a","diploma"),
                 ("502__b","university"),
                 ("502__c","defense_date"))
-        marc, "502__", {'diploma':value['a'], 'university':value['b'], 'defense_date':value['c']}
+        marc, "502..", {'diploma':value['a'], 'university':value['b'], 'defense_date':value['c']}
     producer:
         json_for_marc(), {"502__a": "diploma", "502__b": "university", "502__b": "defense_date"}
 
@@ -387,7 +387,7 @@ doi:
     creator:
         @legacy((("024", "0247_", "0247_%"), ""),
                 ("0247_a", ""))
-        marc, "0247_", get_doi(value)
+        marc, "0247.", get_doi(value)
     producer:
         json_for_marc(), {'0247_2': 'str("DOI")', '0247_a': ''}
 
@@ -396,7 +396,7 @@ edition_statement:
     creator:
         @legacy((("250", "250__", "250__%"), ""),
                 ("250__a", ""))
-        marc, "250__", value['a']
+        marc, "250..", value['a']
     producer:
         json_for_marc(), {"250__a": ""}
 
@@ -404,7 +404,7 @@ email:
     creator:
         @legacy((("856", "8560_", "8560_%"), ""),
                 ("8560_f", "email"))
-        marc, "8560_", value['f']
+        marc, "8560.", value['f']
     producer:
         json_for_marc(), {"8560_f": ""}
 
@@ -414,7 +414,7 @@ email_message:
                 ("859__a","contact"),
                 ("859__f","address"),
                 ("859__x","date"))
-        marc, "859__", {'contact':value['a'], 'address':value['f'], 'date':value['x']}
+        marc, "859..", {'contact':value['a'], 'address':value['f'], 'date':value['x']}
     producer:
         json_for_marc(), {"859__a": 'contact',"859__f": 'address', "859__x": 'date'}
 
@@ -461,7 +461,7 @@ fft:
                         'format_moreinfo': value['u']
                        }
         @only_if_master_value(is_local_url(value['u']))
-        marc, "8564_", {'hots_name': value['a'],
+        marc, "8564.", {'hots_name': value['a'],
                         'access_number': value['b'],
                         'compression_information': value['c'],
                         'path':value['d'],
@@ -485,7 +485,7 @@ funding_info:
                 ("536__c", "grant_number"),
                 ("536__f", "project_number"),
                 ("536__r", "access_info"))
-        marc, "536__", {'agency':value['a'], 'grant_number':value['c'], 'project_number':value['f'], 'access_info':value['r']}
+        marc, "536..", {'agency':value['a'], 'grant_number':value['c'], 'project_number':value['f'], 'access_info':value['r']}
     producer:
         json_for_marc(), {"536__a": "agency", "536__c": "grant_number", "536__f": "project_number", "536__r": "access_info"}
 
@@ -497,7 +497,7 @@ imprint:
                 ("260__b", "publisher_name"),
                 ("260__c", "date"),
                 ("260__g", "reprinted_editions"))
-        marc, "260__", {'place':value['a'], 'publisher_name':value['b'], 'date':value['c'], 'reprinted_editions':value['g']}
+        marc, "260..", {'place':value['a'], 'publisher_name':value['b'], 'date':value['c'], 'reprinted_editions':value['g']}
     producer:
         json_for_marc(), {"260__a": "place", "260__b": "publisher_name", "260__c": "date", "260__g": "reprinted_editions"}
 
@@ -508,7 +508,7 @@ internal_notes:
                 ("595__d", "control_field"),
                 ("595__i", "inspec_number"),
                 ("595__s", "subject"))
-        marc, "595__", {'internal_note':value['a'], 'control_field':value['d'], 'inspec_number':value['i'], 'subject':value['s']}
+        marc, "595..", {'internal_note':value['a'], 'control_field':value['d'], 'inspec_number':value['i'], 'subject':value['s']}
     producer:
         json_for_marc(), {"595__a": "internal_note", "595__d": "control_field","595__i": "inspec_number", "595__s": "subject"}
 
@@ -517,7 +517,7 @@ isbn:
         @legacy((("020", "020__", "020__%"), ""),
                 ("020__a", "isbn", "isbn"),
                 ("020__u", "medium"))
-        marc, "020__", {'isbn':value['a'], 'medium':value['u']}
+        marc, "020..", {'isbn':value['a'], 'medium':value['u']}
     producer:
         json_for_marc(), {"020__a": "isbn", "020__u": "medium"}
 
@@ -525,7 +525,7 @@ isn:
     creator:
         @legacy((("021", "021__", "021__%"), ""),
                 ("021__a", ""))
-        marc, "021__", value['a']
+        marc, "021..", value['a']
     producer:
         json_for_marc(), {"021__a": ""}
 
@@ -533,7 +533,7 @@ issn:
     creator:
         @legacy((("022", "022__", "022__%"), ""),
                 ("022__a", "issn", ""))
-        marc, "022__", value['a']
+        marc, "022..", value['a']
     producer:
         json_for_marc(), {"022__a": ""}
 
@@ -541,7 +541,7 @@ item:
     creator:
         @legacy((("964", "964__", "964__%"), ""),
                 ("964__a", ""))
-        marc, "964__", value['a']
+        marc, "964..", value['a']
     producer:
         json_for_marc(), {"964__a": ""}
 
@@ -575,7 +575,7 @@ keywords:
                 ("6531_v", "v"),
                 ("6531_y", "y"),
                 ("6531_9", "institute"))
-        marc, "6531_", { 'term': value['a'], 'institute': value['9'] }
+        marc, "6531.", { 'term': value['a'], 'institute': value['9'] }
     producer:
         json_for_marc(), {"6531_a": "term", "6531_9": "institute"}
 
@@ -583,7 +583,7 @@ language:
     creator:
         @legacy((("041", "041__", "041__%"), ""),
                 ("041__a", ""))
-        marc, "041__", value['a']
+        marc, "041..", value['a']
     producer:
         json_for_marc(), {"041__a": ""}
         json_for_dc(), {"dc:language": ""}
@@ -593,7 +593,7 @@ language_note:
         @legacy((("546", "546__", "546__%"), ""),
                 ("546__a", "language_note"),
                 ("546__g", "target_language"))
-        marc, "546__", {'language_note':value['a'], 'target_language':value['g']}
+        marc, "546..", {'language_note':value['a'], 'target_language':value['g']}
     producer:
         json_for_marc(), {"546__a": "language_note", "546__g": "target_language"}
 
@@ -602,7 +602,7 @@ library_of_congress_call_number:
         @legacy((("050", "050__", "050__%"), ""),
                 ("050__a", "classification_number"),
                 ("050__b", "item_number"))
-        marc, "050__", {'classification_number':value['a'], 'item_number':value['b']}
+        marc, "050..", {'classification_number':value['a'], 'item_number':value['b']}
     producer:
         json_for_marc(), {"050__a": "classification_number", "050__b": "item_number"}
 
@@ -613,7 +613,7 @@ license:
                 ("540__b", "imposing"),
                 ("540__u", "url"),
                 ("540__3", "material"))
-        marc, "540__", {'license':value['a'], 'imposing':value['b'], 'url':value['u'], 'material':value['3'],}
+        marc, "540..", {'license':value['a'], 'imposing':value['b'], 'url':value['u'], 'material':value['3'],}
     producer:
         json_for_marc(), {"540__a": "license", "540__b": "imposing", "540__u": "url", "540__3": "material"}
 
@@ -621,7 +621,7 @@ location:
     creator:
         @legacy((("852", "852__", "852__%"), ""),
                 ("852__a", ""))
-        marc, "852__", value['a']
+        marc, "852..", value['a']
     producer:
         json_for_marc(), {"852__a": ""}
 
@@ -632,7 +632,7 @@ medium:
                 ("340__c", "suface"),
                 ("340__d", "recording_technique"),
                 ("340__d", "cd-rom"))
-        marc, "340__", {'material':value['a'], 'surface':value['c'], 'recording_technique':value['d'], 'cd-rom':value['9']}
+        marc, "340..", {'material':value['a'], 'surface':value['c'], 'recording_technique':value['d'], 'cd-rom':value['9']}
     producer:
         json_for_marc(), {"340__a": "material", "340__c": "suface", "340__d": "recording_technique", "340__d": "cd-rom"}
 
@@ -648,7 +648,7 @@ _first_meeting_name:
                 ("111__w", "country"),
                 ("111__z", "closing_date"),
                 ("111__9", "opening_date"))
-        marc, "111__", {'meeting':value['a'], 'location':value['c'], 'date':value['d'], 'year':value['f'], 'coference_code':value['g'], 'number_of_parts':value['n'], 'country':value['w'], 'closing_date':value['z'], 'opening_date':value['9']}
+        marc, "111..", {'meeting':value['a'], 'location':value['c'], 'date':value['d'], 'year':value['f'], 'coference_code':value['g'], 'number_of_parts':value['n'], 'country':value['w'], 'closing_date':value['z'], 'opening_date':value['9']}
     producer:
         json_for_marc(), {"111__a": "meeting", "111__c": "location", "111__d": "date","111__f": "year", "111__g": "coference_code", "111__n": "number_of_parts", "111__w": "country", "111__z": "closing_date", "111__9": "opening_date"}
 
@@ -662,7 +662,7 @@ _additional_meeting_names:
                 ("711__g", "coference_code"),
                 ("711__n", "number_of_parts"),
                 ("711__9", "opening_date"))
-        marc, "711__", {'meeting':value['a'], 'location':value['c'], 'date':value['d'], 'work_date':value['f'], 'coference_code':value['g'], 'number_of_parts':value['n'], 'opening_date':value['9']}
+        marc, "711..", {'meeting':value['a'], 'location':value['c'], 'date':value['d'], 'work_date':value['f'], 'coference_code':value['g'], 'number_of_parts':value['n'], 'opening_date':value['9']}
     producer:
         json_for_marc(), {"711__a": "meeting", "711__c": "location", "711__d": "date", "711__f": "work_date", "711__g": "coference_code", "711__n": "number_of_parts", "711__9": "opening_date"}
 
@@ -680,7 +680,7 @@ oai:
         @legacy((("024", "0248_", "0248_%"), ""),
                 ("0248_a", "oai"),
                 ("0248_p", "indicator"))
-        marc, "0248_", {'value': value['a'], 'indicator': value['p']}
+        marc, "0248.", {'value': value['a'], 'indicator': value['p']}
     producer:
         json_for_marc(), {"0248_a": "oai", "0248_p": "indicator"}
 
@@ -688,7 +688,7 @@ observation:
     creator:
         @legacy((("691", "691__", "691__%"), ""),
                 ("691__a", ""))
-        marc, "691__", value['a']
+        marc, "691..", value['a']
     producer:
         json_for_marc(), {"691__a": ""}
 
@@ -696,7 +696,7 @@ observation_french:
     creator:
         @legacy((("597", "597__", "597__%"), ""),
                 ("597__a", ""))
-        marc, "597__", value['a']
+        marc, "597..", value['a']
     producer:
         json_for_marc(), {"597__a": ""}
 
@@ -706,7 +706,7 @@ other_report_number:
                 ("084__a", "clasification_number"),
                 ("084__b", "collection_short"),
                 ("084__2", "source_number"))
-        marc, "084__", {'clasification_number':value['a'], 'collection_short':value['b'], 'source_number':value['2'],}
+        marc, "084..", {'clasification_number':value['a'], 'collection_short':value['b'], 'source_number':value['2'],}
     producer:
         json_for_marc(), {"084__a": "clasification_number", "084__b": "collection_short", "084__2": "source_number"}
 
@@ -714,7 +714,7 @@ owner:
     creator:
         @legacy((("963", "963__", "963__%"), ""),
                 ("963__a",""))
-        marc, "963__", value['a']
+        marc, "963..", value['a']
     producer:
         json_for_marc(), {"963__a": ""}
 
@@ -728,7 +728,7 @@ prepublication:
                 ("269__a", "place"),
                 ("269__b", "publisher_name"),
                 ("269__c", "date"))
-        marc, "269__", {'place':value['a'], 'publisher_name': value['b'], 'date':value['c']}
+        marc, "269..", {'place':value['a'], 'publisher_name': value['b'], 'date':value['c']}
     producer:
         json_for_marc(), {"269__a": "place", "269__b": "publisher_name", "269__c": "date"}
 
@@ -736,7 +736,7 @@ primary_report_number:
     creator:
         @legacy((("037", "037__", "037__%"), ""),
                 ("037__a", "primary report number", ""), )
-        marc, "037__", value['a']
+        marc, "037..", value['a']
     producer:
         json_for_marc(), {"037__a": ""}
 
@@ -756,7 +756,7 @@ publication_info:
                 ("773__t", "talk"),
                 ("773__w", "cnum"),
                 ("773__x", "reference"))
-        marc, "773__", {'doi':value['a'], 'pagination':value['c'], 'date':value['d'], 'recid':value['e'], 'note':value['f'], 'title':value['p'], 'url':value['u'], 'volume':value['v'], 'year':value['y'], 'talk':value['t'], 'cnum':value['w'], 'reference':value['x']}
+        marc, "773..", {'doi':value['a'], 'pagination':value['c'], 'date':value['d'], 'recid':value['e'], 'note':value['f'], 'title':value['p'], 'url':value['u'], 'volume':value['v'], 'year':value['y'], 'talk':value['t'], 'cnum':value['w'], 'reference':value['x']}
     producer:
         json_for_marc(), {"773__a": "doi", "773__c": "pagination", "773__d": "date", "773__e": "recid", "773__f": "note", "773__p": "title", "773__u": "url", "773__v": "volume", "773__y": "year", "773__t": "talk", "773__w": "cnum", "773__x": "reference"}
 
@@ -765,7 +765,7 @@ physical_description:
         @legacy((("300", "300__", "300__%", "")),
                 ("300__a", "pagination"),
                 ("300__b", "details"))
-        marc, "300__", {'pagination':value['a'], 'details':value['b']}
+        marc, "300..", {'pagination':value['a'], 'details':value['b']}
     producer:
         json_for_marc(), {"300__a": "pagination", "300__b": "details"}
 
@@ -793,7 +793,7 @@ restriction_access:
         @legacy((("506", "506__", "506__%"), ""),
                 ("506__a", "terms"),
                 ("506__9", "local_info"))
-        marc, "506__", {'terms':value['a'], 'local_info':value['9']}
+        marc, "506..", {'terms':value['a'], 'local_info':value['9']}
     producer:
         json_for_marc(), {"506__a": "terms", "506__9": "local_info"}
 
@@ -802,7 +802,7 @@ report_number:
         @legacy((("088", "088__", "088__%"), ""),
                 ("088__a", "additional report number", "report_number"),
                 ("088__9", "internal"))
-        marc, "088__", {'report_number':value['a'], 'internal':value['9']}
+        marc, "088..", {'report_number':value['a'], 'internal':value['9']}
     producer:
         json_for_marc(), {"088__a": "report_number", "088__9": "internal"}
 
@@ -811,7 +811,7 @@ series:
         @legacy((("490", "490__", "490__%"), ""),
                 ("490__a", "statement"),
                 ("490__v", "volume"))
-        marc, "490__", {'statement':value['a'], 'volume':value['v']}
+        marc, "490..", {'statement':value['a'], 'volume':value['v']}
     producer:
         json_for_marc(), {"490__a": "statement", "490__v": "volume"}
 
@@ -819,7 +819,7 @@ slac_note:
     creator:
         @legacy((("596", "596__", "596__%"), ""),
                 ("596__a", "slac_note", ""), )
-        marc, "596__", value['a']
+        marc, "596..", value['a']
     producer:
         json_for_marc(), {"596__a": ""}
 
@@ -832,7 +832,7 @@ source_of_acquisition:
                 ("541_f_","owner"),
                 ("541__h","price_paid"),
                 ("541__9","price_user"))
-        marc, "541__", {'source_of_acquisition':value['a'], 'date':value['d'], 'accession_number':value['e'], 'owner':value['f'], 'price_paid':value['h'], 'price_user':value['9']}
+        marc, "541..", {'source_of_acquisition':value['a'], 'date':value['d'], 'accession_number':value['e'], 'owner':value['f'], 'price_paid':value['h'], 'price_user':value['9']}
     producer:
         json_for_marc(), {"541__a": "source_of_acquisition", "541__d": "date", "541__e": "accession_number", "541_f_": "owner", "541__h": "price_paid", "541__9":"price_user"}
 
@@ -845,7 +845,7 @@ status_week:
                 ("916__s","status"),
                 ("916__w","status_week"),
                 ("916__y","year"))
-        marc, "916__", {'acquistion_proceedings':value['a'], 'display_period':value['d'], 'copies_bought':value['e'], 'status':value['s'], 'status_week':value['w'], 'year':value['y']}
+        marc, "916..", {'acquistion_proceedings':value['a'], 'display_period':value['d'], 'copies_bought':value['e'], 'status':value['s'], 'status_week':value['w'], 'year':value['y']}
     producer:
         json_for_marc(), {"916__a": "acquistion_proceedings", "916__d": "display_period", "916__e": "copies_bought", "916__s": "status", "916__w": "status_week", "916__y":"year"}
 
@@ -885,7 +885,7 @@ system_control_number:
         @legacy((("035", "035__", "035__%"), ""),
                 ("035__a", "system_control_number"),
                 ("035__9", "institute"))
-        marc, "035__", {'value': value['a'], 'canceled':value['z'], 'linkpage':value['6'], 'institute':value['9']}
+        marc, "035..", {'value': value['a'], 'canceled':value['z'], 'linkpage':value['6'], 'institute':value['9']}
     producer:
         json_for_marc(), {"035__a": "system_control_number", "035__9": "institute"}
 
@@ -895,7 +895,7 @@ system_number:
         @legacy((("970", "970__", "970__%"), ""),
                 ("970__a", "sysno"),
                 ("970__d", "recid"))
-        marc, "970__", {'value':value['a'], 'recid':value['d']}
+        marc, "970..", {'value':value['a'], 'recid':value['d']}
     producer:
         json_for_marc(), {"970__a": "sysno", "970__d": "recid"}
 
@@ -904,7 +904,7 @@ thesaurus_terms:
         @legacy((("695", "695__", "695__%"), ""),
                 ("695__a", "term"),
                 ("695__9", "institute"))
-        marc, "695__", {'term':value['a'], 'institute':value['9']}
+        marc, "695..", {'term':value['a'], 'institute':value['9']}
     producer:
         json_for_marc(), {"695__a": "term", "695__9": "institute"}
 
@@ -916,7 +916,7 @@ time_and_place_of_event_note:
                 ("518__h", "starting_time"),
                 ("518__l", "speech_length"),
                 ("518__r", "meeting"))
-        marc, "519__", {'date':value['d'], 'conference_identification':value['g'], 'starting_time':value['h'], 'speech_length':value['l'], 'meeting':value['r']}
+        marc, "518..", {'date':value['d'], 'conference_identification':value['g'], 'starting_time':value['h'], 'speech_length':value['l'], 'meeting':value['r']}
     producer:
         json_for_marc(), {"518__d": "date", "518__g": "conference_identification", "518__h": "starting_time", "518__l": "speech_length", "518__r": "meeting"}
 
@@ -924,7 +924,7 @@ abbreviated_title:
     creator:
         @legacy((("210", "210__", "210__%"), ""),
                 ("210__a", ""))
-        marc, "210__", value['a']
+        marc, "210..", value['a']
     producer:
         json_for_marc(), {"210__a": ""}
 
@@ -933,7 +933,7 @@ main_title_statement:
         @legacy((("145", "145__", "145__%"), ""),
                 ("145__a", "title"),
                 ("145__b", "subtitle"),)
-        marc, "145__", {'title':value['a'], 'subtitle':value['b']}
+        marc, "145..", {'title':value['a'], 'subtitle':value['b']}
     producer:
         json_for_marc(), {"145__a": "title", "145__b": "subtitle"}
 
@@ -947,7 +947,7 @@ title_additional:
                 ("246__i", "text"),
                 ("246__n", "part_number"),
                 ("246__p", "part_name"))
-        marc, "246__", { 'title':value['a'], 'subtitle':value['b'], 'misc':value['g'], 'text':value['i'], 'part_number':value['n'], 'part_name':value['p']}
+        marc, "246..", { 'title':value['a'], 'subtitle':value['b'], 'misc':value['g'], 'text':value['i'], 'part_number':value['n'], 'part_name':value['p']}
     producer:
         json_for_marc(), {"246__a": "title", "246__b": "subtitle", "246__g": "misc", "246__i": "text", "246__n": "part_number", "246__p": "part_name"}
 
@@ -960,7 +960,7 @@ title:
                 ("245__s", "version"),
                 ("245__n", "volume"),
                 ("245__k", "form"))
-        marc, "245__", { 'title':value['a'], 'subtitle':value['b'], 'version': value['s'], 'volume': value['n'], 'form':value['k'] }
+        marc, "245..", { 'title':value['a'], 'subtitle':value['b'], 'version': value['s'], 'volume': value['n'], 'form':value['k'] }
     producer:
         json_for_marc(), {"245__a": "title", "245__b": "subtitle", "245__k": "form"}
         json_for_dc(), {"dc:title": "title"}
@@ -969,7 +969,7 @@ title_key:
     creator:
         @legacy((("222", "222__", "222__%"), ""),
                 ("222__a", ""))
-        marc, "222__", value['a']
+        marc, "222..", value['a']
     producer:
         json_for_marc(), {"222__a": ""}
 
@@ -998,7 +998,7 @@ title_translation:
                 ("242__a", "title"),
                 ("242__b", "subtitle"),
                 ("242__y", "language"))
-        marc, "242__", {'title':value['a'], 'subtitle':value['b'], 'language':value['y']}
+        marc, "242..", {'title':value['a'], 'subtitle':value['b'], 'language':value['y']}
     producer:
         json_for_marc(), {"242__a": "title", "242__b": "subtitle", "242__y": "language"}
 
@@ -1006,7 +1006,7 @@ type:
     creator:
         @legacy((("594", "594__", "594__%"), ""),
                 ("594__a", ""))
-        marc, "594__", value['a']
+        marc, "594..", value['a']
     producer:
         json_for_marc(), {"594__a": ""}
 
@@ -1014,7 +1014,7 @@ udc:
     creator:
         @legacy((("080", "080__", "080__%"), ""),
                 ("080__a", ""))
-        marc, "080__", value['a']
+        marc, "080..", value['a']
     producer:
         json_for_marc(), {"080__a": ""}
 
@@ -1036,7 +1036,7 @@ url:
                 ("8564_y", "caption", "description"),
                 ("8564_z", "comment"))
         @only_if_master_value((not is_local_url(value['u']), ))
-        marc, "8564_", {'host_name': value['a'],
+        marc, "8564.", {'host_name': value['a'],
                         'access_number': value['b'],
                         'compression_information': value['c'],
                         'path':value['d'],
@@ -1065,7 +1065,7 @@ electronic_location:
         @legacy((('856', '8567_', '8567_%'), ''),
                 ('8567_2', 'access_method'),
                 ('8567_u', 'uri'))
-        marc, "8567_", {'method':value['2'], 'uri':value['u']}
+        marc, "8567.", {'method':value['2'], 'uri':value['u']}
 
 citation:
     creator:
@@ -1078,14 +1078,14 @@ citation:
                 ('913__y', 'year'),
                 ('913__s', 'FIXME_subject'),
                 ('913__k', 'FIXME_number'))
-        marc, "913__", {'citation':value['c'], 'references':value['p'], 'title_abbreviation':value['t'], 'uri':value['u'], 'volume':value['v'], 'year':value['y'], 'FIXME_subject':value['s'], 'FIXME_number':value['k']}
+        marc, "913..", {'citation':value['c'], 'references':value['p'], 'title_abbreviation':value['t'], 'uri':value['u'], 'volume':value['v'], 'year':value['y'], 'FIXME_subject':value['s'], 'FIXME_number':value['k']}
 
 universal_decimal_classification:
     creator:
         @legacy((('914', '914__', '914__%'), ''),
                 ('914__u', 'secondary_udc_number'),
                 ('914__v', 'shelving_code'))
-        marc, "914__", {'secondary_udc_number':value['u'], 'shelving_code':value['v']}
+        marc, "914..", {'secondary_udc_number':value['u'], 'shelving_code':value['v']}
 
 FIXME_CERN_internal_number:
     creator:
@@ -1191,7 +1191,7 @@ chronological_term:
                 ('148__x', 'general_subdivision'),
                 ('148__y', 'chronological_subdivision'),
                 ('148__z', 'geographical_subdivision'))
-        marc, "148__", {'term':value['a'], 'form_subdivision':value['v'], 'general_subdivision':value['x'], 'chronological_subdivision':value['y'], 'geographical_subdivision':value['z']}
+        marc, "148..", {'term':value['a'], 'form_subdivision':value['v'], 'general_subdivision':value['x'], 'chronological_subdivision':value['y'], 'geographical_subdivision':value['z']}
 
 
 topical_term:
@@ -1203,7 +1203,7 @@ topical_term:
                 ('150__x', 'general_subdivision'),
                 ('150__y', 'chronological_subdivision'),
                 ('150__z', 'geographical_subdivision'))
-        marc, "150__", {'term_or_geographical_entry':value['a'], 'term_and_geographical_entry':value['b'], 'form_subdivision':value['v'], 'general_subdivision':value['x'], 'chronological_subdivision':value['y'], 'geographical_subdivision':value['z']}
+        marc, "150..", {'term_or_geographical_entry':value['a'], 'term_and_geographical_entry':value['b'], 'form_subdivision':value['v'], 'general_subdivision':value['x'], 'chronological_subdivision':value['y'], 'geographical_subdivision':value['z']}
 
 authority_topical_term, authority_subject:
     creator:
@@ -1214,7 +1214,7 @@ authority_topical_term, authority_subject:
                 ('450__x', 'general_subdivision'),
                 ('450__y', 'chronological_subdivision'),
                 ('450__z', 'geographical_subdivision'))
-        marc, "450__", {'term_or_geographical_entry':value['a'], 'term_and_geographical_entry':value['b'], 'form_subdivision':value['v'], 'general_subdivision':value['x'], 'chronological_subdivision':value['y'], 'geographical_subdivision':value['z']}
+        marc, "450..", {'term_or_geographical_entry':value['a'], 'term_and_geographical_entry':value['b'], 'form_subdivision':value['v'], 'general_subdivision':value['x'], 'chronological_subdivision':value['y'], 'geographical_subdivision':value['z']}
 
 authority_another_topical_term, authority_another_subject:
     creator:
@@ -1225,7 +1225,7 @@ authority_another_topical_term, authority_another_subject:
                 ('550__x', 'general_subdivision'),
                 ('550__y', 'chronological_subdivision'),
                 ('550__z', 'geographical_subdivision'))
-        marc, "550__", {'term_or_geographical_entry':value['a'], 'term_and_geographical_entry':value['b'], 'form_subdivision':value['v'], 'general_subdivision':value['x'], 'chronological_subdivision':value['y'], 'geographical_subdivision':value['z']}
+        marc, "550..", {'term_or_geographical_entry':value['a'], 'term_and_geographical_entry':value['b'], 'form_subdivision':value['v'], 'general_subdivision':value['x'], 'chronological_subdivision':value['y'], 'geographical_subdivision':value['z']}
 
 series_statement:
     creator:
@@ -1235,7 +1235,7 @@ series_statement:
                 ('440__p', 'name_of_part'),
                 ('440__v', 'volume'),
                 ('440__x', 'international_standard_serial_number'))
-        marc, "150__", {'title':value['a'], 'number_of_part':value['n'], 'name_of_part':value['p'], 'volume':value['v']}
+        marc, "440..", {'title':value['a'], 'number_of_part':value['n'], 'name_of_part':value['p'], 'volume':value['v']}
 
 other_restriction_access:
     creator:
@@ -1251,14 +1251,14 @@ authority_institution:
         @legacy((('510', '510__', '510__%'), ''),
                 ('510__a', 'institution'),
                 ('510__b', 'subunit'))
-        marc, "510__", {'institution':value['a'], 'subunit':value['b']}
+        marc, "510..", {'institution':value['a'], 'subunit':value['b']}
 
 source_of_description:
     creator:
         @legacy((('588', '588__', '588__%'), ''),
-                ('510__a', 'note'),
-                ('510__5', 'institution'))
-        marc, "510__", {'note':value['a'], 'institution':value['5']}
+                ('588__a', 'note'),
+                ('588__5', 'institution'))
+        marc, "588..", {'note':value['a'], 'institution':value['5']}
 
 publisher, issuing_body:
     creator:
@@ -1266,14 +1266,14 @@ publisher, issuing_body:
                 ('643__a', 'place'),
                 ('643__b', 'publisher'),
                 ('643__d', 'volumes'))
-        marc, "643__", {'place':value['a'], 'publisher':value['b'], 'vaolumes':value['d']}
+        marc, "643..", {'place':value['a'], 'publisher':value['b'], 'vaolumes':value['d']}
 
 public_general_note:
     creator:
         @legacy((('680', '680__', '680__%'), ''),
                 ('680__a', 'heading'),
                 ('680__i', 'explanatory_text'))
-        marc, "680__", {'heading':value['a'], 'explanatory_text':value['i']}
+        marc, "680..", {'heading':value['a'], 'explanatory_text':value['i']}
 
 source_data_found:
     creator:
@@ -1281,7 +1281,7 @@ source_data_found:
                 ('670__a', 'source_citation'),
                 ('670__b', 'information_found'),
                 ('670__u', 'uri'))
-        marc, "670__", {'source_citation':value['a'], 'information_found':value['b'], 'uri':value['u']}
+        marc, "670..", {'source_citation':value['a'], 'information_found':value['b'], 'uri':value['u']}
 
 other_institution:
     creator:
@@ -1289,7 +1289,7 @@ other_institution:
                 ('920__0', 'reference'),
                 ('920__v', 'name'),
                 ('920__d', 'some_date'))
-        marc, "920__", {'reference':value['0'], 'name':value['v'], 'some_date':value['d']}
+        marc, "920..", {'reference':value['0'], 'name':value['v'], 'some_date':value['d']}
 
 
 ###############################################################################

--- a/invenio/modules/uploader/recordext/fields/files.cfg
+++ b/invenio/modules/uploader/recordext/fields/files.cfg
@@ -62,7 +62,7 @@ files_to_upload:
                         'format_moreinfo': value['u']
                        }
         @only_if_master_value(is_local_url(value['u']))
-        marc, "8564_", {'source': value['a'],
+        marc, "8564.", {'source': value['a'],
                         'access_number': value['b'],
                         'compression_information': value['c'],
                         'path':value['d'],

--- a/invenio/testsuite/data/test_authors.cfg
+++ b/invenio/testsuite/data/test_authors.cfg
@@ -28,7 +28,7 @@ authors[0], creator:
                 ("100__h", "CCID"),
                 ("100__i", "INSPIRE_number"),
                 ("100__u", "first author affiliation", "affiliation"))
-        marc, "100__", { 'full_name':value['a'], 'first_name':util_split(value['a'],',',1), 'last_name':util_split(value['a'],',',0), 'relator_name':value['e'], 'CCID':value['h'], 'INSPIRE_number':value['i'], 'affiliation':value['u'] }
+        marc, "100..", { 'full_name':value['a'], 'first_name':util_split(value['a'],',',1), 'last_name':util_split(value['a'],',',0), 'relator_name':value['e'], 'CCID':value['h'], 'INSPIRE_number':value['i'], 'affiliation':value['u'] }
     checker:
         check_field_existence(0,1)
         check_field_type('str')
@@ -43,7 +43,7 @@ authors[n], contributor:
         @legacy((("700", "700__", "700__%"), ""),
                 ("700__a", "additional author name", "full_name"),
                 ("700__u", "additional author affiliation", "affiliation"))
-        marc, "700__", {'full_name': value['a'], 'first_name':util_split(value['a'],',',1), 'last_name':util_split(value['a'],',',0), 'relator_name':value['e'], 'CCID':value['h'], 'INSPIRE_number':value['i'], 'affiliation':value['u'] }
+        marc, "700..", {'full_name': value['a'], 'first_name':util_split(value['a'],',',1), 'last_name':util_split(value['a'],',',0), 'relator_name':value['e'], 'CCID':value['h'], 'INSPIRE_number':value['i'], 'affiliation':value['u'] }
     checker:
         check_field_existence(0,'n')
         check_field_type('str')


### PR DESCRIPTION
* Introduces support for accepting MARC fields having any indicator
  (closes #1722)

* Fixes the definition of time_and_place_of_event_note,
  series_statement and source_of_description fields.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>
Reported-by: Ferran Jorba <Ferran.Jorba@uab.cat>