### PR TITLE
oauthclient: orcid login fix + tests

### DIFF
--- a/invenio/modules/oauthclient/config.py
+++ b/invenio/modules/oauthclient/config.py
@@ -183,3 +183,6 @@ OAUTHCLIENT_SESSION_KEY_PREFIX = "oauth_token"
 
 OAUTHCLIENT_STATE_EXPIRES = 300
 """Number of seconds after which the state token expires."""
+
+OAUTHCLIENT_STATE_ENABLED = True
+"""Internal variable used to disable state validation during tests."""

--- a/invenio/modules/oauthclient/contrib/orcid.py
+++ b/invenio/modules/oauthclient/contrib/orcid.py
@@ -69,17 +69,18 @@ In templates you can add a sign in/up link:
 
 .. code-block:: jinja
 
-    <a href="{{url_for('oauthclient.login', remote_app='orcid')}}">Sign in with ORCID</a>
+    <a href="{{url_for('oauthclient.login', remote_app='orcid')}}">
+      Sign in with ORCID
+    </a>
 
 """
 
 import copy
 
-from flask import current_app, session
+from flask import current_app, redirect, url_for
 from flask.ext.login import current_user
 
 from invenio.ext.sqlalchemy.utils import session_manager
-
 
 REMOTE_APP = dict(
     title='ORCID',
@@ -87,7 +88,7 @@ REMOTE_APP = dict(
     icon='',
     authorized_handler="invenio.modules.oauthclient.handlers"
                        ":authorized_signup_handler",
-    disconnect_handler="invenio.modules.oauthclient.handlers"
+    disconnect_handler="invenio.modules.oauthclient.contrib.orcid"
                        ":disconnect_handler",
     signup_handler=dict(
         info="invenio.modules.oauthclient.contrib.orcid:account_info",
@@ -97,7 +98,7 @@ REMOTE_APP = dict(
     params=dict(
         request_token_params={'scope': '/authenticate',
                               'show_login': 'true'},
-        base_url='https://pub.orcid.com/',
+        base_url='https://pub.orcid.org/v1.2/',
         request_token_url=None,
         access_token_url="https://pub.orcid.org/oauth/token",
         access_token_method='POST',
@@ -121,60 +122,65 @@ REMOTE_SANDBOX_APP['params'].update(dict(
 def account_info(remote, resp):
     """Retrieve remote account information used to find local user."""
     account_info = dict(external_id=resp.get("orcid"), external_method="orcid")
-
     return account_info
 
 
+def disconnect_handler(remote, *args, **kwargs):
+    """Handle unlinking of remote account."""
+    from invenio.modules.oauthclient.utils import oauth_unlink_external_id
+    from invenio.modules.oauthclient.models import RemoteAccount
+
+    if not current_user.is_authenticated():
+        return current_app.login_manager.unauthorized()
+
+    account = RemoteAccount.get(user_id=current_user.get_id(),
+                                client_id=remote.consumer_key)
+    orcid = account.extra_data.get('orcid')
+
+    if orcid:
+        oauth_unlink_external_id(dict(id=orcid, method='orcid'))
+    if account:
+        account.delete()
+
+    return redirect(url_for('oauthclient_settings.index'))
+
+
 @session_manager
-def account_setup(remote, token):
+def account_setup(remote, token, resp):
     """Perform additional setup after user have been logged in."""
-    from invenio.modules.accounts.models import User, UserEXT
+    from invenio.modules.oauthclient.utils import oauth_link_external_id
     from invenio.ext.sqlalchemy import db
-    from ..handlers import token_session_key
 
-    from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+    # Retrieve ORCID from response.
+    orcid = resp.get("orcid")
 
-    import json
-    import requests
+    # Set ORCID in extra_data.
+    token.remote_account.extra_data = {"orcid": orcid}
+    user = token.remote_account.user
 
-    orcid = session.get(token_session_key(remote.name) +
-                        "_account_info").get("external_id")
-
-    extra_data = {
-        "orcid": orcid
-        }
-    token.remote_account.extra_data = extra_data
-
-    try:
-        user = User.query.join(UserEXT).filter_by(id=orcid,
-                                                  method="orcid").one()
-    except (MultipleResultsFound, NoResultFound):
-        current_app.logger.exception("No user entry in userEXT.")
+    # Create user <-> external id link.
+    oauth_link_external_id(user, dict(id=orcid, method="orcid"))
 
     # Fill user full name if not already set
     if user and not any([user.given_names, user.family_name]):
         # Query ORCID to get the real name
-        request_url = 'http://orcid.org/{0}/orcid-bio'.format(orcid)
+        response = remote.get("{0}/orcid-bio".format(orcid),
+                              headers={'Accept': 'application/orcid+json'},
+                              content_type="application/json")
 
-        headers = {'Accept': 'application/orcid+json'}
-        response = requests.get(request_url, headers=headers)
-        code = response.status_code
-
-        if code == requests.codes.ok:
+        if response.status == 200:
             try:
-                orcid_bio = json.loads(response.content)
-            except ValueError:
-                current_app.logger.exception("Not valid JSON response from " +
-                                             "ORCID:\n {0}".format(repr(orcid_bio)))
-                return
-            try:
-                name = orcid_bio["orcid-profile"]["orcid-bio"]["personal-details"]
+                name = response.data["orcid-profile"]["orcid-bio"][
+                    "personal-details"]
                 user.given_names = name["given-names"]["value"]
                 user.family_name = name["family-name"]["value"]
             except KeyError:
-                current_app.logger.exception("Unexpected return format " +
-                                             "from ORCID:\n {0}".format(repr(orcid_bio)))
+                current_app.logger.exception(
+                    "Unexpected return format from ORCID: {0}".format(
+                        repr(response.data)))
                 return
+
             db.session.add(user)
+
             # Refresh user cache
             current_user.reload()

--- a/invenio/modules/oauthclient/handlers.py
+++ b/invenio/modules/oauthclient/handlers.py
@@ -19,12 +19,14 @@
 
 """Handlers for customizing oauthclient endpoints."""
 
-import six
+import warnings
+
+from functools import partial, wraps
 
 from flask import current_app, flash, redirect, render_template, \
     request, session, url_for
 from flask.ext.login import current_user
-from functools import partial, wraps
+import six
 from werkzeug.utils import import_string
 
 from invenio.base.globals import cfg
@@ -178,7 +180,7 @@ def oauth_error_handler(f):
                 e.remote, e.response, e.code, e.uri, e.description
             )
         except OAuthRejectedRequestError:
-            flash("You rejected the authentication request.")
+            flash("You rejected the authentication request.", category='info')
             return redirect('/')
     return inner
 
@@ -229,6 +231,8 @@ def authorized_signup_handler(resp, remote, *args, **kwargs):
                     token_session_key(remote.name) + '_autoregister'] = True
                 session[token_session_key(remote.name) +
                         "_account_info"] = account_info
+                session[token_session_key(remote.name) +
+                        "_response"] = resp
                 return redirect(url_for(
                     ".signup",
                     remote_app=remote.name,
@@ -249,9 +253,15 @@ def authorized_signup_handler(resp, remote, *args, **kwargs):
 
     # Setup account
     # -------------
-    if not token.remote_account.extra_data and \
-       remote.name in signup_handlers:
-        handlers['setup'](token)
+    if not token.remote_account.extra_data:
+        try:
+            handlers['setup'](token, resp)
+        except TypeError:
+            warnings.warn('Method signature of setup signup handler is '
+                          'deprecated. It must take three arguments (remote,'
+                          ' token, response).',
+                          DeprecationWarning)
+            handlers['setup'](token)
 
     # Redirect to next
     next_url = get_session_next_url(remote.name)
@@ -261,7 +271,6 @@ def authorized_signup_handler(resp, remote, *args, **kwargs):
         return redirect('/')
 
 
-@oauth_error_handler
 def disconnect_handler(remote, *args, **kwargs):
     """Handle unlinking of remote account.
 
@@ -293,16 +302,19 @@ def signup_handler(remote, *args, **kwargs):
     if not oauth_token:
         return redirect("/")
 
+    session_prefix = token_session_key(remote.name)
+
     # Test to see if this is coming from on authorized request
-    if not session.get(token_session_key(remote.name) + '_autoregister',
+    if not session.get(session_prefix + '_autoregister',
                        False):
         return redirect(url_for(".login", remote_app=remote.name))
 
     form = EmailSignUpForm(request.form)
 
     if form.validate_on_submit():
-        account_info = session.get(token_session_key(remote.name) +
-                                   "_account_info")
+        account_info = session.get(session_prefix + "_account_info")
+        response = session.get(session_prefix + "_response")
+
         # Register user
         user = oauth_register(account_info, form.data)
 
@@ -310,7 +322,7 @@ def signup_handler(remote, *args, **kwargs):
             raise OAuthError("Could not create user.", remote)
 
         # Remove session key
-        session.pop(token_session_key(remote.name) + '_autoregister', None)
+        session.pop(session_prefix + '_autoregister', None)
 
         # Authenticate the user
         if not oauth_authenticate(remote.consumer_key, user,
@@ -327,10 +339,18 @@ def signup_handler(remote, *args, **kwargs):
             raise OAuthError("Could not create token for user.", remote)
 
         if not token.remote_account.extra_data:
-            handlers['setup'](token)
+            try:
+                handlers['setup'](token, response)
+            except TypeError:
+                warnings.warn('Method signature of setup signup handler is '
+                              'deprecated. It must take three arguments'
+                              ' (remote, token, response).',
+                              DeprecationWarning)
+                handlers['setup'](token)
 
         # Remove account info from session
-        session.pop(token_session_key(remote.name) + '_account_info', None)
+        session.pop(session_prefix + '_account_info', None)
+        session.pop(session_prefix + '_response', None)
 
         # Redirect to next
         next_url = get_session_next_url(remote.name)
@@ -365,7 +385,7 @@ def make_handler(f, remote, with_response=True):
 
     :param f: Callable or an import path to a callable
     """
-    if isinstance(f, six.text_type):
+    if isinstance(f, six.string_types):
         f = import_string(f)
 
     @wraps(f)

--- a/invenio/modules/oauthclient/testsuite/fixture.py
+++ b/invenio/modules/oauthclient/testsuite/fixture.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""ORCID response fixture."""
+
+orcid_bio = """{
+  "message-version" : "1.1",
+  "orcid-profile" : {
+    "orcid" : null,
+    "orcid-identifier" : {
+      "value" : null,
+      "uri" : "http://orcid.org/0000-0002-1825-0097",
+      "path" : "0000-0002-1825-0097",
+      "host" : "orcid.org"
+    },
+    "orcid-preferences" : {
+      "locale" : "EN"
+    },
+    "orcid-history" : {
+      "creation-method" : "WEBSITE",
+      "completion-date" : {
+        "value" : 1352727077585
+      },
+      "submission-date" : {
+        "value" : 1352723476658
+      },
+      "last-modified-date" : {
+        "value" : 1415635049863
+      },
+      "claimed" : {
+        "value" : true
+      },
+      "source" : null,
+      "visibility" : null
+    },
+    "orcid-bio" : {
+      "personal-details" : {
+        "given-names" : {
+          "value" : "Josiah"
+        },
+        "family-name" : {
+          "value" : "Carberry"
+        },
+        "other-names" : {
+          "other-name" : [ {
+            "value" : "J. Carberry, Josiah Stinkney Carberry, J. S. Carberry"
+          } ],
+          "visibility" : null
+        }
+      },
+      "biography" : {
+        "value" : "Josiah Carberry is a fictitious person. This account is used as a demonstration account by ORCID, CrossRef and others who wish to demonstrate the interaction of ORCID with other scholarly communication systems without having to use a real-person's account.\\n\\nJosiah Stinkney Carberry is a fictional professor, created as a joke in 1929. He is said to still teach at Brown University, and to be known for his work in \\"psychoceramics\\", the supposed study of \\"cracked pots\\". See his Wikipedia entry for more details.",
+        "visibility" : null
+      },
+      "researcher-urls" : {
+        "researcher-url" : [ {
+          "url-name" : {
+            "value" : "Wikipedia Entry"
+          },
+          "url" : {
+            "value" : "http://en.wikipedia.org/wiki/Josiah_Carberry"
+          }
+        }, {
+          "url-name" : {
+            "value" : "Brown University Page"
+          },
+          "url" : {
+            "value" : "http://library.brown.edu/about/hay/carberry.php"
+          }
+        } ],
+        "visibility" : null
+      },
+      "keywords" : {
+        "keyword" : [ {
+          "value" : "psychoceramics"
+        } ],
+        "visibility" : null
+      },
+      "external-identifiers" : {
+        "external-identifier" : [ {
+          "external-id-orcid" : {
+            "value" : null,
+            "uri" : "http://orcid.org/0000-0002-5982-8983",
+            "path" : "0000-0002-5982-8983",
+            "host" : "orcid.org"
+          },
+          "external-id-common-name" : {
+            "value" : "Scopus Author ID"
+          },
+          "external-id-reference" : {
+            "value" : "7007156898"
+          },
+          "external-id-url" : {
+            "value" : "http://www.scopus.com/inward/authorDetails.url?authorID=7007156898&partnerID=MN8TOARS"
+          }
+        } ],
+        "visibility" : null
+      },
+      "delegation" : null,
+      "applications" : null,
+      "scope" : null
+    },
+    "orcid-activities" : {
+      "affiliations" : null
+    },
+    "type" : "USER",
+    "group-type" : null,
+    "client-type" : null
+  }
+}"""

--- a/invenio/modules/oauthclient/testsuite/test_contrib_orcid.py
+++ b/invenio/modules/oauthclient/testsuite/test_contrib_orcid.py
@@ -1,0 +1,276 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Test case for ORCID oauth remote app."""
+
+from __future__ import absolute_import
+
+from flask import session, url_for
+from mock import MagicMock
+from six.moves.urllib_parse import parse_qs, urlparse
+
+import httpretty
+
+from invenio.ext.sqlalchemy import db
+from invenio.testsuite import make_test_suite, run_test_suite
+
+from ..contrib.orcid import REMOTE_APP, account_info
+from .helpers import OAuth2ClientTestCase
+
+
+class OrcidTestCase(OAuth2ClientTestCase):
+
+    """ORCID OAuth remote app test case."""
+
+    example_data = {
+        "name": "Josiah Carberry",
+        "expires_in": 3599,
+        "orcid": "0000-0002-1825-0097",
+        "access_token": "test_access_token",
+        "refresh_token": "test_refresh_token",
+        "scope": "/authenticate",
+        "token_type": "bearer"
+    }
+    example_email = "orcidtest@invenio-software.org"
+    existing_email = "existing@invenio-software.org"
+
+    def create_app(self):
+        """Create Flask application object."""
+        app = super(OrcidTestCase, self).create_app()
+        app.testing = True
+        app.config.update(dict(
+            WTF_CSRF_ENABLED=False,
+            OAUTHCLIENT_STATE_ENABLED=False,
+            CACHE_TYPE='simple',
+            OAUTHCLIENT_REMOTE_APPS=dict(orcid=REMOTE_APP)
+        ))
+        return app
+
+    def setUp(self):
+        """Setup test."""
+        from invenio.modules.oauthclient.models import RemoteToken, \
+            RemoteAccount
+        from invenio.modules.accounts.models import UserEXT, User
+        RemoteToken.query.delete()
+        RemoteAccount.query.delete()
+        UserEXT.query.delete()
+        User.query.filter_by(email=self.example_email).delete()
+
+        self.u = User(email=self.existing_email, nickname='tester')
+        self.u.password = "tester"
+        db.session.add(self.u)
+        db.session.commit()
+
+    def tearDown(self):
+        """Tear down test."""
+        from invenio.modules.oauthclient.models import RemoteToken, \
+            RemoteAccount
+        from invenio.modules.accounts.models import UserEXT, User
+        RemoteToken.query.delete()
+        RemoteAccount.query.delete()
+        UserEXT.query.delete()
+        User.query.filter_by(email=self.example_email).delete()
+        User.query.filter_by(email=self.existing_email).delete()
+        db.session.commit()
+
+    def mock_response(self, app='test', data=None):
+        """Mock the oauth response to use the remote."""
+        from invenio.modules.oauthclient.client import oauth
+
+        # Mock oauth remote application
+        oauth.remote_apps[app].handle_oauth2_response = MagicMock(
+            return_value=data or self.example_data
+        )
+
+    def _get_state(self):
+        from invenio.modules.oauthclient.views.client import serializer
+        return serializer.dumps({'app': 'orcid', 'sid': session.sid,
+                                 'next': None, })
+
+    def test_account_info(self):
+        """Test account info extraction."""
+        from invenio.modules.oauthclient.client import oauth
+        # Ensure remote apps have been loaded (due to before first
+        # request)
+        self.client.get(url_for("oauthclient.login", remote_app='orcid'))
+
+        self.assertEqual(
+            account_info(oauth.remote_apps['orcid'], self.example_data),
+            dict(external_id="0000-0002-1825-0097",
+                 external_method="orcid")
+        )
+        self.assertEqual(
+            account_info(oauth.remote_apps['orcid'], {}),
+            dict(external_id=None,
+                 external_method="orcid")
+        )
+
+    def test_login(self):
+        """Test ORCID login."""
+        resp = self.client.get(
+            url_for("oauthclient.login", remote_app='orcid',
+                    next='/someurl/')
+        )
+        self.assertStatus(resp, 302)
+
+        params = parse_qs(urlparse(resp.location).query)
+        self.assertEqual(params['response_type'], ['code'])
+        self.assertEqual(params['show_login'], ['true'])
+        self.assertEqual(params['scope'], ['/authenticate'])
+        assert params['redirect_uri']
+        assert params['client_id']
+        assert params['state']
+
+    def test_authorized_signup(self):
+        """Test authorized callback with sign-up."""
+        from invenio.modules.accounts.models import UserEXT, User
+
+        with self.app.test_client() as c:
+            from invenio.modules.oauthclient.testsuite.fixture import orcid_bio
+
+            # Ensure remote apps have been loaded (due to before first
+            # request)
+            c.get(url_for("oauthclient.login", remote_app='orcid'))
+            self.mock_response(app='orcid')
+
+            # User authorized the requests and is redirect back
+            resp = c.get(
+                url_for("oauthclient.authorized",
+                        remote_app='orcid', code='test',
+                        state=self._get_state()))
+            self.assertStatus(resp, 302)
+            self.assertRedirects(resp, url_for('oauthclient.signup',
+                                               remote_app='orcid'))
+
+            # User load sign-up page.
+            resp = c.get(url_for('oauthclient.signup', remote_app='orcid'))
+            self.assertStatus(resp, 200)
+
+            # Mock request to ORCID to get user bio.
+            httpretty.enable()
+            httpretty.register_uri(
+                httpretty.GET,
+                "http://orcid.org/{0}/orcid-bio".format(
+                    self.example_data['orcid']),
+                body=orcid_bio,
+                content_type="application/orcid+json; qs=2;charset=UTF-8",
+            )
+
+            # User fills in email address.
+            resp = c.post(url_for('oauthclient.signup', remote_app='orcid'),
+                          data=dict(email=self.example_email))
+            self.assertStatus(resp, 302)
+            httpretty.disable()
+
+            # Assert database state (Sign-up complete)
+            u = User.query.filter_by(email=self.example_email).one()
+            UserEXT.query.filter_by(
+                method='orcid', id_user=u.id,
+                id=self.example_data['orcid']
+            ).one()
+            self.assertEqual(u.given_names, "Josiah")
+            self.assertEqual(u.family_name, "Carberry")
+
+            # Disconnect link
+            resp = c.get(
+                url_for("oauthclient.disconnect", remote_app='orcid'))
+            self.assertStatus(resp, 302)
+
+            # User exists
+            u = User.query.filter_by(email=self.example_email).one()
+            # UserEXT removed.
+            assert 0 == UserEXT.query.filter_by(
+                method='orcid', id_user=u.id,
+                id=self.example_data['orcid']
+            ).count()
+
+    def test_authorized_reject(self):
+        """Test a rejected request."""
+        with self.app.test_client() as c:
+            c.get(url_for("oauthclient.login", remote_app='orcid'))
+            resp = c.get(
+                url_for("oauthclient.authorized",
+                        remote_app='orcid', error='access_denied',
+                        error_description='User denied access',
+                        state=self._get_state()))
+            self.assertRedirects(resp, "/")
+            # Check message flash
+            self.assertEqual(session['_flashes'][0][0], 'info')
+
+    def test_authorized_already_authenticated(self):
+        """Test authorized callback with sign-up."""
+        from invenio.modules.accounts.models import UserEXT, User
+        from invenio.modules.oauthclient.testsuite.fixture import orcid_bio
+
+        # User logins
+        self.login("tester", "tester")
+
+        # Mock access token request
+        self.mock_response(app='orcid')
+
+        # Mock request to ORCID to get user bio.
+        httpretty.enable()
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://pub.orcid.org/v1.2/{0}/orcid-bio".format(
+                self.example_data['orcid']),
+            body=orcid_bio,
+            content_type="application/orcid+json; qs=2;charset=UTF-8",
+        )
+
+        # User then goes to "Linked accounts" and clicks "Connect"
+        resp = self.client.get(
+            url_for("oauthclient.login", remote_app='orcid',
+                    next='/someurl/')
+        )
+        self.assertStatus(resp, 302)
+
+        # User authorized the requests and is redirected back
+        resp = self.client.get(
+            url_for("oauthclient.authorized",
+                    remote_app='orcid', code='test',
+                    state=self._get_state()))
+        httpretty.disable()
+
+        # Assert database state (Sign-up complete)
+        u = User.query.filter_by(email=self.existing_email).one()
+        UserEXT.query.filter_by(
+            method='orcid', id_user=u.id,
+            id=self.example_data['orcid']
+        ).one()
+        self.assertEqual(u.given_names, "Josiah")
+        self.assertEqual(u.family_name, "Carberry")
+
+        # Disconnect link
+        resp = self.client.get(
+            url_for("oauthclient.disconnect", remote_app='orcid'))
+        self.assertStatus(resp, 302)
+
+        # User exists
+        u = User.query.filter_by(email=self.existing_email).one()
+        # UserEXT removed.
+        assert 0 == UserEXT.query.filter_by(
+            method='orcid', id_user=u.id,
+            id=self.example_data['orcid']
+        ).count()
+
+TEST_SUITE = make_test_suite(OrcidTestCase)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
* Adds tests for ORCID client.

* Fixes issue with ORCID client not properly cleaning up UserEXT.

* Fixes issue with ORCID client not properly creating UserEXT links
  when user is already logged in.

* Fixes undefined variable issue.

* Fixes flashing of message when user rejects requests.

* Fixes ORCID API endpoint.

* Changes request library to use Flask-OAuthlib internal.

* NOTE Changes method signature of account_setup handler to take 3
  arguments instead of 2. DeprecationWarnings are issued for
  existing account_setup methods.

* NOTE Supersedes PR #2712

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>


Test coverage:
```
Name                                         Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------
invenio.modules.oauthclient                      1      0   100%
invenio.modules.oauthclient.client               9      0   100%
invenio.modules.oauthclient.config               6      0   100%
invenio.modules.oauthclient.contrib              1      0   100%
invenio.modules.oauthclient.contrib.orcid       42      1    98%   181
invenio.modules.oauthclient.errors              16      0   100%
invenio.modules.oauthclient.forms               17      0   100%
invenio.modules.oauthclient.handlers           155     19    88%   71, 77, 150-154, 161, 242-252, 282, 298, 303, 310, 322, 332, 344, 349, 376-377
invenio.modules.oauthclient.models              60      1    98%   169
invenio.modules.oauthclient.utils               58     12    79%   38, 50, 61-63, 73-76, 78, 104-105
invenio.modules.oauthclient.views                5      0   100%
invenio.modules.oauthclient.views.client        65      2    97%   97, 190
invenio.modules.oauthclient.views.settings      33      0   100%
--------------------------------------------------------------------------
TOTAL                                          468     35    93%
----------------------------------------------------------------------
Ran 25 tests in 17.029s

OK (SKIP=4)
```