### PR TITLE
oauthclient: cross-site request forgery fix

### DIFF
--- a/invenio/modules/oauthclient/config.py
+++ b/invenio/modules/oauthclient/config.py
@@ -17,13 +17,15 @@
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-""" Configuration variables for defining remote applications.
+"""Configuration variables for defining remote applications.
 
 ================================ ==============================================
 `OAUTHCLIENT_REMOTE_APPS`        Dictionary of remote applications. See example
                                  below. **Default:** ``{}``.
 `OAUTHCLIENT_SESSION_KEY_PREFIX` Prefix for the session key used to store the
                                  an access token. **Default:** ``oauth_token``.
+`OAUTHCLIENT_STATE_EXPIRES`      Number of seconds after which the state token
+                                 expires. Defaults to 300 seconds.
 ================================ ==============================================
 
 Each remote application must be defined in the ``OAUTHCLIENT_REMOTE_APPS``
@@ -178,3 +180,6 @@ OAUTHCLIENT_REMOTE_APPS = {}
 
 OAUTHCLIENT_SESSION_KEY_PREFIX = "oauth_token"
 """Session key prefix used when storing the access token for a remote app."""
+
+OAUTHCLIENT_STATE_EXPIRES = 300
+"""Number of seconds after which the state token expires."""

--- a/invenio/modules/oauthclient/contrib/orcid.py
+++ b/invenio/modules/oauthclient/contrib/orcid.py
@@ -95,12 +95,13 @@ REMOTE_APP = dict(
         view="invenio.modules.oauthclient.handlers:signup_handler",
     ),
     params=dict(
-        request_token_params={'scope': '/authenticate'},
+        request_token_params={'scope': '/authenticate',
+                              'show_login': 'true'},
         base_url='https://pub.orcid.com/',
         request_token_url=None,
         access_token_url="https://pub.orcid.org/oauth/token",
         access_token_method='POST',
-        authorize_url="https://orcid.org/oauth/authorize#show_login",
+        authorize_url="https://orcid.org/oauth/authorize",
         app_key="ORCID_APP_CREDENTIALS",
         content_type="application/json",
     )

--- a/invenio/modules/oauthclient/handlers.py
+++ b/invenio/modules/oauthclient/handlers.py
@@ -40,6 +40,17 @@ from .utils import oauth_authenticate, oauth_get_user, oauth_register
 #
 # Token handling
 #
+def get_session_next_url(remote_app):
+    return session.get(
+        "%s_%s" % (token_session_key(remote_app), "next_url")
+    )
+
+
+def set_session_next_url(remote_app, url):
+    session["%s_%s" % (token_session_key(remote_app), "next_url")] = \
+        url
+
+
 def token_session_key(remote_app):
     """Generate a session key used to store the token for a remote app."""
     return '%s_%s' % (cfg['OAUTHCLIENT_SESSION_KEY_PREFIX'], remote_app)
@@ -213,7 +224,6 @@ def authorized_signup_handler(resp, remote, *args, **kwargs):
                 return redirect(url_for(
                     ".signup",
                     remote_app=remote.name,
-                    next=request.args.get('next', '/')
                 ))
 
         # Authenticate user
@@ -236,8 +246,9 @@ def authorized_signup_handler(resp, remote, *args, **kwargs):
         handlers['setup'](token)
 
     # Redirect to next
-    if request.args.get('next', None):
-        return redirect(request.args.get('next'))
+    next_url = get_session_next_url(remote.name)
+    if next_url:
+        return redirect(next_url)
     else:
         return redirect('/')
 
@@ -314,8 +325,9 @@ def signup_handler(remote, *args, **kwargs):
         session.pop(token_session_key(remote.name) + '_account_info', None)
 
         # Redirect to next
-        if request.args.get('next', None):
-            return redirect(request.args.get('next'))
+        next_url = get_session_next_url(remote.name)
+        if next_url:
+            return redirect(next_url)
         else:
             return redirect('/')
 

--- a/invenio/modules/oauthclient/testsuite/test_forms.py
+++ b/invenio/modules/oauthclient/testsuite/test_forms.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2015 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from __future__ import absolute_import
+
+from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+from mock import MagicMock, Mock, patch
+from sqlalchemy.exc import SQLAlchemyError
+
+
+class FormTestCase(InvenioTestCase):
+
+    @patch('invenio.modules.oauthclient.forms.User')
+    def test_validate_email(self, user):
+        from invenio.modules.oauthclient.forms import EmailSignUpForm
+
+        self.assertFalse(EmailSignUpForm(email='invalidemail').validate())
+
+        # Mock query
+        obj = MagicMock()
+        obj.one = MagicMock(side_effect=SQLAlchemyError())
+        user.query.filter = Mock(return_value=obj)
+        self.assertTrue(
+            EmailSignUpForm(email='good@invenio-software.org').validate()
+        )
+
+        user.query.filter = MagicMock()
+        self.assertFalse(
+            EmailSignUpForm(email='bad@invenio-software.org').validate()
+        )
+
+
+TEST_SUITE = make_test_suite(FormTestCase)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)

--- a/invenio/utils/url.py
+++ b/invenio/utils/url.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -105,6 +105,27 @@ def wash_url_argument(var, new_type):
         else:
             out = {0: var}
     return out
+
+
+from urlparse import urlparse, urljoin
+from flask import request, url_for
+
+def is_local_url(target):
+    """Determine if URL is a local."""
+    ref_url = urlparse(cfg.get('CFG_SITE_SECURE_URL'))
+    test_url = urlparse(urljoin(cfg.get('CFG_SITE_SECURE_URL'), target))
+    return test_url.scheme in ('http', 'https') and \
+           ref_url.netloc == test_url.netloc
+
+
+def get_safe_redirect_target(arg='next'):
+    """Get URL to redirect to and ensure that it is local."""
+    for target in request.args.get(arg), request.referrer:
+        if not target:
+            continue
+        if is_local_url(target):
+            return target
+    return None
 
 
 def redirect_to_url(req, url, redirection_type=None, norobot=False):


### PR DESCRIPTION
* Fixes a CSRF issue in oauthclient in which the next parameter to
  "/oauth/login/app/?next=" could be used by an attacker to redirect
  the end-user to an external URL.

* Adds use of OAuth 2.0 state parameter for all oauthclients for
  further CSRF protection.

Reported-by: rcpeters <info@rcpeters.com>
Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>