### PR TITLE
submit: fix foreign keys definition in models

### DIFF
--- a/invenio/modules/submit/__init__.py
+++ b/invenio/modules/submit/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013 CERN.
+# Copyright (C) 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,3 +16,5 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Submit module."""

--- a/invenio/modules/submit/models.py
+++ b/invenio/modules/submit/models.py
@@ -17,100 +17,119 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""
-websubmit database models.
-"""
+"""WebSubmit database models."""
 
 # General imports.
 from invenio.ext.sqlalchemy import db
 
 # Create your models here.
 
+
 class SbmACTION(db.Model):
-    """Represents a SbmACTION record."""
+
+    """Represent a SbmACTION record."""
+
     __tablename__ = 'sbmACTION'
     lactname = db.Column(db.Text, nullable=True)
     sactname = db.Column(db.Char(3), nullable=False, server_default='',
-                primary_key=True)
+                         primary_key=True)
     dir = db.Column(db.Text, nullable=True)
     cd = db.Column(db.Date, nullable=True)
     md = db.Column(db.Date, nullable=True)
     actionbutton = db.Column(db.Text, nullable=True)
     statustext = db.Column(db.Text, nullable=True)
 
+
 class SbmALLFUNCDESCR(db.Model):
-    """Represents a SbmALLFUNCDESCR record."""
+
+    """Represent a SbmALLFUNCDESCR record."""
+
     __tablename__ = 'sbmALLFUNCDESCR'
-    #FIX ME pk
+    # FIX ME pk
     function = db.Column(db.String(40), nullable=False, server_default='',
-                primary_key=True)
-    description	= db.Column(db.TinyText, nullable=True)
+                         primary_key=True)
+    description = db.Column(db.TinyText, nullable=True)
+
 
 class SbmAPPROVAL(db.Model):
-    """Represents a SbmAPPROVAL record."""
+
+    """Represent a SbmAPPROVAL record."""
+
     __tablename__ = 'sbmAPPROVAL'
     doctype = db.Column(db.String(10), nullable=False,
-                server_default='')
+                        server_default='')
     categ = db.Column(db.String(50), nullable=False,
-                server_default='')
+                      server_default='')
     rn = db.Column(db.String(50), nullable=False, server_default='',
-                primary_key=True)
+                   primary_key=True)
     status = db.Column(db.String(10), nullable=False,
-                server_default='')
+                       server_default='')
     dFirstReq = db.Column(db.DateTime, nullable=False,
-        server_default='1900-01-01 00:00:00')
+                          server_default='1900-01-01 00:00:00')
     dLastReq = db.Column(db.DateTime, nullable=False,
-        server_default='1900-01-01 00:00:00')
+                         server_default='1900-01-01 00:00:00')
     dAction = db.Column(db.DateTime, nullable=False,
-        server_default='1900-01-01 00:00:00')
+                        server_default='1900-01-01 00:00:00')
     access = db.Column(db.String(20), nullable=False,
-                server_default='0')
+                       server_default='0')
     note = db.Column(db.Text, nullable=False)
 
+
 class SbmCATEGORIES(db.Model):
-    """Represents a SbmCATEGORIES record."""
+
+    """Represent a SbmCATEGORIES record."""
+
     __tablename__ = 'sbmCATEGORIES'
     doctype = db.Column(db.String(10), nullable=False, server_default='',
-                primary_key=True, index=True)
+                        primary_key=True, index=True)
     sname = db.Column(db.String(75), nullable=False, server_default='',
-                primary_key=True, index=True)
+                      primary_key=True, index=True)
     lname = db.Column(db.String(75), nullable=False,
-                server_default='')
+                      server_default='')
     score = db.Column(db.TinyInteger(3, unsigned=True), nullable=False,
-                server_default='0')
+                      server_default='0')
+
 
 class SbmCHECKS(db.Model):
-    """Represents a SbmCHECKS record."""
+
+    """Represent a SbmCHECKS record."""
+
     __tablename__ = 'sbmCHECKS'
     chname = db.Column(db.String(15), nullable=False, server_default='',
-                primary_key=True)
+                       primary_key=True)
     chdesc = db.Column(db.Text, nullable=True)
     cd = db.Column(db.Date, nullable=True)
     md = db.Column(db.Date, nullable=True)
     chefi1 = db.Column(db.Text, nullable=True)
     chefi2 = db.Column(db.Text, nullable=True)
 
+
 class SbmCOLLECTION(db.Model):
+
     """Represents a SbmCOLLECTION record."""
+
     __tablename__ = 'sbmCOLLECTION'
     id = db.Column(db.Integer(11), nullable=False,
-                primary_key=True,
-                autoincrement=True)
+                   primary_key=True,
+                   autoincrement=True)
     name = db.Column(db.String(100), nullable=False,
-                server_default='')
+                     server_default='')
+
 
 class SbmCOLLECTIONSbmCOLLECTION(db.Model):
+
     """Represents a SbmCOLLECTIONSbmCOLLECTION record."""
+
     __tablename__ = 'sbmCOLLECTION_sbmCOLLECTION'
 
     id = db.Column(db.Integer(11), nullable=False, autoincrement=True,
                    primary_key=True)
     _id_father = db.Column(db.Integer(11), db.ForeignKey(SbmCOLLECTION.id),
-                nullable=True, name='id_father')
+                           nullable=True, name='id_father')
     id_son = db.Column(db.Integer(11), db.ForeignKey(SbmCOLLECTION.id),
-                nullable=False)
+                       nullable=False)
     catalogue_order = db.Column(db.Integer(11), nullable=False,
-                server_default='0')
+                                server_default='0')
 
     son = db.relationship(
         SbmCOLLECTION,
@@ -137,27 +156,31 @@ class SbmCOLLECTIONSbmCOLLECTION(db.Model):
 
 
 class SbmDOCTYPE(db.Model):
+
     """Represents a SbmDOCTYPE record."""
+
     __tablename__ = 'sbmDOCTYPE'
     ldocname = db.Column(db.Text, nullable=True)
     sdocname = db.Column(db.String(10), nullable=True,
-                primary_key=True)
+                         primary_key=True)
     cd = db.Column(db.Date, nullable=True)
     md = db.Column(db.Date, nullable=True)
     description = db.Column(db.Text, nullable=True)
 
 
 class SbmCOLLECTIONSbmDOCTYPE(db.Model):
+
     """Represents a SbmCOLLECTIONSbmDOCTYPE record."""
+
     __tablename__ = 'sbmCOLLECTION_sbmDOCTYPE'
     id = db.Column(db.Integer(11), nullable=False, autoincrement=True,
                    primary_key=True)
     _id_father = db.Column(db.Integer(11), db.ForeignKey(SbmCOLLECTION.id),
-                nullable=True, name="id_father")
+                           nullable=True, name="id_father")
     id_son = db.Column(db.Char(10), db.ForeignKey(SbmDOCTYPE.sdocname),
-                nullable=False)
+                       nullable=False)
     catalogue_order = db.Column(db.Integer(11), nullable=False,
-                server_default='0')
+                                server_default='0')
 
     father = db.relationship(
         SbmCOLLECTION,
@@ -176,60 +199,67 @@ class SbmCOLLECTIONSbmDOCTYPE(db.Model):
 
 
 class SbmCOOKIES(db.Model):
+
     """Represents a SbmCOOKIES record."""
+
     __tablename__ = 'sbmCOOKIES'
     id = db.Column(db.Integer(15, unsigned=True), nullable=False,
-                primary_key=True, autoincrement=True)
+                   primary_key=True, autoincrement=True)
     name = db.Column(db.String(100), nullable=False)
     value = db.Column(db.Text, nullable=True)
     uid = db.Column(db.Integer(15), nullable=False)
 
+
 class SbmCPLXAPPROVAL(db.Model):
+
     """Represents a SbmCPLXAPPROVAL record."""
+
     __tablename__ = 'sbmCPLXAPPROVAL'
     doctype = db.Column(db.String(10), nullable=False,
-                server_default='')
+                        server_default='')
     categ = db.Column(db.String(50), nullable=False,
-                server_default='')
+                      server_default='')
     rn = db.Column(db.String(50), nullable=False, server_default='',
-                primary_key=True)
+                   primary_key=True)
     type = db.Column(db.String(10), nullable=False,
-                primary_key=True)
+                     primary_key=True)
     status = db.Column(db.String(10), nullable=False)
     id_group = db.Column(db.Integer(15, unsigned=True), nullable=False,
-                server_default='0')
+                         server_default='0')
     id_bskBASKET = db.Column(db.Integer(15, unsigned=True), nullable=False,
-                server_default='0')
+                             server_default='0')
     id_EdBoardGroup = db.Column(db.Integer(15, unsigned=True), nullable=False,
-                server_default='0')
+                                server_default='0')
     dFirstReq = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                          server_default='1900-01-01 00:00:00')
     dLastReq = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                         server_default='1900-01-01 00:00:00')
     dEdBoardSel = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                            server_default='1900-01-01 00:00:00')
     dRefereeSel = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                            server_default='1900-01-01 00:00:00')
     dRefereeRecom = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                              server_default='1900-01-01 00:00:00')
     dEdBoardRecom = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                              server_default='1900-01-01 00:00:00')
     dPubComRecom = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                             server_default='1900-01-01 00:00:00')
     dProjectLeaderAction = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                                     server_default='1900-01-01 00:00:00')
 
 
 class SbmFIELD(db.Model):
+
     """Represents a SbmFIELD record."""
+
     __tablename__ = 'sbmFIELD'
     subname = db.Column(db.String(13), nullable=True,
-                primary_key=True)
+                        primary_key=True)
     pagenb = db.Column(db.Integer(11), nullable=True,
-                primary_key=True, autoincrement=False)
+                       primary_key=True, autoincrement=False)
     fieldnb = db.Column(db.Integer(11), nullable=True)
     fidesc = db.Column(db.String(15), nullable=True,
-                primary_key=True)
+                       primary_key=True)
     fitext = db.Column(db.Text, nullable=True)
     level = db.Column(db.Char(1), nullable=True)
     sdesc = db.Column(db.Text, nullable=True)
@@ -241,10 +271,12 @@ class SbmFIELD(db.Model):
 
 
 class SbmFIELDDESC(db.Model):
+
     """Represents a SbmFIELDDESC record."""
+
     __tablename__ = 'sbmFIELDDESC'
-    name = db.Column(db.String(15), #db.ForeignKey(SbmFIELD.fidesc),
-                nullable=False, server_default='', primary_key=True)
+    name = db.Column(db.String(15),  # db.ForeignKey(SbmFIELD.fidesc),
+                     nullable=False, server_default='', primary_key=True)
     alephcode = db.Column(db.String(50), nullable=True)
     marccode = db.Column(db.String(50), nullable=False, server_default='')
     type = db.Column(db.Char(1), nullable=True)
@@ -259,57 +291,70 @@ class SbmFIELDDESC(db.Model):
     modifytext = db.Column(db.Text, nullable=True)
     fddfi2 = db.Column(db.Text, nullable=True)
     cookie = db.Column(db.Integer(11), nullable=True,
-                server_default='0')
+                       server_default='0')
     #field = db.relationship(SbmFIELD, backref='fielddescs')
 
 
 class SbmFORMATEXTENSION(db.Model):
+
     """Represents a SbmFORMATEXTENSION record."""
+
     __tablename__ = 'sbmFORMATEXTENSION'
     FILE_FORMAT = db.Column(db.Text(50), nullable=False,
-                primary_key=True)
+                            primary_key=True)
     FILE_EXTENSION = db.Column(db.Text(10), nullable=False,
-                primary_key=True)
+                               primary_key=True)
 
 
 class SbmFUNCTIONS(db.Model):
+
     """Represents a SbmFUNCTIONS record."""
+
     __tablename__ = 'sbmFUNCTIONS'
     action = db.Column(db.String(10), nullable=False,
-                server_default='', primary_key=True)
+                       server_default='', primary_key=True)
     doctype = db.Column(db.String(10), nullable=False,
-                server_default='', primary_key=True)
+                        server_default='', primary_key=True)
     function = db.Column(db.String(40), nullable=False,
-                server_default='', primary_key=True)
+                         server_default='', primary_key=True)
     score = db.Column(db.Integer(11), nullable=False,
-                server_default='0', primary_key=True)
+                      server_default='0', primary_key=True)
     step = db.Column(db.TinyInteger(4), nullable=False,
-                server_default='1', primary_key=True)
+                     server_default='1', primary_key=True)
+
 
 class SbmFUNDESC(db.Model):
+
     """Represents a SbmFUNDESC record."""
+
     __tablename__ = 'sbmFUNDESC'
     function = db.Column(db.String(40), nullable=False,
-                server_default='', primary_key=True)
+                         server_default='', primary_key=True)
     param = db.Column(db.String(40), primary_key=True)
 
+
 class SbmGFILERESULT(db.Model):
+
     """Represents a SbmGFILERESULT record."""
+
     __tablename__ = 'sbmGFILERESULT'
     FORMAT = db.Column(db.Text(50), nullable=False,
-                primary_key=True)
+                       primary_key=True)
     RESULT = db.Column(db.Text(50), nullable=False,
-                primary_key=True)
+                       primary_key=True)
+
 
 class SbmIMPLEMENT(db.Model):
+
     """Represents a SbmIMPLEMENT record."""
+
     __tablename__ = 'sbmIMPLEMENT'
     docname = db.Column(db.String(10), nullable=True)
     actname = db.Column(db.Char(3), nullable=True)
     displayed = db.Column(db.Char(1), nullable=True)
     subname = db.Column(db.String(13), nullable=True, primary_key=True)
     nbpg = db.Column(db.Integer(11), nullable=True, primary_key=True,
-                autoincrement=False)
+                     autoincrement=False)
     cd = db.Column(db.Date, nullable=True)
     md = db.Column(db.Date, nullable=True)
     buttonorder = db.Column(db.Integer(11), nullable=True)
@@ -319,52 +364,60 @@ class SbmIMPLEMENT(db.Model):
     stpage = db.Column(db.Integer(11), nullable=False, server_default='0')
     endtxt = db.Column(db.String(100), nullable=False, server_default='')
 
+
 class SbmPARAMETERS(db.Model):
+
     """Represents a SbmPARAMETERS record."""
+
     __tablename__ = 'sbmPARAMETERS'
     doctype = db.Column(db.String(10), nullable=False,
-                server_default='', primary_key=True)
+                        server_default='', primary_key=True)
     name = db.Column(db.String(40), nullable=False,
-                server_default='', primary_key=True)
+                     server_default='', primary_key=True)
     value = db.Column(db.Text, nullable=False)
 
+
 class SbmPUBLICATION(db.Model):
+
     """Represents a SbmPUBLICATION record."""
+
     __tablename__ = 'sbmPUBLICATION'
     doctype = db.Column(db.String(10), nullable=False,
-                server_default='', primary_key=True)
+                        server_default='', primary_key=True)
     categ = db.Column(db.String(50), nullable=False,
-                server_default='', primary_key=True)
+                      server_default='', primary_key=True)
     rn = db.Column(db.String(50), nullable=False, server_default='',
-                primary_key=True)
+                   primary_key=True)
     status = db.Column(db.String(10), nullable=False, server_default='')
     dFirstReq = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                          server_default='1900-01-01 00:00:00')
     dLastReq = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                         server_default='1900-01-01 00:00:00')
     dAction = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                        server_default='1900-01-01 00:00:00')
     accessref = db.Column(db.String(20), nullable=False, server_default='')
     accessedi = db.Column(db.String(20), nullable=False, server_default='')
     access = db.Column(db.String(20), nullable=False, server_default='')
     referees = db.Column(db.String(50), nullable=False, server_default='')
     authoremail = db.Column(db.String(50), nullable=False,
-                server_default='')
+                            server_default='')
     dRefSelection = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                              server_default='1900-01-01 00:00:00')
     dRefRec = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                        server_default='1900-01-01 00:00:00')
     dEdiRec = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                        server_default='1900-01-01 00:00:00')
     accessspo = db.Column(db.String(20), nullable=False, server_default='')
     journal = db.Column(db.String(100), nullable=True)
 
 
 class SbmPUBLICATIONCOMM(db.Model):
+
     """Represents a SbmPUBLICATIONCOMM record."""
+
     __tablename__ = 'sbmPUBLICATIONCOMM'
     id = db.Column(db.Integer(11), nullable=False,
-                primary_key=True, autoincrement=True)
+                   primary_key=True, autoincrement=True)
     id_parent = db.Column(db.Integer(11), server_default='0', nullable=True)
     rn = db.Column(db.String(100), nullable=False, server_default='')
     firstname = db.Column(db.String(100), nullable=True)
@@ -376,47 +429,55 @@ class SbmPUBLICATIONCOMM(db.Model):
 
 
 class SbmPUBLICATIONDATA(db.Model):
+
     """Represents a SbmPUBLICATIONDATA record."""
+
     __tablename__ = 'sbmPUBLICATIONDATA'
     doctype = db.Column(db.String(10), nullable=False,
-                server_default='', primary_key=True)
+                        server_default='', primary_key=True)
     editoboard = db.Column(db.String(250), nullable=False, server_default='')
     base = db.Column(db.String(10), nullable=False, server_default='')
     logicalbase = db.Column(db.String(10), nullable=False, server_default='')
     spokesperson = db.Column(db.String(50), nullable=False, server_default='')
 
+
 class SbmREFEREES(db.Model):
+
     """Represents a SbmREFEREES record."""
+
     __tablename__ = 'sbmREFEREES'
     doctype = db.Column(db.String(10), nullable=False, server_default='')
     categ = db.Column(db.String(10), nullable=False, server_default='')
     name = db.Column(db.String(50), nullable=False, server_default='')
     address = db.Column(db.String(50), nullable=False, server_default='')
     rid = db.Column(db.Integer(11), nullable=False, primary_key=True,
-                autoincrement=True)
+                    autoincrement=True)
+
 
 class SbmSUBMISSIONS(db.Model):
+
     """Represents a SbmSUBMISSIONS record."""
+
     __tablename__ = 'sbmSUBMISSIONS'
     email = db.Column(db.String(50), nullable=False,
-                server_default='')
+                      server_default='')
     doctype = db.Column(db.String(10), nullable=False,
-                server_default='')
+                        server_default='')
     action = db.Column(db.String(10), nullable=False,
-                server_default='')
+                       server_default='')
     status = db.Column(db.String(10), nullable=False,
-                server_default='')
+                       server_default='')
     id = db.Column(db.String(30), nullable=False,
-                server_default='')
+                   server_default='')
     reference = db.Column(db.String(40), nullable=False,
-                server_default='')
+                          server_default='')
     cd = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                   server_default='1900-01-01 00:00:00')
     md = db.Column(db.DateTime, nullable=False,
-                server_default='1900-01-01 00:00:00')
+                   server_default='1900-01-01 00:00:00')
     log_id = db.Column(db.Integer(11), nullable=False,
-                primary_key=True,
-                autoincrement=True)
+                       primary_key=True,
+                       autoincrement=True)
 
 
 __all__ = ['SbmACTION',

--- a/invenio/modules/submit/models.py
+++ b/invenio/modules/submit/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2011, 2012 CERN.
+# Copyright (C) 2011, 2012, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -102,12 +102,39 @@ class SbmCOLLECTION(db.Model):
 class SbmCOLLECTIONSbmCOLLECTION(db.Model):
     """Represents a SbmCOLLECTIONSbmCOLLECTION record."""
     __tablename__ = 'sbmCOLLECTION_sbmCOLLECTION'
-    id_father = db.Column(db.Integer(11), db.ForeignKey(SbmCOLLECTION.id),
-                nullable=False, server_default='0', primary_key=True)
+
+    id = db.Column(db.Integer(11), nullable=False, autoincrement=True,
+                   primary_key=True)
+    _id_father = db.Column(db.Integer(11), db.ForeignKey(SbmCOLLECTION.id),
+                nullable=True, name='id_father')
     id_son = db.Column(db.Integer(11), db.ForeignKey(SbmCOLLECTION.id),
-                nullable=False, server_default='0', primary_key=True)
+                nullable=False)
     catalogue_order = db.Column(db.Integer(11), nullable=False,
                 server_default='0')
+
+    son = db.relationship(
+        SbmCOLLECTION,
+        backref=db.backref('father', uselist=False),
+        single_parent=True,
+        primaryjoin="and_(SbmCOLLECTIONSbmCOLLECTION.id_son==SbmCOLLECTION.id) "
+    )
+    father = db.relationship(
+        SbmCOLLECTION,
+        backref=db.backref('son', uselist=False),
+        single_parent=True,
+        primaryjoin="and_(SbmCOLLECTIONSbmCOLLECTION.id_father==SbmCOLLECTION.id) "
+    )
+
+    @db.hybrid_property
+    def id_father(self):
+        """Get id_father."""
+        return self._id_father
+
+    @id_father.setter
+    def id_father(self, value):
+        """Set id_father."""
+        self._id_father = value or None
+
 
 class SbmDOCTYPE(db.Model):
     """Represents a SbmDOCTYPE record."""
@@ -123,12 +150,30 @@ class SbmDOCTYPE(db.Model):
 class SbmCOLLECTIONSbmDOCTYPE(db.Model):
     """Represents a SbmCOLLECTIONSbmDOCTYPE record."""
     __tablename__ = 'sbmCOLLECTION_sbmDOCTYPE'
-    id_father = db.Column(db.Integer(11), db.ForeignKey(SbmCOLLECTION.id),
-                nullable=False, server_default='0', primary_key=True)
+    id = db.Column(db.Integer(11), nullable=False, autoincrement=True,
+                   primary_key=True)
+    _id_father = db.Column(db.Integer(11), db.ForeignKey(SbmCOLLECTION.id),
+                nullable=True, name="id_father")
     id_son = db.Column(db.Char(10), db.ForeignKey(SbmDOCTYPE.sdocname),
-                nullable=False, server_default='0', primary_key=True)
+                nullable=False)
     catalogue_order = db.Column(db.Integer(11), nullable=False,
                 server_default='0')
+
+    father = db.relationship(
+        SbmCOLLECTION,
+        backref=db.backref('sonDoctype', uselist=False),
+    )
+
+    @db.hybrid_property
+    def id_father(self):
+        """Get id_father."""
+        return self._id_father
+
+    @id_father.setter
+    def id_father(self, value):
+        """Set id_father."""
+        self._id_father = value or None
+
 
 class SbmCOOKIES(db.Model):
     """Represents a SbmCOOKIES record."""

--- a/invenio/modules/submit/upgrades/__init__.py
+++ b/invenio/modules/submit/upgrades/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
-##
-## This file is part of Invenio.
-## Copyright (C) 2015 CERN.
-##
-## Invenio is free software; you can redistribute it and/or
-## modify it under the terms of the GNU General Public License as
-## published by the Free Software Foundation; either version 2 of the
-## License, or (at your option) any later version.
-##
-## Invenio is distributed in the hope that it will be useful, but
-## WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Invenio; if not, write to the Free Software Foundation, Inc.,
-## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Upgrade Submit models."""

--- a/invenio/modules/submit/upgrades/__init__.py
+++ b/invenio/modules/submit/upgrades/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2015 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Upgrade Submit models."""

--- a/invenio/modules/submit/upgrades/submit_2015_03_03_fix_models.py
+++ b/invenio/modules/submit/upgrades/submit_2015_03_03_fix_models.py
@@ -1,21 +1,21 @@
 # -*- coding: utf-8 -*-
-##
-## This file is part of Invenio.
-## Copyright (C) 2015 CERN.
-##
-## Invenio is free software; you can redistribute it and/or
-## modify it under the terms of the GNU General Public License as
-## published by the Free Software Foundation; either version 2 of the
-## License, or (at your option) any later version.
-##
-## Invenio is distributed in the hope that it will be useful, but
-## WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Invenio; if not, write to the Free Software Foundation, Inc.,
-## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Upgrade Submit models."""
 

--- a/invenio/modules/submit/upgrades/submit_2015_03_03_fix_models.py
+++ b/invenio/modules/submit/upgrades/submit_2015_03_03_fix_models.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2015 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Upgrade Submit models."""
+
+from invenio.ext.sqlalchemy import db
+from invenio.legacy.dbquery import run_sql
+from invenio.modules.upgrader.api import op
+
+depends_on = ['invenio_release_1_1_0']
+
+
+def info():
+    """Info."""
+    return "Add a autoincrement id in sbmCOLLECTION_sbmDOCTYPE " + \
+        "and sbmCOLLECTION_sbmCOLLECTION table"
+
+
+def do_upgrade():
+    """Implement your upgrades here."""
+    # Table sbmCOLLECTION_sbmCOLLECTION
+
+    # add column "id" in the table
+    op.add_column('sbmCOLLECTION_sbmCOLLECTION',
+                  db.Column('id', db.Integer(11), nullable=False))
+
+    # set all new ids
+    records = run_sql("""SELECT id_father, id_son FROM sbmCOLLECTION_sbmCOLLECTION AS ssc
+                      ORDER BY ssc.id_father, ssc.id_son""")
+    for index, rec in enumerate(records):
+        run_sql("""UPDATE sbmCOLLECTION_sbmCOLLECTION
+                SET id = %s WHERE id_father = %s AND id_son = %s """,
+                (index + 1, rec[0], rec[1]))
+
+    # drop primary keys
+    op.drop_constraint(None, 'sbmCOLLECTION_sbmCOLLECTION',
+                       type_='primary')
+    # create new primary key with id
+    op.create_primary_key('pk_sbmCOLLECTION_sbmCOLLECTION_id',
+                          'sbmCOLLECTION_sbmCOLLECTION', ['id'])
+    # set id as autoincrement
+    op.alter_column('sbmCOLLECTION_sbmCOLLECTION', 'id',
+                    existing_type=db.Integer(11),
+                    existing_nullable=False, autoincrement=True)
+    # fix columns id_father and id_son
+    op.alter_column('sbmCOLLECTION_sbmCOLLECTION', 'id_father',
+                    existing_type=db.Integer(11),
+                    nullable=True, server_default=None)
+    op.alter_column('sbmCOLLECTION_sbmCOLLECTION', 'id_son',
+                    existing_type=db.Integer(11),
+                    nullable=False, server_default=None)
+    op.create_index('id_father', 'sbmCOLLECTION_sbmCOLLECTION',
+                    columns=['id_father'])
+
+    # Table sbmCOLLECTION_sbmDOCTYPE
+
+    # add column "id" in the table
+    op.add_column('sbmCOLLECTION_sbmDOCTYPE',
+                  db.Column('id', db.Integer(11), nullable=False))
+
+    # set all new ids
+    records = run_sql("""SELECT id_father, id_son
+                      FROM sbmCOLLECTION_sbmDOCTYPE AS ssd
+                      ORDER BY ssd.id_father, ssd.id_son""")
+    for index, rec in enumerate(records):
+        run_sql("""UPDATE sbmCOLLECTION_sbmDOCTYPE
+                SET id = %s WHERE id_father = %s AND id_son = %s """,
+                (index + 1, rec[0], rec[1]))
+
+    # drop primary keys
+    op.drop_constraint('id_father', 'sbmCOLLECTION_sbmDOCTYPE', type_='primary')
+    # create new primary key with id
+    op.create_primary_key('pk_sbmCOLLECTION_sbmDOCTYPE_id',
+                          'sbmCOLLECTION_sbmDOCTYPE', ['id'])
+    # set id as autoincrement
+    op.alter_column('sbmCOLLECTION_sbmDOCTYPE', 'id',
+                    existing_type=db.Integer(11),
+                    existing_nullable=False, autoincrement=True)
+    # fix columns id_father and id_son
+    op.alter_column('sbmCOLLECTION_sbmDOCTYPE', 'id_father',
+                    existing_type=db.Integer(11),
+                    nullable=True, server_default=None)
+    op.alter_column('sbmCOLLECTION_sbmDOCTYPE', 'id_son',
+                    existing_type=db.Char(10),
+                    nullable=False, server_default=None)
+    op.create_index('id_father', 'sbmCOLLECTION_sbmDOCTYPE',
+                    columns=['id_father'])
+
+
+def estimate():
+    """Estimate running time of upgrade in seconds (optional)."""
+    num_ssc = run_sql("SELECT count(*) FROM sbmCOLLECTION_sbmCOLLECTION")
+    num_ssd = run_sql("SELECT count(*) FROM sbmCOLLECTION_sbmDOCTYPE")
+    total = int(num_ssc[0][0]) + int(num_ssd[0][0])
+    return int(float(total) / 1000) + 1
+
+
+def pre_upgrade():
+    """Run pre-upgrade checks (optional)."""
+    # Example of raising errors:
+    # raise RuntimeError("Description of error 1", "Description of error 2")
+
+
+def post_upgrade():
+    """Run post-upgrade checks (optional)."""
+    # Example of issuing warnings:
+    # warnings.warn("A continuable error occurred")


### PR DESCRIPTION
* Fixes id_father foreign keys to support Null value.

* Removes invalid default values.

* PEP8/257 fixes.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>