### PR TITLE
WebSearch: limit on refersto and simular keywords

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -699,6 +699,18 @@ CFG_WEBSEARCH_COLLECTION_NAMES_SEARCH = 0
 ## (0=simple, 1=advanced, 2=add-to-search)
 CFG_WEBSEARCH_DEFAULT_SEARCH_INTERFACE = 0
 
+## CFG_WEBSEARCH_MAX_RECORDS_REFERSTO -- in order to limit denial of service
+## attacks the total number of records for which we look for incoming citations
+## (all the records that have a reference/citation to the specified records)
+## will be limited to this number. This does not limit the number of records in
+## the result.
+CFG_WEBSEARCH_MAX_RECORDS_REFERSTO = 50000
+
+## CFG_WEBSEARCH_MAX_RECORDS_CITEDBY -- in order to limit denial of service
+## attacks the total number of records for which we look for outgoing citations
+## (all the records referenced/cited by the specified records) will be limited
+## to this number. This does not limit the number of records in the result.
+CFG_WEBSEARCH_MAX_RECORDS_CITEDBY = 50000
 
 #######################################
 ## Part 4: BibHarvest OAI parameters ##

--- a/modules/bibrank/lib/bibrank_citation_searcher.py
+++ b/modules/bibrank/lib/bibrank_citation_searcher.py
@@ -190,47 +190,71 @@ def get_records_with_num_cites(numstr, allrecs=intbitset([]),
     return matches
 
 
-def get_cited_by_list(recids):
-    """Return a tuple of ([recid,list_of_citing_records],...) for all the
-       records in recordlist.
+def get_cited_by_list(recids, record_limit=None):
+    """
+    Return a tuple of ([recid,list_of_citing_records],...) for all the records
+    in recordlist.
+
+    The parameter 'record_limit' is the maximum number of records of 'recids' to
+    consider. If it is None (the default value) all the records will be used.
     """
     if not recids:
         return []
 
-    in_sql = ','.join('%s' for dummy in recids)
+    # We don't want to overwrite the input parameter
+    if record_limit is not None:
+        limited_recids = recids[:record_limit]
+    else:
+        limited_recids = recids
+
+    in_sql = ','.join('%s' for dummy in limited_recids)
     rows = run_sql("""SELECT citer, citee FROM rnkCITATIONDICT
-                       WHERE citee IN (%s)""" % in_sql, recids)
+                       WHERE citee IN (%s)""" % in_sql, limited_recids)
 
     cites = {}
     for citer, citee in rows:
         cites.setdefault(citee, set()).add(citer)
 
-    return [(recid, cites.get(recid, set())) for recid in recids]
+    return [(recid, cites.get(recid, set())) for recid in limited_recids]
 
 
-def get_refers_to_list(recids):
-    """Return a tuple of ([recid,list_of_citing_records],...) for all the
-       records in recordlist.
+def get_refers_to_list(recids, record_limit=None):
+    """
+    Return a tuple of ([recid,list_of_citing_records],...) for all the records
+    in recordlist.
+
+    The parameter 'record_limit' is the maximum number of records of 'recids' to
+    consider. If it is None (the default value) all the records will be used.
     """
     if not recids:
         return []
 
-    in_sql = ','.join('%s' for dummy in recids)
+    # We don't want to overwrite the input parameter
+    if record_limit is not None:
+        limited_recids = recids[:record_limit]
+    else:
+        limited_recids = recids
+
+    in_sql = ','.join('%s' for dummy in limited_recids)
     rows = run_sql("""SELECT citee, citer FROM rnkCITATIONDICT
-                       WHERE citer IN (%s)""" % in_sql, recids)
+                       WHERE citer IN (%s)""" % in_sql, limited_recids)
 
     refs = {}
     for citee, citer in rows:
         refs.setdefault(citer, set()).add(citee)
 
-    return [(recid, refs.get(recid, set())) for recid in recids]
+    return [(recid, refs.get(recid, set())) for recid in limited_recids]
 
 
-def get_refersto_hitset(ahitset):
+def get_refersto_hitset(ahitset, record_limit=None):
     """
     Return a hitset of records that refers to (cite) some records from
     the given ahitset.  Useful for search engine's
     refersto:author:ellis feature.
+
+    The parameter 'record_limit' is the maximum number of records of 'ahitset'
+    to consider. If it is None (the default value) all the records will be
+    used.
     """
     out = intbitset()
     if ahitset:
@@ -240,11 +264,18 @@ def get_refersto_hitset(ahitset):
             # ignore attempt to iterate over infinite ahitset
             pass
         else:
-            in_sql = ','.join('%s' for dummy in ahitset)
+            # We don't want to overwrite the input parameter
+            if record_limit is not None:
+                limited_ahitset = ahitset[:record_limit]
+            else:
+                limited_ahitset = ahitset
+
+            in_sql = ','.join('%s' for dummy in limited_ahitset)
             rows = run_sql("""SELECT citer FROM rnkCITATIONDICT
-                              WHERE citee IN (%s)""" % in_sql, ahitset)
+                              WHERE citee IN (%s)""" % in_sql, limited_ahitset)
             out = intbitset(rows)
     return out
+
 
 def get_one_cited_by_weight(recID):
     """Returns a number_of_citing_records for one record
@@ -252,6 +283,7 @@ def get_one_cited_by_weight(recID):
     weight = get_citation_dict("citations_weights")
 
     return weight.get(recID, 0)
+
 
 def get_cited_by_weight(recordlist):
     """Return a tuple of ([recid,number_of_citing_records],...) for all the
@@ -266,10 +298,14 @@ def get_cited_by_weight(recordlist):
     return result
 
 
-def get_citedby_hitset(ahitset):
+def get_citedby_hitset(ahitset, record_limit=None):
     """
     Return a hitset of records that are cited by records in the given
-    ahitset.  Useful for search engine's citedby:author:ellis feature.
+    ahitset. Useful for search engine's citedby:author:ellis feature.
+
+    The parameter 'record_limit' is the maximum number of records of 'ahitset'
+    to consider. If it is None (the default value) all the records will be
+    used.
     """
     out = intbitset()
     if ahitset:
@@ -279,9 +315,15 @@ def get_citedby_hitset(ahitset):
             # ignore attempt to iterate over infinite ahitset
             pass
         else:
-            in_sql = ','.join('%s' for dummy in ahitset)
+            # We don't want to overwrite the input parameter
+            if record_limit is not None:
+                limited_ahitset = ahitset[:record_limit]
+            else:
+                limited_ahitset = ahitset
+
+            in_sql = ','.join('%s' for dummy in limited_ahitset)
             rows = run_sql("""SELECT citee FROM rnkCITATIONDICT
-                              WHERE citer IN (%s)""" % in_sql, ahitset)
+                              WHERE citer IN (%s)""" % in_sql, limited_ahitset)
             out = intbitset(rows)
     return out
 

--- a/modules/bibrank/lib/bibrank_selfcites_searcher.py
+++ b/modules/bibrank/lib/bibrank_selfcites_searcher.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2013 CERN.
+## Copyright (C) 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -28,13 +28,22 @@ def get_self_cited_by(recid):
     return intbitset(run_sql(sql, [recid]))
 
 
-def get_self_cited_by_list(recids):
-    in_sql = ','.join('%s' for dummy in recids)
+def get_self_cited_by_list(recids, record_limit=None):
+    if not recids:
+        return []
+
+    # We don't want to overwrite the input parameter
+    if record_limit is not None:
+        limited_recids = recids[:record_limit]
+    else:
+        limited_recids = recids
+
+    in_sql = ','.join('%s' for dummy in limited_recids)
     sql = "SELECT citee, citer FROM rnkSELFCITEDICT WHERE citee IN (%s)"
     cites = {}
-    for citee, citer in run_sql(sql % in_sql, recids):
+    for citee, citer in run_sql(sql % in_sql, limited_recids):
         cites.setdefault(citee, set()).add(citer)
-    return [(recid, cites.get(recid, set())) for recid in recids]
+    return [(recid, cites.get(recid, set())) for recid in limited_recids]
 
 
 def get_self_refers_to(recid):
@@ -42,10 +51,19 @@ def get_self_refers_to(recid):
     return intbitset(run_sql(sql, [recid]))
 
 
-def get_self_refers_to_list(recids):
-    in_sql = ','.join('%s' for dummy in recids)
+def get_self_refers_to_list(recids, record_limit=None):
+    if not recids:
+        return []
+
+    # We don't want to overwrite the input parameter
+    if record_limit is not None:
+        limited_recids = recids[:record_limit]
+    else:
+        limited_recids = recids
+
+    in_sql = ','.join('%s' for dummy in limited_recids)
     sql = "SELECT citer, citee FROM rnkSELFCITEDICT WHERE citer IN (%s)"
     refs = {}
-    for citer, citee in run_sql(sql % in_sql, recids):
+    for citer, citee in run_sql(sql % in_sql, limited_recids):
         refs.setdefault(citer, set()).add(citee)
-    return [(recid, refs.get(recid, set())) for recid in recids]
+    return [(recid, refs.get(recid, set())) for recid in limited_recids]

--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -87,11 +87,15 @@ from invenio.config import \
      CFG_BIBSORT_ENABLED, \
      CFG_XAPIAN_ENABLED, \
      CFG_BIBINDEX_CHARS_PUNCTUATION, \
-     CFG_BASE_URL
+     CFG_BASE_URL, \
+     CFG_WEBSEARCH_MAX_RECORDS_REFERSTO, \
+     CFG_WEBSEARCH_MAX_RECORDS_CITEDBY
 
 from invenio.search_engine_config import \
      InvenioWebSearchUnknownCollectionError, \
      InvenioWebSearchWildcardLimitError, \
+     InvenioWebSearchReferstoLimitError, \
+     InvenioWebSearchCitedbyLimitError, \
      CFG_WEBSEARCH_IDXPAIRS_FIELDS,\
      CFG_WEBSEARCH_IDXPAIRS_EXACT_SEARCH
 from invenio.search_engine_utils import (get_fieldvalues,
@@ -2155,6 +2159,15 @@ def search_pattern(req=None, p=None, f=None, m=None, ap=0, of="id", verbose=0, l
             basic_search_unit_hitset = excp.res
             if of.startswith("h"):
                 write_warning(_("Search term too generic, displaying only partial results..."), req=req)
+        except InvenioWebSearchReferstoLimitError, excp:
+            basic_search_unit_hitset = excp.res
+            if of.startswith("h"):
+                write_warning(_("Search term after reference operator too generic, displaying only partial results..."), req=req)
+        except InvenioWebSearchCitedbyLimitError, excp:
+            basic_search_unit_hitset = excp.res
+            if of.startswith("h"):
+                write_warning(_("Search term after citedby operator too generic, displaying only partial results..."), req=req)
+
         # FIXME: print warning if we use native full-text indexing
         if bsu_f == 'fulltext' and bsu_m != 'w' and of.startswith('h') and not CFG_SOLR_URL:
             write_warning(_("No phrase index available for fulltext yet, looking for word combination..."), req=req)
@@ -2950,7 +2963,11 @@ def search_unit_refersto(query):
     """
     if query:
         ahitset = search_pattern(p=query)
-        return get_refersto_hitset(ahitset)
+        res = get_refersto_hitset(ahitset, record_limit=CFG_WEBSEARCH_MAX_RECORDS_REFERSTO)
+
+        if len(ahitset) >= CFG_WEBSEARCH_MAX_RECORDS_REFERSTO:
+            raise InvenioWebSearchReferstoLimitError(res)
+        return res
     else:
         return intbitset([])
 
@@ -2962,11 +2979,14 @@ def search_unit_refersto_excluding_selfcites(query):
     if query:
         ahitset = search_pattern(p=query)
         citers = intbitset()
-        citations = get_cited_by_list(ahitset)
-        selfcitations = get_self_cited_by_list(ahitset)
+        citations = get_cited_by_list(ahitset, record_limit=CFG_WEBSEARCH_MAX_RECORDS_REFERSTO)
+        selfcitations = get_self_cited_by_list(ahitset, record_limit=CFG_WEBSEARCH_MAX_RECORDS_REFERSTO)
         for cites, selfcites in zip(citations, selfcitations):
             # cites is in the form [(citee, citers), ...]
             citers += cites[1] - selfcites[1]
+
+        if len(ahitset) >= CFG_WEBSEARCH_MAX_RECORDS_REFERSTO:
+            raise InvenioWebSearchReferstoLimitError(citers)
         return citers
     else:
         return intbitset([])
@@ -3013,7 +3033,11 @@ def search_unit_citedby(query):
     if query:
         ahitset = search_pattern(p=query)
         if ahitset:
-            return get_citedby_hitset(ahitset)
+            res = get_citedby_hitset(ahitset, record_limit=CFG_WEBSEARCH_MAX_RECORDS_CITEDBY)
+
+            if len(ahitset) >= CFG_WEBSEARCH_MAX_RECORDS_CITEDBY:
+                raise InvenioWebSearchCitedbyLimitError(res)
+            return res
         else:
             return intbitset([])
     else:
@@ -3027,11 +3051,14 @@ def search_unit_citedby_excluding_selfcites(query):
     if query:
         ahitset = search_pattern(p=query)
         citees = intbitset()
-        references = get_refers_to_list(ahitset)
-        selfreferences = get_self_refers_to_list(ahitset)
+        references = get_refers_to_list(ahitset, record_limit=CFG_WEBSEARCH_MAX_RECORDS_CITEDBY)
+        selfreferences = get_self_refers_to_list(ahitset, record_limit=CFG_WEBSEARCH_MAX_RECORDS_CITEDBY)
         for refs, selfrefs in zip(references, selfreferences):
             # refs is in the form [(citer, citees), ...]
             citees += refs[1] - selfrefs[1]
+
+        if len(ahitset) >= CFG_WEBSEARCH_MAX_RECORDS_CITEDBY:
+            raise InvenioWebSearchCitedbyLimitError(citees)
         return citees
     else:
         return intbitset([])

--- a/modules/websearch/lib/search_engine_config.py
+++ b/modules/websearch/lib/search_engine_config.py
@@ -65,3 +65,19 @@ class InvenioWebSearchWildcardLimitError(Exception):
     def __init__(self, res):
         """Initialization."""
         self.res = res
+
+class InvenioWebSearchReferstoLimitError(Exception):
+    """
+    Exception raised when CFG_WEBSEARCH_MAX_RECORDS_REFERSTO limit is reached.
+    """
+    def __init__(self, res):
+        """Initialization."""
+        self.res = res
+
+class InvenioWebSearchCitedbyLimitError(Exception):
+    """
+    Exception raised when CFG_WEBSEARCH_MAX_RECORDS_CITEDBY limit is reached.
+    """
+    def __init__(self, res):
+        """Initialization."""
+        self.res = res

--- a/modules/websearch/lib/websearch_regression_tests.py
+++ b/modules/websearch/lib/websearch_regression_tests.py
@@ -1963,11 +1963,16 @@ class WebSearchSearchEnginePythonAPITest(InvenioXmlTestCase):
 
 </collection>""")
 
-
     def test_search_engine_python_api_long_author_with_quotes(self):
         """websearch - search engine Python API for p=author:"Abbot, R B"'""" \
         """this test was written along with a bug report, needs fixing."""
         self.assertEqual([16], perform_request_search(p='author:"Abbott, R B"'))
+
+    def test_search_engine_python_api_search_refersto_year_2000(self):
+        """websearch - search engine Python API for failed query"""
+        self.assertEqual([92],
+                         perform_request_search(p='refersto:year:2000'))
+
 
 class WebSearchSearchEngineWebAPITest(InvenioTestCase):
     """Check typical search engine Web API calls on the demo data."""


### PR DESCRIPTION
* Limit DOS attacks with 'refersto' and similar keywords (e.g.
  'refersto:year:0-->9999').

* Adds configuration variable CFG_WEBSEARCH_MAX_RECORDS_REFERSTO and
  CFG_WEBSEARCH_MAX_RECORDS_CITEDBY.

* Limits result used by 'refersto', 'referstoexcludingselfcites' to
  CFG_WEBSEARCH_MAX_RECORDS_REFERSTO.

* Limits result used by 'citedby', 'citedbyexcludingselfcites' to
  CFG_WEBSEARCH_MAX_RECORDS_CITEDBY.

* Adds classes 'InvenioWebSearchReferstoLimitError' and
  'InvenioWebSearchCitedbyLimitError'.

* Adds warning messages when the limit CFG_WEBSEARCH_MAX_RECORDS_*
  is reached.

* In BibRank adds 'input_limits' parameter to 'get_refersto_by_list',
  'get_refersto_hitset', 'get_cited_by_list', 'get_citedby_hitset'
  (default to None).

* Adds regression test for the query 'refersto:year:2000'.

Signed-off-by: Federico Poli <federico.poli@cern.ch>
Reviewed-by: Samuele Kaplun <samuele.kaplun@cern.ch>