### PR TITLE
oairepository: schema/namespace fix

### DIFF
--- a/invenio/base/config.py
+++ b/invenio/base/config.py
@@ -517,11 +517,11 @@ CFG_OAI_LICENSE_TERMS_SUBFIELD = "a"
 CFG_OAI_LICENSE_URI_SUBFIELD = "u"
 CFG_OAI_LOAD = 500
 CFG_OAI_METADATA_FORMATS = {
-    'marcxml': ('XOAIMARC', 'http://www.openarchives.org/OAI/1.1/dc.xsd',
-                            'http://purl.org/dc/elements/1.1/'),
-    'oai_dc': ('XOAIDC',
-               'http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd',
-               'http://www.loc.gov/MARC21/slim'),
+    'oai_dc': ('XOAIMARC', 'http://www.openarchives.org/OAI/1.1/dc.xsd',
+                           'http://purl.org/dc/elements/1.1/'),
+    'marcxml': ('XOAIDC',
+                'http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd',
+                'http://www.loc.gov/MARC21/slim'),
 }
 CFG_OAI_PREVIOUS_SET_FIELD = "909COq"
 CFG_OAI_PROVENANCE_ALTERED_SUBFIELD = "t"


### PR DESCRIPTION
* Fixes wrong namespace and schema URLs for OAI_DC and MARCXMLmetadata formats in OAI-PMH server. (addresses EUDAT-B2SHARE/b2share#536)

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
