### PR TITLE
installation: Pillow minimum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ extras_require = {
     ],
     "img": [
         "qrcode",
-        "Pillow"
+        "Pillow>=2.7.0"
     ],
     "mongo": [
         "pymongo"


### PR DESCRIPTION
* Adds minimum version requirement on Pillow due to DOS vulnerability
  in previous version (see CVE-2014-9601).

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>