### PR TITLE
WebSearch: removes hardcoded collection requirement

### DIFF
--- a/modules/miscutil/demo/democfgdata.sql
+++ b/modules/miscutil/demo/democfgdata.sql
@@ -96,7 +96,6 @@ INSERT INTO collectiondetailedrecordpagetabs VALUES (29, 'files;references;keywo
 INSERT INTO collectiondetailedrecordpagetabs VALUES (30, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
 INSERT INTO collectiondetailedrecordpagetabs VALUES (31, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
 INSERT INTO collectiondetailedrecordpagetabs VALUES (32, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
-INSERT INTO collectiondetailedrecordpagetabs VALUES (33, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
 INSERT INTO collectiondetailedrecordpagetabs VALUES (34, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
 INSERT INTO collectiondetailedrecordpagetabs VALUES (35, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
 INSERT INTO collectiondetailedrecordpagetabs VALUES (36, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');

--- a/modules/miscutil/demo/democfgdata.sql
+++ b/modules/miscutil/demo/democfgdata.sql
@@ -68,10 +68,41 @@ INSERT INTO collection VALUES (36, 'Institutes', 'collection:INSTITUTE', null, n
 INSERT INTO collection VALUES (37, 'Journals', 'collection:JOURNAL', null, null);
 INSERT INTO collection VALUES (38, 'Subjects', 'collection:SUBJECT', null, null);
 
+INSERT INTO collectiondetailedrecordpagetabs VALUES (2, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (4, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (5, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (6, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
 INSERT INTO collectiondetailedrecordpagetabs VALUES (8, 'usage;comments;metadata');
-INSERT INTO collectiondetailedrecordpagetabs VALUES (19, 'usage;comments;metadata');
-INSERT INTO collectiondetailedrecordpagetabs VALUES (18, 'usage;comments;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (10, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (11, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (12, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (13, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (14, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (15, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (16, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
 INSERT INTO collectiondetailedrecordpagetabs VALUES (17, 'usage;comments;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (18, 'usage;comments;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (19, 'usage;comments;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (20, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (21, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (22, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (23, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (24, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (25, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (26, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (27, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (28, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (29, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (30, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (31, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (32, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (33, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (34, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (35, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (36, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (37, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+INSERT INTO collectiondetailedrecordpagetabs VALUES (38, 'files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata');
+
 
 INSERT INTO clsMETHOD VALUES (1,'HEP','http://invenio-software.org/download/invenio-demo-site-files/HEP.rdf','High Energy Physics Taxonomy','0000-00-00 00:00:00');
 INSERT INTO clsMETHOD VALUES (2,'NASA-subjects','http://invenio-software.org/download/invenio-demo-site-files/NASA-subjects.rdf','NASA Subjects','0000-00-00 00:00:00');

--- a/modules/miscutil/lib/upgrades/invenio_2015_01_13_hide_holdings.py
+++ b/modules/miscutil/lib/upgrades/invenio_2015_01_13_hide_holdings.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2014 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Upgrade for explicitly hiding the 'holdings' tab for all collections\
+ except 'Books' without an existing rule"""
+
+from invenio.dbquery import run_sql
+
+depends_on = ['invenio_release_1_1_0']
+
+
+def info():
+    """Upgrade recipe information."""
+    return "Updates the collectiondetailedrecordpagetabs to hide 'holdings' for every collection \
+            except 'Books' without an existing rule."
+
+
+def do_upgrade():
+    """Upgrade recipe procedure."""
+    # Show holdings for the 'Books' collection unless there's an existing rule
+    run_sql("""
+    INSERT IGNORE INTO collectiondetailedrecordpagetabs (id_collection, tabs)
+    SELECT id, "files;references;keywords;plots;hepdata;holdings;comments;linkbacks;citations;usage;metadata"
+    """)
+
+    # Insert the rest of the rules
+    run_sql("""
+    INSERT IGNORE INTO collectiondetailedrecordpagetabs (id_collection, tabs)
+    SELECT id, "files;references;keywords;plots;hepdata;comments;linkbacks;citations;usage;metadata"
+    FROM collection
+    """)
+
+
+def estimate():
+    """Upgrade recipe time estimate."""
+    return 1

--- a/modules/miscutil/lib/upgrades/invenio_2015_01_13_hide_holdings.py
+++ b/modules/miscutil/lib/upgrades/invenio_2015_01_13_hide_holdings.py
@@ -37,6 +37,7 @@ def do_upgrade():
     run_sql("""
     INSERT IGNORE INTO collectiondetailedrecordpagetabs (id_collection, tabs)
     SELECT id, "files;references;keywords;plots;hepdata;holdings;comments;linkbacks;citations;usage;metadata"
+    FROM collection WHERE name = 'Books'
     """)
 
     # Insert the rest of the rules

--- a/modules/websearch/lib/websearchadminlib.py
+++ b/modules/websearch/lib/websearchadminlib.py
@@ -3524,11 +3524,6 @@ def get_detailed_page_tabs(colID=None, recID=None, ln=CFG_SITE_LANG):
         if disable_files_tab_p:
             tabs['files']['enabled'] = False
 
-        #Disable holdings tab if collection != Books
-        collection = run_sql("""select name from collection where id=%s""", (colID, ))
-        if collection[0][0] != 'Books':
-            tabs['holdings']['enabled'] = False
-
         # Disable Plots tab if no docfile of doctype Plot found
         brd =  BibRecDocs(recID)
         if len(brd.list_bibdocs('Plot')) == 0:


### PR DESCRIPTION
* Removes hardcoded requirement that only allows the 'holdings'
  tab to be displayed for the 'Books' collection (closes #2592)

* Adds an upgrade file that can be run on any installation to
  reflect this in the database (i.e. adds a new rule to show all
  but 'holdings' for every collection without a preexisting rule)

* Adds insert statements in the demo SQL file to reflect this.

Signed-off-by: Oystein Blixhavn <oystein@tind.io>