### PR TITLE
global: test suite original modification date fix

### DIFF
--- a/modules/bibindex/lib/bibindex_regression_tests.py
+++ b/modules/bibindex/lib/bibindex_regression_tests.py
@@ -786,7 +786,7 @@ class BibIndexAuthorityRecordTest(InvenioTestCase):
         index_name = 'author'
         table = "idxWORD%02dF" % get_index_id_from_index_name(index_name)
         reindex_for_type_with_bibsched(index_name)
-        original_modification_date = run_sql("SELECT modification_date FROM bibrec WHERE id=%s", (authRecID,))
+        original_modification_date = run_sql("SELECT modification_date FROM bibrec WHERE id=%s", (authRecID,))[0][0]
         run_sql("UPDATE bibrec SET modification_date = now() WHERE id=%s", (authRecID,))
         # run bibindex again
         task_id = reindex_for_type_with_bibsched(index_name, force_all=True)

--- a/modules/pdfchecker/lib/arxiv_pdf_checker_regression_tests.py
+++ b/modules/pdfchecker/lib/arxiv_pdf_checker_regression_tests.py
@@ -79,7 +79,7 @@ La(2-x)Ba(x)CuO(4) family of high-temperature superconductors.
 class TestTask(InvenioTestCase):
     def setUp(self, recid=RECID, arxiv_id=ARXIV_ID):
         self.recid = recid
-        self.original_modification_date = run_sql("SELECT modification_date FROM bibrec WHERE id=%s", (self.recid,))
+        self.original_modification_date = run_sql("SELECT modification_date FROM bibrec WHERE id=%s", (self.recid,))[0][0]
         self.arxiv_id = arxiv_id
         self.arxiv_version = 1
         self.bibupload_xml = """<record>


### PR DESCRIPTION
* Fixes test suite's handling of record original modification dates that
  was causing troubles on a Debian 6 installation using Python-2.6,
  MySQL-5.1, MySQLdb-1.2.4.  (closes #2737)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>