### PR TITLE
docs: more complete list of past authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Past contributors:
 
 * Alberto Pepe <alberto.pepe@cern.ch>
 * Alessio Deiana <alessio.deiana@cern.ch>
+* Alexandra Silva <xana@correio.ci.uminho.pt>
 * Anna Afshar <anna.afsharghasemlouy@epfl.ch>
 * Axel Voitier <axel.voitier@gmail.com>
 * Benoit Thiell <benoit.thiell@cern.ch>
@@ -42,7 +43,9 @@ Past contributors:
 * Diane Berkovits <diane.berkovits@cern.ch>
 * Eduardo Margallo <eduardo.margallo@cern.ch>
 * Erik Simon <erik.simon@unine.ch>
+* Eric Stahl <eric.stahl@utbm.fr>
 * Fabio Souto <fsoutomoure@gmail.com>
+* Franck Grenier <franckgrenier@wanadoo.fr>
 * Frederic Gobry <frederic.gobry@epfl.ch>
 * Gabriel Hase <gabriel.hase@cern.ch>
 * Giovanni Di Milia <gdimilia@cfa.harvard.edu>
@@ -56,6 +59,7 @@ Past contributors:
 * Jerome Caffaro <jerome.caffaro@cern.ch>
 * Joaquim Rodrigues Silvestre <joaquim.rodrigues.silvestre@cern.ch>
 * Joe Blaylock <jrbl@slac.stanford.edu>
+* Joël Vogt <joel.vogt@unifr.ch>
 * Johann C. Rocholl <johann@browsershots.org>
 * Jorge Aranda Sumarroca <jorge.aranda.sumarroca@cern.ch>
 * Juan Francisco Pereira Corral <juan.francisco.pereira.corral@cern.ch>
@@ -63,6 +67,7 @@ Past contributors:
 * Krzysztof Jedrzejek <krzysztof.jedrzejek@cern.ch>
 * Kyriakos Liakopoulos <kyriakos.liakopoulos@cern.ch>
 * Lars Christian Raae <lars.christian.raae@cern.ch>
+* Maja Gracco <maja.gracco@cern.ch>
 * Marcus Johansson <marcus.johansson@cern.ch>
 * Marko Niinimaki <manzikki@gmail.com>
 * Martin Vesely <martin.vesely@cern.ch>
@@ -79,9 +84,11 @@ Past contributors:
 * Piotr Praczyk <piotr.praczyk@piotr.praczyk@gmail.com>
 * Radoslav Ivanov <radoslav.ivanov@cern.ch>
 * Richard Owen <ro@tes.la>
+* Roberta Faggian <roberta.faggian@cern.ch>
 * Ruben Pollan <ruben.pollan@cern.ch>
 * Samuele Carli <samuele.carli@cern.ch>
 * Thomas Baron <thomas.baron@cern.ch>
+* Tiberiu Dondera <tiberiu.dondera@pronet-consulting.com>
 * Tony Ohls <tony.ohls@cern.ch>
 * Tony Osborne <tony.osborne@cern.ch>
 * Travis Brooks <travis@slac.stanford.edu>


### PR DESCRIPTION
* Completes the list of past authors with people that did not explicitly
  appear as the CVS commit authors.  (From pre-Git times.)  Names taken
  from the old format of the AUTHORS file.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>