### PR TITLE
legacy: fix import overriding local variable

### DIFF
--- a/invenio/legacy/bibupload/engine.py
+++ b/invenio/legacy/bibupload/engine.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -564,8 +564,8 @@ def bibupload(record, opt_mode=None, opt_notimechange=0, oai_rec_id="", pretend=
             # concurrent processes call get_record at the same time and the
             # does not exists (i.e. all process will try to generate and save
             # the recjson)
-            from invenio.modules.records.api import get_record
-            get_record(rec_id, reset_cache=True)
+            from invenio.modules.records.api import get_record as _get_record
+            _get_record(rec_id, reset_cache=True)
 
             # Fire record signals.
             from invenio.base import signals


### PR DESCRIPTION
* Renames import in order to avoid overriding local variable.
  (closes #2665)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>