### PR TITLE
WebSession: delegate group admin rights (adresses #1586)

### DIFF
--- a/modules/miscutil/lib/solrutils_bibrank_searcher.py
+++ b/modules/miscutil/lib/solrutils_bibrank_searcher.py
@@ -215,4 +215,8 @@ def word_similarity_solr(pattern, hitset, params, verbose, explicit_field, ranke
     if verbose > 0:
         voutput += "Not ranked: %s<br/>" % not_ranked
 
+    # Similar-to-recid requires reverse order
+    if search_units[0][2] == 'recid':
+        ranked_result.reverse()
+
     return (ranked_result, params["prefix"], params["postfix"], voutput)

--- a/modules/websession/lib/webgroup.py
+++ b/modules/websession/lib/webgroup.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -23,9 +23,9 @@ import sys
 
 from invenio.config import CFG_SITE_LANG
 from invenio.messages import gettext_set_language
-from invenio.websession_config import CFG_WEBSESSION_INFO_MESSAGES, \
+from invenio.websession_config import CFG_WEBSESSION_GROUP_JOIN_POLICY, \
       CFG_WEBSESSION_USERGROUP_STATUS, \
-      CFG_WEBSESSION_GROUP_JOIN_POLICY, \
+      CFG_WEBSESSION_INFO_MESSAGES, \
       InvenioWebSessionError, \
       InvenioWebSessionWarning
 from invenio.webuser import nickname_valid_p, get_user_info
@@ -61,12 +61,12 @@ def perform_request_groups_display(uid, infos=[], warnings = [], \
     body_moderator = display_moderator_groups(uid, ln)
 
     body = websession_templates.tmpl_display_all_groups(infos=infos,
-        admin_group_html=body_admin,
-        member_group_html=body_member,
-        moderator_group_html=body_moderator,
-        external_group_html=body_external,
-        warnings=warnings,
-        ln=ln)
+                                                        admin_group_html=body_admin,
+                                                        member_group_html=body_member,
+                                                        moderator_group_html=body_moderator,
+                                                        external_group_html=body_external,
+                                                        warnings=warnings,
+                                                        ln=ln)
     return body
 
 def display_admin_groups(uid, ln=CFG_SITE_LANG):
@@ -113,6 +113,7 @@ def display_external_groups(uid, ln=CFG_SITE_LANG):
         body = None
     return body
 
+
 def display_moderator_groups(uid, ln=CFG_SITE_LANG):
     """Display groups the user is moderator of.
     @param uid: user id
@@ -121,11 +122,10 @@ def display_moderator_groups(uid, ln=CFG_SITE_LANG):
     body : html groups representation the user is moderator of
     """
     body = ""
-    records = db.get_groups_by_user_status(uid,
-        user_status=CFG_WEBSESSION_USERGROUP_STATUS["MODERATOR"] )
-    body = websession_templates.tmpl_display_moderator_groups(groups=records,
-                                                           ln=ln)
+    records = db.get_groups_by_user_status(uid, user_status=CFG_WEBSESSION_USERGROUP_STATUS["MODERATOR"])
+    body = websession_templates.tmpl_display_moderator_groups(groups=records, ln=ln)
     return body
+
 
 def perform_request_input_create_group(group_name,
                                        group_description,
@@ -588,22 +588,19 @@ def perform_request_manage_member(uid,
             register_exception()
             body = websession_templates.tmpl_error(exc.message, ln)
             return body
-    members = db.get_users_by_status(grpID,
-        CFG_WEBSESSION_USERGROUP_STATUS["MEMBER"])
-    pending_members = db.get_users_by_status(grpID,
-        CFG_WEBSESSION_USERGROUP_STATUS["PENDING"])
-    moderator_members = db.get_users_by_status(grpID,
-        CFG_WEBSESSION_USERGROUP_STATUS["MODERATOR"])
+    members = db.get_users_by_status(grpID, CFG_WEBSESSION_USERGROUP_STATUS["MEMBER"])
+    pending_members = db.get_users_by_status(grpID, CFG_WEBSESSION_USERGROUP_STATUS["PENDING"])
+    moderator_members = db.get_users_by_status(grpID, CFG_WEBSESSION_USERGROUP_STATUS["MODERATOR"])
 
     body = websession_templates.tmpl_display_manage_member(grpID=grpID,
-        group_name=group_infos[0][1],
-        user_status=user_status[0][0],
-        members=members,
-        pending_members=pending_members,
-        moderator_members=moderator_members,
-        warnings=warnings,
-        infos=infos,
-        ln=ln)
+                                                           group_name=group_infos[0][1],
+                                                           user_status=user_status[0][0],
+                                                           members=members,
+                                                           pending_members=pending_members,
+                                                           moderator_members=moderator_members,
+                                                           warnings=warnings,
+                                                           infos=infos,
+                                                           ln=ln)
     return body
 
 def perform_request_remove_member(uid, grpID, member_id, ln=CFG_SITE_LANG):
@@ -782,6 +779,7 @@ def perform_request_reject_member(uid,
     return body
 
 def perform_request_add_moderator(uid, grpID, user_id, ln=CFG_SITE_LANG):
+
     """Add waiting member to a group.
     @param uid: user ID
     @param grpID: ID of the group
@@ -789,6 +787,7 @@ def perform_request_add_moderator(uid, grpID, user_id, ln=CFG_SITE_LANG):
     @param ln: language
     @return: body with warnings
     """
+
     body = ''
     warnings = []
     infos = []
@@ -827,17 +826,15 @@ def perform_request_add_moderator(uid, grpID, user_id, ln=CFG_SITE_LANG):
                                                  ln=ln)
         else:
             db.add_moderator_member(grpID,
-                user_id,
-                CFG_WEBSESSION_USERGROUP_STATUS["MODERATOR"])
+                                    user_id,
+                                    CFG_WEBSESSION_USERGROUP_STATUS["MODERATOR"])
             infos.append(CFG_WEBSESSION_INFO_MESSAGES["MODERATOR_ADDED"])
             group_infos = db.get_group_infos(grpID)
             group_name = group_infos[0][1]
             user = get_user_info(user_id, ln)[2]
-            msg_subjet, msg_body = websession_templates.tmpl_moderator_msg(
-                group_name=group_name,ln=ln)
-            (body, dummy, dummy) = perform_request_send(
-                uid, msg_to_user=user, msg_to_group="", msg_subject=msg_subjet,
-                msg_body=msg_body, ln=ln)
+            msg_subjet, msg_body = websession_templates.tmpl_moderator_msg(group_name=group_name, ln=ln)
+            (body, dummy, dummy) = perform_request_send(uid, msg_to_user=user, msg_to_group="", msg_subject=msg_subjet,
+                                                        msg_body=msg_body, ln=ln)
             body = perform_request_manage_member(uid,
                                                  grpID,
                                                  infos=infos,
@@ -847,6 +844,7 @@ def perform_request_add_moderator(uid, grpID, user_id, ln=CFG_SITE_LANG):
 
 
 def perform_request_remove_moderator(uid, grpID, member_id, ln=CFG_SITE_LANG):
+
     """Remove moderator from a group.
     @param uid: user ID
     @param grpID: ID of the group
@@ -877,7 +875,7 @@ def perform_request_remove_moderator(uid, grpID, member_id, ln=CFG_SITE_LANG):
                                              warnings=warnings,
                                              ln=ln)
     else:
-        db.delete_moderator_member(grpID, member_id,CFG_WEBSESSION_USERGROUP_STATUS["MEMBER"])
+        db.delete_moderator_member(grpID, member_id, CFG_WEBSESSION_USERGROUP_STATUS["MEMBER"])
         infos.append(CFG_WEBSESSION_INFO_MESSAGES["MODERATOR_DELETED"])
         body = perform_request_manage_member(uid,
                                              grpID,

--- a/modules/websession/lib/webgroup_dblayer.py
+++ b/modules/websession/lib/webgroup_dblayer.py
@@ -348,6 +348,27 @@ def add_pending_member(grpID, member_id, user_status):
                   (user_status, date, grpID, member_id))
     return res
 
+def add_moderator_member(grpID, member_id, user_status):
+    """Change user status:
+    normal member becomes moderator member"""
+    date = convert_datestruct_to_datetext(localtime())
+    res = run_sql("""UPDATE user_usergroup
+                        SET user_status = %s, user_status_date = %s
+                        WHERE id_usergroup = %s
+                        AND id_user = %s""",
+                  (user_status, date, grpID, member_id))
+    return res
+
+def delete_moderator_member(grpID, member_id, user_status):
+    """Delete moderator :Change user status,
+    moderator member becomes normal member"""
+    date = convert_datestruct_to_datetext(localtime())
+    res = run_sql("""UPDATE user_usergroup
+                        SET user_status = %s, user_status_date = %s
+                        WHERE id_usergroup = %s
+                        AND id_user = %s""",
+                  (user_status, date, grpID, member_id))
+    return res
 
 def leave_group(grpID, uid):
     """Remove user from the group member list."""

--- a/modules/websession/lib/webgroup_dblayer.py
+++ b/modules/websession/lib/webgroup_dblayer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -360,7 +360,7 @@ def add_moderator_member(grpID, member_id, user_status):
     return res
 
 def delete_moderator_member(grpID, member_id, user_status):
-    """Delete moderator :Change user status,
+    """Delete moderator:
     moderator member becomes normal member"""
     date = convert_datestruct_to_datetext(localtime())
     res = run_sql("""UPDATE user_usergroup

--- a/modules/websession/lib/websession_config.py
+++ b/modules/websession/lib/websession_config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -30,10 +30,10 @@ CFG_WEBSESSION_GROUP_JOIN_POLICY = {'VISIBLEOPEN': 'VO',
                                     'VISIBLEEXTERNAL' : 'VE'
                                     }
 
-CFG_WEBSESSION_USERGROUP_STATUS = {'ADMIN':  'A',
-                                   'MEMBER':'M',
-                                   'PENDING':'P',
-                                   'MODERATOR':'O'
+CFG_WEBSESSION_USERGROUP_STATUS = {'ADMIN': 'A',
+                                   'MEMBER': 'M',
+                                   'PENDING': 'P',
+                                   'MODERATOR': 'O'
                                    }
 
 CFG_WEBSESSION_INFO_MESSAGES = {"GROUP_CREATED": 'You have successfully created a new group.',
@@ -47,8 +47,8 @@ CFG_WEBSESSION_INFO_MESSAGES = {"GROUP_CREATED": 'You have successfully created 
                                 "LEAVE_GROUP": 'You have successfully left a group.',
                                 "MODERATOR_ADDED": 'You have successfully added a moderator.',
                                 "MODERATOR_DELETED": 'You have successfully remove a moderator. This user is still a member of group.'
+                                }
 
-}
 
 # Choose the providers which will be dislayed bigger (48x48) on login page.
 # The order of the list decides the order of the login buttons.
@@ -78,25 +78,33 @@ CFG_EXTERNAL_LOGIN_FORM_LABELS = {
 }
 
 CFG_WEBSESSION_COOKIE_NAME = "INVENIOSESSION"
-CFG_WEBSESSION_ONE_DAY = 86400 #: how many seconds are there in one day
-CFG_WEBSESSION_CLEANUP_CHANCE = 10000 #: cleanups have 1 in CLEANUP_CHANCE chance
+CFG_WEBSESSION_ONE_DAY = 86400  #: how many seconds are there in one day
+CFG_WEBSESSION_CLEANUP_CHANCE = 10000  #: cleanups have 1 in CLEANUP_CHANCE chance
 
 # Exceptions: errors
+
+
 class InvenioWebSessionError(Exception):
+
     """A generic error for WebSession."""
     def __init__(self, message):
         """Initialisation."""
         self.message = message
+
     def __str__(self):
         """String representation."""
         return repr(self.message)
 
 # Exceptions: warnings
+
+
 class InvenioWebSessionWarning(Exception):
+
     """A generic warning for WebSession."""
     def __init__(self, message):
         """Initialisation."""
         self.message = message
+
     def __str__(self):
         """String representation."""
         return repr(self.message)

--- a/modules/websession/lib/websession_config.py
+++ b/modules/websession/lib/websession_config.py
@@ -32,7 +32,8 @@ CFG_WEBSESSION_GROUP_JOIN_POLICY = {'VISIBLEOPEN': 'VO',
 
 CFG_WEBSESSION_USERGROUP_STATUS = {'ADMIN':  'A',
                                    'MEMBER':'M',
-                                   'PENDING':'P'
+                                   'PENDING':'P',
+                                   'MODERATOR':'O'
                                    }
 
 CFG_WEBSESSION_INFO_MESSAGES = {"GROUP_CREATED": 'You have successfully created a new group.',
@@ -43,7 +44,9 @@ CFG_WEBSESSION_INFO_MESSAGES = {"GROUP_CREATED": 'You have successfully created 
                                 "MEMBER_ADDED": 'You have successfully added a new member.',
                                 "MEMBER_REJECTED": 'You have successfully removed a waiting member from the list.',
                                 "JOIN_REQUEST": 'The group administrator has been notified of your request.',
-                                "LEAVE_GROUP": 'You have successfully left a group.'
+                                "LEAVE_GROUP": 'You have successfully left a group.',
+                                "MODERATOR_ADDED": 'You have successfully added a moderator.',
+                                "MODERATOR_DELETED": 'You have successfully remove a moderator. This user is still a member of group.'
 
 }
 

--- a/modules/websession/lib/websession_templates.py
+++ b/modules/websession/lib/websession_templates.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2014 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -44,7 +44,9 @@ from invenio.urlutils import make_canonical_urlargd, create_url, create_html_lin
 from invenio.htmlutils import escape_html, nmtoken_from_string
 from invenio.messages import gettext_set_language, language_list_long
 from invenio.websession_config import CFG_WEBSESSION_GROUP_JOIN_POLICY, \
-      CFG_WEBSESSION_USERGROUP_STATUS
+                                      CFG_WEBSESSION_USERGROUP_STATUS
+
+
 class Template:
     def tmpl_back_form(self, ln, message, url, link):
         """
@@ -1878,11 +1880,8 @@ class Template:
         <img src="%(siteurl)s/img/%(img)s" alt="%(text)s" style="border:0" width="25"
         height="25" /><br /><small>%(text)s</small>
         </a>"""
-
-
         out = self.tmpl_group_table_title(img="/img/group_admin.png",
-                                          text=_("You are a moderator of the following groups:") )
-
+                                          text=_("You are a moderator of the following groups:"))
         out += """
 <table class="mailbox">
   <thead class="mailboxheader">
@@ -1899,24 +1898,23 @@ class Template:
       <td></td>
     </tr>
   </tfoot>
-  <tbody class="mailboxbody">""" %(_("Group"), _("Description"))
+  <tbody class="mailboxbody">""" % (_("Group"), _("Description"))
         if len(groups) == 0:
             out += """
     <tr class="mailboxrecord" style="height: 100px;">
       <td colspan="3" style="text-align: center;">
         <small>%s</small>
       </td>
-    </tr>""" %(_("You are not a moderator of any groups."),)
+    </tr>""" % _("You are not a moderator of any groups.")
         for group_data in groups:
             (grpID, name, description) = group_data
-            members_link = img_link % {'siteurl' : CFG_SITE_URL,
-                                       'grpID' : grpID,
+            members_link = img_link % {'siteurl': CFG_SITE_URL,
+                                       'grpID': grpID,
                                        'ln': ln,
-                                       'img':"webbasket_usergroup.png",
-                                       'text':_("Edit %s members") % '',
-                                       'action':"members"
+                                       'img': "webbasket_usergroup.png",
+                                       'text': _("Edit %s members") % '',
+                                       'action': "members"
                                        }
-             
             out += """
     <tr class="mailboxrecord">
       <td>%s</td>
@@ -1933,7 +1931,6 @@ class Template:
 </table>
  """
         return out
-
 
     def tmpl_display_input_group_info(self,
                                       group_name,
@@ -2315,12 +2312,11 @@ class Template:
             <td style="padding: 0 5 10 5;">
             <input type="submit" name="remove_member" value="%s" class="nonsubmitbutton"/>
             </td>""" %  (member_list,_("Remove member"))
-            if user_status == CFG_WEBSESSION_USERGROUP_STATUS['ADMIN'] :
+            if user_status == CFG_WEBSESSION_USERGROUP_STATUS['ADMIN']:
                 member_text += """<td style="padding: 0 5 10 5;">
                 <input type="submit" name="add_moderator" value="%s" class="nonsubmitbutton"/>
                 </td>""" % _("Add as moderator")
-            
-        else :
+        else:
             member_text = """<td style="padding: 0 5 10 5;" colspan="2">%s</td>""" % _("No members.")
         if pending_members :
             pending_list =   self.__create_select_menu("pending_member_id", pending_members, _("Please select:"))
@@ -2332,7 +2328,7 @@ class Template:
             <td style="padding: 0 5 10 5;">
             <input type="submit" name="reject_member" value="%s" class="nonsubmitbutton"/>
             </td>""" %  (pending_list,_("Accept member"), _("Reject member"))
-        else :
+        else:
             pending_text = """<td style="padding: 0 5 10 5;" colspan="2">%s</td>""" % _("No members awaiting approval.")
         moderator_text = ""        
         if user_status == CFG_WEBSESSION_USERGROUP_STATUS['ADMIN']:
@@ -2357,7 +2353,7 @@ class Template:
       <tr>
         <td colspan="2">
           <table>
-            <tr>""" % (CFG_SITE_URL,self.tmpl_group_table_title(text= _("Current moderators")))
+            <tr>""" % (CFG_SITE_URL, self.tmpl_group_table_title(text=_("Current moderators")))
             if moderator_members :
                 moderator_list = self.__create_select_menu("moderator_member_id", moderator_members, _("Please select:"))  
                 moderator_text += """            
@@ -2365,7 +2361,7 @@ class Template:
                 <td style="padding: 0 5 10 5;">
                 <input type="submit" name="remove_moderator" value="%s" class="nonsubmitbutton"/>
                </td>""" % (moderator_list,_("Remove moderator"))
-            else :
+            else:
                 moderator_text += """<td style="padding: 0 5 10 5;" colspan="2">%s</td>""" % _("No moderators.")
             moderator_text += """</tr>
           </table>
@@ -2378,7 +2374,6 @@ class Template:
         header1 = self.tmpl_group_table_title(text=_("Current members"))
         header2 = self.tmpl_group_table_title(text=_("Members awaiting approval"))
         header3 = _("Invite new members")
-        
         write_a_message_url = create_url(
             "%s/yourmessages/write" % CFG_SITE_URL,
             {
@@ -2733,8 +2728,8 @@ Best regards.
         return subject, body
 
     def tmpl_moderator_msg(self,
-                        group_name,
-                        ln=CFG_SITE_LANG):
+                           group_name,
+                           ln=CFG_SITE_LANG):
         """
         return message content when new moderator is added
         - 'group_name' *string* - name of the group
@@ -2743,13 +2738,13 @@ Best regards.
         _ = gettext_set_language(ln)
         subject = _("Group %s: You has been added as moderator") % (group_name)
         body = _("Your are choosen as a moderator for the group %s .") % (group_name)
-        
         url = CFG_SITE_URL + "/yourgroups/display?ln=" + ln
         body += '<br />'
         body += _("You can consult the list of %(x_url_open)syour groups%(x_url_close)s.") % {'x_url_open': '<a href="' + url + '">',
                                                                                               'x_url_close': '</a>'}
         body += '<br />'
         return subject, body
+
 
     def tmpl_group_info(self, nb_admin_groups=0, nb_member_groups=0, nb_total_groups=0, ln=CFG_SITE_LANG):
         """

--- a/modules/websession/lib/websession_webinterface.py
+++ b/modules/websession/lib/websession_webinterface.py
@@ -1758,10 +1758,12 @@ class WebInterfaceYourGroupsPages(WebInterfaceDirectory):
         """member(): interface for managing members of a group
         @param grpID: : group ID
         @param add_member: button add_member pressed
+        @param add_moderator: button add_moderator pressed
         @param remove_member: button remove_member pressed
         @param reject_member: button reject__member pressed
         @param delete: button delete group pressed
         @param member_id: : ID of the existing member selected
+        @param moderator_member_id: : ID of the moderator member selected
         @param pending_member_id: : ID of the pending member selected
         @param cancel: button cancel pressed
         @param info: : info about last user action
@@ -1773,7 +1775,10 @@ class WebInterfaceYourGroupsPages(WebInterfaceDirectory):
                                    'add_member': (str, ""),
                                    'remove_member': (str, ""),
                                    'reject_member': (str, ""),
+                                   'add_moderator': (str, ""),
+                                   'remove_moderator': (str, ""),
                                    'member_id': (int, 0),
+                                   'moderator_member_id': (int, 0),
                                    'pending_member_id': (int, 0)
                                    })
         uid = webuser.getUid(req)
@@ -1803,11 +1808,21 @@ class WebInterfaceYourGroupsPages(WebInterfaceDirectory):
                                                           grpID=argd['grpID'],
                                                           user_id=argd['pending_member_id'],
                                                           ln=argd['ln'])
-
         elif argd['add_member']:
             body = webgroup.perform_request_add_member(uid=uid,
+                                                          grpID=argd['grpID'],
+                                                          user_id=argd['pending_member_id'],
+                                                          ln=argd['ln'])
+        elif argd['remove_moderator']:
+            body = webgroup.perform_request_remove_moderator(uid=uid,
                                                        grpID=argd['grpID'],
-                                                       user_id=argd['pending_member_id'],
+                                                       member_id=argd['moderator_member_id'],
+                                                       ln=argd['ln'])
+
+	elif argd['add_moderator']:
+            body = webgroup.perform_request_add_moderator(uid=uid,
+                                                       grpID=argd['grpID'],
+                                                       user_id=argd['member_id'],
                                                        ln=argd['ln'])
 
         else:

--- a/modules/websession/lib/websession_webinterface.py
+++ b/modules/websession/lib/websession_webinterface.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2014 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -1810,20 +1810,20 @@ class WebInterfaceYourGroupsPages(WebInterfaceDirectory):
                                                           ln=argd['ln'])
         elif argd['add_member']:
             body = webgroup.perform_request_add_member(uid=uid,
-                                                          grpID=argd['grpID'],
-                                                          user_id=argd['pending_member_id'],
-                                                          ln=argd['ln'])
+                                                       grpID=argd['grpID'],
+                                                       user_id=argd['pending_member_id'],
+                                                       ln=argd['ln'])
         elif argd['remove_moderator']:
             body = webgroup.perform_request_remove_moderator(uid=uid,
-                                                       grpID=argd['grpID'],
-                                                       member_id=argd['moderator_member_id'],
-                                                       ln=argd['ln'])
+                                                             grpID=argd['grpID'],
+                                                             member_id=argd['moderator_member_id'],
+                                                             ln=argd['ln'])
 
 	elif argd['add_moderator']:
             body = webgroup.perform_request_add_moderator(uid=uid,
-                                                       grpID=argd['grpID'],
-                                                       user_id=argd['member_id'],
-                                                       ln=argd['ln'])
+                                                          grpID=argd['grpID'],
+                                                          user_id=argd['member_id'],
+                                                          ln=argd['ln'])
 
         else:
             body= webgroup.perform_request_manage_member(uid=uid,


### PR DESCRIPTION
Groups can only be administered by the user who created them.
To enable the possibility to delegate the rights of approving new members and removing members from the group, a new user group status "MODERATOR" is added and the admin of the group can choose ,from group's members, one or more moderator .
