### PR TITLE
global: canonical demo.invenio-software.org URL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -622,7 +622,7 @@ Contents
           This step is recommended to test your local Invenio
           installation.  It should give you our "Atlantis Institute of
           Science" demo installation, exactly as you see it at
-          <http://invenio-demo.cern.ch/>.
+          <http://demo.invenio-software.org/>.
 
       $ sudo -u www-data /opt/invenio/bin/inveniocfg --load-demo-records
 

--- a/modules/bibharvest/web/test_insert_oai_source.html
+++ b/modules/bibharvest/web/test_insert_oai_source.html
@@ -44,7 +44,7 @@
 <tr>
 	<td>type</td>
 	<td>oai_src_baseurl</td>
-	<td>http://invenio-demo.cern.ch/oai2d</td>
+	<td>http://demo.invenio-software.org/oai2d</td>
 </tr>
 <tr>
 	<td>clickAndWait</td>

--- a/modules/bibmatch/lib/bibmatch_regression_tests.py
+++ b/modules/bibmatch/lib/bibmatch_regression_tests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2002-2010 CERN.
+## Copyright (C) 2002-2010, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -774,14 +774,14 @@ class BibMatchTest(unittest.TestCase):
     def test_check_remote(self):
         """bibmatch - check remote match (Invenio demo site)"""
         records = create_records(self.recxml1)
-        [dummy1, matchedrecs, dummy3, fuzzyrecs] = match_records(records, server_url="http://invenio-demo.cern.ch")
+        [dummy1, matchedrecs, dummy3, fuzzyrecs] = match_records(records, server_url="http://demo.invenio-software.org")
         self.assertEqual(1,len(matchedrecs))
 
     def test_check_textmarc(self):
         """bibmatch - check textmarc as input"""
         marcxml = transform_input_to_marcxml("", self.textmarc)
         records = create_records(marcxml)
-        [dummy1, matchedrecs, dummy3, fuzzyrecs] = match_records(records, server_url="http://invenio-demo.cern.ch")
+        [dummy1, matchedrecs, dummy3, fuzzyrecs] = match_records(records, server_url="http://demo.invenio-software.org")
         self.assertEqual(2,len(matchedrecs))
 
     def test_check_altered(self):

--- a/modules/miscutil/lib/__init__.py
+++ b/modules/miscutil/lib/__init__.py
@@ -7,7 +7,7 @@ To learn more about Invenio software, please go to U{Invenio software
 distribution site <http://invenio-software.org/>}.
 
 To learn more about Invenio modules and programming, please go to
-U{Hacking Invenio <http://invenio-demo.cern.ch/help/hacking/>} web pages.
+U{Hacking Invenio <http://demo.invenio-software.org/help/hacking/>} web pages.
 
 To browse Invenio source code repository, inspect commits,
 revisions and the like, please go to U{Invenio git web repository

--- a/modules/websearch/lib/websearch_external_collections_config.py
+++ b/modules/websearch/lib/websearch_external_collections_config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010 CERN.
+## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -89,31 +89,31 @@ CFG_EXTERNAL_COLLECTIONS = {
         {'engine': 'SPIRESBooks'},
     'Atlantis Institute Books':
         {'engine': 'Invenio',
-         'base_url': 'http://invenio-demo.cern.ch/',
+         'base_url': 'http://demo.invenio-software.org/',
          'parser_params':
-            {'host': 'invenio-demo.cern.ch',
+            {'host': 'demo.invenio-software.org',
              'path': '',
              'parser': InvenioHTMLExternalCollectionResultsParser,
              'fetch_format': 'hb',
              'num_results_regex_str': r'<strong>([0-9,]+?)</strong> records found',
              'nbrecs_regex_str': r'<!-- Search-Engine-Total-Number-Of-Results: ([0-9,]+?) -->',
-             'nbrecs_url': 'http://invenio-demo.cern.ch/search?c=Books&rg=0&of=xm'},
-         'search_url': 'http://invenio-demo.cern.ch/search?cc=Books&p=',
-         'record_url': 'http://invenio-demo.cern.ch/record/',
+             'nbrecs_url': 'http://demo.invenio-software.org/search?c=Books&rg=0&of=xm'},
+         'search_url': 'http://demo.invenio-software.org/search?cc=Books&p=',
+         'record_url': 'http://demo.invenio-software.org/record/',
          'selected_by_default': False},
     'Atlantis Institute Articles':
         {'engine': 'Invenio',
-         'base_url': 'http://invenio-demo.cern.ch/',
+         'base_url': 'http://demo.invenio-software.org/',
          'parser_params':
-            {'host': 'invenio-demo.cern.ch',
+            {'host': 'demo.invenio-software.org',
              'path': '',
              'parser': InvenioXMLExternalCollectionResultsParser,
              'fetch_format': 'xm',
              'num_results_regex_str': r'<!-- Search-Engine-Total-Number-Of-Results: ([0-9,]+?) -->',
              'nbrecs_regex_str': r'<!-- Search-Engine-Total-Number-Of-Results: ([0-9,]+?) -->',
-             'nbrecs_url': 'http://invenio-demo.cern.ch/search?cc=Articles&rg=0&of=xm'},
-         'search_url': 'http://invenio-demo.cern.ch/search?cc=Articles&p=',
-         'record_url': 'http://invenio-demo.cern.ch/record/',
+             'nbrecs_url': 'http://demo.invenio-software.org/search?cc=Articles&rg=0&of=xm'},
+         'search_url': 'http://demo.invenio-software.org/search?cc=Articles&p=',
+         'record_url': 'http://demo.invenio-software.org/record/',
          'selected_by_default': True},
     'CDS DEV':
         {'engine': 'Invenio',


### PR DESCRIPTION
* FIX Replaces `invenio-demo.cern.ch` by `demo.invenio-software.org`
  which is the new canonical URL of the demo site.  (addresses #2867)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
Reviewed-by: Jiri Kuncar <jiri.kuncar@cern.ch>