### PR TITLE
jsonalchemy: function for safe conversion to integer

### DIFF
--- a/invenio/modules/jsonalchemy/jsonext/functions/to_int.py
+++ b/invenio/modules/jsonalchemy/jsonext/functions/to_int.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2015 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Improved function for type conversion to int."""
+
+
+def to_int(probably_a_string):
+    """Helper function to convert safely a value to int.
+
+    In case of wrong type returns a value which can be handled by JSONAlchemy.
+    It helps in the situation where an integer subfield is optional.
+
+    :param probably_a_string: A value to convert. Doesn't have to be a string.
+
+    :return: The integer value or None in case of error.
+    """
+    try:
+        return int(probably_a_string)
+    except TypeError:
+        return None

--- a/invenio/modules/jsonalchemy/testsuite/fields/toint.cfg
+++ b/invenio/modules/jsonalchemy/testsuite/fields/toint.cfg
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2015 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+with_integers:
+    schema:
+        {'with_integers': {'type': 'list', 'force': True, 'items': {
+         'some_int': {'type': 'integer', 'nullable': True},
+         'something_else': {'type': 'string', 'required': True}
+         }}}
+    creator:
+        marc, "999__", {'some_int': to_int(value['a']),
+                        'something_else': value['b']}

--- a/invenio/modules/jsonalchemy/testsuite/models/test_toint.cfg
+++ b/invenio/modules/jsonalchemy/testsuite/models/test_toint.cfg
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2015 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""A model for integration test for to_int."""
+
+fields:
+    with_integers

--- a/invenio/modules/jsonalchemy/testsuite/test_functions.py
+++ b/invenio/modules/jsonalchemy/testsuite/test_functions.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2015 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Unit tests for testing Jsonext's functions."""
+
+from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
+
+from .test_bases import field_definitions, model_definitions, \
+    clean_field_model_definitions
+from ..jsonext.functions.to_int import to_int
+
+
+class TestToInt(InvenioTestCase):
+
+    """Tests for ``to_int`` function."""
+    def setUp(self):
+        """Prepare the JSONAlchemy input."""
+        clean_field_model_definitions()
+        self.app.extensions['registry'][
+            'testsuite.fields'] = field_definitions()
+        self.app.extensions['registry'][
+            'testsuite.models'] = model_definitions()
+
+    def tearDown(self):
+        """Clean the JSONAlchemy input."""
+        clean_field_model_definitions()
+        del self.app.extensions['registry']['testsuite.fields']
+        del self.app.extensions['registry']['testsuite.models']
+
+    def test_toint_results(self):
+        """Test ``to_int`` function itself."""
+        self.assertIsNone(to_int(None))
+        self.assertEqual(to_int("-1"), -1)
+
+    def test_jsonalchemy_toint_usage(self):
+        """Test the usage of ``to_int`` function in real life example.
+
+        The ``test_toint`` model contains a field which contains an integer
+        subfield. Whenever the record is obtained from ``MARCXML``, the
+        string in mentioned subfield has to be converted to an integer.
+
+        However, JSONAlchemy fills every absent subfield with a ``None`` value.
+        If the record is not provided with the integer subfield and the
+        built-in ``int`` function is used, the code will crash.
+
+        The ``to_int`` function used inside definition of ``test_toint`` field
+        prevents it. Here the unprovided subfield is ``999__a``.
+        """
+        xml = '<collection><record><datafield tag="999" ind1="" ind2= "">' \
+              '<subfield code="b">Value</subfield></datafield></record>' \
+              '</collection>'
+        from invenio.modules.records.api import Record
+        simple_record = Record.create(xml, master_format='marc',
+                                      model="test_toint",
+                                      namespace='testsuite')
+
+        self.assertEqual(len(simple_record.__dict__['_dict']['__meta_metadata__']['__errors__']), 0)
+
+        # Check if it works when the value is provided.
+        xml = '<collection><record><datafield tag="999" ind1="" ind2= "">' \
+              '<subfield code="a">9999</subfield>' \
+              '<subfield code="b">Value</subfield></datafield></record>' \
+              '</collection>'
+
+        simple_record = Record.create(xml, master_format='marc',
+                                      model="test_toint",
+                                      namespace='testsuite')
+        self.assertEqual(simple_record['with_integers'][0]['some_int'], 9999)
+
+TEST_SUITE = make_test_suite(TestToInt)
+
+if __name__ == '__main__':
+    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
Signed-off-by: Mateusz Susik <mateusz.susik@cern.ch>

When a field is optional in the jsonalchemy record definition file, and it contains an integer, the behaviour when the integer subfield is missing is weird.

``` python
experiments:
    """Contains information about experiments."""
    schema:
        {'experiments': {'type': 'list', 'force': True, 'items': {
         'id': {'type': 'string'},
         'start_year': {'type': 'integer', 'nullable': True,
                        'min': __import__('flask').current_app.config['INSPIRE_YEAR_MIN'],
                        'max': __import__('flask').current_app.config['INSPIRE_YEAR_MAX']},
         'end_year': {'type': 'integer', 'nullable': True,
                      'min': __import__('flask').current_app.config['INSPIRE_YEAR_MIN'],
                      'max': __import__('flask').current_app.config['INSPIRE_YEAR_MAX']},
         'status': {'type': 'string', 'nullable': True,
                    'allowed': __import__('flask').current_app.config['INSPIRE_EXPERIMENT_STATUS']}
         }}}
    creator:
        marc, "693__", {'id': value['e'], 'start_year': int(value['s']),
                        'end_year': int(value['d']), 'status': value['z']}
    producer:
        json_for_marc(), {"693__e": "id", "693__s": "start_year",
                          "693__d": "end_year", "693__z": "status"}
```

If the MARCXML doesn't contain one of `start_year` or `end_year`, when creating the record, the developer gets:

``` python
TypeError: int() argument must be a string or a number, not 'NoneType'
```

as `JSONAlchemy` by default put `None`s in missing subfields.

With this PR, you can use `to_int` instead of `int`, and don't care about the missing value.