### PR TITLE
installation: fix missing pkg-config dependency

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -36,6 +36,7 @@ Contents
               python-4suite-xml python-simplejson python-xml \
               gnuplot poppler-utils \
               gs-common clisp gettext libapache2-mod-wsgi unzip \
+              pkg-config \
               python-dateutil python-rdflib python-pyparsing \
               python-gnuplot python-magic pdftk html2text giflib-tools \
               pstotext netpbm python-pypdf python-chardet python-lxml \


### PR DESCRIPTION
The pkg-config package needs to be installed, else `pip install -r requirements.txt` will fail when installing matplotlib. See https://github.com/matplotlib/matplotlib/issues/3029/ and https://github.com/brucellino/zenodo-docker-role/issues/3