### PR TITLE
OAIHarvest: harvesting "from beginning" fix

### DIFF
--- a/modules/bibauthorid/lib/bibauthorid_webinterface.py
+++ b/modules/bibauthorid/lib/bibauthorid_webinterface.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2011, 2012 CERN.
+# Copyright (C) 2011, 2012, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -26,7 +26,9 @@ from cgi import escape
 
 from pprint import pformat
 from operator import itemgetter
+
 import re
+import urllib
 
 try:
     from invenio.jsonutils import json, json_unicode_to_utf8, CFG_JSON_AVAILABLE
@@ -981,7 +983,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
             userinfo = "%s||%s" % (uid, req.remote_ip)
             webapi.add_person_external_id(pid, ext_sys, ext_id, userinfo)
 
-            return redirect_to_url(req, "%s/author/manage_profile/%s" % (CFG_SITE_URL, webapi.get_person_redirect_link(pid)))
+            return redirect_to_url(req, "%s/author/manage_profile/%s" % (CFG_SITE_URL, urllib.quote(webapi.get_person_redirect_link(pid))))
 
         def set_uid():
             '''
@@ -1010,7 +1012,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
                 dest_uid_arxiv_papers = webapi.get_arxiv_papers_of_author(dest_uid_pid)
                 webapi.add_arxiv_papers_to_author(dest_uid_arxiv_papers, pid)
 
-            return redirect_to_url(req, "%s/author/manage_profile/%s" % (CFG_SITE_URL, webapi.get_person_redirect_link(pid)))
+            return redirect_to_url(req, "%s/author/manage_profile/%s" % (CFG_SITE_URL, urllib.quote(webapi.get_person_redirect_link(pid))))
 
         def add_missing_external_ids():
             if argd['pid'] > -1:
@@ -1021,7 +1023,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
 
             update_external_ids_of_authors([pid], overwrite=False)
 
-            return redirect_to_url(req, "%s/author/manage_profile/%s" % (CFG_SITE_URL, webapi.get_person_redirect_link(pid)))
+            return redirect_to_url(req, "%s/author/manage_profile/%s" % (CFG_SITE_URL, urllib.quote(webapi.get_person_redirect_link(pid))))
 
         def associate_profile():
             '''
@@ -1044,12 +1046,12 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
                 pinfo['should_check_to_autoclaim'] = True
                 pinfo["login_info_message"] = "confirm_success"
                 session.dirty = True
-                redirect_to_url(req, '%s/author/manage_profile/%s' % (CFG_SITE_URL, redirect_pid))
+                redirect_to_url(req, '%s/author/manage_profile/%s' % (CFG_SITE_URL, urllib.quote(redirect_pid)))
             # if someone have already claimed this profile it redirects to choose_profile with an error message
             else:
                 param=''
                 if 'search_param' in argd and argd['search_param']:
-                    param = '&search_param=' + argd['search_param']
+                    param = '&search_param=' + urllib.quote(argd['search_param'])
                 redirect_to_url(req, '%s/author/choose_profile?failed=%s%s' % (CFG_SITE_URL, True, param))
 
         def bibref_check_submit():
@@ -1119,7 +1121,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
 
             session.dirty = True
 
-            redirect_url = "%s/author/manage_profile/%s" % (CFG_SITE_URL, primary_cname)
+            redirect_url = "%s/author/manage_profile/%s" % (CFG_SITE_URL, urllib.quote(primary_cname))
             return redirect_to_url(req, redirect_url)
 
         def cancel_rt_ticket():
@@ -1144,7 +1146,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
                 rt_id = int(bibrefrecs[0])
                 webapi.delete_request_ticket(pid, rt_id)
 
-            return redirect_to_url(req, "%s/author/claim/%s" % (CFG_SITE_URL, pid))
+            return redirect_to_url(req, "%s/author/claim/%s" % (CFG_SITE_URL, urllib.quote(str(pid))))
 
         def cancel_search_ticket(without_return=False):
             if 'search_ticket' in pinfo:
@@ -1155,7 +1157,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
                 pid = pinfo["claimpaper_admin_last_viewed_pid"]
 
                 if not without_return:
-                    return redirect_to_url(req, "%s/author/claim/%s" % (CFG_SITE_URL, webapi.get_person_redirect_link(pid)))
+                    return redirect_to_url(req, "%s/author/claim/%s" % (CFG_SITE_URL, urllib.quote(webapi.get_person_redirect_link(pid))))
 
             if not without_return:
                 return self.search(req, form)
@@ -1246,7 +1248,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
 
             session.dirty = True
 
-            return redirect_to_url(req, "%s/author/claim/%s" % (CFG_SITE_URL, webapi.get_person_redirect_link(pid)))
+            return redirect_to_url(req, "%s/author/claim/%s" % (CFG_SITE_URL, urllib.quote(webapi.get_person_redirect_link(pid))))
 
         def claim_to_other_person():
             if argd['selection'] is not None:
@@ -1300,7 +1302,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
                 t = WebInterfaceAuthorTicketHandling()
                 t.add_operation(req, form)
 
-            return redirect_to_url(req, "%s/author/claim/%s" % (CFG_SITE_URL, webapi.get_person_redirect_link(pid)))
+            return redirect_to_url(req, "%s/author/claim/%s" % (CFG_SITE_URL, urllib.quote(webapi.get_person_redirect_link(pid))))
 
         def delete_external_ids():
             '''
@@ -1321,7 +1323,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
             userinfo = "%s||%s" % (uid, req.remote_ip)
             webapi.delete_person_external_ids(pid, existing_ext_ids, userinfo)
 
-            return redirect_to_url(req, "%s/author/manage_profile/%s" % (CFG_SITE_URL, webapi.get_person_redirect_link(pid)))
+            return redirect_to_url(req, "%s/author/manage_profile/%s" % (CFG_SITE_URL, urllib.quote(webapi.get_person_redirect_link(pid))))
 
         def none_action():
             return self._error_page(req, ln,
@@ -1363,7 +1365,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
                 pinfo['merge_info_message'] = ("failure", "confirm_failure")
                 session.dirty = True
 
-                redirect_url = "%s/author/merge_profiles?primary_profile=%s" % (CFG_SITE_URL, primary_cname)
+                redirect_url = "%s/author/merge_profiles?primary_profile=%s" % (CFG_SITE_URL, urllib.quote(primary_cname))
                 return redirect_to_url(req, redirect_url)
 
             if is_admin:
@@ -1399,7 +1401,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
 
             session.dirty = True
 
-            redirect_url = "%s/author/manage_profile/%s" % (CFG_SITE_URL, primary_cname)
+            redirect_url = "%s/author/manage_profile/%s" % (CFG_SITE_URL, urllib.quote(primary_cname))
             return redirect_to_url(req, redirect_url)
 
         def send_message():
@@ -1491,7 +1493,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
             else:
                 webapi.update_person_canonical_name(pid, cname, userinfo)
 
-            return redirect_to_url(req, "%s/author/claim/%s%s" % (CFG_SITE_URL, webapi.get_person_redirect_link(pid), '#tabData'))
+            return redirect_to_url(req, "%s/author/claim/%s%s" % (CFG_SITE_URL, urllib.quote(webapi.get_person_redirect_link(pid)), '#tabData'))
 
         action_functions = {'add_external_id': add_external_id,
                             'set_uid': set_uid,
@@ -1610,7 +1612,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
         '''
         webapi.delete_request_ticket(pid, tid)
         return redirect_to_url(req, "%s/author/claim/%s" %
-                               (CFG_SITE_URL, webapi.get_person_redirect_link(str(pid))))
+                               (CFG_SITE_URL, urllib.quote(webapi.get_person_redirect_link(str(pid)))))
 
 
     def _cancel_transaction_from_rt_ticket(self, tid, pid, action, bibref):
@@ -1643,7 +1645,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
 
         webapi.delete_request_ticket(pid, tid)
 
-        redirect_to_url(req, "%s/author/claim/%s" % (CFG_SITE_URL, pid))
+        redirect_to_url(req, "%s/author/claim/%s" % (CFG_SITE_URL, urllib.quote(str(pid))))
 
 
     def _error_page(self, req, ln=CFG_SITE_LANG, message=None, intro=True):
@@ -2259,7 +2261,7 @@ class WebInterfaceBibAuthorIDClaimPages(WebInterfaceDirectory):
             redirect_pid = pid
             if last_visited_pid:
                 redirect_pid = last_visited_pid
-            redirect_to_url(req, '%s/author/manage_profile/%s' % (CFG_SITE_URL, str(redirect_pid)))
+            redirect_to_url(req, '%s/author/manage_profile/%s' % (CFG_SITE_URL, urllib.quote(str(redirect_pid))))
         else:
             # get name strings and email addresses from SSO/Oauth logins: {'system':{'name':[variant1,...,variantn], 'email':'blabla@bla.bla', 'pants_size':20}}
             remote_login_systems_info = webapi.get_remote_login_systems_info(req, login_info['logged_in_to_remote_systems'])
@@ -3724,7 +3726,7 @@ class WebInterfaceAuthor(WebInterfaceDirectory):
             try:
                 pid = int(self.path)
             except ValueError:
-                redirect_to_url(req, "%s/author/search?q=%s" % (CFG_BASE_URL, self.path))
+                redirect_to_url(req, "%s/author/search?q=%s" % (CFG_BASE_URL, urllib.quote(self.path)))
                 return
             else:
                 if author_has_papers(pid):

--- a/modules/miscutil/lib/upgrades/invenio_2015_04_15_collection_names_with_slashes.py
+++ b/modules/miscutil/lib/upgrades/invenio_2015_04_15_collection_names_with_slashes.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Check collection table and warn user about collection names with slashes."""
+
+from invenio.dbquery import run_sql
+
+depends_on = ['invenio_release_1_2_0']
+
+
+def info():
+    """Return upgrade recipe information."""
+    return "Warns user about collection names with slashes."
+
+
+def do_upgrade():
+    """Carry out the upgrade."""
+    res = run_sql("SELECT name FROM collection WHERE name LIKE '%/%'")
+    for row in res:
+        print "WARNING: Collection '%s' contains forward slashes" \
+            " which is not recommended." % row[0]
+        print "WARNING: You may safely continue, but we recommend" \
+            " changing this collection name to avoid slashes."
+
+
+def estimate():
+    """Estimate running time of upgrade in seconds (optional)."""
+    return 1
+
+
+def pre_upgrade():
+    """Pre-upgrade checks."""
+    pass  # because slashes would still work
+
+
+def post_upgrade():
+    """Post-upgrade checks."""
+    pass

--- a/modules/oaiharvest/lib/oai_harvest_daemon.py
+++ b/modules/oaiharvest/lib/oai_harvest_daemon.py
@@ -379,11 +379,11 @@ def harvest_step(repository, harvestpath, identifiers, dates, current_progress):
         write_message("source %s was successfully harvested" % \
                       (repository["name"],))
 
-    elif not dates and repository["lastrun"] is None and repository["frequency"] != 0:
+    elif not dates and not repository["lastrun"] and repository["frequency"] != 0:
         # First time we harvest from this repository
         write_message("source %s was never harvested before - harvesting whole repository" % \
                       (repository["name"],))
-        harvested_files_list, error_code = harvest_by_dates(repository, harvestpath, current_progress)
+        harvested_files_list, error_code = harvest_by_dates(repository, harvestpath, progress=current_progress)
         if error_code:
             return [], error_code
         write_message("source %s was successfully harvested" % \

--- a/modules/websearch/lib/websearch_webcoll.py
+++ b/modules/websearch/lib/websearch_webcoll.py
@@ -1,5 +1,5 @@
 # This file is part of Invenio.
-# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
+# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -308,7 +308,7 @@ class Collection:
         # open file:
         dirname = "%s/collections" % (CFG_CACHEDIR)
         mymkdir(dirname)
-        fullfilename = dirname + "/%s.html" % filename
+        fullfilename = dirname + "/%s.html" % filename.replace('/', '___SLASH___')
         try:
             os.umask(022)
             f = open(fullfilename, "wb")
@@ -927,8 +927,9 @@ def perform_display_collection(colID, colname, aas, ln, em, show_help_boxes):
     em - code to display just part of the page
     show_help_boxes - whether to show the help boxes or not"""
     # check and update cache if necessary
-    cachedfile = open("%s/collections/%s-ln=%s.html" %
-                      (CFG_CACHEDIR, colname, ln), "rb")
+    cachedfile = open(r"%s/collections/%s-ln=%s.html" %
+                      (CFG_CACHEDIR, colname.replace('/', '___SLASH___'), ln),
+                      "rb")
     try:
         data = cPickle.load(cachedfile)
     except ValueError:


### PR DESCRIPTION
* Fixes an exception that would happen upon the initial harvest
  of a new OAI harvest source marked to be harvested "from beginning".

Reported-by: Jean-Yves Le Meur <Jean-Yves.Le.Meur@cern.ch>
Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>