### PR TITLE
installation: compile catalog and install recorder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,8 @@ class _install_lib(install_lib):  # noqa
 
     def run(self):
         """Compile catalog before running installation command."""
-        self.run_command('compile_catalog')
         install_lib.run(self)
+        self.run_command('compile_catalog')
 
 
 install_requires = [


### PR DESCRIPTION
* FIX Reorders 'compile_catalog' and 'install' commands to fix installation process from PyPI.

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>