### PR TITLE
installation: explicitly specify versions for jquery plugins

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -143,19 +143,19 @@ install-jquery-plugins:
 	mkdir -p $(prefix)/var/www/css
 	(cd ${prefix}/var/www/js && \
 	wget -O jquery.min.js http://invenio-software.org/download/jquery/jquery-1.7.1.min.js && \
-	wget -O jquery-ui.min.js http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.17/jquery-ui.min.js && \
-	wget -O jquery.jeditable.mini.js http://invenio-software.org/download/jquery/v1.5/js/jquery.jeditable.mini.js && \
-	wget -O jquery.form.js https://raw.githubusercontent.com/malsup/form/3.51/jquery.form.js --no-check-certificate && \
-	wget -O jquery.MultiFile.js http://jquery-multifile-plugin.googlecode.com/svn-history/r54/trunk/jquery.MultiFile.js && \
+	wget -N http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.17/jquery-ui.min.js && \
+	wget -N http://invenio-software.org/download/jquery/v1.5/js/jquery.jeditable.mini.js && \
+	wget -N https://raw.githubusercontent.com/malsup/form/3.51/jquery.form.js --no-check-certificate && \
+	wget -N http://jquery-multifile-plugin.googlecode.com/svn-history/r54/trunk/jquery.MultiFile.js && \
 	wget -O jquery.tablesorter.zip http://invenio-software.org/download/jquery/jquery.tablesorter.20111208.zip && \
 	wget -O uploadify.zip http://invenio-software.org/download/jquery/uploadify-v2.1.4.zip && \
-	wget -O jquery.dataTables.min.js http://cdn.datatables.net/1.10.4/js/jquery.dataTables.min.js && \
-	wget -O jquery.bookmark.package-1.4.0.zip http://invenio-software.org/download/jquery/jquery.bookmark.package-1.4.0.zip && \
+	wget -N http://cdn.datatables.net/1.10.4/js/jquery.dataTables.min.js && \
+	wget -N http://invenio-software.org/download/jquery/jquery.bookmark.package-1.4.0.zip && \
 	unzip -u jquery.tablesorter.zip -d tablesorter && \
 	rm jquery.tablesorter.zip && \
 	rm -rf uploadify && \
 	unzip -u uploadify.zip -d uploadify && \
-	wget -O flot-0.6.zip http://invenio-software.org/download/jquery/flot-0.6.zip && \
+	wget -N http://invenio-software.org/download/jquery/flot-0.6.zip && \
 	wget -O jquery-ui-timepicker-addon.js http://invenio-software.org/download/jquery/jquery-ui-timepicker-addon-1.0.3.js && \
 	unzip -u flot-0.6.zip && \
 	mv flot/jquery.flot.selection.min.js flot/jquery.flot.min.js flot/excanvas.min.js ./ && \
@@ -164,12 +164,12 @@ install-jquery-plugins:
 	mv uploadify/cancel.png uploadify/uploadify.css uploadify/uploadify.allglyphs.swf uploadify/uploadify.fla uploadify/uploadify.swf ../img/ && \
 	mv uploadify/jquery.uploadify.v2.1.4.min.js ./jquery.uploadify.min.js && \
 	rm uploadify.zip && rm -r uploadify && \
-	wget -O json2.js https://github.com/douglascrockford/JSON-js/raw/master/json2.js --no-check-certificate && \
+	wget -N https://github.com/douglascrockford/JSON-js/raw/master/json2.js --no-check-certificate && \
 	wget -O jquery.hotkeys.js http://invenio-software.org/download/jquery/jquery.hotkeys-0.8.js && \
-	wget -O jquery.treeview.zip http://invenio-software.org/download/jquery/jquery.treeview.zip && \
+	wget -N http://invenio-software.org/download/jquery/jquery.treeview.zip && \
 	unzip -u jquery.treeview.zip -d jquery-treeview && \
 	rm jquery.treeview.zip && \
-	wget -O jquery.ajaxPager.js http://invenio-software.org/download/jquery/v1.5/js/jquery.ajaxPager.js && \
+	wget -N http://invenio-software.org/download/jquery/v1.5/js/jquery.ajaxPager.js && \
 	unzip -u jquery.bookmark.package-1.4.0.zip && \
 	rm -f jquery.bookmark.ext.* bookmarks-big.png bookmarkBasic.html jquery.bookmark.js jquery.bookmark.pack.js && \
 	mv bookmarks.png ../img/ && \
@@ -181,8 +181,8 @@ install-jquery-plugins:
 	wget -r -np -nH --cut-dirs=4 -A "png,css" -P jquery-ui/themes http://jquery-ui.googlecode.com/svn/tags/1.8.17/themes/smoothness/ && \
 	wget -r -np -nH --cut-dirs=4 -A "png,css" -P jquery-ui/themes http://jquery-ui.googlecode.com/svn/tags/1.8.17/themes/redmond/ && \
 	wget -O datatables_jquery-ui.css https://raw.githubusercontent.com/DataTables/DataTables/1.10.0/media/css/demo_table_jui.css --no-check-certificate && \
-	wget -O jquery-ui.css http://jquery-ui.googlecode.com/svn/tags/1.8.17/themes/redmond/jquery-ui.css && \
-	wget -O calendar.gif http://jquery-ui.googlecode.com/svn/tags/1.8.17/demos/images/calendar.gif && \
+	wget -N http://jquery-ui.googlecode.com/svn/tags/1.8.17/themes/redmond/jquery-ui.css && \
+	wget -N http://jquery-ui.googlecode.com/svn/tags/1.8.17/demos/images/calendar.gif && \
 	wget -r -np -nH --cut-dirs=5 -A "png" http://jquery-ui.googlecode.com/svn/tags/1.8.17/themes/redmond/images/)
 	@echo "***********************************************************"
 	@echo "** The jQuery plugins were successfully installed.       **"

--- a/Makefile.am
+++ b/Makefile.am
@@ -142,21 +142,20 @@ install-jquery-plugins:
 	mkdir -p ${prefix}/var/www/js
 	mkdir -p $(prefix)/var/www/css
 	(cd ${prefix}/var/www/js && \
-	wget http://invenio-software.org/download/jquery/jquery-1.7.1.min.js && \
-	mv jquery-1.7.1.min.js jquery.min.js && \
-	wget http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.17/jquery-ui.min.js && \
-        wget http://invenio-software.org/download/jquery/v1.5/js/jquery.jeditable.mini.js && \
-	wget https://raw.github.com/malsup/form/master/jquery.form.js --no-check-certificate && \
-	wget http://jquery-multifile-plugin.googlecode.com/svn/trunk/jquery.MultiFile.pack.js && \
+	wget -O jquery.min.js http://invenio-software.org/download/jquery/jquery-1.7.1.min.js && \
+	wget -O jquery-ui.min.js http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.17/jquery-ui.min.js && \
+	wget -O jquery.jeditable.mini.js http://invenio-software.org/download/jquery/v1.5/js/jquery.jeditable.mini.js && \
+	wget -O jquery.form.js https://raw.githubusercontent.com/malsup/form/3.51/jquery.form.js --no-check-certificate && \
+	wget -O jquery.MultiFile.js http://jquery-multifile-plugin.googlecode.com/svn-history/r54/trunk/jquery.MultiFile.js && \
 	wget -O jquery.tablesorter.zip http://invenio-software.org/download/jquery/jquery.tablesorter.20111208.zip && \
-	wget http://invenio-software.org/download/jquery/uploadify-v2.1.4.zip -O uploadify.zip && \
-	wget http://www.datatables.net/download/build/jquery.dataTables.min.js && \
-	wget http://invenio-software.org/download/jquery/jquery.bookmark.package-1.4.0.zip && \
-	unzip jquery.tablesorter.zip -d tablesorter && \
+	wget -O uploadify.zip http://invenio-software.org/download/jquery/uploadify-v2.1.4.zip && \
+	wget -O jquery.dataTables.min.js http://cdn.datatables.net/1.10.4/js/jquery.dataTables.min.js && \
+	wget -O jquery.bookmark.package-1.4.0.zip http://invenio-software.org/download/jquery/jquery.bookmark.package-1.4.0.zip && \
+	unzip -u jquery.tablesorter.zip -d tablesorter && \
 	rm jquery.tablesorter.zip && \
 	rm -rf uploadify && \
 	unzip -u uploadify.zip -d uploadify && \
-	wget http://invenio-software.org/download/jquery/flot-0.6.zip && \
+	wget -O flot-0.6.zip http://invenio-software.org/download/jquery/flot-0.6.zip && \
 	wget -O jquery-ui-timepicker-addon.js http://invenio-software.org/download/jquery/jquery-ui-timepicker-addon-1.0.3.js && \
 	unzip -u flot-0.6.zip && \
 	mv flot/jquery.flot.selection.min.js flot/jquery.flot.min.js flot/excanvas.min.js ./ && \
@@ -165,13 +164,13 @@ install-jquery-plugins:
 	mv uploadify/cancel.png uploadify/uploadify.css uploadify/uploadify.allglyphs.swf uploadify/uploadify.fla uploadify/uploadify.swf ../img/ && \
 	mv uploadify/jquery.uploadify.v2.1.4.min.js ./jquery.uploadify.min.js && \
 	rm uploadify.zip && rm -r uploadify && \
-	wget --no-check-certificate https://github.com/douglascrockford/JSON-js/raw/master/json2.js && \
-	wget http://invenio-software.org/download/jquery/jquery.hotkeys-0.8.js -O jquery.hotkeys.js && \
-	wget http://invenio-software.org/download/jquery/jquery.treeview.zip && \
-	unzip jquery.treeview.zip -d jquery-treeview && \
+	wget -O json2.js https://github.com/douglascrockford/JSON-js/raw/master/json2.js --no-check-certificate && \
+	wget -O jquery.hotkeys.js http://invenio-software.org/download/jquery/jquery.hotkeys-0.8.js && \
+	wget -O jquery.treeview.zip http://invenio-software.org/download/jquery/jquery.treeview.zip && \
+	unzip -u jquery.treeview.zip -d jquery-treeview && \
 	rm jquery.treeview.zip && \
-	wget http://invenio-software.org/download/jquery/v1.5/js/jquery.ajaxPager.js && \
-	unzip jquery.bookmark.package-1.4.0.zip && \
+	wget -O jquery.ajaxPager.js http://invenio-software.org/download/jquery/v1.5/js/jquery.ajaxPager.js && \
+	unzip -u jquery.bookmark.package-1.4.0.zip && \
 	rm -f jquery.bookmark.ext.* bookmarks-big.png bookmarkBasic.html jquery.bookmark.js jquery.bookmark.pack.js && \
 	mv bookmarks.png ../img/ && \
 	mv jquery.bookmark.css ../css/ && \
@@ -181,9 +180,9 @@ install-jquery-plugins:
 	wget -r -np -nH --cut-dirs=4 -A "png,css" -P jquery-ui/themes http://jquery-ui.googlecode.com/svn/tags/1.8.17/themes/base/ && \
 	wget -r -np -nH --cut-dirs=4 -A "png,css" -P jquery-ui/themes http://jquery-ui.googlecode.com/svn/tags/1.8.17/themes/smoothness/ && \
 	wget -r -np -nH --cut-dirs=4 -A "png,css" -P jquery-ui/themes http://jquery-ui.googlecode.com/svn/tags/1.8.17/themes/redmond/ && \
-	wget --no-check-certificate -O datatables_jquery-ui.css https://raw.githubusercontent.com/DataTables/DataTables/1.10.0/media/css/demo_table_jui.css && \
-	wget http://jquery-ui.googlecode.com/svn/tags/1.8.17/themes/redmond/jquery-ui.css && \
-	wget http://jquery-ui.googlecode.com/svn/tags/1.8.17/demos/images/calendar.gif && \
+	wget -O datatables_jquery-ui.css https://raw.githubusercontent.com/DataTables/DataTables/1.10.0/media/css/demo_table_jui.css --no-check-certificate && \
+	wget -O jquery-ui.css http://jquery-ui.googlecode.com/svn/tags/1.8.17/themes/redmond/jquery-ui.css && \
+	wget -O calendar.gif http://jquery-ui.googlecode.com/svn/tags/1.8.17/demos/images/calendar.gif && \
 	wget -r -np -nH --cut-dirs=5 -A "png" http://jquery-ui.googlecode.com/svn/tags/1.8.17/themes/redmond/images/)
 	@echo "***********************************************************"
 	@echo "** The jQuery plugins were successfully installed.       **"


### PR DESCRIPTION
Explicitly specify versions for jquery plugins:
* jquery.form.js
* jquery.MultiFile.js
* jquery.dataTables.min.js
Add `-O` parameters for all wget commands within jquery installations to avoid piling up files.
Dump `jquery.min.js` to the proper name right away.
Add `-u` to `unzip` calls to avoid queries in case file exists

*TODO*: `json2.js` does not provide any version tags on github. This is the only one that still comes in the latest version.

This addresses issue #11 for maint-1.1