### PR TITLE
WebSession: no differentiated guest user support

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -1293,11 +1293,6 @@ CFG_WEBSESSION_ADDRESS_ACTIVATION_EXPIRE_IN_DAYS = 3
 ## registeration, after how many days will it expire?
 CFG_WEBSESSION_NOT_CONFIRMED_EMAIL_ADDRESS_EXPIRE_IN_DAYS = 10
 
-## CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS -- when set to 1, the session
-## system allocates the same uid=0 to all guests users regardless of where they
-## come from. 0 allocate a unique uid to each guest.
-CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS = 0
-
 ## CFG_WEBSESSION_IPADDR_CHECK_SKIP_BITS -- to prevent session cookie
 ## stealing, Invenio checks that the IP address of a connection is the
 ## same as that of the connection which created the initial session.

--- a/modules/bibcirculation/lib/bibcirculation_webinterface.py
+++ b/modules/bibcirculation/lib/bibcirculation_webinterface.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013 CERN.
+## Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -33,7 +33,6 @@ from invenio.config import CFG_SITE_LANG, \
                            CFG_SITE_URL, \
                            CFG_SITE_SECURE_URL, \
                            CFG_ACCESS_CONTROL_LEVEL_SITE, \
-                           CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS, \
                            CFG_SITE_RECORD, \
                            CFG_CERN_SITE
 from invenio.webuser import getUid, page_not_authorized, isGuestUser, \
@@ -951,16 +950,15 @@ class WebInterfaceHoldingsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/%s/%s/holdings/request%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/%s/%s/holdings/request%s" % (
-                        CFG_SITE_SECURE_URL,
-                        CFG_SITE_RECORD,
-                        self.recid,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})), norobot=True)
+                    CFG_SITE_RECORD,
+                    self.recid,
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})), norobot=True)
 
         user_info = collect_user_info(req)
         (auth_code, auth_msg) = check_user_can_view_record(user_info, self.recid)
@@ -1045,16 +1043,15 @@ class WebInterfaceHoldingsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/%s/%s/holdings/request%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/%s/%s/holdings/request%s" % (
-                        CFG_SITE_SECURE_URL,
-                        CFG_SITE_RECORD,
-                        self.recid,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})), norobot=True)
+                    CFG_SITE_RECORD,
+                    self.recid,
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})), norobot=True)
 
         user_info = collect_user_info(req)
         (auth_code, auth_msg) = check_user_can_view_record(user_info, self.recid)
@@ -1145,16 +1142,15 @@ class WebInterfaceHoldingsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/%s/%s/holdings/ill_request_with_recid%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/%s/%s/holdings/ill_request_with_recid%s" % (
-                        CFG_SITE_SECURE_URL,
-                        CFG_SITE_RECORD,
-                        self.recid,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    CFG_SITE_RECORD,
+                    self.recid,
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
 
         user_info = collect_user_info(req)
@@ -1243,16 +1239,15 @@ class WebInterfaceHoldingsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/%s/%s/holdings/ill_request_with_recid%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/%s/%s/holdings/ill_request_with_recid%s" % (
-                        CFG_SITE_SECURE_URL,
-                        CFG_SITE_RECORD,
-                        self.recid,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    CFG_SITE_RECORD,
+                    self.recid,
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
 
         user_info = collect_user_info(req)

--- a/modules/webbasket/lib/webbasket_regression_tests.py
+++ b/modules/webbasket/lib/webbasket_regression_tests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2010, 2011 CERN.
+## Copyright (C) 2006, 2007, 2008, 2010, 2011, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -25,7 +25,7 @@ from invenio.testutils import InvenioTestCase
 import mechanize
 import re
 
-from invenio.config import CFG_SITE_URL, CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS
+from invenio.config import CFG_SITE_URL
 from invenio.testutils import make_test_suite, run_test_suite, \
                               test_web_page_content, make_url, make_surl, merge_error_messages
 
@@ -44,9 +44,6 @@ class WebBasketWebPagesAvailabilityTest(InvenioTestCase):
                     'write_public_note', 'save_public_note',]
 
         error_messages = []
-        if CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-            for url in [baseurl + page for page in _exports]:
-                error_messages.extend(test_web_page_content(url))
         for url in [baseurl + page for page in _exports]:
             error_messages.extend(test_web_page_content(url, username='jekyll', password='j123ekyll'))
         for url in [baseurl + page for page in ['list_public_baskets', 'display_public']]:
@@ -159,15 +156,6 @@ class WebBasketRecordsAdditionTest(InvenioTestCase):
                           'Thermal conductivity of dense quark matter and cooling of stars',
                           'The total cross section for the production of heavy quarks in hadronic collisions']
         self._check_basket_content(browser, expected_texts)
-
-    def xtest_records_addition_as_guest_user(self):
-        """webbasket - addition of records as guest"""
-        # FIXME: needs updating as per the new WebBasket UI
-
-        if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-            self.fail('SKIPPED: guests users are not differentiated')
-        browser = mechanize.Browser()
-        self._add_records_to_basket_and_check_content(browser)
 
     def xtest_records_addition_as_registered_user(self):
         """webbasket - addition of records as registered user"""

--- a/modules/webbasket/lib/webbasket_webinterface.py
+++ b/modules/webbasket/lib/webbasket_webinterface.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+## Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -27,7 +27,6 @@ import cgi
 import urllib
 from invenio.config import CFG_SITE_SECURE_URL, \
                            CFG_ACCESS_CONTROL_LEVEL_SITE, \
-                           CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS, \
                            CFG_SITE_SECURE_URL, CFG_PREFIX, CFG_SITE_LANG
 from invenio.messages import gettext_set_language
 from invenio.webpage import page
@@ -305,14 +304,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
             return page_not_authorized(req, "../yourbaskets/display",
                                        navmenuid = 'yourbaskets')
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/display%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/display%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         user_info = collect_user_info(req)
         if not user_info['precached_usebaskets']:
@@ -391,14 +389,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
             return page_not_authorized(req, "../yourbaskets/search",
                                        navmenuid = 'yourbaskets')
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/search%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/search%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         user_info = collect_user_info(req)
         if not user_info['precached_usebaskets']:
@@ -456,14 +453,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/write_note%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/write_note%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         user_info = collect_user_info(req)
         if not user_info['precached_usebaskets']:
@@ -524,14 +520,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/save_note%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/save_note%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         user_info = collect_user_info(req)
         if not user_info['precached_usebaskets']:
@@ -602,14 +597,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/delete_note%s" % (
+            return redirect_to_url(req, "%s/youraccount/delete_note%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/display%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/display%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         user_info = collect_user_info(req)
         if not user_info['precached_usebaskets']:
@@ -691,14 +685,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/add%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/add%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         user_info = collect_user_info(req)
         if not user_info['precached_usebaskets']:
@@ -770,14 +763,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/delete%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/delete%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         user_info = collect_user_info(req)
         if not user_info['precached_usebaskets']:
@@ -858,14 +850,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/modify%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/modify%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         user_info = collect_user_info(req)
         if not user_info['precached_usebaskets']:
@@ -963,14 +954,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/edit%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/edit%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         _ = gettext_set_language(argd['ln'])
         user_info = collect_user_info(req)
@@ -1083,14 +1073,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/edit_topic%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/edit_topic%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         _ = gettext_set_language(argd['ln'])
         user_info = collect_user_info(req)
@@ -1182,14 +1171,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/create_basket%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/create_basket%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         user_info = collect_user_info(req)
         _ = gettext_set_language(argd['ln'])
@@ -1415,14 +1403,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/subscribe%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/subscribe%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         user_info = collect_user_info(req)
         if not user_info['precached_usebaskets']:
@@ -1475,14 +1462,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/unsubscribe%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/unsubscribe%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         user_info = collect_user_info(req)
         if not user_info['precached_usebaskets']:
@@ -1537,14 +1523,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/write_public_note%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/write_public_note%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         user_info = collect_user_info(req)
         if not user_info['precached_usebaskets']:
@@ -1599,14 +1584,13 @@ class WebInterfaceYourBasketsPages(WebInterfaceDirectory):
                                        navmenuid = 'yourbaskets')
 
         if isGuestUser(uid):
-            if not CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                return redirect_to_url(req, "%s/youraccount/login%s" % (
+            return redirect_to_url(req, "%s/youraccount/login%s" % (
+                CFG_SITE_SECURE_URL,
+                    make_canonical_urlargd({
+                'referer' : "%s/yourbaskets/save_public_note%s" % (
                     CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd({
-                    'referer' : "%s/yourbaskets/save_public_note%s" % (
-                        CFG_SITE_SECURE_URL,
-                        make_canonical_urlargd(argd, {})),
-                    "ln" : argd['ln']}, {})))
+                    make_canonical_urlargd(argd, {})),
+                "ln" : argd['ln']}, {})))
 
         user_info = collect_user_info(req)
         if not user_info['precached_usebaskets']:

--- a/modules/webhelp/web/admin/howto/howto-run.webdoc
+++ b/modules/webhelp/web/admin/howto/howto-run.webdoc
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2007, 2008, 2009, 2010, 2011, 2013, 2014 CERN.
+## Copyright (C) 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -272,20 +272,6 @@ The rebalancing might be run weekly or even daily.
 <p>The tool <code>inveniogc</code> provides a garbage collector for
 the database, temporary files, and the like.</p>
 
-<p>If you choose to differentiate between guest users
-(see <code>CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS</code>
-in <code>invenio.conf</code>), then guest users can create a lot of
-entries in Invenio tables that are related to their web sessions,
-their search history, personal baskets, etc.  This data has to be
-garbage-collected periodically.  You can run this, say every Sunday
-between 01:00 and 05:00, via:
-
-<blockquote>
-<pre>
-$ inveniogc -s 7d -L 'Sunday 01:00-05:00'
-</pre>
-</blockquote>
-</p>
 
 <p>Different temporary log and err files are created
 in <code>/opt/invenio/var/log</code>

--- a/modules/websession/lib/websession_templates.py
+++ b/modules/websession/lib/websession_templates.py
@@ -1,5 +1,5 @@
 ## This file is part of Invenio.
-## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2014 CERN.
+## Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -30,7 +30,6 @@ from invenio.config import \
      CFG_SITE_URL, \
      CFG_WEBSESSION_RESET_PASSWORD_EXPIRE_IN_DAYS, \
      CFG_WEBSESSION_ADDRESS_ACTIVATION_EXPIRE_IN_DAYS, \
-     CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS, \
      CFG_WEBSEARCH_MAX_RECORDS_IN_GROUPS, \
      CFG_ACCESS_CONTROL_LEVEL_ACCOUNTS, \
      CFG_SITE_RECORD
@@ -622,8 +621,6 @@ class Template:
             'your_comments' : _("Your Comments"),
             'comments_explain' : _("Display all the comments you have submitted so far."),
             }
-        if guest and CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-            out += self.tmpl_warning_guest_user(ln = ln, type = "baskets")
         out += """</dd>
         <dt><a href="../youralerts/list?ln=%(ln)s">%(your_alerts)s</a></dt>
         <dd>%(explain_alerts)s""" % {
@@ -631,8 +628,6 @@ class Template:
           'your_alerts' : _("Your Alerts"),
           'explain_alerts' : _("Subscribe to a search which will be run periodically by our service. The result can be sent to you via Email or stored in one of your baskets."),
         }
-        if guest and CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-            out += self.tmpl_warning_guest_user(type="alerts", ln = ln)
         out += "</dd>"
         if CFG_CERN_SITE:
             out += """</dd>

--- a/modules/websession/lib/webuser.py
+++ b/modules/websession/lib/webuser.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2014 CERN.
+## Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008,
+##               2009, 2010, 2011, 2012, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -58,7 +59,6 @@ from invenio.config import \
      CFG_SITE_SUPPORT_EMAIL, \
      CFG_SITE_SECURE_URL, \
      CFG_SITE_URL, \
-     CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS, \
      CFG_WEBSESSION_ADDRESS_ACTIVATION_EXPIRE_IN_DAYS, \
      CFG_CERN_SITE, \
      CFG_INSPIRE_SITE, \
@@ -198,17 +198,12 @@ def getUid(req):
     uid = session.get('uid', -1)
     if not session.need_https:
         if uid == -1: # first time, so create a guest user
-            if CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-                uid = session['uid'] = createGuestUser()
+            if CFG_ACCESS_CONTROL_LEVEL_GUESTS == 0:
+                session['uid'] = 0
                 session.set_remember_me(False)
-                guest = 1
+                return 0
             else:
-                if CFG_ACCESS_CONTROL_LEVEL_GUESTS == 0:
-                    session['uid'] = 0
-                    session.set_remember_me(False)
-                    return 0
-                else:
-                    return -1
+                return -1
         else:
             if not hasattr(req, '_user_info') and 'user_info' in session:
                 req._user_info = session['user_info']
@@ -786,14 +781,8 @@ def logoutUser(req):
     """It logout the user of the system, creating a guest user.
     """
     session = get_session(req)
-    if CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-        uid = createGuestUser()
-        session['uid'] = uid
-        session.set_remember_me(False)
-        session.save()
-    else:
-        uid = 0
-        session.invalidate()
+    uid = 0
+    session.invalidate()
     if hasattr(req, '_user_info'):
         delattr(req, '_user_info')
     return uid

--- a/modules/webstat/lib/webstat_regression_tests.py
+++ b/modules/webstat/lib/webstat_regression_tests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2009, 2010, 2011 CERN.
+## Copyright (C) 2009, 2010, 2011, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -23,8 +23,7 @@ __revision__ = "$Id$"
 
 from invenio.testutils import InvenioTestCase
 
-from invenio.config import CFG_SITE_URL, \
-     CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS
+from invenio.config import CFG_SITE_URL
 from invenio.testutils import make_test_suite, run_test_suite, \
      test_web_page_content, merge_error_messages
 
@@ -41,9 +40,6 @@ class WebStatWebPagesAvailabilityTest(InvenioTestCase):
                     'search_type_distribution', 'download_frequency']
 
         error_messages = []
-        if CFG_WEBSESSION_DIFFERENTIATE_BETWEEN_GUESTS:
-            for url in [baseurl + page for page in _exports]:
-                error_messages.extend(test_web_page_content(url))
         for url in [baseurl + page for page in _exports]:
             error_messages.extend(test_web_page_content(url, username='admin'))
         if error_messages:


### PR DESCRIPTION
* Removes support for differentiated guest users in order to simplify
  session management.
  (closes #2786)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>