### PR TITLE
global: refactored `CFG` variables

### DIFF
--- a/invenio/base/config.py
+++ b/invenio/base/config.py
@@ -24,6 +24,9 @@ from __future__ import unicode_literals
 import distutils.sysconfig
 from os.path import join
 
+from werkzeug import LocalProxy
+
+from invenio.utils.deprecation import deprecated, RemovedInInvenio22Warning
 from invenio.utils.shell import which
 from invenio.version import __version__
 
@@ -77,26 +80,39 @@ LEGACY_WEBINTERFACE_EXCLUDE = [
     'invenio.legacy.websubmit',
 ]
 
-CFG_PREFIX = distutils.sysconfig.get_config_var("prefix")
+_cfg_prefix = distutils.sysconfig.get_config_var("prefix")
 
-CFG_BATCHUPLOADER_DAEMON_DIR = join(CFG_PREFIX, "var", "batchupload")
-CFG_BIBDOCFILE_FILEDIR = join(CFG_PREFIX, "var", "data", "files")
-CFG_BINDIR = join(CFG_PREFIX, "bin")
-CFG_CACHEDIR = join(CFG_PREFIX, "var", "cache")
-CFG_ETCDIR = join(CFG_PREFIX, "etc")
-CFG_LOCALEDIR = join(CFG_PREFIX, "share", "locale")
-CFG_LOGDIR = join(CFG_PREFIX, "var", "log")
-CFG_RUNDIR = join(CFG_PREFIX, "var", "run")
-CFG_PYLIBDIR = join(CFG_PREFIX, "lib", "python")
-CFG_TMPDIR = join(CFG_PREFIX, "var", "tmp")
-CFG_TMPSHAREDDIR = join(CFG_PREFIX, "var", "tmp-shared")
-CFG_WEBDIR = join(CFG_PREFIX, "var", "www")
-CFG_WEBSUBMIT_BIBCONVERTCONFIGDIR = join(CFG_PREFIX, "etc", "bibconvert", "config")
-CFG_WEBSUBMIT_COUNTERSDIR = join(CFG_PREFIX, "var", "data", "submit", "counters")
-CFG_WEBSUBMIT_STORAGEDIR = join(CFG_PREFIX, "var", "data", "submit", "storage")
-CFG_BIBEDIT_CACHEDIR = join(CFG_PREFIX, "var", "tmp-shared", "bibedit-cache")
 
-#FIXME check the usage and replace by SQLALCHEMY_URL
+@deprecated(
+    'Use a more specific variable from invenio/base/config.py instead',
+    RemovedInInvenio22Warning)
+def _cfg_prefix_for_proxy():
+    return _cfg_prefix
+
+CFG_PREFIX = LocalProxy(_cfg_prefix_for_proxy)
+CFG_DATADIR = join(_cfg_prefix, 'var', 'data')
+CFG_BATCHUPLOADER_DAEMON_DIR = join(_cfg_prefix, "var", "batchupload")
+CFG_BATCHUPLOADER_DAEMON_DIR = CFG_BATCHUPLOADER_DAEMON_DIR[0] == '/' and CFG_BATCHUPLOADER_DAEMON_DIR \
+    or _cfg_prefix + '/' + CFG_BATCHUPLOADER_DAEMON_DIR
+CFG_BIBDOCFILE_FILEDIR = join(CFG_DATADIR, "files")
+CFG_BINDIR = join(_cfg_prefix, "bin")
+CFG_ETCDIR = join(_cfg_prefix, "etc")
+CFG_CACHEDIR = join(_cfg_prefix, "var", "cache")
+CFG_LOGDIR = join(_cfg_prefix, "var", "log")
+CFG_RUNDIR = join(_cfg_prefix, "var", "run")
+CFG_TMPDIR = join(_cfg_prefix, "var", "tmp")
+CFG_WEBDIR = join(_cfg_prefix, "var", "www")
+CFG_PYLIBDIR = join(_cfg_prefix, "lib", "python")
+CFG_LOCALEDIR = join(_cfg_prefix, "share", "locale")
+CFG_TMPSHAREDDIR = join(_cfg_prefix, "var", "tmp-shared")
+CFG_WEBSUBMIT_BIBCONVERTCONFIGDIR = join(_cfg_prefix, "etc", "bibconvert", "config")
+CFG_WEBSUBMIT_COUNTERSDIR = join(CFG_DATADIR, "submit", "counters")
+CFG_WEBSUBMIT_STORAGEDIR = join(CFG_DATADIR, "submit", "storage")
+CFG_BIBEDIT_CACHEDIR = join(_cfg_prefix, "var", "tmp-shared", "bibedit-cache")
+CFG_COMMENTSDIR = join(CFG_DATADIR, "comments")
+CFG_BASKETSDIR = join(CFG_DATADIR, "baskets")
+
+# FIXME check the usage and replace by SQLALCHEMY_URL
 CFG_DATABASE_HOST = "localhost"
 CFG_DATABASE_NAME = "invenio"
 CFG_DATABASE_PASS = "my123p$ss"
@@ -415,7 +431,7 @@ CFG_BIBSCHED_GC_TASKS_TO_ARCHIVE = ['bibupload', 'oairepositoryupdater', ]
 CFG_BIBSCHED_GC_TASKS_TO_REMOVE = [
     'bibindex', 'bibreformat', 'webcoll', 'bibrank', 'inveniogc', ]
 CFG_BIBSCHED_LOG_PAGER = which("less")
-CFG_BIBSCHED_LOGDIR = join(CFG_PREFIX, "var", "log", "bibsched")
+CFG_BIBSCHED_LOGDIR = join(_cfg_prefix, "var", "log", "bibsched")
 CFG_BIBSCHED_MAX_ARCHIVED_ROWS_DISPLAY = 500
 CFG_BIBSCHED_MAX_NUMBER_CONCURRENT_TASKS = 1
 CFG_BIBSCHED_NODE_TASKS = {}

--- a/invenio/base/scripts/config.py
+++ b/invenio/base/scripts/config.py
@@ -69,8 +69,8 @@ def get(name):
     """
     Return value of VARNAME read from CONF files.
 
-    Useful for third-party programs to access values of conf options such as
-    CFG_PREFIX.  Return None if VARNAME is not found.
+    Useful for third-party programs to access values of conf options.
+    Return None if VARNAME is not found.
 
     """
     try:

--- a/invenio/base/scripts/demosite.py
+++ b/invenio/base/scripts/demosite.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -80,7 +80,6 @@ def populate(packages=[], default_data=True, files=None,
         packages = ['invenio_demosite.base']
 
     from werkzeug.utils import import_string
-    from invenio.config import CFG_PREFIX
     map(import_string, packages)
 
     from invenio.ext.sqlalchemy import db
@@ -98,29 +97,28 @@ def populate(packages=[], default_data=True, files=None,
         bibupload_flags = '-i -r --force'
     for f in files:
         job_id += 1
-        for cmd in ["%s/bin/bibupload -u admin %s %s" % (CFG_PREFIX, bibupload_flags, f),
-                    "%s/bin/bibupload %d" % (CFG_PREFIX, job_id)]:
+        for cmd in ["bibupload -u admin %s %s" % (bibupload_flags, f),
+                    "bibupload %d" % (job_id)]:
             if os.system(cmd):
                 print("ERROR: failed execution of", cmd)
                 sys.exit(1)
 
-    i = count(1).next
-    for cmd in ["bin/bibdocfile --textify --with-ocr --recid 97",
-                "bin/bibdocfile --textify --all",
-                "bin/bibindex -u admin",
-                "bin/bibindex %d" % (job_id + i(),),
-                "bin/bibindex -u admin -w global",
-                "bin/bibindex %d" % (job_id + i(),),
-                "bin/bibreformat -u admin -o HB",
-                "bin/bibreformat %d" % (job_id + i(),),
-                "bin/bibrank -u admin",
-                "bin/bibrank %d" % (job_id + i(),),
-                "bin/bibsort -u admin -R",
-                "bin/bibsort %d" % (job_id + i(),),
-                "bin/oairepositoryupdater -u admin",
-                "bin/oairepositoryupdater %d" % (job_id + i(),),
-                "bin/bibupload %d" % (job_id + i(),)]:
-        cmd = os.path.join(CFG_PREFIX, cmd)
+    i = count(job_id).next
+    for cmd in ("bibdocfile --textify --with-ocr --recid 97",
+                "bibdocfile --textify --all",
+                "bibindex -u admin",
+                "bibindex %d" % i(),
+                "bibindex -u admin -w global",
+                "bibindex %d" % i(),
+                "bibreformat -u admin -o HB",
+                "bibreformat %d" % i(),
+                "bibrank -u admin",
+                "bibrank %d" % i(),
+                "bibsort -u admin -R",
+                "bibsort %d" % i(),
+                "oairepositoryupdater -u admin",
+                "oairepositoryupdater %d" % i(),
+                "bibupload %d" % i()):
         if os.system(cmd):
             print("ERROR: failed execution of", cmd)
             sys.exit(1)

--- a/invenio/base/scripts/demosite.py
+++ b/invenio/base/scripts/demosite.py
@@ -21,19 +21,23 @@
 
 from __future__ import print_function
 
+import os
+import sys
 import warnings
+from itertools import count
+
+import pkg_resources
+
+from invenio.base.utils import run_py_func
+from invenio.ext.script import Manager
+
 
 warnings.warn("Use of `inveniomanage demosite populate` is being deprecated. "
               "Please use `uploader` module to insert demo records.",
               PendingDeprecationWarning)
 
-import os
-import pkg_resources
-import sys
 
-from itertools import count
 
-from invenio.ext.script import Manager
 
 manager = Manager(usage=__doc__)
 
@@ -68,6 +72,15 @@ def populate(packages=[], default_data=True, files=None,
     """Load demo records.  Useful for testing purposes."""
     from invenio.utils.text import wrap_text_in_a_box, wait_for_user
 
+    # Load cli interfaces for tools that we are going to need
+    from invenio.legacy.bibupload.engine import main as bibupload
+    from invenio.legacy.bibindex.engine import main as bibindex
+    from invenio.legacy.bibformat.bibreformat import main as bibreformat
+    from invenio.legacy.oairepository.updater import main as oairepositoryupdater
+    from invenio.legacy.bibsort.daemon import main as bibsort
+    from invenio.legacy.bibdocfile.cli import main as bibdocfile
+    from invenio.legacy.bibrank.cli import main as bibrank
+
     ## Step 0: confirm deletion
     wait_for_user(wrap_text_in_a_box(
         "WARNING: You are going to override data in tables!"
@@ -97,30 +110,34 @@ def populate(packages=[], default_data=True, files=None,
         bibupload_flags = '-i -r --force'
     for f in files:
         job_id += 1
-        for cmd in ["bibupload -u admin %s %s" % (bibupload_flags, f),
-                    "bibupload %d" % (job_id)]:
-            if os.system(cmd):
-                print("ERROR: failed execution of", cmd)
+        for cmd in (
+            (bibupload, "bibupload -u admin %s %s" % (bibupload_flags, f)),
+            (bibupload, "bibupload %d" % (job_id))
+        ):
+            if run_py_func(*cmd, passthrough=True).exit_code:
+                print("ERROR: failed execution of", *cmd)
                 sys.exit(1)
 
-    i = count(job_id).next
-    for cmd in ("bibdocfile --textify --with-ocr --recid 97",
-                "bibdocfile --textify --all",
-                "bibindex -u admin",
-                "bibindex %d" % i(),
-                "bibindex -u admin -w global",
-                "bibindex %d" % i(),
-                "bibreformat -u admin -o HB",
-                "bibreformat %d" % i(),
-                "bibrank -u admin",
-                "bibrank %d" % i(),
-                "bibsort -u admin -R",
-                "bibsort %d" % i(),
-                "oairepositoryupdater -u admin",
-                "oairepositoryupdater %d" % i(),
-                "bibupload %d" % i()):
-        if os.system(cmd):
-            print("ERROR: failed execution of", cmd)
+    i = count(job_id + 1).next
+    for cmd in (
+        (bibdocfile, "bibdocfile --textify --with-ocr --recid 97"),
+        (bibdocfile, "bibdocfile --textify --all"),
+        (bibindex, "bibindex -u admin"),
+        (bibindex, "bibindex %d" % i()),
+        (bibindex, "bibindex -u admin -w global"),
+        (bibindex, "bibindex %d" % i()),
+        (bibreformat, "bibreformat -u admin -o HB"),
+        (bibreformat, "bibreformat %d" % i()),
+        (bibrank, "bibrank -u admin"),
+        (bibrank, "bibrank %d" % i()),
+        (bibsort, "bibsort -u admin -R"),
+        (bibsort, "bibsort %d" % i()),
+        (oairepositoryupdater, "oairepositoryupdater -u admin"),
+        (oairepositoryupdater, "oairepositoryupdater %d" % i()),
+        (bibupload, "bibupload %d" % i()),
+    ):
+        if run_py_func(*cmd, passthrough=True).exit_code:
+            print("ERROR: failed execution of", *cmd)
             sys.exit(1)
     print(">>> Demo records loaded successfully.")
 

--- a/invenio/base/utils.py
+++ b/invenio/base/utils.py
@@ -27,7 +27,7 @@ import sys
 import warnings
 
 from collections import namedtuple
-import StringIO
+from six import StringIO
 import logging
 import shlex
 import six
@@ -262,8 +262,8 @@ def run_py_func(manager_run, command_line, passthrough=False):
     """
     sys_stderr_orig = sys.stderr
     sys_stdout_orig = sys.stdout
-    sys.stdout = StringIO.StringIO()
-    sys.stderr = StringIO.StringIO()
+    sys.stdout = StringIO()
+    sys.stderr = StringIO()
     sys_argv_orig = sys.argv
 
     formatter = logging.Formatter('%(message)s', '')

--- a/invenio/ext/legacy/__init__.py
+++ b/invenio/ext/legacy/__init__.py
@@ -38,7 +38,6 @@ from .request_class import LegacyRequest
 
 def cli_cmd_reset(sender, yes_i_know=False, drop=True, **kwargs):
     """Reset legacy values."""
-    from invenio.config import CFG_PREFIX
     from invenio.ext.sqlalchemy import db
     from invenio.modules.accounts.models import User
     # from invenio.legacy.inveniocfg import cli_cmd_reset_sitename
@@ -53,9 +52,9 @@ def cli_cmd_reset(sender, yes_i_know=False, drop=True, **kwargs):
     db.session.commit()
     # cli_cmd_reset_fieldnames(conf)
 
-    for cmd in ["%s/bin/webaccessadmin -u admin -c -a -D" % CFG_PREFIX,
-                "%s/bin/bibsort -u admin --load-config" % CFG_PREFIX,
-                "%s/bin/bibsort 1" % CFG_PREFIX, ]:
+    for cmd in ("webaccessadmin -u admin -c -a -D",
+                "bibsort -u admin --load-config",
+                "bibsort 1"):
         if os.system(cmd):
             print("ERROR: failed execution of", cmd)
             sys.exit(1)

--- a/invenio/ext/logging/__init__.py
+++ b/invenio/ext/logging/__init__.py
@@ -157,9 +157,6 @@ Please follow Invenio :ref:`deprecationpolicy` section.
 from __future__ import absolute_import
 
 import logging
-import warnings
-
-from functools import wraps
 
 from .wrappers import get_pretty_traceback, register_exception
 
@@ -171,21 +168,3 @@ def setup_app(app):
         logger = logging.getLogger('py.warnings')
         logger.addHandler(logging.StreamHandler())
         logger.setLevel(logging.WARNING)
-
-
-# Improved version of http://code.activestate.com/recipes/391367-deprecated/
-def deprecated(message, category=DeprecationWarning):
-    def wrap(func):
-        """Decorator which can be used to mark functions as deprecated.
-
-        :param message: text to include in the warning
-        :param category: warning category
-        """
-        @wraps(func)
-        def new_func(*args, **kwargs):
-            warnings.warn(message, category, stacklevel=3)
-            return func(*args, **kwargs)
-        return new_func
-    return wrap
-
-__all__ = ('register_exception', 'get_pretty_traceback')

--- a/invenio/legacy/batchuploader/cli.py
+++ b/invenio/legacy/batchuploader/cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2010, 2011, 2013 CERN.
+# Copyright (C) 2010, 2011, 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -35,8 +35,7 @@ import tempfile
 import shutil
 from invenio.config import (CFG_TMPSHAREDDIR,
                             CFG_BATCHUPLOADER_DAEMON_DIR,
-                            CFG_BATCHUPLOADER_FILENAME_MATCHING_POLICY,
-                            CFG_PREFIX)
+                            CFG_BATCHUPLOADER_FILENAME_MATCHING_POLICY)
 from invenio.legacy.bibsched.bibtask import (
     task_init,
     task_set_option,
@@ -67,12 +66,10 @@ def task_run_core():
         and uploads them.
         Files are then moved to the corresponding DONE folders.
     """
-    daemon_dir = CFG_BATCHUPLOADER_DAEMON_DIR[0] == '/' and CFG_BATCHUPLOADER_DAEMON_DIR \
-                 or CFG_PREFIX + '/' + CFG_BATCHUPLOADER_DAEMON_DIR
     # Check if directory /batchupload exists
     if not task_get_option('documents'):
         # Metadata upload
-        parent_dir = daemon_dir + "/metadata/"
+        parent_dir = os.path.join(CFG_BATCHUPLOADER_DAEMON_DIR, "metadata/")
         progress = 0
         try:
             os.makedirs(parent_dir)

--- a/invenio/legacy/batchuploader/engine.py
+++ b/invenio/legacy/batchuploader/engine.py
@@ -38,7 +38,7 @@ from invenio.config import CFG_BINDIR, CFG_TMPSHAREDDIR, CFG_LOGDIR, \
                             CFG_OAI_ID_FIELD, CFG_BATCHUPLOADER_DAEMON_DIR, \
                             CFG_BATCHUPLOADER_WEB_ROBOT_RIGHTS, \
                             CFG_BATCHUPLOADER_WEB_ROBOT_AGENTS, \
-                            CFG_PREFIX, CFG_SITE_LANG
+                            CFG_SITE_LANG
 from invenio.utils.text import encode_for_xml
 from invenio.legacy.bibsched.bibtask import task_low_level_submission
 from invenio.base.i18n import gettext_set_language
@@ -400,9 +400,7 @@ def get_daemon_doc_files():
     files = {}
     for folder in ['/revise', '/append']:
         try:
-            daemon_dir = CFG_BATCHUPLOADER_DAEMON_DIR[0] == '/' and CFG_BATCHUPLOADER_DAEMON_DIR \
-                         or CFG_PREFIX + '/' + CFG_BATCHUPLOADER_DAEMON_DIR
-            directory = daemon_dir + '/documents' + folder
+            directory = os.path.join(CFG_BATCHUPLOADER_DAEMON_DIR, 'documents', folder)
             files[directory] = [(filename, []) for filename in os.listdir(directory) if os.path.isfile(os.path.join(directory, filename))]
             for file_instance, info in files[directory]:
                 stat_info = os.lstat(os.path.join(directory, file_instance))
@@ -421,9 +419,7 @@ def get_daemon_meta_files():
     files = {}
     for folder in ['/correct', '/replace', '/insert', '/append']:
         try:
-            daemon_dir = CFG_BATCHUPLOADER_DAEMON_DIR[0] == '/' and CFG_BATCHUPLOADER_DAEMON_DIR \
-                         or CFG_PREFIX + '/' + CFG_BATCHUPLOADER_DAEMON_DIR
-            directory = daemon_dir + '/metadata' + folder
+            directory = os.path.join(CFG_BATCHUPLOADER_DAEMON_DIR, 'metadata', folder)
             files[directory] = [(filename, []) for filename in os.listdir(directory) if os.path.isfile(os.path.join(directory, filename))]
             for file_instance, info in files[directory]:
                 stat_info = os.lstat(os.path.join(directory, file_instance))

--- a/invenio/legacy/bibsched/bibtask.py
+++ b/invenio/legacy/bibsched/bibtask.py
@@ -969,7 +969,7 @@ def authenticate(user, authorization_action, authorization_msg=""):
             if not CFG_EXTERNAL_AUTHENTICATION[login_method]:
                 try:
                     u = User.query.filter_by(id=uid).one()
-                    if u.verify_password(password_entered, migrate=Tru):
+                    if u.verify_password(password_entered, migrate=True):
                         ok = True
                 except Exception:
                     pass

--- a/invenio/legacy/bibsched/bibtask.py
+++ b/invenio/legacy/bibsched/bibtask.py
@@ -23,7 +23,7 @@ from __future__ import print_function
 
 BibTask class.
 
-A BibTask is an executable under CFG_BINDIR, whose name is stored in
+A BibTask is a resolvable executable, whose name is stored in
 bibtask_config.CFG_BIBTASK_VALID_TASKS.
 A valid task must call the task_init function with the proper parameters.
 Generic task related parameters (user, sleeptime, runtime, task_id, task_name
@@ -66,8 +66,6 @@ from invenio.legacy.dbquery import run_sql, _db_login
 from invenio.modules.accounts.models import User
 from invenio.modules.access.engine import acc_authorize_action
 from invenio.config import (
-    CFG_PREFIX,
-    CFG_BINDIR,
     CFG_BIBSCHED_PROCESS_USER,
     CFG_TMPDIR,
     CFG_SITE_SUPPORT_EMAIL,
@@ -156,8 +154,7 @@ def get_sleeptime(argv):
 
 def task_low_level_submission(name, user, *argv):
     """Let special lowlevel enqueuing of a task on the bibsche queue.
-    @param name: is the name of the bibtask. It must be a valid executable under
-        C{CFG_BINDIR}.
+    @param name: is the name of the bibtask. It must be a valid executable.
     @type name: string
     @param user: is a string that will appear as the "user" submitting the task.
         Since task are submitted via API it make sense to set the
@@ -302,7 +299,7 @@ def task_low_level_submission(name, user, *argv):
         sleeptime = get_sleeptime(argv)
         sequenceid = get_sequenceid(argv)
         host = get_host(argv)
-        argv = tuple([os.path.join(CFG_BINDIR, name)] + list(argv))
+        argv = tuple([name] + list(argv))
 
         if special_name:
             name = '%s:%s' % (name, special_name)
@@ -513,7 +510,7 @@ def task_init(authorization_action="",
     setup_loggers(_TASK_PARAMS.get('task_id'))
 
     task_name = os.path.basename(sys.argv[0])
-    if task_name not in CFG_BIBTASK_VALID_TASKS or os.path.realpath(os.path.join(CFG_BINDIR, task_name)) != os.path.realpath(sys.argv[0]):
+    if task_name not in CFG_BIBTASK_VALID_TASKS:
         raise OSError("%s is not in the allowed modules" % sys.argv[0])
 
     from invenio.base.factory import configure_warnings

--- a/invenio/legacy/bibsched/cli.py
+++ b/invenio/legacy/bibsched/cli.py
@@ -39,7 +39,6 @@ from invenio.legacy.bibsched.bibtask_config import \
     CFG_BIBTASK_MONOTASKS, \
     CFG_BIBTASK_FIXEDTIMETASKS
 from invenio.config import \
-    CFG_PREFIX, \
     CFG_TMPSHAREDDIR, \
     CFG_BIBSCHED_REFRESHTIME, \
     CFG_BINDIR, \
@@ -204,7 +203,7 @@ def get_my_pid(process, args=''):
 def get_task_pid(task_id):
     """Return the pid of task_name/task_id"""
     try:
-        path = os.path.join(CFG_PREFIX, 'var', 'run', 'bibsched_task_%d.pid' % task_id)
+        path = os.path.join(CFG_RUNDIR, 'bibsched_task_%d.pid' % task_id)
         pid = int(open(path).read())
         os.kill(pid, 0)
         return pid

--- a/invenio/legacy/ckeditor/connector.py
+++ b/invenio/legacy/ckeditor/connector.py
@@ -2,7 +2,7 @@
 # Comments and reviews for records.
 
 # This file is part of Invenio.
-# Copyright (C) 2008, 2010, 2011 CERN.
+# Copyright (C) 2008, 2010, 2011, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -53,7 +53,7 @@ def process_CKEditor_upload(form, uid, user_files_path, user_files_absolute_path
     @type user_files_path: string
     @param user_files_absolute_path: the base path on the server where
         the files should be saved.
-        Eg:C{%(CFG_PREFIX)s/var/data/comments/%(recid)s/%(uid)s}
+        Eg:C{%(CFG_DATADIR)s/comments/%(recid)s/%(uid)s}
     @type user_files_absolute_path: string
     @param recid: the record ID for which we upload a file. Leave None if not relevant.
     @type recid: int

--- a/invenio/legacy/webbasket/webinterface.py
+++ b/invenio/legacy/webbasket/webinterface.py
@@ -33,6 +33,7 @@ from invenio.base.globals import cfg
 from invenio.base.i18n import gettext_set_language
 from invenio.legacy.webpage import page
 from invenio.legacy.webuser import getUid, page_not_authorized, isGuestUser
+from invenio.config import CFG_BASKETSDIR
 from invenio.legacy.webbasket.api import \
      check_user_can_comment, \
      check_sufficient_rights, \
@@ -176,7 +177,7 @@ class WebInterfaceBasketCommentsFiles(WebInterfaceDirectory):
 
             # Check that we are really accessing attachements
             # directory, for the declared basket and record.
-            if path.startswith(os.path.join(CFG_BASKETDIR, 'comments',
+            if path.startswith(os.path.join(CFG_BASKETSDIR, 'comments',
                                str(argd['bskid']), str(argd['recid']))) and \
                                os.path.exists(path):
                 return stream_file(req, path)

--- a/invenio/legacy/webbasket/webinterface.py
+++ b/invenio/legacy/webbasket/webinterface.py
@@ -170,15 +170,14 @@ class WebInterfaceBasketCommentsFiles(WebInterfaceDirectory):
         if not argd['file'] is None:
             # Prepare path to file on disk. Normalize the path so that
             # ../ and other dangerous components are removed.
-            path = os.path.abspath(CFG_PREFIX + '/var/data/baskets/comments/' + \
-                                   str(argd['bskid']) + '/'  + str(argd['recid']) + '/' + \
-                                   str(argd['uid']) + '/' + argd['type'] + '/' + \
-                                   argd['file'])
+            path = os.path.abspath(os.path.join(CFG_BASKETSDIR, 'comments',
+                                   str(argd['bskid']), str(argd['recid']),
+                                   str(argd['uid']), argd['type'], argd['file']))
 
             # Check that we are really accessing attachements
             # directory, for the declared basket and record.
-            if path.startswith(CFG_PREFIX + '/var/data/baskets/comments/' + \
-                               str(argd['bskid']) + '/' + str(argd['recid'])) and \
+            if path.startswith(os.path.join(CFG_BASKETDIR, 'comments',
+                               str(argd['bskid']), str(argd['recid']))) and \
                                os.path.exists(path):
                 return stream_file(req, path)
 

--- a/invenio/legacy/webcomment/webinterface.py
+++ b/invenio/legacy/webcomment/webinterface.py
@@ -59,7 +59,8 @@ from invenio.config import \
      CFG_SITE_RECORD, \
      CFG_WEBCOMMENT_MAX_ATTACHMENT_SIZE, \
      CFG_WEBCOMMENT_MAX_ATTACHED_FILES, \
-     CFG_ACCESS_CONTROL_LEVEL_SITE
+     CFG_ACCESS_CONTROL_LEVEL_SITE, \
+     CFG_COMMENTSDIR
 from invenio.legacy.webuser import getUid, page_not_authorized, isGuestUser, collect_user_info
 from invenio.legacy.webpage import page, pageheaderonly, pagefooteronly
 from invenio.legacy.search_engine import create_navtrail_links, \
@@ -863,7 +864,7 @@ class WebInterfaceCommentsFiles(WebInterfaceDirectory):
             # Check that we are really accessing attachements
             # directory, for the declared record.
             if path.startswith(os.path.join(CFG_COMMENTSDIR,
-                               str(self.recid))) and \
+                                            str(self.recid))) and \
                     os.path.exists(path):
                 return stream_file(req, path)
 

--- a/invenio/legacy/webcomment/webinterface.py
+++ b/invenio/legacy/webcomment/webinterface.py
@@ -2,7 +2,7 @@
 # Comments and reviews for records.
 
 # This file is part of Invenio.
-# Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2012, 2013 CERN.
+# Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2012, 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -47,22 +47,20 @@ from invenio.modules.comments.api import check_recID_is_in_range, \
     perform_display_your_comments
 
 from invenio.config import \
-    CFG_TMPSHAREDDIR, \
-    CFG_SITE_LANG, \
-    CFG_SITE_URL, \
-    CFG_SITE_SECURE_URL, \
-    CFG_PREFIX, \
-    CFG_SITE_NAME, \
-    CFG_SITE_NAME_INTL, \
-    CFG_WEBCOMMENT_ALLOW_COMMENTS,\
-    CFG_WEBCOMMENT_ALLOW_REVIEWS, \
-    CFG_WEBCOMMENT_USE_MATHJAX_IN_COMMENTS, \
-    CFG_SITE_RECORD, \
-    CFG_WEBCOMMENT_MAX_ATTACHMENT_SIZE, \
-    CFG_WEBCOMMENT_MAX_ATTACHED_FILES, \
-    CFG_ACCESS_CONTROL_LEVEL_SITE
-from invenio.legacy.webuser import getUid, page_not_authorized, isGuestUser, \
-    collect_user_info
+     CFG_TMPSHAREDDIR, \
+     CFG_SITE_LANG, \
+     CFG_SITE_URL, \
+     CFG_SITE_SECURE_URL, \
+     CFG_SITE_NAME, \
+     CFG_SITE_NAME_INTL, \
+     CFG_WEBCOMMENT_ALLOW_COMMENTS,\
+     CFG_WEBCOMMENT_ALLOW_REVIEWS, \
+     CFG_WEBCOMMENT_USE_MATHJAX_IN_COMMENTS, \
+     CFG_SITE_RECORD, \
+     CFG_WEBCOMMENT_MAX_ATTACHMENT_SIZE, \
+     CFG_WEBCOMMENT_MAX_ATTACHED_FILES, \
+     CFG_ACCESS_CONTROL_LEVEL_SITE
+from invenio.legacy.webuser import getUid, page_not_authorized, isGuestUser, collect_user_info
 from invenio.legacy.webpage import page, pageheaderonly, pagefooteronly
 from invenio.legacy.search_engine import create_navtrail_links, \
     guess_primary_collection_of_a_record
@@ -857,15 +855,16 @@ class WebInterfaceCommentsFiles(WebInterfaceDirectory):
         if not argd['file'] is None:
             # Prepare path to file on disk. Normalize the path so that
             # ../ and other dangerous components are removed.
-            path = os.path.abspath(CFG_PREFIX + '/var/data/comments/' + \
-                                   str(self.recid) + '/'  + str(argd['comid']) + \
-                                   '/' + argd['file'])
+            path = os.path.abspath(os.path.join(CFG_COMMENTSDIR,
+                                                str(self.recid),
+                                                str(argd['comid']),
+                                                argd['file']))
 
             # Check that we are really accessing attachements
             # directory, for the declared record.
-            if path.startswith(CFG_PREFIX + '/var/data/comments/' + \
-                               str(self.recid)) and \
-                   os.path.exists(path):
+            if path.startswith(os.path.join(CFG_COMMENTSDIR,
+                               str(self.recid))) and \
+                    os.path.exists(path):
                 return stream_file(req, path)
 
         # Send error 404 in all other cases

--- a/invenio/legacy/webdoc/api.py
+++ b/invenio/legacy/webdoc/api.py
@@ -30,7 +30,7 @@ from six import iteritems
 from . import registry
 
 from invenio.config import \
-     CFG_PREFIX, \
+     CFG_LOCALEDIR, \
      CFG_SITE_LANG, \
      CFG_SITE_LANGS, \
      CFG_SITE_NAME, \
@@ -739,7 +739,8 @@ def get_mo_last_modification():
     """
     # Take one of the mo files. They are all installed at the same
     # time, so last modication date should be the same
-    mo_file = '%s/share/locale/%s/LC_MESSAGES/invenio.mo' % (CFG_PREFIX, CFG_SITE_LANG)
+    mo_file = os.path.join(CFG_LOCALEDIR, CFG_SITE_LANG, 'LC_MESSAGES',
+                           'invenio.mo')
 
     if os.path.exists(os.path.abspath(mo_file)):
         return os.stat(mo_file).st_mtime

--- a/invenio/legacy/websession/inveniogc.py
+++ b/invenio/legacy/websession/inveniogc.py
@@ -32,7 +32,7 @@ import os
 
 from invenio.legacy.dbquery import run_sql, wash_table_column_name
 from invenio.config import CFG_LOGDIR, CFG_TMPDIR, CFG_CACHEDIR, \
-        CFG_TMPSHAREDDIR, CFG_WEBSEARCH_RSS_TTL, CFG_PREFIX, \
+        CFG_TMPSHAREDDIR, CFG_WEBSEARCH_RSS_TTL, CFG_TMPDIR, \
         CFG_WEBSESSION_NOT_CONFIRMED_EMAIL_ADDRESS_EXPIRE_IN_DAYS, \
         CFG_INSPIRE_SITE
 from invenio.legacy.bibsched.bibtask import task_init, task_set_option, task_get_option, \
@@ -197,7 +197,7 @@ def clean_tempfiles():
     write_message("- deleting old temporary files attached with CKEditor")
     gc_exec_command('find %s/var/tmp/attachfile/ '
         ' -atime +%s -exec rm %s -f {} \;' \
-            % (CFG_PREFIX, CFG_MAX_ATIME_RM_WEBSUBMIT_CKEDITOR_FILE,
+            % (CFG_TMPDIR, CFG_MAX_ATIME_RM_WEBSUBMIT_CKEDITOR_FILE,
                vstr))
 
     write_message("- deleting old XML files submitted via BibEdit")

--- a/invenio/legacy/websubmit/admincli.py
+++ b/invenio/legacy/websubmit/admincli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010 CERN.
+# Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -74,7 +74,7 @@ import time
 import tempfile
 from MySQLdb.converters import conversions
 from MySQLdb import escape, escape_string
-from invenio.config import CFG_PREFIX, CFG_TMPDIR
+from invenio.config import CFG_TMPDIR
 from invenio.legacy.dbquery import run_sql
 from invenio.utils.shell import run_shell_command
 
@@ -240,7 +240,7 @@ def load_submission(doctype, dump, method=None):
         remove_submission(doctype, method)
 
     # Load the dump
-    (exit_code, out_msg, err_msg) = run_shell_command("%s/bin/dbexec < %s", (CFG_PREFIX, os.path.abspath(dump_path)))
+    (exit_code, out_msg, err_msg) = run_shell_command("dbexec < %s", (os.path.abspath(dump_path)))
     if exit_code:
         messages.append("ERROR: failed to load submission:" + err_msg)
         return (1, messages)

--- a/invenio/legacy/websubmit/functions/Move_CKEditor_Files_to_Storage.py
+++ b/invenio/legacy/websubmit/functions/Move_CKEditor_Files_to_Storage.py
@@ -84,7 +84,7 @@ def Move_CKEditor_Files_to_Storage(parameters, curdir, form, user_info=None):
                 # Does original file exists, or do we just have the
                 # icon? We expect the original file at a well defined
                 # location
-                possible_original_path = os.path.join(CFG_TMPDIR
+                possible_original_path = os.path.join(CFG_TMPDIR,
                                                       'attachfile',
                                                       uid,
                                                       file_type,

--- a/invenio/legacy/websubmit/functions/Move_CKEditor_Files_to_Storage.py
+++ b/invenio/legacy/websubmit/functions/Move_CKEditor_Files_to_Storage.py
@@ -1,5 +1,5 @@
 # This file is part of Invenio.
-# Copyright (C) 2009, 2010, 2011 CERN.
+# Copyright (C) 2009, 2010, 2011, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -27,7 +27,7 @@ from invenio.legacy.bibdocfile.api import decompose_file
 from invenio.config import \
      CFG_SITE_URL, \
      CFG_SITE_SECURE_URL, \
-     CFG_PREFIX, \
+     CFG_TMPDIR, \
      CFG_SITE_RECORD
 
 re_ckeditor_link = re.compile('"(' + CFG_SITE_URL + '|' + CFG_SITE_SECURE_URL + ')' + \
@@ -84,8 +84,7 @@ def Move_CKEditor_Files_to_Storage(parameters, curdir, form, user_info=None):
                 # Does original file exists, or do we just have the
                 # icon? We expect the original file at a well defined
                 # location
-                possible_original_path = os.path.join(CFG_PREFIX,
-                                                      'var', 'tmp',
+                possible_original_path = os.path.join(CFG_TMPDIR
                                                       'attachfile',
                                                       uid,
                                                       file_type,

--- a/invenio/legacy/websubmit/webinterface.py
+++ b/invenio/legacy/websubmit/webinterface.py
@@ -666,7 +666,7 @@ class WebInterfaceSubmitPages(WebInterfaceDirectory):
 
             # Check that we are really accessing attachements
             # directory, for the declared record.
-            if path.startswith(os.path.join(CFG_TMPDIR, 'attachfile/') and os.path.exists(path):
+            if path.startswith(os.path.join(CFG_TMPDIR, 'attachfile')) and os.path.exists(path):
                 return stream_file(req, path)
 
         # Send error 404 in all other cases

--- a/invenio/legacy/websubmit/webinterface.py
+++ b/invenio/legacy/websubmit/webinterface.py
@@ -1,5 +1,5 @@
 # This file is part of Invenio.
-# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
+# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -37,7 +37,7 @@ from invenio.config import \
      CFG_SITE_URL, \
      CFG_SITE_SECURE_URL, \
      CFG_WEBSUBMIT_STORAGEDIR, \
-     CFG_PREFIX, \
+     CFG_TMPDIR, \
      CFG_CERN_SITE
 from invenio.utils.crossref import get_marcxml_for_doi, CrossrefError
 from invenio.utils import apache
@@ -554,16 +554,10 @@ class WebInterfaceSubmitPages(WebInterfaceDirectory):
 
 
         # URL where the file can be fetched after upload
-        user_files_path = '%(CFG_SITE_URL)s/submit/getattachedfile/%(uid)s' % \
-                          {'uid': uid,
-                           'CFG_SITE_URL': CFG_SITE_URL,
-                           'filetype': filetype}
+        user_files_path = os.path.join(CFG_SITE_URL, 'submit', 'getattachedfile', uid)
 
         # Path to directory where uploaded files are saved
-        user_files_absolute_path = '%(CFG_PREFIX)s/var/tmp/attachfile/%(uid)s/%(filetype)s' % \
-                                   {'uid': uid,
-                                    'CFG_PREFIX': CFG_PREFIX,
-                                    'filetype': filetype}
+        user_files_absolute_path = os.path.join(CFG_TMPDIR, 'attachfile', uid, filetype)
         try:
             os.makedirs(user_files_absolute_path)
         except:
@@ -666,13 +660,13 @@ class WebInterfaceSubmitPages(WebInterfaceDirectory):
         if not argd['file'] is None:
             # Prepare path to file on disk. Normalize the path so that
             # ../ and other dangerous components are removed.
-            path = os.path.abspath(CFG_PREFIX + '/var/tmp/attachfile/' + \
-                                   '/'  + str(argd['uid']) + \
-                                   '/' + argd['type'] + '/' + argd['file'])
+            path = os.path.abspath(os.path.join(CFG_TMPDIR, 'attachfile',
+                                                str(argd['uid']),
+                                                argd['type'], argd['file']))
 
             # Check that we are really accessing attachements
             # directory, for the declared record.
-            if path.startswith(CFG_PREFIX + '/var/tmp/attachfile/') and os.path.exists(path):
+            if path.startswith(os.path.join(CFG_TMPDIR, 'attachfile/') and os.path.exists(path):
                 return stream_file(req, path)
 
         # Send error 404 in all other cases

--- a/invenio/modules/comments/api.py
+++ b/invenio/modules/comments/api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is part of Invenio.
-# Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2012, 2013, 2014 CERN.
+# Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2012, 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -34,7 +34,7 @@ from six import iteritems
 # Invenio imports:
 
 from invenio.legacy.dbquery import run_sql
-from invenio.config import CFG_PREFIX, \
+from invenio.config import CFG_COMMENTSDIR, \
     CFG_SITE_LANG, \
     CFG_WEBALERT_ALERT_ENGINE_EMAIL,\
     CFG_SITE_SUPPORT_EMAIL,\
@@ -1001,8 +1001,7 @@ def move_attached_files_to_storage(attached_files, recID, comid):
     @param comid: the comment ID to which we attach the files
     """
     for filename, filepath in iteritems(attached_files):
-        dest_dir = os.path.join(CFG_PREFIX, 'var', 'data', 'comments',
-                                str(recID), str(comid))
+        dest_dir = os.path.join(CFG_COMMENTSDIR, str(recID), str(comid))
         try:
             os.makedirs(dest_dir)
         except:
@@ -1018,11 +1017,10 @@ def get_attached_files(recid, comid):
     @param recid: the recid to which the comment belong
     @param comid: the commment id for which we want to retrieve files
     """
-    base_dir = os.path.join(CFG_PREFIX, 'var', 'data', 'comments',
-                            str(recid), str(comid))
+    base_dir = os.path.join(CFG_COMMENTSDIR, str(recid), str(comid))
     if os.path.isdir(base_dir):
         filenames = os.listdir(base_dir)
-        return [(filename, os.path.join(CFG_PREFIX, 'var', 'data', 'comments',
+        return [(filename, os.path.join(CFG_COMMENTSDIR,
                                         str(recid), str(comid), filename),
                  CFG_SITE_URL + '/'+ CFG_SITE_RECORD +'/' + str(recid) + '/comments/attachments/get/' + str(comid) + '/' + filename) \
                 for filename in filenames]

--- a/invenio/modules/workflows/models.py
+++ b/invenio/modules/workflows/models.py
@@ -28,7 +28,7 @@ from datetime import datetime
 from invenio.base.globals import cfg
 from invenio.base.helpers import unicodifier
 from invenio.base.utils import classproperty
-from invenio.ext.logging import deprecated
+from invenio.utils.deprecation import deprecated, RemovedInInvenio22Warning
 from invenio.ext.sqlalchemy import db
 from invenio.ext.sqlalchemy.utils import session_manager
 
@@ -56,7 +56,7 @@ class ObjectVersion(object):
 
     @classproperty
     @deprecated("Please use ObjectVersion.COMPLETED "
-                "instead of ObjectVersion.FINAL")
+                "instead of ObjectVersion.FINAL", RemovedInInvenio22Warning)
     def FINAL(cls):
         return cls.COMPLETED
 

--- a/invenio/testsuite/test_legacy_docextract_convert_journals.py
+++ b/invenio/testsuite/test_legacy_docextract_convert_journals.py
@@ -24,7 +24,7 @@ from tempfile import NamedTemporaryFile, mkstemp
 
 from invenio.testsuite import InvenioXmlTestCase
 from invenio.testsuite import make_test_suite, run_test_suite
-from invenio.testsuite.test_manage import run
+from invenio.base.utils import run_py_func
 
 
 class ConverterTests(InvenioXmlTestCase):
@@ -58,8 +58,8 @@ class ScriptTests(InvenioXmlTestCase):
         from invenio.legacy.docextract.convert_journals import USAGE_MESSAGE
         from invenio.legacy.docextract.scripts.convert_journals import main
 
-        out = run(["convert_journals", "-h"], main, capture_stderr=True)[0]
-        self.assert_(USAGE_MESSAGE in out)
+        err = run_py_func(main, ["convert_journals", "-h"]).err
+        self.assert_(USAGE_MESSAGE in err)
 
     def test_main(self):
         from invenio.config import CFG_TMPDIR
@@ -81,9 +81,9 @@ class ScriptTests(InvenioXmlTestCase):
         dest_temp_fd, dest_temp_path = mkstemp(dir=CFG_TMPDIR)
         try:
             os.close(dest_temp_fd)
-            run(['convert_journals', xml_temp_file.name,
-                 '--kb', kb_temp_file.name,
-                 '-o', dest_temp_path], main)
+            run_py_func(main, ['convert_journals', xml_temp_file.name,
+                               '--kb', kb_temp_file.name,
+                               '-o', dest_temp_path])
 
             transformed_xml = open(dest_temp_path).read()
             self.assertXmlEqual(transformed_xml, """<?xml version="1.0" encoding="UTF-8"?>

--- a/invenio/utils/deprecation.py
+++ b/invenio/utils/deprecation.py
@@ -72,6 +72,10 @@ fixing all places ``old_method`` is used, so that it can be easily removed
 once Invenio v2.1 has been released.
 """
 
+import warnings
+
+from functools import wraps
+
 
 class RemovedInInvenio23Warning(PendingDeprecationWarning):
 
@@ -81,3 +85,19 @@ class RemovedInInvenio23Warning(PendingDeprecationWarning):
 class RemovedInInvenio22Warning(DeprecationWarning):
 
     """Mark feature that will be removed in Invenio version 2.2."""
+
+
+# Improved version of http://code.activestate.com/recipes/391367-deprecated/
+def deprecated(message, category):
+    def wrap(func=None):
+        """Decorator which can be used to mark functions as deprecated.
+
+        :param message: text to include in the warning
+        :param category: warning category
+        """
+        @wraps(func)
+        def new_func(*args, **kwargs):
+            warnings.warn(message, category, stacklevel=3)
+            return func(*args, **kwargs)
+        return new_func
+    return wrap


### PR DESCRIPTION
* Replaces custom path concatenations with `os.path.join`

* Refactors commonly used paths to use config variables.

* ~~Renames `CFG_PREFIX` to `_CFG_PREFIX`.~~ updated by @jirikuncar

---

I would like some input on this in order to drop the WIP tag quicker:
Some references to `_CFG_PREFIX` remain and perhaps some `legacy/` files were better off remaining similar to their `master` equivalents.

If accepted, supersedes  #2818