### PR TITLE
WebStyle: ping handler to return 200

### DIFF
--- a/modules/webstyle/lib/ping_webinterface.py
+++ b/modules/webstyle/lib/ping_webinterface.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2012 CERN.
+## Copyright (C) 2012, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -26,6 +26,7 @@ class WebInterfacePingPages(WebInterfaceDirectory):
     _exports = [""]
 
     def __call__(self, req, form):
+        req.status = 200
         return 'OK'
 
     index = __call__


### PR DESCRIPTION
* When queried by a load-balancer (such as haproxy) have the /ping
  web handler to return HTTP status code 200, even e.g. if
  ACCESS_CONTROL_LEVEL_SITE is set to 1 (which implies returning
  HTTP error status code 503 for any other web handler so that
  crawlers don't register these requests).

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>