### PR TITLE
installation: all upgrade recipes in tabcreate

### DIFF
--- a/modules/miscutil/sql/tabcreate.sql
+++ b/modules/miscutil/sql/tabcreate.sql
@@ -5044,5 +5044,6 @@ INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_08_13_tag_recjsonva
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_11_04_format_recjson',NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_08_31_next_collection_tree',NOW());
 INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2015_01_13_hide_holdings',NOW());
+INSERT INTO upgrade (upgrade, applied) VALUES ('invenio_2014_06_02_oaiHARVEST_arguments_cfg_namechange',NOW());
 
 -- end of file


### PR DESCRIPTION
* Adds missing upgrade recipe from PR #1753 to `tabcreate.sql`, which
  makes that all upgrade recipes are listed there now.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>