### PR TITLE
WIP relationships: picking up MSusik's work

### DIFF
--- a/invenio/base/scripts/database.py
+++ b/invenio/base/scripts/database.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -105,7 +105,7 @@ def drop(yes_i_know=False, quiet=False):
     from invenio.ext.sqlalchemy.utils import test_sqla_connection, test_sqla_utf8_chain
     from invenio.ext.sqlalchemy import db, models
     from invenio.legacy.bibdocfile.api import _make_base_dir
-    from invenio.modules.jsonalchemy.wrappers import StorageEngine
+    from invenio.modules.relationships.node import StorageEngine
 
     ## Step 0: confirm deletion
     wait_for_user(wrap_text_in_a_box(
@@ -191,7 +191,7 @@ def create(default_data=True, quiet=False):
     from invenio.utils.date import get_time_estimator
     from invenio.ext.sqlalchemy.utils import test_sqla_connection, test_sqla_utf8_chain
     from invenio.ext.sqlalchemy import db, models
-    from invenio.modules.jsonalchemy.wrappers import StorageEngine
+    from invenio.modules.relationships.node import StorageEngine
 
     test_sqla_connection()
     test_sqla_utf8_chain()

--- a/invenio/modules/documents/api.py
+++ b/invenio/modules/documents/api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -122,6 +122,11 @@ class Document(SmartJson):
         if not include_deleted and document['deleted']:
             raise errors.DeletedDocument
         return document
+
+    @classmethod
+    def get_entity(cls, id):
+        """Get document. Implementation of ``Node`` interface method."""
+        return cls.get_document(id)
 
     def _save(self):
         try:

--- a/invenio/modules/records/api.py
+++ b/invenio/modules/records/api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -44,7 +44,7 @@ class Record(SmartJson):
         if not json or '__meta_metadata__' not in json:
             kwargs['namespace'] = kwargs.get('namespace', 'recordext')
             kwargs['master_format'] = kwargs.get('master_format', 'json')
-        super(Record, self).__init__(json, **kwargs)
+        SmartJson.__init__(self, json, **kwargs)
         self.get_blob = lambda: self.blob
 
     @classmethod
@@ -92,9 +92,14 @@ class Record(SmartJson):
         return record
 
     @classmethod
+    def get_entity(cls, id):
+        """Get the record. Implements ``Node`` interface function."""
+        return cls.get_record(id)
+
+    @classmethod
     def get_blob(cls, recid):
         """Get the blob from where the record was created."""
-        #FIXME: start using bibarchive or bibingest for this
+        # FIXME: start using bibarchive or bibingest for this
         from invenio.modules.formatter.models import Bibfmt
         from zlib import decompress
         try:

--- a/invenio/modules/relationships/__init__.py
+++ b/invenio/modules/relationships/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Module for model linking."""

--- a/invenio/modules/relationships/api.py
+++ b/invenio/modules/relationships/api.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Relationship API."""
+
+import importlib
+
+from .config import RELATIONSHIP_ENGINE, RELATIONSHIP_NODE
+
+# FIXME: The code is currently working around the fact that Flask-registry
+# is run before the application context is ready, therefore one can't use
+# the LocalProxy defined in invenio.base.globals. For more details see: 
+# https://github.com/inveniosoftware/invenio/pull/2719/files#r25151156
+try:
+    __engine = __import__('flask').current_app.config['RELATIONSHIP_ENGINE']
+except RuntimeError:
+    __engine = RELATIONSHIP_ENGINE
+
+try:
+    __node = __import__('flask').current_app.config['RELATIONSHIP_NODE']
+except RuntimeError:
+    __node = RELATIONSHIP_NODE
+
+Node = getattr(importlib.import_module(__node[0]), __node[1])
+Relationship = getattr(importlib.import_module(__engine[0]), __engine[1])

--- a/invenio/modules/relationships/config.py
+++ b/invenio/modules/relationships/config.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Config for relationship module."""
+
+RELATIONSHIP_NODE = ('invenio.modules.relationships.engines.sqlalchemy',
+                     'SQLAlchemyNode')
+RELATIONSHIP_ENGINE = ('invenio.modules.relationships.engines.sqlalchemy',
+                       'SQLAlchemyRelationship')

--- a/invenio/modules/relationships/engines/__init__.py
+++ b/invenio/modules/relationships/engines/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Relationship module."""

--- a/invenio/modules/relationships/engines/sqlalchemy.py
+++ b/invenio/modules/relationships/engines/sqlalchemy.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Implementation of ``Node`` using ``SQLAlchemy``."""
+
+from invenio.ext.sqlalchemy import db
+
+from ..models import Relationship as SQLAlchemyRelationship
+from ..node import Node
+
+
+class SQLAlchemyNode(Node):
+
+    """Node implementation for ``SQLAlchemy``."""
+
+    def __init__(self, id=None, storagename=None):
+        """Initialize node.
+
+        :param json: SmartJSON
+            The entity. If not provided, both ``id`` and ``namespace`` need
+            to be provided.
+        :param id: integer
+            The id of the entity.
+        :param namespace: string
+            The namespace the entity belongs to.
+
+        :raise ValueError:
+            Unless sufficient arguments are provided.
+        """
+        super(SQLAlchemyNode, self).__init__(id, storagename)
+
+    def __hash__(self):
+        """Get simplified hash.
+
+        As hash(int) equals int, it won't cause unwanted collisions.
+        """
+        return hash(self.node_id) ^ hash(self.node_storagename)
+
+    def degree(self, inwards=True, outwards=True, link_type=None):
+        """Get number of edges belonging to this node.
+
+        :param inwards: boolean
+            Count the edges that are coming in to this node.
+        :param outwards: boolean
+            Count the edges that are coming out from this node.
+        :param link_type: string
+            Count only this type of edges. Optional.
+
+        :returns: int
+            Number of edges.
+        """
+        return len(self.edges(inwards, outwards, link_type))
+
+    def edges(self, inwards=True, outwards=True, link_type=None,
+              loops_doubled=True):
+        """Get all the edges of this node.
+
+        There are no guarantees on the order of the result.
+
+        :param inwards: boolean
+            Get the edges that are coming in to this node.
+        :param outwards: boolean
+            Get the edges that are coming out from this node.
+        :param link_type: string
+            Type of the edges. Optional.
+        :param loops_doubled: boolean
+            If true, return every loop twice.
+
+        :returns: list
+            Edges belonging to this node.
+        """
+        edges = SQLAlchemyRelationship.query
+        if inwards and outwards:
+            edges = edges.filter(db.or_(SQLAlchemyRelationship.id_to ==
+                                        self.node_id,
+                                        SQLAlchemyRelationship.id_from ==
+                                        self.node_id))
+        elif inwards:
+            edges = edges.filter_by(id_to=self.node_id)
+        elif outwards:
+            edges = edges.filter_by(id_from=self.node_id)
+        else:
+            return []
+        if link_type:
+            edges = edges.filter_by(link_type=link_type)
+
+        if inwards and outwards and loops_doubled:
+            # Special case for loops. Second query needed.
+            reflexives = SQLAlchemyRelationship.query.filter(
+                db.and_(SQLAlchemyRelationship.id_to == self.node_id,
+                        SQLAlchemyRelationship.id_from == self.node_id))
+            if link_type:
+                reflexives = reflexives.filter(link_type=link_type)
+            return edges.all() + reflexives.all()
+
+        return edges.all()
+
+    def neighbours(self, inwards=True, outwards=True, link_type=None):
+        """Get all the nodes which are neighbours of this node.
+
+        :param inwards: boolean
+            Get the vertices that are sources for this node.
+        :param outwards: boolean
+            Get the vertices that are destinations from this node.
+        :param link_type: string
+            Type of the edges. Optional.
+
+        :returns: set
+            Nodes that are neighbours of this node.
+        """
+        edges = self.edges(inwards, outwards, link_type, loops_doubled=False)
+        set1 = set(SQLAlchemyNode(id=node.id_from,
+                                  storagename=node.storagename_from)
+                   for node in edges)
+        set2 = set(SQLAlchemyNode(id=node.id_to,
+                                  storagename=node.storagename_to)
+                   for node in edges)
+        union = set1 | set2
+
+        return {node.get_entity() for node in union}

--- a/invenio/modules/relationships/models.py
+++ b/invenio/modules/relationships/models.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Database model for persisting relationships."""
+
+from uuid import uuid4
+
+from invenio.ext.sqlalchemy import db, utils
+
+from sqlalchemy_utils import UUIDType
+
+
+class Relationship(db.Model):
+
+    """Represent a graph edge."""
+
+    uuid = db.Column(UUIDType(binary=False), primary_key=True)
+    storagename_from = db.Column(db.String(255), index=True)
+    id_from = db.Column(db.String(255), index=True)
+    link_type = db.Column(db.String(255), index=True)
+    # FIX ME: add index
+    link_attributes = db.Column(db.JSON)
+    storagename_to = db.Column(db.String(255), index=True)
+    id_to = db.Column(db.String(255), index=True)
+
+    def __init__(self, json_from, link_type, json_to, uuid=None):
+        """Initialize the relationship between two records.
+
+        Parameters
+        ----------
+        :param json_from: integer
+            The source record.
+        :param link_type: string
+            Name of the relation.
+        :param json_to: string
+            The destination record.
+        :param uuid: UUID
+            Presetted uuid. Optional
+        """
+        self.uuid = uuid4() if uuid is None else uuid
+        self.id_from = str(json_from['_id'])
+        self.storagename_from = json_from.__storagename__
+        self.link_type = link_type
+        self.id_to = str(json_to['_id'])
+        self.storagename_to = json_to.__storagename__
+
+    @utils.session_manager
+    def save(self):
+        """Helper method for adding to ``SQLAlchemy`` session."""
+        db.session.add(self)
+
+
+__all__ = ("Relationship")

--- a/invenio/modules/relationships/node.py
+++ b/invenio/modules/relationships/node.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Node interface and StorageEngine metaclass."""
+
+from flask import current_app
+
+from invenio.utils.memoise import memoize
+
+from six import add_metaclass, string_types
+
+from werkzeug.utils import import_string
+
+
+class StorageEngine(type):
+
+    """Storage metaclass for parsing application config."""
+
+    __storage_engine_registry__ = []
+    __entity_types_registry__ = {}
+
+    def __init__(cls, name, bases, dct):
+        """Register cls to type registry."""
+        if hasattr(cls, '__storagename__'):
+            cls.__storage_engine_registry__.append(cls)
+            if cls.__storagename__ not in cls.__entity_types_registry__:
+                cls.__entity_types_registry__.update({cls.__storagename__:
+                                                     cls})
+
+        super(StorageEngine, cls).__init__(name, bases, dct)
+
+    @property
+    def storage_engine(cls):
+        """Return an instance of storage engine defined in application config.
+
+        It looks for key "ENGINE' prefixed by ``__storagename__.upper()`` for
+        example::
+
+            class Dummy(SmartJson):
+                __storagename__ = 'dummy'
+
+        will look for key "DUMMY_ENGINE" and
+        "DUMMY_`DUMMY_ENGINE.__name__.upper()`" should contain dictionary with
+        keyword arguments of the engine defined in "DUMMY_ENGINE".
+        """
+        storagename = cls.__storagename__.lower()
+        return cls._engine(storagename)
+
+    @staticmethod
+    @memoize
+    def _engine(storagename):
+        prefix = storagename.upper()
+        engine = current_app.config['{0}_ENGINE'.format(prefix)]
+        if isinstance(engine, string_types):
+            engine = import_string(engine)
+
+        key = engine.__name__.upper()
+        kwargs = current_app.config.get('{0}_{1}'.format(prefix, key), {})
+        return engine(**kwargs)
+
+
+@add_metaclass(StorageEngine)
+class Node(object):
+
+    """Superclass representing abstract node."""
+
+    def __init__(self, id=None, storagename=None):
+        """Initialize node.
+
+        :param id: integer
+            The id of the entity.
+        :param storagename: string
+            The namespace the entity belongs to.
+
+        :raise ValueError:
+            Unless sufficient arguments are provided.
+        """
+        self.node_storagename = storagename
+        self.node_id = id
+
+    def __eq__(self, other):
+        """Overwritten equality function for Node.
+
+        Node is equal only to another node which shares the same ``_id`` and
+        ``namespace``. Such node is unique.
+        """
+        if isinstance(other, Node):
+            return (self.node_id == other.node_id and
+                    self.node_storagename == other.node_storagename)
+        return False
+
+    def degree(self, inwards=True, outwards=True, link_type=None, **kwargs):
+        """Get number of edges belonging to this node.
+
+        :param inwards: boolean
+            Count the edges that are coming in to this node.
+        :param outwards: boolean
+            Count the edges that are coming out from this node.
+        :param link_type: string
+            Count only this type of edges. Optional.
+
+        :returns: int
+            Number of edges.
+        """
+        raise NotImplementedError
+
+    def edges(self, inwards=True, outwards=True, link_type=None,
+              loops_doubled=True, **kwargs):
+        """Get all the edges of this node.
+
+        There are no guarantees on the order of the result.
+
+        :param inwards: boolean
+            Get the edges that are coming in to this node.
+        :param outwards: boolean
+            Get the edges that are coming out from this node.
+        :param link_type: string
+            Type of the edges. Optional.
+        :param loops_doubled: boolean
+            If true, return every loop twice.
+
+        :returns: list
+            Edges belonging to this node.
+        """
+        raise NotImplementedError
+
+    def neighbours(self, inwards=True, outwards=True, link_type=None,
+                   **kwargs):
+        """Get all the nodes which are neighbours of this node.
+
+        :param inwards: boolean
+            Get the vertices that are sources for this node.
+        :param outwards: boolean
+            Get the vertices that are destinations from this node.
+        :param link_type: string
+            Type of the edges. Optional.
+
+        :returns: set
+            Nodes that are neighbours of this node.
+        """
+        raise NotImplementedError
+
+    def get_entity(self):
+        """Get the entity that is represented by this node.
+
+        :returns: SmartJSON object
+            The entity with the metadata included.
+        """
+        implemented_by = self.__class__.\
+            __entity_types_registry__[self.node_storagename]
+
+        return implemented_by.get_entity(self.node_id)

--- a/invenio/modules/relationships/testsuite/__init__.py
+++ b/invenio/modules/relationships/testsuite/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Tests for relationship module."""

--- a/invenio/modules/relationships/testsuite/test_nodes.py
+++ b/invenio/modules/relationships/testsuite/test_nodes.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Tests for Node class."""
+from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+
+
+class RelationshipNodeTestCase(InvenioTestCase):
+
+    """Test mehods of ``Node`` class."""
+
+    def setUp(self):
+        """Import modules and create dummy record and a dummy relationship."""
+        self._importContext()
+        self._empty_record = self.Document.create({'title': 'Document 1',
+                                                   'description': 'Testing 1'})
+        self._relationship = self.Relationship(self._empty_record, 'default',
+                                               self._empty_record)
+        self._relationship.save()
+        self.db.session.commit()
+        self._id = self._empty_record['_id']
+        self._dummy_record = self.Document.get_document(self._id)
+
+    def _importContext(self):
+        from invenio.ext.sqlalchemy import db
+        from invenio.modules.documents.api import Document
+        from invenio.modules.documents.models import Document as DocumentModel
+        from ..api import Node, Relationship
+        self.db = db
+        self.Node = Node
+        self.Document = Document
+        self.DocumentModel = DocumentModel
+        self.Relationship = Relationship
+
+    def tearDown(self):
+        """Delete dummy record and dummy relationship."""
+        self.db.session.delete(self._relationship)
+        docs = self.DocumentModel.query.filter_by(id=self._id).all()
+        for doc in docs:
+            self.db.session.delete(doc)
+        self.db.session.commit()
+
+    def test_get_sources(self):
+        """Check reflexiveness of the dummy relationhip.
+
+        Test the edge coming out.
+        """
+        self.assertEqual(self._dummy_record['_id'],
+                         self._dummy_record.neighbours(outwards=False
+                                                       ).pop()['_id'])
+
+    def test_get_destinations(self):
+        """Check reflexiveness of the dummy relationship.
+
+        Test the edge coming in.
+        """
+        self.assertEqual(self._dummy_record['_id'],
+                         self._dummy_record.neighbours(inwards=False
+                                                       ).pop()['_id'])
+
+    def test_neighbours(self):
+        """Check if every node is returned only once."""
+        neighbours = self._dummy_record.neighbours()
+        self.assertEqual(len(neighbours), 1)
+        self.assertEqual(self._dummy_record['_id'], neighbours.pop()['_id'])
+
+    def test_edges(self):
+        """Check the difference between both values of ``loops_doubled``."""
+        self.assertEqual(self._dummy_record.degree(), 2)
+        self.assertEqual(len(self._dummy_record.edges(loops_doubled=False)), 1)
+
+
+TEST_SUITE = make_test_suite(RelationshipNodeTestCase)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)

--- a/invenio/modules/relationships/testsuite/test_relationship.py
+++ b/invenio/modules/relationships/testsuite/test_relationship.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Tests for Relationship model."""
+from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+
+
+class RelationshipModelTestCase(InvenioTestCase):
+
+    """Test additional features of Relationship model."""
+
+    def setUp(self):
+        """Import modules and prepare a dummy record."""
+        self._import_context()
+        self._dummy_record = self.Document.create({'title': 'Document 1',
+                                                   'description': 'Testing 1'})
+        self._id = self._dummy_record['_id']
+        self.db.session.commit()
+
+    def tearDown(self):
+        docs = self.DocumentModel.query.filter_by(id=self._id).all()
+        for doc in docs:
+            self.db.session.delete(doc)
+        self.db.session.commit()
+
+    def _import_context(self):
+        from uuid import UUID
+        from invenio.ext.sqlalchemy import db
+        from invenio.modules.documents.api import Document
+        from invenio.modules.documents.models import Document as DocumentModel
+        from ..models import Relationship
+        self.db = db
+        self.Document = Document
+        self.DocumentModel = DocumentModel
+        self.Relationship = Relationship
+        self.UUID = UUID
+
+    def test_correct_relationship(self):
+        """Check a reflexive relationship."""
+        rec = self._dummy_record
+        relationship = self.Relationship(rec, 'default', rec)
+        self.assertEqual(relationship.uuid.__class__, self.UUID)
+        self.assertEqual(relationship.link_type, 'default')
+
+
+TEST_SUITE = make_test_suite(RelationshipModelTestCase)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
In this PR I will continue @MSusik's work on the `relationships` module than began in #2719. Here's a tentative roadmap:

- [x] Rebase on top of current `pu`
- [ ] Refactor the methods in `invenio/modules/relationships/engines/sqlalchemy.py`, and design a comprehensive API

(I will replace the `inwards` and `outwards` boolean parameters with the methods `in_degree`, `out_degree`, `in_edges`, and `out_edges`; I also think that in some cases the `neighbours` method should return a `list` and not a `set`, and I'm thinking how to accomplish that. I'm reading #2573 to understand all requirements.)

- [ ] Wait for `invenio/modules/jsonalchemy` to be fully evicted from Invenio (#2815) 
- [ ] Work around the fact that the code is currently using the internals of `jsonalchemy`.

I'm not sure about the rest. I've postponed fixing https://github.com/inveniosoftware/invenio/compare/inveniosoftware:pu...jacquerie:rebase-relationships?expand=1#diff-53f9b6baea75d29500a64134c2d2b8efR26, and I might try to avoid the cute but complex metaclass trick of https://github.com/inveniosoftware/invenio/compare/inveniosoftware:pu...jacquerie:rebase-relationships?expand=1#diff-c0075666ce0e4fba6cbd934a9f84ade7R39.

[skip ci]