### PR TITLE
WebSubmit: Set_Embargo optional and functional

### DIFF
--- a/modules/websubmit/lib/functions/Set_Embargo.py
+++ b/modules/websubmit/lib/functions/Set_Embargo.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2011 CERN.
+## Copyright (C) 2011, 2012, 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -15,13 +15,17 @@
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
+"""File which contains the WebSubmit function Set_Embargo."""
+
 import os
 import time
 
 from invenio.bibdocfile import BibRecDocs
 
+
 def Set_Embargo(parameters, curdir, form):
     """set the embargo on all the documents of a given record.
+
     @param date_file: the file from which to read the embargo end date.
     @param date_format: the format in which the date in L{date_file} is
         expected to be found. (default C{%Y-%m-%d})
@@ -33,12 +37,13 @@ def Set_Embargo(parameters, curdir, form):
     """
     ## Let's retrieve the date from date_file.
     date_file = parameters['date_file']
-    if not date_file:
+
+    if not date_file or not os.path.isfile(os.path.join(curdir, date_file)):
         return
+
     date = open(os.path.join(curdir, date_file)).read().strip()
     if not date:
         return
-
     ## Let's retrieve the expected date format.
     date_format = parameters['date_format'].strip()
     if not date_format:
@@ -48,11 +53,11 @@ def Set_Embargo(parameters, curdir, form):
     date = time.strftime("%Y-%m-%d", time.strptime(date, date_format))
 
     ## Let's prepare the firerole rule.
-    firerole = """\
+    firerole = """
 deny until "%s"
 allow all
 """ % date
 
     ## Applying the embargo.
     for bibdoc in BibRecDocs(sysno).list_bibdocs():
-        bibdoc.set_status("firerole: %s")
+        bibdoc.set_status("firerole: {0}".format(firerole))


### PR DESCRIPTION
websubmit: Set_Embargo optional and functional

* Check if file for date exists. This allows to not meet
  IOError exception if the field creating the file is
  optional and has not been filled.

* Fix a bug where the status was set to an incorrect value.

Signed-off-by: Guillaume Lastecoueres <guillaume@tind.io>