### PR TITLE
Template: Adds 'characters' filter (similar to sentences)

### DIFF
--- a/invenio/ext/template/__init__.py
+++ b/invenio/ext/template/__init__.py
@@ -170,6 +170,12 @@ def setup_app(app):
         """Return first `limit` number of sentences ending by `separator`."""
         return separator.join(value.split(separator)[:limit])
 
+    @app.template_filter('characters')
+    def _characters(value, limit, extension=' [...]'):
+        """Return first `limit` characters of input, rounded up to nearest space."""
+        nearest_space = value[limit:].find(' ')
+        return value[:limit+nearest_space] + extension
+
     @app.template_filter('path_join')
     def _os_path_join(d):
         """Shortcut for `os.path.join`."""


### PR DESCRIPTION
* Adds a 'characters' filter, where the input string is truncated
  by `limit` characters, rounded up to nearest space (' ') and
  extended with `extension` (default ' [...]').

Signed-off-by: Øystein Blixhavn <oystein@blixhavn.no>