### PR TITLE
installation: better description and pip tests target

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,14 +17,22 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""Invenio is Fun.
+"""Invenio is a framework for digital libraries and data repositories.
+
+Invenio enables you to run your own digital library or document
+repository on the web.  Invenio covers all aspects of digital library
+management, from document ingestion, through classification, indexing
+and further processing, to curation, archiving, and dissemination.
+The flexibility and performance of Invenio make it a comprehensive
+solution for management of document repositories of moderate to large
+sizes (several millions of records).
 
 Links
 -----
 
 * `website <http://invenio-software.org/>`_
 * `documentation <http://invenio.readthedocs.org/en/latest/>`_
-* `development version <https://github.com/inveniosoftware/invenio>`_
+* `development <https://github.com/inveniosoftware/invenio>`_
 
 """
 
@@ -37,14 +45,14 @@ from setuptools import find_packages, setup
 from setuptools.command.install_lib import install_lib
 
 
-class _build(build):
+class _build(build):  # noqa
 
     """Compile catalog before building the package."""
 
     sub_commands = [('compile_catalog', None)] + build.sub_commands
 
 
-class _install_lib(install_lib):
+class _install_lib(install_lib):  # noqa
 
     """Custom install_lib command."""
 
@@ -52,6 +60,7 @@ class _install_lib(install_lib):
         """Compile catalog before running installation command."""
         self.run_command('compile_catalog')
         install_lib.run(self)
+
 
 install_requires = [
     "alembic>=0.6.6",
@@ -209,6 +218,9 @@ tests_require = [
     "unittest2>=0.5",
 ]
 
+# Add `tests` dependencies to `extras_require` so that developers
+# could install test dependencies also with pip:
+extras_require["tests"] = tests_require
 
 # Compatibility with Python 2.6
 if sys.version_info < (2, 7):
@@ -250,7 +262,8 @@ setup(
             'batchuploader = invenio.legacy.bibupload.scripts.batchuploader',
             'bibcheck = invenio.legacy.bibcheck.scripts.bibcheck:main',
             'bibcircd = invenio.legacy.bibcirculation.scripts.bibcircd:main',
-            'bibauthorid = invenio.legacy.bibauthorid.scripts.bibauthorid:main',
+            'bibauthorid = '
+            ' invenio.legacy.bibauthorid.scripts.bibauthorid:main',
             'bibcatalog = invenio.legacy.bibcatalog.scripts.bibcatalog:main',
             'bibclassify = invenio.modules.classifier.scripts.classifier:main',
             'bibconvert = invenio.legacy.bibconvert.scripts.bibconvert:main',
@@ -270,28 +283,38 @@ setup(
             'bibtasklet = invenio.legacy.bibsched.scripts.bibtasklet:main',
             'bibtex = invenio.modules.sequencegenerator.scripts.bibtex:main',
             'bibupload = invenio.legacy.bibupload.scripts.bibupload:main',
-            'convert_journals = invenio.legacy.docextract.scripts.convert_journals:main',
+            'convert_journals = '
+            ' invenio.legacy.docextract.scripts.convert_journals:main',
             'dbexec = invenio.legacy.miscutil.scripts.dbexec:main',
             'dbdump = invenio.legacy.miscutil.scripts.dbdump:main',
             'docextract = invenio.legacy.docextract.scripts.docextract:main',
             'elmsubmit = invenio.legacy.elmsubmit.scripts.elmsubmit:main',
             'gotoadmin = invenio.modules.redirector.scripts.redirector:main',
-            'hepdataharvest = invenio.utils.hepdata.scripts.hepdataharvest:main',
+            'hepdataharvest = '
+            ' invenio.utils.hepdata.scripts.hepdataharvest:main',
             'inveniocfg = invenio.legacy.inveniocfg:main',
             'inveniogc = invenio.legacy.websession.scripts.inveniogc:main',
-            'inveniounoconv = invenio.legacy.websubmit.scripts.inveniounoconv:main',
+            'inveniounoconv = '
+            ' invenio.legacy.websubmit.scripts.inveniounoconv:main',
             'oaiharvest = invenio.legacy.oaiharvest.scripts.oaiharvest:main',
-            'oairepositoryupdater = invenio.legacy.oairepository.scripts.oairepositoryupdater:main',
+            'oairepositoryupdater = '
+            ' invenio.legacy.oairepository.scripts.oairepositoryupdater:main',
             'arxiv-pdf-checker = invenio.legacy.pdfchecker:main',
             'refextract = invenio.legacy.refextract.scripts.refextract:main',
-            'textmarc2xmlmarc = invenio.legacy.bibrecord.scripts.textmarc2xmlmarc:main',
-            'webaccessadmin = invenio.modules.access.scripts.webaccessadmin:main',
-            'webauthorprofile = invenio.legacy.webauthorprofile.scripts.webauthorprofile:main',
+            'textmarc2xmlmarc = '
+            ' invenio.legacy.bibrecord.scripts.textmarc2xmlmarc:main',
+            'webaccessadmin = '
+            ' invenio.modules.access.scripts.webaccessadmin:main',
+            'webauthorprofile = '
+            ' invenio.legacy.webauthorprofile.scripts.webauthorprofile:main',
             'webcoll = invenio.legacy.websearch.scripts.webcoll:main',
-            'webmessageadmin = invenio.legacy.webmessage.scripts.webmessageadmin:main',
+            'webmessageadmin = '
+            ' invenio.legacy.webmessage.scripts.webmessageadmin:main',
             'webstatadmin = invenio.legacy.webstat.scripts.webstatadmin:main',
-            'websubmitadmin = invenio.legacy.websubmit.scripts.websubmitadmin:main',
-            'xmlmarc2textmarc = invenio.legacy.bibrecord.scripts.xmlmarc2textmarc:main',
+            'websubmitadmin = '
+            ' invenio.legacy.websubmit.scripts.websubmitadmin:main',
+            'xmlmarc2textmarc = '
+            ' invenio.legacy.bibrecord.scripts.xmlmarc2textmarc:main',
             'xmlmarclint = invenio.legacy.bibrecord.scripts.xmlmarclint:main',
         ],
         "distutils.commands": [


### PR DESCRIPTION
* Expands project description in place of "Invenio is Fun".

* Adds `tests` target to `extras_require` so that developers could
  install test-related dependencies via `pip install -e .[tests]`.

* Improves PEP-8 compliance and code kwalitee.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>