### PR TITLE
base: page template block addition

### DIFF
--- a/invenio/base/templates/page_base.html
+++ b/invenio/base/templates/page_base.html
@@ -1,6 +1,6 @@
 {#
 ## This file is part of Invenio.
-## Copyright (C) 2012, 2013, 2014 CERN.
+## Copyright (C) 2012, 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -153,6 +153,7 @@
   {% endblock %}
 {%- endblock %}
 {%- block javascript %}{% endblock %}
+{%- block trackingcode %}{% endblock %}
 {%- block body_end %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
* Creates an extra block trackingcode to allow addition of
  tracking JavaScript like Piwik without conflicting with the
  usage of JavaScript block in other modules.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>