### PR TITLE
BibEdit: fix recID type

### DIFF
--- a/modules/bibformat/lib/elements/bfe_edit_record.py
+++ b/modules/bibformat/lib/elements/bfe_edit_record.py
@@ -36,7 +36,7 @@ def format_element(bfo, style):
     out = ""
 
     user_info = bfo.user_info
-    if user_can_edit_record_collection(user_info, bfo.recID):
+    if user_can_edit_record_collection(user_info, int(bfo.recID)):
         linkattrd = {}
         if style != '':
             linkattrd['style'] = style


### PR DESCRIPTION
- Various functions working with the recid expect it to be
  an integer, rather than a string.

Signed-off-by: Ludmila Marian ludmila.marian@gmail.com
