### PR TITLE
installation: RabbitMQ and anyjson requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,6 +183,9 @@ extras_require = {
         # Any other versions are not supported.
         "pyRXP==1.16-daily-unix"
     ],
+    "rabbitmq": [
+        "amqp>=1.4.5",
+    ],
     "github": [
         "github3.py>=0.9"
     ],


### PR DESCRIPTION
* Adds missing anyjson and amqp packages.

Signed-off-by: Wojciech Ziolek <wojciech.ziolek@cern.ch>