### PR TITLE
records: multiple `system_control_number`s

### DIFF
--- a/invenio/modules/records/testsuite/fields/atlantis.cfg
+++ b/invenio/modules/records/testsuite/fields/atlantis.cfg
@@ -881,6 +881,8 @@ subject_indicator:
 
 @persistent_identifier(2)
 system_control_number:
+    schema:
+        {'system_control_number': {'type': 'list', 'force': True}}
     creator:
         @legacy((("035", "035__", "035__%"), ""),
                 ("035__a", "system_control_number"),


### PR DESCRIPTION
* Forces `system_control_number` to always return a list, since it is
  possible that multiple exist and the output be consistent regardless.

Signed-off-by: Dimitrios Semitsoglou-Tsiapos <dsemitso@cern.ch>