### PR TITLE
MiscUtils: urlutils: escape unsafe characters

### DIFF
--- a/modules/bibdocfile/lib/bibdocfile_templates.py
+++ b/modules/bibdocfile/lib/bibdocfile_templates.py
@@ -22,7 +22,7 @@ from invenio.config import CFG_SITE_URL, \
      CFG_SITE_LANG, CFG_SITE_RECORD, CFG_INSPIRE_SITE
 from invenio.messages import gettext_set_language
 from invenio.dateutils import convert_datestruct_to_dategui
-from invenio.urlutils import create_html_link
+from invenio.urlutils import create_html_link, url_safe_escape
 from invenio.textutils import nice_size
 
 def list_types_from_array(bibdocs):
@@ -300,7 +300,7 @@ class Template:
                        <img src='%(imageurl)s' border="0" />&nbsp;&nbsp;%(docname)s
                      </td>
                    </tr>""" % {
-                     'imageurl' : imageurl,
+                     'imageurl' : url_safe_escape(imageurl),
                      'docname' : cgi.escape(docname),
                      'restriction_label': status and ('<tr><td colspan="2" class="restrictedfilerowheader">%s</td></tr>' % _('Restricted')) or ''
                    }

--- a/modules/miscutil/lib/urlutils.py
+++ b/modules/miscutil/lib/urlutils.py
@@ -855,3 +855,17 @@ def get_relative_url(url):
         return baseurl[:-1]
     else:
         return baseurl
+
+def url_safe_escape(url):
+    """Escape the url from unsafe characters.
+
+    :param str url: the url to be cleaned
+    :return: the cleaned url
+    :rtype: str
+    """
+    clean_url = url
+    try:
+        clean_url = quote(url, safe="%/:=&?~#+!$,;'@()*[]")
+    except:
+        pass
+    return clean_url


### PR DESCRIPTION
* Adds escaping url from unsafe characters.

* Updates bibdocfile templates.

Signed-off-by: Harris Tzovanakis <me@drjova.com>