### PR TITLE
formatter: support for dates < 1900

### DIFF
--- a/invenio/modules/formatter/format_elements/bfe_date.py
+++ b/invenio/modules/formatter/format_elements/bfe_date.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -20,8 +20,7 @@
 """
 __revision__ = "$Id$"
 
-import time
-from invenio.utils.date import guess_datetime
+from invenio.utils.date import strftime, strptime, guess_datetime
 
 def format_element(bfo, date_format='%d %B %Y', source_formats='%Y-%m-%d', source_fields="260__c",
                    guess_source_format="no", ignore_date_format_for_year_only="yes"):
@@ -91,7 +90,7 @@ def format_element(bfo, date_format='%d %B %Y', source_formats='%Y-%m-%d', sourc
             else:
                 for source_format in source_formats:
                     try:
-                        parsed_datetime_value = time.strptime(date_value, source_format)
+                        parsed_datetime_value = strptime(date_value, source_format)
                         break
                     except:
                         pass
@@ -100,6 +99,6 @@ def format_element(bfo, date_format='%d %B %Y', source_formats='%Y-%m-%d', sourc
                 break
 
     if parsed_datetime_value:
-        return time.strftime(date_format, parsed_datetime_value)
+        return strftime(date_format, parsed_datetime_value)
     else:
         return first_matched_raw_date

--- a/invenio/modules/formatter/format_elements/bfe_imprint.py
+++ b/invenio/modules/formatter/format_elements/bfe_imprint.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -20,7 +20,7 @@
 """
 __revision__ = "$Id$"
 
-import time
+from invenio.utils.date import strftime, strptime
 
 def format_element(bfo, place_label, publisher_label, date_label,
            separator=', ', date_format=""):
@@ -55,8 +55,8 @@ def format_element(bfo, place_label, publisher_label, date_label,
     if len(date) > 0:
         if date_format != '':
             try:
-                date_time = time.strptime(date, "%Y-%m-%d")
-                out += date_label + " " + time.strftime(date_format, date_time)
+                date_time = strptime(date, "%Y-%m-%d")
+                out += date_label + " " + strftime(date_format, date_time)
             except ValueError:
                 out += date_label + ' ' + date
         else:

--- a/invenio/modules/formatter/format_elements/bfe_meta.py
+++ b/invenio/modules/formatter/format_elements/bfe_meta.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2013, 2014 CERN.
+## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -23,7 +23,7 @@ __revision__ = "$Id$"
 
 import cgi
 import re
-import time
+from invenio.utils.date import strftime, strptime
 import string
 from datetime import datetime
 from invenio.modules.formatter.format_elements.bfe_server_info import format_element as server_info
@@ -213,7 +213,7 @@ def parse_date_for_googlescholar(datetime_string):
     parsed_datetime = None
     for dateformat in CFG_POSSIBLE_DATE_FORMATS:
         try:
-            parsed_datetime = time.strptime(datetime_string.strip(), dateformat)
+            parsed_datetime = strptime(datetime_string.strip(), dateformat)
             break
         except:
             pass
@@ -223,13 +223,13 @@ def parse_date_for_googlescholar(datetime_string):
         translated_datetime_string = CFG_MONTHS_I18N_PATTERN_RE.sub(replace_month, datetime_string)
         for dateformat in CFG_POSSIBLE_DATE_FORMATS:
             try:
-                parsed_datetime = time.strptime(translated_datetime_string.strip(), dateformat)
+                parsed_datetime = strptime(translated_datetime_string.strip(), dateformat)
                 break
             except:
                 pass
 
     if parsed_datetime:
-        return datetime(*(parsed_datetime[0:6])).strftime('%Y/%m/%d')
+        return strftime('%Y/%m/%d', parsed_datetime)
     else:
         # Look for a year inside the string:
         try:


### PR DESCRIPTION
* Uses `strftime` and `strptime` from `invenio.utils.date`
  instead of these from Standard Library.

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>