### PR TITLE
BibDocFile: Copyright and license for files

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -929,6 +929,8 @@ CFG_BIBDOCFILE_DOCUMENT_FILE_MANAGER_RESTRICTIONS = [
 CFG_BIBDOCFILE_DOCUMENT_FILE_MANAGER_MISC = {
     'can_revise_doctypes': ['*'],
     'can_comment_doctypes': ['*'],
+    'can_change_copyright_doctypes': ['*'],
+    'can_change_advanced_copyright_doctypes': ['*'],
     'can_describe_doctypes': ['*'],
     'can_delete_doctypes': ['*'],
     'can_keep_doctypes': ['*'],

--- a/modules/bibdocfile/lib/bibdocfile_config.py
+++ b/modules/bibdocfile/lib/bibdocfile_config.py
@@ -22,6 +22,8 @@ try:
 except ImportError:
     CFG_BIBDOCFILE_DOCUMENT_FILE_MANAGER_MISC = {
         'can_revise_doctypes': ['*'],
+        'can_change_copyright_doctypes': ['*'],
+        'can_change_advanced_copyright_doctypes': ['*'],
         'can_comment_doctypes': ['*'],
         'can_describe_doctypes': ['*'],
         'can_delete_doctypes': ['*'],

--- a/modules/bibdocfile/lib/bibdocfile_managedocfiles.py
+++ b/modules/bibdocfile/lib/bibdocfile_managedocfiles.py
@@ -73,6 +73,11 @@ import cPickle
 import os
 import time
 import cgi
+import sys
+if sys.hexversion < 0x2060000:
+    import simplejson as json
+else:
+    import json
 
 from urllib import urlencode
 
@@ -97,7 +102,9 @@ from invenio.dbquery import run_sql
 from invenio.urlutils import create_html_mailto
 from invenio.htmlutils import escape_javascript_string
 from invenio.bibtask import task_low_level_submission, bibtask_allocate_sequenceid
-CFG_ALLOWED_ACTIONS = ['revise', 'delete', 'add', 'addFormat']
+from invenio.bibfield import get_record
+from invenio.bibknowledge import get_kbr_items
+CFG_ALLOWED_ACTIONS = ['revise', 'delete', 'add', 'addFormat', 'copyrightChange']
 
 params_id = 0
 
@@ -111,6 +118,8 @@ def create_file_upload_interface(recid,
                                  doctypes_and_desc=None,
                                  can_delete_doctypes=None,
                                  can_revise_doctypes=None,
+                                 can_change_copyright_doctypes=None,
+                                 can_change_advanced_copyright_doctypes=None,
                                  can_describe_doctypes=None,
                                  can_comment_doctypes=None,
                                  can_keep_doctypes=None,
@@ -121,6 +130,8 @@ def create_file_upload_interface(recid,
                                  keep_default=True, show_links=True,
                                  file_label=None, filename_label=None,
                                  description_label=None, comment_label=None,
+                                 copyright_label=None,
+                                 advanced_copyright_label=None,
                                  restrictions_and_desc=None,
                                  can_restrict_doctypes=None,
                                  restriction_label=None,
@@ -211,6 +222,20 @@ def create_file_upload_interface(recid,
                                 Eg: ['main', 'additional']
                                 Use ['*'] for "all doctypes"
     @type can_revise_doctypes: list(string)
+
+    @param can_change_copyright_doctypes: the list of doctypes for which users
+                                           are allowed to select predefined
+                                           copyright and license
+                                           Eg: ['main', 'additional']
+                                           Use ['*'] for "all doctypes"
+    @type can_change_copyright_doctypes: list(string)
+
+    @param can_change_advanced_copyright_doctypes: the list of doctypes for
+                                           which users are allowed to manually
+                                           edit copyright and license
+                                           Eg: ['main', 'additional']
+                                           Use ['*'] for "all doctypes"
+    @type can_change_advanced_copyright_doctypes: list(string)
 
     @param can_describe_doctypes: the list of doctypes that users are
                                   allowed to describe
@@ -327,6 +352,12 @@ def create_file_upload_interface(recid,
     @param comment_label: the label for the comments field
     @type comment_label: string
 
+    @param copyright_label: the label for the copyright field
+    @type copyright_label: string
+
+    @param advanced_copyright_label: the label for the advanced copyright link
+    @type advanced_copyright_label: string
+
     @param restriction_label: the label in front of the restrictions list
     @type restriction_label: string
 
@@ -400,6 +431,10 @@ def create_file_upload_interface(recid,
         description_label = _('Description')
     if not comment_label:
         comment_label = _('Comment')
+    if not copyright_label:
+        copyright_label = _('Copyright and license')
+    if not advanced_copyright_label:
+        advanced_copyright_label = _('Advanced')
     if not restriction_label:
         restriction_label = _('Access')
     if not doctypes_and_desc:
@@ -408,6 +443,10 @@ def create_file_upload_interface(recid,
         can_delete_doctypes = []
     if not can_revise_doctypes:
         can_revise_doctypes = []
+    if not can_change_copyright_doctypes:
+        can_change_copyright_doctypes = []
+    if not can_change_advanced_copyright_doctypes:
+        can_change_advanced_copyright_doctypes = []
     if not can_describe_doctypes:
         can_describe_doctypes = []
     if not can_comment_doctypes:
@@ -488,14 +527,16 @@ def create_file_upload_interface(recid,
         parameters = _read_file_revision_interface_configuration_from_disk(working_dir)
         (minsize, maxsize, doctypes_and_desc, doctypes,
          can_delete_doctypes, can_revise_doctypes,
+         can_change_copyright_doctypes,
+         can_change_advanced_copyright_doctypes,
          can_describe_doctypes,
          can_comment_doctypes, can_keep_doctypes,
          can_rename_doctypes,
          can_add_format_to_doctypes, create_related_formats,
          can_name_new_files, keep_default, show_links,
          file_label, filename_label, description_label,
-         comment_label, restrictions_and_desc,
-         can_restrict_doctypes,
+         comment_label, copyright_label, advanced_copyright_label,
+         restrictions_and_desc, can_restrict_doctypes,
          restriction_label, doctypes_to_default_filename,
          max_files_for_doctype, print_outside_form_tag,
          display_hidden_files, protect_hidden_files,
@@ -505,14 +546,16 @@ def create_file_upload_interface(recid,
         # disk for later reuse
         parameters = (minsize, maxsize, doctypes_and_desc, doctypes,
                       can_delete_doctypes, can_revise_doctypes,
+                      can_change_copyright_doctypes,
+                      can_change_advanced_copyright_doctypes,
                       can_describe_doctypes,
                       can_comment_doctypes, can_keep_doctypes,
                       can_rename_doctypes,
                       can_add_format_to_doctypes, create_related_formats,
                       can_name_new_files, keep_default, show_links,
                       file_label, filename_label, description_label,
-                      comment_label, restrictions_and_desc,
-                      can_restrict_doctypes,
+                      comment_label, copyright_label, advanced_copyright_label,
+                      restrictions_and_desc, can_restrict_doctypes,
                       restriction_label, doctypes_to_default_filename,
                       max_files_for_doctype, print_outside_form_tag,
                       display_hidden_files, protect_hidden_files,
@@ -543,7 +586,9 @@ def create_file_upload_interface(recid,
         ## Get and clean parameters received from user
         (file_action, file_target, file_target_doctype,
          keep_previous_files, file_description, file_comment, file_rename,
-         file_doctype, file_restriction, uploaded_filename, uploaded_filepath) = \
+         file_doctype, file_restriction, uploaded_filename, uploaded_filepath,
+         copyright_holder, copyright_date, copyright_message,
+         copyright_holder_contact, license, license_url, license_body) = \
          wash_form_parameters(form, abstract_bibdocs, can_keep_doctypes,
          keep_default, can_describe_doctypes, can_comment_doctypes,
          can_rename_doctypes, can_name_new_files, can_restrict_doctypes,
@@ -679,6 +724,12 @@ def create_file_upload_interface(recid,
                                    file_doctype, keep_previous_files,
                                    file_restriction,
                                    create_related_formats and defer_related_formats_creation)
+                        # Every time we log add action, we need to also log copyright/license change action
+                        log_copyright_action(working_dir, "copyrightChange",
+                                            filename, copyright_holder,
+                                            copyright_date, copyright_message,
+                                            copyright_holder_contact, license,
+                                            license_url, license_body)
 
                         # Automatically create additional formats when
                         # possible AND wanted
@@ -702,6 +753,12 @@ def create_file_upload_interface(recid,
                                file_target_doctype, keep_previous_files,
                                file_restriction, create_related_formats and defer_related_formats_creation)
 
+                    # Every time we log revise action, we need to also log copyright/license change action
+                    log_copyright_action(working_dir, "copyrightChange",
+                                        file_target, copyright_holder,
+                                        copyright_date, copyright_message,
+                                        copyright_holder_contact, license,
+                                        license_url, license_body)
                     # Automatically create additional formats when
                     # possible AND wanted
                     additional_formats = []
@@ -759,6 +816,12 @@ def create_file_upload_interface(recid,
                            file_description, file_comment,
                            file_target_doctype, keep_previous_files,
                            file_restriction)
+                # Every time we log revise action, we need to also log copyright/license change action
+                log_copyright_action(working_dir, "copyrightChange",
+                                     file_target, copyright_holder,
+                                     copyright_date, copyright_message,
+                                     copyright_holder_contact, license,
+                                     license_url, license_body)
 
 
         elif file_action == "delete" and file_target != "" and \
@@ -794,6 +857,8 @@ def create_file_upload_interface(recid,
     js_can_describe_doctypes = repr({}.fromkeys(can_describe_doctypes, ''))
     js_can_comment_doctypes = repr({}.fromkeys(can_comment_doctypes, ''))
     js_can_restrict_doctypes = repr({}.fromkeys(can_restrict_doctypes, ''))
+    js_can_change_copyright_doctypes = repr({}.fromkeys(can_change_copyright_doctypes, ''))
+    js_can_change_advanced_copyright_doctypes = repr({}.fromkeys(can_change_advanced_copyright_doctypes, ''))
 
     # Prepare to display file revise panel "balloon".  Check if we
     # should display the list of doctypes or if it is not necessary (0
@@ -808,7 +873,7 @@ def create_file_upload_interface(recid,
                              if bibdoc['get_type'] == doctype]))]
     doctypes_list = ""
     if len(cleaned_doctypes) > 1:
-        doctypes_list = '<select id="fileDoctype" name="fileDoctype" onchange="var idx=this.selectedIndex;var doctype=this.options[idx].value;updateForm(doctype,'+','.join([js_can_describe_doctypes, js_can_comment_doctypes, js_can_restrict_doctypes])+');">' + \
+        doctypes_list = '<select id="fileDoctype" name="fileDoctype" onchange="var idx=this.selectedIndex;var doctype=this.options[idx].value;updateForm(doctype,'+','.join([js_can_describe_doctypes, js_can_comment_doctypes, js_can_restrict_doctypes, js_can_change_copyright_doctypes, js_can_change_advanced_copyright_doctypes])+');">' + \
                         '\n'.join(['<option value="' + cgi.escape(doctype, True) + '">' + \
                                    cgi.escape(description) + '</option>' \
                                    for (doctype, description) \
@@ -841,6 +906,23 @@ def create_file_upload_interface(recid,
     else:
         restrictions_list = '<select style="display:none" id="fileRestriction" name="fileRestriction"></select>'
 
+    # Load copyright mappings from kb and populate the select list
+    copyright_items = get_kbr_items("Copyrights")
+    copyrights_list = ""
+    copyrights_list += '<select id="copyright" name="copyright">'
+    copyrights_list += '<option value="">Same as record</option>'
+    for copyright_item in copyright_items:
+        copyrights_list += '<option value="' + copyright_item.get('key') + '">'+ copyright_item.get('key') + '</option>'
+    copyrights_list += '<option value="Other">%(other)s</option>' % {'other': _("Other")}
+    copyrights_list += '</select>'
+
+    # Save the date of the record in JavaScript so it will accessible later
+    try:
+        record_date = get_record(recid).get('imprint','').get('date','')
+    except AttributeError:
+        record_date = ''
+    body += """<script>var recordDate = '%s';</script>""" % record_date
+
     # List the files
     body += '''
 <div id="reviseControl">
@@ -852,6 +934,8 @@ def create_file_upload_interface(recid,
             body += create_file_row(bibdoc, can_delete_doctypes,
                                     can_rename_doctypes,
                                     can_revise_doctypes,
+                                    can_change_copyright_doctypes,
+                                    can_change_advanced_copyright_doctypes,
                                     can_describe_doctypes,
                                     can_comment_doctypes,
                                     can_keep_doctypes,
@@ -859,21 +943,24 @@ def create_file_upload_interface(recid,
                                     doctypes_list,
                                     show_links,
                                     can_restrict_doctypes,
+                                    copyright_items,
                                     even=not (i % 2),
                                     ln=ln,
                                     form_url_params=form_url_params,
                                     protect_hidden_files=protect_hidden_files)
     body += '</table>'
     if len(cleaned_doctypes) > 0:
-        (revise_panel, javascript_prefix) = javascript_display_revise_panel(action='add', target='', show_doctypes=True, show_keep_previous_versions=False, show_rename=can_name_new_files, show_description=True, show_comment=True, bibdocname='', description='', comment='', show_restrictions=True, restriction=len(restrictions_and_desc) > 0 and restrictions_and_desc[0][0] or '', doctypes=doctypes_list)
-        body += '''%(javascript_prefix)s<input type="button" onclick="%(display_revise_panel)s;updateForm('%(defaultSelectedDoctype)s', %(can_describe_doctypes)s, %(can_comment_doctypes)s, %(can_restrict_doctypes)s);return false;" value="%(add_new_file)s"/>''' % \
+        (revise_panel, javascript_prefix) = javascript_display_revise_panel(action='add', target='', show_doctypes=True, show_keep_previous_versions=False, show_rename=can_name_new_files, show_description=True, show_comment=True, show_copyright=True, show_advanced_copyright=True, bibdocname='', description='', comment='', copyright='', copyright_holder='', copyright_date='', copyright_message='', copyright_holder_contact='', license='', license_url='', license_body='', show_restrictions=True, restriction=len(restrictions_and_desc) > 0 and restrictions_and_desc[0][0] or '', doctypes=doctypes_list)
+        body += '''%(javascript_prefix)s<input type="button" onclick="%(display_revise_panel)s;updateForm('%(defaultSelectedDoctype)s', %(can_describe_doctypes)s, %(can_comment_doctypes)s, %(can_restrict_doctypes)s, %(can_change_copyright_doctypes)s, %(can_change_advanced_copyright_doctypes)s);return false;" value="%(add_new_file)s"/>''' % \
                {'display_revise_panel': revise_panel,
                 'javascript_prefix': javascript_prefix,
                 'defaultSelectedDoctype': escape_javascript_string(cleaned_doctypes[0], escape_quote_for_html=True),
                 'add_new_file': _("Add new file"),
                 'can_describe_doctypes':js_can_describe_doctypes,
                 'can_comment_doctypes': repr({}.fromkeys(can_comment_doctypes, '')),
-                'can_restrict_doctypes': repr({}.fromkeys(can_restrict_doctypes, ''))}
+                'can_restrict_doctypes': repr({}.fromkeys(can_restrict_doctypes, '')),
+                'can_change_copyright_doctypes': repr({}.fromkeys(can_change_copyright_doctypes, '')),
+                'can_change_advanced_copyright_doctypes': repr({}.fromkeys(can_change_advanced_copyright_doctypes, ''))}
 
     body += '</div>'
 
@@ -885,8 +972,8 @@ def create_file_upload_interface(recid,
                    get_upload_file_interface_css() + \
                    body
 
-        # Display markup of the revision panel. This one is also
-        # printed only at the beginning, so that it does not need to
+        # Display markup of the revision and copyright panels. Those ones are also
+        # printed only at the beginning, so that they do not need to
         # be returned with each response
         body += revise_balloon % \
            {'CFG_SITE_URL': CFG_SITE_URL,
@@ -894,6 +981,9 @@ def create_file_upload_interface(recid,
             'filename_label': filename_label,
             'description_label': description_label,
             'comment_label': comment_label,
+            'copyright_label': copyright_label,
+            'copyrights': copyrights_list,
+            'advanced_copyright_label': advanced_copyright_label,
             'restrictions': restrictions_list,
             'previous_versions_help': _('You can decide to hide or not previous version(s) of this file.').replace("'", "\\'"),
             'revise_format_help': _('When you revise a file, the additional formats that you might have previously uploaded are removed, since they no longer up-to-date with the new file.').replace("'", "\\'"),
@@ -904,6 +994,10 @@ def create_file_upload_interface(recid,
             'uploading_label': _('Uploading...'),
             'postprocess_label': _('Please wait...'),
             'submit_or_button': form_url_params and 'button' or 'submit'}
+        body += copyright_balloon % \
+        {
+        'close': _('Close')
+        }
         body += '''
         <input type="hidden" name="recid" value="%(recid)i"/>
         <input type="hidden" name="ln" value="%(ln)s"/>
@@ -942,9 +1036,12 @@ Best regards""") % {'recid': recid or ''})
 
 def create_file_row(abstract_bibdoc, can_delete_doctypes,
                     can_rename_doctypes, can_revise_doctypes,
+                    can_change_copyright_doctypes,
+                    can_change_advanced_copyright_doctypes,
                     can_describe_doctypes, can_comment_doctypes,
                     can_keep_doctypes, can_add_format_to_doctypes,
                     doctypes_list, show_links, can_restrict_doctypes,
+                    copyright_items,
                     even=False, ln=CFG_SITE_LANG, form_url_params='',
                     protect_hidden_files=True):
     """
@@ -961,6 +1058,12 @@ def create_file_row(abstract_bibdoc, can_delete_doctypes,
 
     @param can_revise_doctypes: the list of doctypes that users are
                              allowed to revise.
+
+    @param can_change_copyright_doctypes: the list of doctypes for which users
+                             are allowed to select copyright and license.
+
+    @param can_change_advanced_copyright_doctypes: the list of doctypes for which users
+                             are allowed to manually change copyright and license.
 
     @param can_describe_doctypes: the list of doctypes that users are
                              allowed to describe.
@@ -980,6 +1083,9 @@ def create_file_row(abstract_bibdoc, can_delete_doctypes,
                              add new formats
 
     @param show_links: if we display links to files
+
+    @param copyright_items: dictionary taken from kb with mappings between
+                            different types of copyrights and copyright data
 
     @param even: if the row is even or odd on the list
     @type even: boolean
@@ -1039,6 +1145,46 @@ def create_file_row(abstract_bibdoc, can_delete_doctypes,
     out += '<td class="reviseControlActionColumn">'
     if main_bibdocfile.get_type() in can_revise_doctypes or \
            '*' in can_revise_doctypes and not (hidden_p and protect_hidden_files):
+        # Advanced copyright panel will be inside revise panel, so we need to
+        # prepare parameters for copyright here
+
+        # Copyright and license link
+        copyright_license = get_copyright_and_license(abstract_bibdoc['list_latest_files'][0])
+        # take the first bibdocfile from list_latest_files, because the
+        # copyright and license for every bibdocfile should be the same
+        # I don't think we need to check this condition
+        # if main_bibdocfile.get_type() in can_change_copyright_doctypes or \
+        #        '*' in can_change_copyright_doctypes and not (hidden_p and protect_hidden_files):
+        copyright_holder = copyright_license.get('copyright_holder', '')
+        copyright_date = copyright_license.get('copyright_date', '')
+        copyright_message = copyright_license.get('copyright_message', '')
+        copyright_holder_contact = copyright_license.get('copyright_holder_contact', '')
+        license = copyright_license.get('license', '')
+        license_url = copyright_license.get('license_url', '')
+        license_body = copyright_license.get('license_body', '')
+
+        # Check which copyright/license option should be selected in select list
+        if copyright_holder or copyright_date or copyright_message or \
+            copyright_holder_contact or license or license_url or license_body:
+            # If at least one copyright/license information is provided it means that the copyright is not the same as record
+            for copyright in copyright_items:
+                copyright_value = json.loads(copyright.get('value')).get('Copyright')
+                license_value = json.loads(copyright.get('value')).get('License')
+                if copyright_value.get('Holder') == copyright_holder and \
+                   copyright_value.get('Message') == copyright_message and \
+                   copyright_value.get('Contact') == copyright_holder_contact and \
+                   license_value.get('License') == license and \
+                   license_value.get('Url') == license_url and \
+                   license_value.get('Body') == license_body:
+                    copyright = copyright.get('key')
+                    break
+            else:
+                # None of the predefined value - someone manually set the copyrights
+                copyright = 'Other'
+        else:
+            # There were no copyrights for this file so far
+            copyright = ''
+
         (revise_panel, javascript_prefix) = javascript_display_revise_panel(
             action='revise',
             target=abstract_bibdoc['get_docname'],
@@ -1047,9 +1193,19 @@ def create_file_row(abstract_bibdoc, can_delete_doctypes,
             show_rename=(main_bibdocfile.get_type() in can_rename_doctypes) or '*' in can_rename_doctypes,
             show_description=(main_bibdocfile.get_type() in can_describe_doctypes) or '*' in can_describe_doctypes,
             show_comment=(main_bibdocfile.get_type() in can_comment_doctypes) or '*' in can_comment_doctypes,
+            show_copyright=(main_bibdocfile.get_type() in can_change_copyright_doctypes) or '*' in can_change_copyright_doctypes,
+            show_advanced_copyright=(main_bibdocfile.get_type() in can_change_advanced_copyright_doctypes) or '*' in can_change_advanced_copyright_doctypes,
             bibdocname=abstract_bibdoc['get_docname'],
             description=description,
             comment=comment,
+            copyright=copyright,
+            copyright_holder=copyright_holder,
+            copyright_date=copyright_date,
+            copyright_message=copyright_message,
+            copyright_holder_contact=copyright_holder_contact,
+            license=license,
+            license_url=license_url,
+            license_body=license_body,
             show_restrictions=(main_bibdocfile.get_type() in can_restrict_doctypes) or '*' in can_restrict_doctypes,
             restriction=restriction,
             doctypes=doctypes_list)
@@ -1106,9 +1262,19 @@ def create_file_row(abstract_bibdoc, can_delete_doctypes,
             show_rename=False,
             show_description=False,
             show_comment=False,
+            show_copyright=False,
+            show_advanced_copyright=False,
             bibdocname='',
             description='',
             comment='',
+            copyright='',
+            copyright_holder='',
+            copyright_date='',
+            copyright_message='',
+            copyright_holder_contact='',
+            license='',
+            license_url='',
+            license_body='',
             show_restrictions=False,
             restriction=restriction,
             doctypes=doctypes_list)
@@ -1172,6 +1338,15 @@ def build_updated_files_list(bibdocs, actions, recid, display_hidden_files=False
     for action, bibdoc_name, file_path, rename, description, \
             comment, doctype, keep_previous_versions, \
             file_restriction, create_related_formats in actions:
+        # Hack, rename parameters if the type of the action is copyrightChange
+        # so it's easier to track what is stored in which variable
+        # We can do this because each action has the same number of parameters
+        if action == "copyrightChange":
+            (copyright_holder, copyright_date,
+            copyright_message, copyright_holder_contact,
+            license, license_url, license_body) = (file_path,
+            rename, description, comment, doctype,
+            keep_previous_versions, file_restriction)
         dirname, filename, fileformat = decompose_file(file_path)
         i += 1
         if action in ["add", "revise"] and \
@@ -1242,6 +1417,13 @@ def build_updated_files_list(bibdocs, actions, recid, display_hidden_files=False
                            docid=-1, status='',
                            checksum=checksum, more_info=more_info))
             abstract_bibdocs[bibdoc_name]['updated'] = True
+        elif action == "copyrightChange":
+            copyright = pack_copyrights(copyright_holder, copyright_date,
+                                        copyright_message, copyright_holder_contact)
+            license = pack_license(license, license_url, license_body)
+            set_copyright_and_license(abstract_bibdocs[bibdoc_name]['list_latest_files'],
+                                      copyright, license)
+            abstract_bibdocs[bibdoc_name]['updated'] = True
 
     # For each BibDoc for which we would like to create related
     # formats, do build the list of formats that should be created
@@ -1291,6 +1473,10 @@ def log_action(log_dir, action, bibdoc_name, file_path, rename,
     format was motivated by the need to have it easily readable by
     other scripts. Not sure it still makes sense nowadays...
 
+    If we no longer need to escape the '---', maybe we can change those log
+    functions into something more generic like a log function
+    that records any arbitrary number of parameters ?
+
     Newlines are also reserved, and are escaped from the input values
     (necessary for the 'comment' field, which is the only one allowing
     newlines from the browser)
@@ -1335,7 +1521,7 @@ def log_action(log_dir, action, bibdoc_name, file_path, rename,
     try:
         file_desc = open(log_file, "a+")
         # We must escape new lines from comments in some way:
-        comment = str(comment).replace('\\', '\\\\').replace('\r\n', '\\n\\r')
+        comment = str(comment).replace('\\', '\\\\').replace('\r\n', '\\n\\r').replace('\n', '\\n')
         msg = action                                 + '<--->' + \
               bibdoc_name.replace('---', '___')      + '<--->' + \
               file_path                              + '<--->' + \
@@ -1351,10 +1537,64 @@ def log_action(log_dir, action, bibdoc_name, file_path, rename,
     except Exception ,e:
         raise e
 
+def log_copyright_action(log_dir, action, bibdoc_name, copyright_holder,
+                         copyright_date, copyright_message,
+                         copyright_holder_contact, license, license_url,
+                         license_body):
+    """
+    Logs copyright change action in the actions log.
+    See log_action() function for more information
+    @param log_dir: directory where to save the log (ie. working_dir)
+
+    @param action: the performed action (one of 'revise', 'delete',
+                   'add', 'addFormat')
+
+    @param bibdoc_name: the name of the bibdoc on which the change is
+                        applied
+
+    @param copyright_holder: holder of the copyright associated with the file
+
+    @param copyright_date: date of the copyright associated with the file
+
+    @param copyright_message: message associated with the copyright
+
+    @param copyright_holder_contact: contact information of the copyright holder
+
+    @param license: license of the file
+
+    @param license_url: url of the license related to the file
+
+    @param license_body: person or institution imposing the license
+                         (author, publisher)
+
+    """
+    log_file = os.path.join(log_dir, 'bibdocactions.log')
+    try:
+        file_desc = open(log_file, "a+")
+        # We must escape new lines from copyright message in some way:
+        copyright_message = str(copyright_message).replace('\\', '\\\\').replace('\r\n', '\\n\\r').replace('\n', '\\n')
+        msg = action                                                + '<--->' + \
+              bibdoc_name.replace('---', '___')                     + '<--->' + \
+              copyright_holder                                      + '<--->' + \
+              copyright_date                                        + '<--->' + \
+              copyright_message                                     + '<--->' + \
+              copyright_holder_contact                              + '<--->' + \
+              license                                               + '<--->' + \
+              license_url                                           + '<--->' + \
+              license_body                                          + '<--->' + \
+              '\n' # This last <---> is to match the number of parameters of log_action function
+        file_desc.write("%s --> %s" %(time.strftime("%Y-%m-%d %H:%M:%S"), msg))
+        file_desc.close()
+    except Exception, e:
+        raise e
+
+
 def read_actions_log(log_dir):
     """
     Reads the logs of action to be performed on files
 
+    Both log_copyright_action and log_action create rows with the same number
+    of parameters, so each action can be treated in the same way.
     See log_action(..) for more information about the structure of the
     log file.
 
@@ -1368,42 +1608,62 @@ def read_actions_log(log_dir):
         file_desc = open(log_file, "r")
         for line in file_desc.readlines():
             (timestamp, action) = line.split(' --> ', 1)
-            try:
-                (action, bibdoc_name, file_path, rename, description,
-                 comment, doctype, keep_previous_versions,
-                 file_restriction, create_related_formats) = action.rstrip('\n').split('<--->')
-            except ValueError, e:
-                # Malformed action log
-                pass
-
-            # Clean newline-escaped comment:
-            comment = comment.replace('\\n\\r', '\r\n').replace('\\\\', '\\')
-
-            # Perform some checking
-            if action not in CFG_ALLOWED_ACTIONS:
-                # Malformed action log
-                pass
-
-            try:
-                keep_previous_versions = int(keep_previous_versions)
-            except:
-                # Malformed action log
-                keep_previous_versions = 1
-                pass
-
-            create_related_formats = create_related_formats == 'True' and True or False
-
-            actions.append((action, bibdoc_name, file_path, rename, \
-                            description, comment, doctype,
-                            keep_previous_versions, file_restriction,
-                            create_related_formats))
+            if action.split('<--->', 1)[0] == 'copyrightChange':
+                try:
+                    # if the action is "copyrightChange" we want to name
+                    # parameters differently for clarity
+                    (action, file_path, copyright_holder, copyright_date, copyright_message,
+                     copyright_holder_contact, license, license_url,
+                     license_body, _) = action.rstrip('\n').split('<--->')
+                except ValueError, e:
+                    # Malformed action log
+                    pass
+                # Clean newline-escaped copyright_message:
+                copyright_message = copyright_message.replace('\\n\\r', '\r\n').replace('\\\\', '\\').replace('\\n', '\n')
+                # Perform some checking
+                if action not in CFG_ALLOWED_ACTIONS:
+                    # Malformed action log
+                    pass
+                actions.append((action, file_path, copyright_holder, copyright_date,
+                                copyright_message, copyright_holder_contact,
+                                license, license_url, license_body, ''))
+            else:
+                try:
+                    (action, bibdoc_name, file_path, rename, description,
+                     comment, doctype, keep_previous_versions,
+                     file_restriction, create_related_formats) = action.rstrip('\n').split('<--->')
+                except ValueError, e:
+                    # Malformed action log
+                    pass
+                # Clean newline-escaped comment:
+                comment = comment.replace('\\n\\r', '\r\n').replace('\\\\', '\\').replace('\\n', '\n')
+                try:
+                    keep_previous_versions = int(keep_previous_versions)
+                except:
+                    # Malformed action log
+                    keep_previous_versions = 1
+                # Perform some checking
+                if action not in CFG_ALLOWED_ACTIONS:
+                    # Malformed action log
+                    pass
+                actions.append((action, bibdoc_name, file_path, rename,
+                                description, comment, doctype,
+                                keep_previous_versions, file_restriction,
+                                create_related_formats))
         file_desc.close()
     except:
         pass
 
     return actions
 
-def javascript_display_revise_panel(action, target, show_doctypes, show_keep_previous_versions, show_rename, show_description, show_comment, bibdocname, description, comment, show_restrictions, restriction, doctypes):
+def javascript_display_revise_panel(action, target, show_doctypes,
+                                    show_keep_previous_versions, show_rename,
+                                    show_description, show_comment, show_copyright,
+                                    show_advanced_copyright, bibdocname, description,
+                                    comment, copyright, copyright_holder, copyright_date,
+                                    copyright_message, copyright_holder_contact,
+                                    license, license_url, license_body,
+                                    show_restrictions, restriction, doctypes):
     """
     Returns a correctly encoded call to the javascript function to
     display the revision panel.
@@ -1420,9 +1680,19 @@ def javascript_display_revise_panel(action, target, show_doctypes, show_keep_pre
                                       "showRename": %(showRename)s,
                                       "showDescription": %(showDescription)s,
                                       "showComment": %(showComment)s,
+                                      "showCopyright": %(showCopyright)s,
+                                      "showAdvancedCopyright": %(showAdvancedCopyright)s,
                                       "bibdocname": "%(bibdocname)s",
                                       "description": "%(description)s",
                                       "comment": "%(comment)s",
+                                      "copyright": "%(copyright)s",
+                                      "copyrightHolder": "%(copyrightHolder)s",
+                                      "copyrightDate": "%(copyrightDate)s",
+                                      "copyrightMessage": "%(copyrightMessage)s",
+                                      "copyrightHolderContact": "%(copyrightHolderContact)s",
+                                      "license": "%(license)s",
+                                      "licenseUrl": "%(licenseUrl)s",
+                                      "licenseBody": "%(licenseBody)s",
                                       "showRestrictions": %(showRestrictions)s,
                                       "restriction": "%(restriction)s",
                                       "doctypes": "%(doctypes)s"}
@@ -1436,8 +1706,18 @@ def javascript_display_revise_panel(action, target, show_doctypes, show_keep_pre
                    'showKeepPreviousVersions': show_keep_previous_versions and 'true' or 'false',
                    'showComment': show_comment and 'true' or 'false',
                    'showDescription': show_description and 'true' or 'false',
+                   'showCopyright': show_copyright and 'true' or 'false',
+                   'showAdvancedCopyright': show_advanced_copyright and 'true' or 'false',
                    'description': description and escape_javascript_string(description, escape_for_html=False) or '',
                    'comment': comment and escape_javascript_string(comment, escape_for_html=False) or '',
+                   'copyright': copyright and escape_javascript_string(copyright, escape_for_html=False) or '',
+                   'copyrightHolder': copyright_holder and escape_javascript_string(copyright_holder, escape_for_html=False) or '',
+                   'copyrightDate': copyright_date and escape_javascript_string(copyright_date, escape_for_html=False) or '',
+                   'copyrightMessage': copyright_message and escape_javascript_string(copyright_message, escape_for_html=False) or '',
+                   'copyrightHolderContact': copyright_holder_contact and escape_javascript_string(copyright_holder_contact, escape_for_html=False) or '',
+                   'license': license and escape_javascript_string(license, escape_for_html=False) or '',
+                   'licenseUrl': license_url and escape_javascript_string(license_url, escape_for_html=False) or '',
+                   'licenseBody': license_body and escape_javascript_string(license_body, escape_for_html=False) or '',
                    'showRestrictions': show_restrictions and 'true' or 'false',
                    'restriction': escape_javascript_string(restriction, escape_for_html=False),
                    'doctypes': escape_javascript_string(doctypes, escape_for_html=False)}
@@ -1457,8 +1737,9 @@ def get_uploaded_files_for_docname(log_dir, docname):
     """
     return [file_path for action, bibdoc_name, file_path, rename, \
             description, comment, doctype, keep_previous_versions , \
-            file_restriction, create_related_formats in read_actions_log(log_dir) \
-            if bibdoc_name == docname and os.path.exists(file_path)]
+            file_restriction, copyright_license in read_actions_log(log_dir) \
+            if action in ['revise', 'add', 'addFormat'] and \
+               bibdoc_name == docname and os.path.exists(file_path)]
 
 def get_bibdoc_for_docname(docname, abstract_bibdocs):
     """
@@ -1549,6 +1830,14 @@ def get_description_and_comment(bibdocfiles):
 
     return (description, comment)
 
+def get_copyright_and_license(bibdocfile):
+    """
+    Returns the copyright and license of a BibDoc as a dictionary
+    """
+    copyright_license = bibdocfile.get_copyright()
+    copyright_license.update(bibdocfile.get_license())
+    return copyright_license
+
 def set_description_and_comment(abstract_bibdocfiles, description, comment):
     """
     Set the description and comment to the given (abstract)
@@ -1570,6 +1859,67 @@ def set_description_and_comment(abstract_bibdocfiles, description, comment):
     for bibdocfile in abstract_bibdocfiles:
         bibdocfile.description = description
         bibdocfile.comment = comment
+
+def set_copyright_and_license(abstract_bibdocfiles, copyright, license):
+    """
+    Set the copyright and license to the given (abstract)
+    bibdocfiles.
+
+    @param abstract_bibdocfiles: the list of 'abstract' files of a
+                        given bibdoc for which we want to set the
+                        copyright and license.
+
+    @param copyright: the new copyright
+    @param license: the new license
+    """
+    for bibdocfile in abstract_bibdocfiles:
+        bibdocfile.copyright = copyright
+        bibdocfile.license = license
+
+def pack_copyrights(copyright_holder, copyright_date, copyright_message,
+                    copyright_holder_contact):
+    """
+    Packs the parameters into copyright dictionary with properly named keys.
+    Since we pass those copyright values in a few places, we pack them
+    here, so when the keys change, we won't have to rename them everywhere.
+
+    @param copyright_holder: holder of the copyright associated with the file
+    @type copyright_holder: string
+    @param copyright_date: date of the copyright associated with the file
+    @type copyright_date: string
+    @param copyright_message: message associated with the copyright
+    @type copyright_message: string
+    @param copyright_holder_contact: contact information of the copyright holder
+    @type copyright_holder_contact: string
+    """
+    copyright = {}
+    copyright['copyright_holder'] = copyright_holder
+    copyright['copyright_date'] = copyright_date
+    copyright['copyright_message'] = copyright_message
+    copyright['copyright_holder_contact'] = copyright_holder_contact
+
+    return copyright
+
+def pack_license(license, license_url, license_body):
+    """
+    Packs the parameters into license dictionary with properly named keys.
+    Since we pass those license values in a couple of places, we pack them
+    here, so when the keys change, we won't have to replace them everywhere
+
+    @param license: license of the file
+    @type license: string
+    @param license_url: url of the license related to the file
+    @type license_url: string
+    @param license_body: person or institution imposing the license
+                         (author, publisher)
+    @type license_body: string
+    """
+    packed_license = {}
+    packed_license['license'] = license
+    packed_license['license_url'] = license_url
+    packed_license['license_body'] = license_body
+
+    return packed_license
 
 def delete_file(working_dir, file_path):
     """
@@ -1641,7 +1991,9 @@ def wash_form_parameters(form, abstract_bibdocs, can_keep_doctypes,
 
     @return: tuple (file_action, file_target, file_target_doctype,
         keep_previous_files, file_description, file_comment,
-        file_rename, file_doctype, file_restriction) where::
+        file_rename, file_doctype, file_restriction, copyright_holder,
+        copyright_date, copyright_message, copyright_holder_contact,
+        license, license_url, license_body) where::
 
          file_action: *str* the performed action ('add',
                        'revise','addFormat' or 'delete')
@@ -1685,14 +2037,32 @@ def wash_form_parameters(form, abstract_bibdocs, can_keep_doctypes,
 
          file_path: *str* the full path to the file
 
+         copyright_holder: *str* holder of the copyright of the file
+
+         copyright_date: *str* date of the copyright
+
+         copyright_message: *str* message of the copyright
+
+         copyright_holder_contact: *str* contact information of the copyright
+                                   holder
+
+         license: *str* license of the file
+
+         license_url: *str* url of the license related to the file
+
+         license_body: *str* person or institution imposing the license
+                       (author, publisher)
+
     @rtype: tuple(string, string, string, boolean, string, string,
-                  string, string, string, string, string)
+                  string, string, string, string, string, string,
+                  string, string, string, string, string, string)
     """
     # Action performed ...
     if form.has_key("fileAction") and \
            form['fileAction'] in CFG_ALLOWED_ACTIONS:
         file_action = str(form['fileAction']) # "add", "revise",
-                                              # "addFormat" or "delete"
+                                              # "addFormat" "copyrightChange"
+                                              # or "delete"
     else:
         file_action = ""
 
@@ -1842,10 +2212,20 @@ def wash_form_parameters(form, abstract_bibdocs, can_keep_doctypes,
         file_name = None
         file_path = None
 
+    # Escape fields related to copyright and license
+    copyright_holder = str(form.get('copyrightHolder',''))
+    copyright_date = str(form.get('copyrightDate',''))
+    copyright_message = str(form.get('copyrightMessage',''))
+    copyright_holder_contact = str(form.get('copyrightHolderContact',''))
+    license = str(form.get('license',''))
+    license_url = str(form.get('licenseUrl',''))
+    license_body = str(form.get('licenseBody',''))
+
     return (file_action, file_target, file_target_doctype,
             keep_previous_files, file_description, file_comment,
             file_rename, file_doctype, file_restriction, file_name,
-            file_path)
+            file_path, copyright_holder, copyright_date, copyright_message,
+            copyright_holder_contact, license, license_url, license_body)
 
 
 def move_uploaded_files_to_storage(working_dir, recid, icon_sizes,
@@ -1934,8 +2314,6 @@ def move_uploaded_files_to_storage(working_dir, recid, icon_sizes,
             if new_bibdoc:
                 newly_added_bibdocs.append(new_bibdoc)
 
-
-
             if create_related_formats:
                 # Schedule creation of related formats
                 create_related_formats_for_bibdocs[rename or bibdoc_name] = True
@@ -1947,13 +2325,22 @@ def move_uploaded_files_to_storage(working_dir, recid, icon_sizes,
         elif action == 'delete':
             delete(bibdoc_name, recid, working_dir, pending_bibdocs,
                    bibrecdocs)
+        elif action == 'copyrightChange':
+            # Don't worry about those strange variable names that are being
+            # send to those two functions below. Those variables store proper
+            # copyright and license data, there is just no point in renaming
+            # them only to pass them as arguments to the functions
+            copyright = pack_copyrights(file_path, rename, description, comment)
+            license = pack_license(doctype, keep_previous_versions, file_restriction)
+            copyright_license_change(file_path, bibdoc_name, copyright,
+                                     license, recid, working_dir, bibrecdocs)
 
     # Finally rename bibdocs that should be named according to a file in
     # curdir (eg. naming according to report number). Only consider
     # file that have just been added.
     parameters = _read_file_revision_interface_configuration_from_disk(working_dir)
     new_names = []
-    doctypes_to_default_filename = parameters[22]
+    doctypes_to_default_filename = parameters[26]
     for bibdoc_to_rename in newly_added_bibdocs:
         bibdoc_to_rename_doctype = bibdoc_to_rename.doctype
         rename_to = doctypes_to_default_filename.get(bibdoc_to_rename_doctype, '')
@@ -2115,6 +2502,28 @@ def add_format(file_path, bibdoc_name, recid, doctype, working_dir,
                            'named %s in record %i.' % \
                            (file_path, bibdoc_name, recid),
                                alert_admin=True)
+def copyright_license_change(file_path, bibdoc_name, copyright, license, recid, working_dir, bibrecdocs):
+    """
+    Changes the copyright and license for the given bibdoc
+    """
+    added_bibdoc = None
+    try:
+        brd = BibRecDocs(recid)
+        bibdoc = bibrecdocs.get_bibdoc(bibdoc_name)
+        bibdoc.set_copyright(copyright)
+        bibdoc.set_license(license)
+        _do_log(working_dir, 'Changed copyright and license of ' + \
+                        brd.get_docname(bibdoc.id) + ': ' + ', '.join(copyright.values() + license.values()))
+
+    except InvenioBibDocFileError, e:
+        # Something went wrong, let's report it !
+        register_exception(prefix='Move_Uploaded_Files_to_Storage ' \
+                           'tried to change copyright and license of a file %s ' \
+                           'named %s in record %i.' % \
+                           (file_path, bibdoc_name, recid),
+                           alert_admin=True)
+
+    return added_bibdoc
 
 def revise(file_path, bibdoc_name, rename, doctype, description,
            comment, file_restriction, icon_sizes, create_icon_doctypes,
@@ -2411,14 +2820,14 @@ $(document).ready(function() {
     $('#bibdocfilemanagedocfileuploadbutton').click(function() {
                 this_form.bibdocfilemanagedocfileuploadbuttonpressed=true;
                 this_form.ajaxSubmit(options);
-    })
+    });
 
 });
 
 // post-submit callback
 function showResponse(responseText, statusText)  {
     hide_upload_progress();
-    hide_revise_panel();
+    hide_panels();
 }
     '''  % {
         'form_url_params': form_url_params,
@@ -2439,14 +2848,24 @@ function display_revise_panel(link, params){
         var showRename = params['showRename'];
         var showDescription = params['showDescription'];
         var showComment = params['showComment'];
+        var showCopyright = params['showCopyright'];
+        var showAdvancedCopyright = params['showAdvancedCopyright'];
         var bibdocname = params['bibdocname'];
         var description = params['description'];
         var comment = params['comment'];
+        var copyright = params['copyright'];
+        var copyrightHolder = params['copyrightHolder'];
+        var copyrightDate = params['copyrightDate'];
+        var copyrightMessage = params['copyrightMessage'];
+        var copyrightHolderContact = params['copyrightHolderContact'];
+        var license = params['license'];
+        var licenseUrl = params['licenseUrl'];
+        var licenseBody = params['licenseBody'];
         var showRestrictions = params['showRestrictions'];
         var restriction = params['restriction'];
         var doctypes = params['doctypes'];
 
-        var balloon = document.getElementById("balloon");
+        var balloon = document.getElementById("reviseBalloon");
         var file_input_block = document.getElementById("balloonReviseFileInputBlock");
         var doctype = document.getElementById("fileDoctypesRow");
         var warningFormats = document.getElementById("warningFormats");
@@ -2454,6 +2873,10 @@ function display_revise_panel(link, params){
         var renameBox = document.getElementById("renameBox");
         var descriptionBox = document.getElementById("descriptionBox");
         var commentBox = document.getElementById("commentBox");
+        var copyrightBox = document.getElementById("copyrightBox");
+        var copyrightSelectList = document.getElementById("copyright");
+        var advancedCopyrightLinkBox = document.getElementById("advancedCopyrightLink");
+        var advancedCopyrightLink = document.getElementById("advancedCopyrightLicense");
         var restrictionBox = document.getElementById("restrictionBox");
         var apply_button = document.getElementById("applyChanges");
         var mainForm = getMainForm();
@@ -2486,6 +2909,16 @@ function display_revise_panel(link, params){
         } else {
             commentBox.style.display = 'none'
         }
+        if ((action == 'revise' || action == 'add') && showCopyright == true){
+            copyrightBox.style.display = ''
+        } else {
+            copyrightBox.style.display = 'none'
+        }
+        if ((action == 'revise' || action == 'add') && showAdvancedCopyright == true){
+            advancedCopyrightLinkBox.style.display = 'inline'
+        } else {
+            advancedCopyrightLinkBox.style.display = 'none'
+        }
         if ((action == 'revise' || action == 'add') && showRestrictions == true){
             restrictionBox.style.display = ''
         } else {
@@ -2506,6 +2939,13 @@ function display_revise_panel(link, params){
         mainForm.rename.value = bibdocname;
         mainForm.comment.value = comment;
         mainForm.description.value = description;
+        mainForm.copyrightHolder.value = copyrightHolder;
+        mainForm.copyrightDate.value = copyrightDate;
+        mainForm.copyrightMessage.value = copyrightMessage;
+        mainForm.copyrightHolderContact.value = copyrightHolderContact;
+        mainForm.license.value = license;
+        mainForm.licenseUrl.value = licenseUrl;
+        mainForm.licenseBody.value = licenseBody;
         var fileRestrictionFound = false;
         for (var i=0; i < mainForm.fileRestriction.length; i++) {
             if (mainForm.fileRestriction[i].value == restriction) {
@@ -2519,6 +2959,9 @@ function display_revise_panel(link, params){
             var lastIndex = mainForm.fileRestriction.length - 1;
             mainForm.fileRestriction.selectedIndex = lastIndex;
         }
+
+        /* Set the correct copyright option in select box*/
+        copyrightSelectList.value = copyright
 
         /* Display and move to correct position*/
         pos = findPosition(link)
@@ -2537,20 +2980,114 @@ function display_revise_panel(link, params){
         if (apply_button) {
             apply_button.disabled = true;
         }
+
+        // Unbind previous binding - otherwise we will get as many update_copyright_fields()
+        //calls as many time we have clicked the "revise" link
+        $('#copyright').off("change");
+        // Bind: changing the select option from copyrights list will update advanced copyrights fields ...
+        $('#copyright').on("change", function(){
+            var val = $('#copyright option:selected').val();
+            update_copyright_fields(val, params);
+        });
+
+        /* ... and trigger it for the first time, so the advanced fields get filled with data */
+        $('#copyright').trigger('change');
+
+        /* Display advanced copyright/license panel*/
+        $(advancedCopyrightLink).click(function(event){
+          link = event.target;
+          display_copyright_panel(link, params);
+          return false;
+        });
+
         /*gray_out(true);*/
 }
-function hide_revise_panel(){
-        var balloon = document.getElementById("balloon");
+
+function display_copyright_panel(link, params){
+        /* Just display here, update takes place in a different function */
+
+        var balloon = document.getElementById("copyrightBalloon");
+        var pos;
+
+        /* Display and move to correct position*/
+        pos = findPosition(link)
+        balloon.style.display = '';
+        balloon.style.position="absolute";
+        balloon.style.left = pos[0] + link.offsetWidth +"px";
+        balloon.style.top = pos[1] - Math.round(balloon.offsetHeight/2) + 5 + "px";
+        balloon.style.zIndex = 1001;
+        balloon.style.display = '';
+}
+
+function hide_panels(){
+        var reviseBalloon = document.getElementById("reviseBalloon");
+        var copyrightBalloon = document.getElementById("copyrightBalloon");
         var apply_button = document.getElementById("applyChanges");
-        balloon.style.display = 'none';
-        if (apply_button) {
-            apply_button.disabled = false;
+        if (copyrightBalloon.style.display != 'none') {
+          copyrightBalloon.style.display = 'none';
+        } else if (reviseBalloon.style.display != 'none') {
+          reviseBalloon.style.display = 'none';
+          if (apply_button) {
+              apply_button.disabled = false;
+          }
         }
         /*gray_out(false);*/
 }
 
+function update_copyright_fields(item, params){
+        var copyrightHolderField = document.getElementById("copyrightHolder");
+        var copyrightDateField = document.getElementById("copyrightDate");
+        var copyrightMessageField = document.getElementById("copyrightMessage");
+        var copyrightHolderContactField = document.getElementById("copyrightHolderContact");
+        var licenseField = document.getElementById("license");
+        var licenseUrlField = document.getElementById("licenseUrl");
+        var licenseBodyField = document.getElementById("licenseBody");
 
-/* Intercept ESC key in order to close revise panel*/
+        if (!item) {
+            /* In case item is empty (the same copyrights for a file as for a record) we want to clear all field anything */
+            copyrightHolderField.value = '';
+            copyrightDateField.value = '';
+            copyrightMessageField.value = '';
+            copyrightHolderContactField.value = '';
+            licenseField.value = '';
+            licenseUrlField.value = '';
+            licenseBodyField.value = '';
+        } else {
+            /* In case item is "Other" try to load initial values (those that
+            were there when to balloon opened) or don't change anything */
+            if (item == "Other") {
+                /* Copyrights will be manually edited by user */
+                copyrightHolderField.value = params['copyrightHolder'];
+                copyrightDateField.value = params['copyrightDate'];
+                copyrightMessageField.value = params['copyrightMessage'];
+                copyrightHolderContactField.value = params['copyrightHolderContact'];
+                licenseField.value = params['license'];
+                licenseUrlField.value = params['licenseUrl'];
+                licenseBodyField.value = params['licenseBody'];
+            } else {
+                /* One of the options in select box is selected */
+                /* Get all mappings for the select item */
+                $.ajax({
+                    url: '%(CFG_SITE_URL)s/kb/export',
+                    dataType: 'json',
+                    type: 'GET',
+                    data: {kbname:"Copyrights", searchkey:item, format: 'kba'},
+                    success: function(json) {
+                        copyrightHolderField.value = json.Copyright.Holder;
+                        /* If the date was not edited by user, use the date of a record */
+                        copyrightDateField.value = params['copyrightDate'] || recordDate;
+                        copyrightMessageField.value = json.Copyright.Message;
+                        copyrightHolderContactField.value = json.Copyright.Contact;
+                        licenseField.value = json.License.License;
+                        licenseUrlField.value = json.License.Url;
+                        licenseBodyField.value = json.License.Body;
+                    }
+                });
+            }
+        }
+}
+
+/* Intercept ESC key in order to close revise or copyright panel*/
 document.onkeyup = keycheck;
 function keycheck(e){
         var KeyID = (window.event) ? event.keyCode : e.keyCode;
@@ -2559,7 +3096,7 @@ function keycheck(e){
             if (upload_in_progress_p) {
                 hide_upload_progress();
             } else {
-                hide_revise_panel();
+                hide_panels();
             }
         }
 }
@@ -2634,7 +3171,7 @@ function nextStep()
       return true;
 }
 
-function updateForm(doctype, can_describe_doctypes, can_comment_doctypes, can_restrict_doctypes) {
+function updateForm(doctype, can_describe_doctypes, can_comment_doctypes, can_restrict_doctypes, can_change_copyright_doctypes, can_change_advanced_copyright_doctypes) {
     /* Update the revision panel to hide or not part of the interface
      * based on selected doctype
      *
@@ -2647,11 +3184,14 @@ function updateForm(doctype, can_describe_doctypes, can_comment_doctypes, can_re
     var renameBox = document.getElementById("renameBox");
     var descriptionBox = document.getElementById("descriptionBox");
     var commentBox = document.getElementById("commentBox");
+    var copyrightBox = document.getElementById("copyrightBox");
     var restrictionBox = document.getElementById("restrictionBox");
 
     if (!can_describe_doctypes) {var can_describe_doctypes = [];}
     if (!can_comment_doctypes)  {var can_comment_doctypes = [];}
     if (!can_restrict_doctypes) {var can_restrict_doctypes = [];}
+    if (!can_change_copyright_doctypes) {var can_change_copyright_doctypes = [];}
+    if (!can_change_advanced_copyright_doctypes) {var can_change_advanced_copyright_doctypes = [];}
 
     if ((doctype in can_describe_doctypes) ||
         ('*' in can_describe_doctypes)){
@@ -2674,8 +3214,15 @@ function updateForm(doctype, can_describe_doctypes, can_comment_doctypes, can_re
         restrictionBox.style.display = 'none'
     }
 
+    if ((doctype in can_change_copyright_doctypes) ||
+        ('*' in can_change_copyright_doctypes)){
+        copyrightBox.style.display = ''
+    } else {
+        copyrightBox.style.display = 'none'
+    }
+
     /* Move the revise panel accordingly */
-    var balloon = document.getElementById("balloon");
+    var balloon = document.getElementById("reviseBalloon");
     pos = findPosition(last_clicked_link)
     balloon.style.display = '';
     balloon.style.position="absolute";
@@ -2751,7 +3298,8 @@ function gray_out(visible) {
 }
 -->
 </script>
-''' % {'CFG_SITE_RECORD': CFG_SITE_RECORD}
+''' % {'CFG_SITE_RECORD': CFG_SITE_RECORD,
+       'CFG_SITE_URL': CFG_SITE_URL}
     return javascript
 
 def get_upload_file_interface_css():
@@ -2828,45 +3376,45 @@ cursor: default
 }
 */
 
-#balloon table{
+.balloon table{
 border-collapse:collapse;
 border-spacing: 0px;
 }
-#balloon table td.topleft{
+.balloon table td.topleft{
 background: transparent url(%(CFG_SITE_URL)s/img/balloon_top_left_shadow.png) no-repeat bottom right;
 }
-#balloon table td.bottomleft{
+.balloon table td.bottomleft{
 background: transparent url(%(CFG_SITE_URL)s/img/balloon_bottom_left_shadow.png) no-repeat top right;
 }
-#balloon table td.topright{
+.balloon table td.topright{
 background: transparent url(%(CFG_SITE_URL)s/img/balloon_top_right_shadow.png) no-repeat bottom left;
 }
-#balloon table td.bottomright{
+.balloon table td.bottomright{
 background: transparent url(%(CFG_SITE_URL)s/img/balloon_bottom_right_shadow.png) no-repeat top left;
 }
-#balloon table td.top{
+.balloon table td.top{
 background: transparent url(%(CFG_SITE_URL)s/img/balloon_top_shadow.png) repeat-x bottom left;
 }
-#balloon table td.bottom{
+.balloon table td.bottom{
 background: transparent url(%(CFG_SITE_URL)s/img/balloon_bottom_shadow.png) repeat-x top left;
 }
-#balloon table td.left{
+.balloon table td.left{
 background: transparent url(%(CFG_SITE_URL)s/img/balloon_left_shadow.png) repeat-y top right;
 text-align:right;
 padding:0;
 }
-#balloon table td.right{
+.balloon table td.right{
 background: transparent url(%(CFG_SITE_URL)s/img/balloon_right_shadow.png) repeat-y top left;
 }
-#balloon table td.arrowleft{
+.balloon table td.arrowleft{
 background: transparent url(%(CFG_SITE_URL)s/img/balloon_arrow_left_shadow.png) no-repeat bottom right;
 width:24px;
 height:27px;
 }
-#balloon table td.center{
+.balloon table td.center{
 background-color:#ffffea;
 }
-#balloon label{
+.balloon label{
 font-size:small;
 }
 #balloonReviseFile{
@@ -2887,6 +3435,16 @@ margin-top:6px;
 }
 #description, #comment, #rename {
 width:90%%;
+}
+label {
+  display: inline-block;
+  min-width: 60px;
+}
+#advancedCopyrightLicense{
+  font-size: smaller;
+}
+#copyrightBox, #restrictionBox{
+  margin: 1px;
 }
 .rotatingprogress, .rotatingpostprocess {
 position:relative;
@@ -2926,7 +3484,7 @@ color: #514100;
 
 # The HTML markup of the revise panel
 revise_balloon = '''
-<div id="balloon" style="display:none;">
+<div id="reviseBalloon" class="balloon" style="display:none;">
 <input type="hidden" name="fileAction" value="" />
 <input type="hidden" name="fileTarget" value="" />
   <table>
@@ -2940,18 +3498,85 @@ revise_balloon = '''
       <td class="center">
         <table id="balloonReviseFile">
           <tr>
-            <td><label for="balloonReviseFileInput">%(file_label)s:</label><br/>
+            <td>
+              <label for="balloonReviseFileInput">%(file_label)s:</label><br/>
               <div style="display:none" id="fileDoctypesRow"></div>
               <div id="balloonReviseFileInputBlock"><input type="file" name="myfile" id="balloonReviseFileInput" size="20" /></div>
                           <!--  <input type="file" name="myfile" id="balloonReviseFileInput" size="20" onchange="var name=getElementById('rename');var filename=this.value.split('/').pop().split('.')[0];name.value=filename;"/> -->
               <div id="renameBox" style=""><label for="rename">%(filename_label)s:</label><br/><input type="text" name="rename" id="rename" size="20" autocomplete="off"/></div>
               <div id="descriptionBox" style=""><label for="description">%(description_label)s:</label><br/><input type="text" name="description" id="description" size="20" autocomplete="off"/></div>
               <div id="commentBox" style=""><label for="comment">%(comment_label)s:</label><br/><textarea name="comment" id="comment" rows="3"/></textarea></div>
+              <div id="copyrightBox" style="display:none;white-space:nowrap;"><label for="copyright">%(copyright_label)s:</label> %(copyrights)s
+                <div id="advancedCopyrightLink" style="display:none;"><a href="" id='advancedCopyrightLicense'>%(advanced_copyright_label)s</a></div>
+              </div>
               <div id="restrictionBox" style="display:none;white-space:nowrap;">%(restrictions)s</div>
               <div id="keepPreviousVersions" style="display:none"><input type="checkbox" id="balloonReviseFileKeep" name="keepPreviousFiles" checked="checked" /><label for="balloonReviseFileKeep">%(previous_versions_label)s</label>&nbsp;<small>[<a href="" onclick="alert('%(previous_versions_help)s');return false;">?</a>]</small></div>
               <p id="warningFormats" style="display:none"><img src="%(CFG_SITE_URL)s/img/warning.png" alt="Warning"/> %(revise_format_warning)s&nbsp;[<a href="" onclick="alert('%(revise_format_help)s');return false;">?</a>]</p>
               <div class="progress"><div class="bar"></div ><div class="percent">0%%</div ></div>
-              <div class="rotatingprogress"><img src="/img/ui-anim_basic_16x16.gif" /> %(uploading_label)s</div><div class="rotatingpostprocess"><img src="/img/ui-anim_basic_16x16.gif" /> %(postprocess_label)s</div><div id="canceluploadbuttongroup" style="text-align:right;margin-top:5px"><input type="button" value="%(cancel)s" onclick="javascript:hide_revise_panel();"/> <input type="%(submit_or_button)s" id="bibdocfilemanagedocfileuploadbutton" onclick="show_upload_progress()" value="%(upload)s"/></div>
+              <div class="rotatingprogress"><img src="/img/ui-anim_basic_16x16.gif" /> %(uploading_label)s</div><div class="rotatingpostprocess"><img src="/img/ui-anim_basic_16x16.gif" /> %(postprocess_label)s</div><div id="canceluploadbuttongroup" style="text-align:center;margin-top:5px"><input type="button" value="%(cancel)s" onclick="javascript:hide_panels();"/> <input type="%(submit_or_button)s" id="bibdocfilemanagedocfileuploadbutton" onclick="show_upload_progress()" value="%(upload)s"/> </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+      <td class="right">&nbsp;</td>
+    </tr>
+    <tr>
+      <td class="bottomleft">&nbsp;</td>
+      <td class="bottom">&nbsp;</td>
+      <td class="bottomright">&nbsp;</td>
+    </tr>
+  </table>
+</div>
+'''
+
+# The HTML markup of the advanced copyright panel
+copyright_balloon = '''
+<div id="copyrightBalloon" class="balloon" style="display:none;">
+  <table>
+    <tr>
+      <td class="topleft">&nbsp;</td>
+      <td class="top">&nbsp;</td>
+      <td class="topright">&nbsp;</td>
+    </tr>
+    <tr>
+      <td class="left" vertical-align="center" width="24"><img alt=" " src="../img/balloon_arrow_left_shadow.png" /></td>
+      <td class="center">
+        <table id="balloonCopyright">
+          <tr>
+            <td>
+              <fieldset>
+                <legend>Copyright</legend>
+                <table>
+                  <tr>
+                    <td class="label" align="right"><label for="copyrightHolder"><span style="color: red;">*</span>Copyright Holder:</label></td>
+                    <td align="left"><input id="copyrightHolder" name="copyrightHolder" type="text" size="23" value="" /></td>
+                  </tr><tr>
+                    <td class="label" align="right"><label for="copyrightDate"><span style="color: red;">*</span>Copyright Date:</label></td>
+                    <td align="left"><input id="copyrightDate" name="copyrightDate" type="text" size="23" value="" /></td>
+                  </tr><tr>
+                    <td class="label" align="right"><label for="copyrightMessage">Copyright Message:</label> </td>
+                    <td align="left"><textarea rows="3" cols="25" id="copyrightMessage" name="copyrightMessage"></textarea></td>
+                  </tr><tr >
+                    <td class="label" align="right"><label for="copyrightHolderContact">Copyright Holder Contact:</label></td>
+                    <td align="left"><input id="copyrightHolderContact" name="copyrightHolderContact" type="text" size="23" value=""/></td>
+                  </tr>
+                </table>
+              </fieldset>
+              <fieldset>
+                <legend>License</legend>
+                <table>
+                  <tr>
+                    <td class="label" align="right"><label for="license">License:</label></td>
+                    <td align="left"><input type="text" value="" name="license" size="23" id="license"></td>
+                  </tr><tr>
+                    <td align="right"><label for="licenseUrl">License URL:</label></td>
+                    <td align="left"><input type="text" value="" name="licenseUrl" size="23" id="licenseUrl"></td>
+                  </tr><tr>
+                    <td align="right"><label for="licenseBody">License Body:</label></td>
+                    <td align="left"><input type="text" value="" name="licenseBody" size="23" id="licenseBody"></td>
+                  </tr>
+                </table>
+              <div id="canceluploadbuttongroup" style="text-align:center;margin-top:5px"> <input type="button" id="bibdocfilemanagedoccopyrightclosebutton" onclick="hide_panels()" value="%(close)s"/> </div>
             </td>
           </tr>
         </table>

--- a/modules/bibrecord/lib/bibrecord.py
+++ b/modules/bibrecord/lib/bibrecord.py
@@ -210,6 +210,8 @@ def filter_field_instances(field_instances, filter_subcode, filter_value, filter
         'e' - looking for exact match in subfield value
         's' - looking for substring in subfield value
         'r' - looking for regular expression in subfield value
+        'n' - looking for fields where subfield doesn't exist (this mode
+              ignores the filter_value)
 
         Example:
         record_filter_field(record_get_field_instances(rec, '999', '%', '%'), 'y', '2001')
@@ -220,7 +222,7 @@ def filter_field_instances(field_instances, filter_subcode, filter_value, filter
         @type filter_subcode: string
         @param filter_value: value of the subfield
         @type filter_value: string
-        @param filter_mode: 'e','s' or 'r'
+        @param filter_mode: 'e','s', 'r' or 'n'
     """
     matched = []
     if filter_mode == 'e':
@@ -243,6 +245,11 @@ def filter_field_instances(field_instances, filter_subcode, filter_value, filter
                    reg_exp.match(subfield[1]) is not None:
                     matched.append(instance)
                     break
+    elif filter_mode == 'n':
+        for instance in field_instances:
+            if filter_subcode not in [subfield[0] for subfield in instance[0]]:
+                matched.append(instance)
+
     return matched
 
 def record_drop_duplicate_fields(record):

--- a/modules/bibupload/lib/bibupload_regression_tests.py
+++ b/modules/bibupload/lib/bibupload_regression_tests.py
@@ -3869,6 +3869,7 @@ class BibUploadFFTModeTest(GenericBibUploadTest):
           <subfield code="u">Test University</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">987654321</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif</subfield>
          </datafield>
@@ -3885,6 +3886,12 @@ class BibUploadFFTModeTest(GenericBibUploadTest):
                                                           str(recid))
         testrec_expected_url = testrec_expected_url.replace('123456789',
                                                           str(recid))
+        # get the bibdocid of latest file inserted
+        # only ony file is added so we don't have to additionally check
+        # if it's really the last file added
+        bibdocid = BibRecDocs(recid).list_latest_files()[0].get_bibdocid()
+        testrec_expected_xm = testrec_expected_xm.replace('987654321',
+                                                          str(bibdocid))
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
         self.failUnless(records_identical(create_record(inserted_xm)[0], create_record(testrec_expected_xm)[0], ignore_subfield_order=True, ignore_field_order=True))
@@ -3920,6 +3927,7 @@ allow any</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">987654321</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif</subfield>
          </datafield>
@@ -3936,6 +3944,12 @@ allow any</subfield>
                                                           str(recid))
         testrec_expected_url = testrec_expected_url.replace('123456789',
                                                           str(recid))
+        # get the bibdocid of latest file inserted
+        # only ony file is added so we don't have to additionally check
+        # if it's really the last file added
+        bibdocid = BibRecDocs(recid).list_latest_files()[0].get_bibdocid()
+        testrec_expected_xm = testrec_expected_xm.replace('987654321',
+                                                          str(bibdocid))
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
         self.failUnless(records_identical(create_record(inserted_xm)[0], create_record(testrec_expected_xm)[0], ignore_subfield_order=True, ignore_field_order=True))
@@ -3975,6 +3989,7 @@ allow any</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">987654321</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif</subfield>
          </datafield>
@@ -3994,6 +4009,12 @@ allow any</subfield>
                                                           str(recid))
         testrec_expected_url = testrec_expected_url.replace('123456789',
                                                           str(recid))
+        # get the bibdocid of latest file inserted
+        # only ony file is added so we don't have to additionally check
+        # if it's really the last file added
+        bibdocid = BibRecDocs(recid).list_latest_files()[0].get_bibdocid()
+        testrec_expected_xm = testrec_expected_xm.replace('987654321',
+                                                          str(bibdocid))
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
         self.failUnless(records_identical(create_record(inserted_xm)[0], create_record(testrec_expected_xm)[0], ignore_subfield_order=True, ignore_field_order=True))
@@ -4051,7 +4072,8 @@ allow any</subfield>
           <subfield code="%(email_code)s">jekyll@cds.cern.ch</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
-         <subfield code="s">4</subfield>
+          <subfield code="8">987654321</subfield>
+          <subfield code="s">4</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/test.ps.Z</subfield>
          </datafield>
         </record>
@@ -4082,6 +4104,13 @@ allow any</subfield>
         recs = bibupload.xml_marc_to_records(testrec_to_append)
         dummy, recid, dummy = bibupload.bibupload_records(recs, opt_mode='append')[0]
         self.check_record_consistency(recid)
+
+        # get the bibdocid of latest file inserted
+        # only ony file is added so we don't have to additionally check
+        # if it's really the last file added
+        bibdocid = BibRecDocs(recid).list_latest_files()[0].get_bibdocid()
+        testrec_expected_xm = testrec_expected_xm.replace('987654321',
+                                                          str(bibdocid))
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
         self.failUnless(records_identical(create_record(inserted_xm)[0], create_record(testrec_expected_xm)[0], ignore_subfield_order=True, ignore_field_order=True))
@@ -4135,12 +4164,14 @@ allow any</subfield>
          <datafield tag="FFT" ind1=" " ind2=" ">
           <subfield code="a">%(siteurl)s/img/site_logo.gif</subfield>
           <subfield code="t">SuperMain</subfield>
+          <subfield code="c">Copyright Holder||1234||CopyrightMessage||jekyll@cds.cern.ch</subfield>
           <subfield code="d">This is a description</subfield>
           <subfield code="z">This is a comment</subfield>
           <subfield code="n">CIDIESSE</subfield>
          </datafield>
          <datafield tag="FFT" ind1=" " ind2=" ">
           <subfield code="a">%(siteurl)s/img/rss.png</subfield>
+          <subfield code="l">License||www.license.url.com||license body</subfield>
           <subfield code="t">SuperMain</subfield>
           <subfield code="f">.jpeg</subfield>
           <subfield code="d">This is a description</subfield>
@@ -4159,13 +4190,28 @@ allow any</subfield>
           <subfield code="a">Test, John</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
+         <datafield tag="540" ind1=" " ind2=" ">
+          <subfield code="8">9876543211</subfield>
+          <subfield code="a">License</subfield>
+          <subfield code="b">www.license.url.com</subfield>
+          <subfield code="u">license body</subfield>
+         </datafield>
+         <datafield tag="542" ind1=" " ind2=" ">
+          <subfield code="8">9876543211</subfield>
+          <subfield code="d">Copyright Holder</subfield>
+          <subfield code="e">jekyll@cds.cern.ch</subfield>
+          <subfield code="f">CopyrightMessage</subfield>
+          <subfield code="g">1234</subfield>
+         </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543211</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/CIDIESSE.gif</subfield>
           <subfield code="y">This is a description</subfield>
           <subfield code="z">This is a comment</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543212</subfield>
           <subfield code="s">530</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/CIDIESSE.jpeg</subfield>
           <subfield code="y">This is a description</subfield>
@@ -4186,6 +4232,16 @@ allow any</subfield>
                                                           str(recid))
         testrec_expected_url2 = testrec_expected_url1.replace('123456789',
                                                           str(recid))
+
+        # get the bibdocid of latest file inserted
+        bibdocids = [x.get_bibdocid() for x in BibRecDocs(recid).list_latest_files()]
+        # replace test buffers with real bibdocid of inserted test file:
+
+        testrec_expected_xm = testrec_expected_xm.replace('9876543211',
+                                                          str(min(bibdocids)))
+        testrec_expected_xm = testrec_expected_xm.replace('9876543212',
+                                                          str(max(bibdocids)))
+
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
         self.failUnless(records_identical(create_record(inserted_xm)[0], create_record(testrec_expected_xm)[0], ignore_subfield_order=True, ignore_field_order=True))
@@ -4237,10 +4293,12 @@ allow any</subfield>
           <subfield code="%(email_code)s">jekyll@cds.cern.ch</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543211</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543212</subfield>
           <subfield code="s">79</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif?subformat=icon</subfield>
           <subfield code="x">icon</subfield>
@@ -4271,6 +4329,16 @@ allow any</subfield>
                                                           str(recid))
         testrec_expected_icon = testrec_expected_icon.replace('123456789',
                                                           str(recid))
+
+        # get the bibdocids of latest file inserted
+        bibdocids = [x.get_bibdocid() for x in BibRecDocs(recid).list_latest_files()]
+        # replace test buffers with real bibdocid of inserted test file:
+
+        testrec_expected_xm = testrec_expected_xm.replace('9876543211',
+                                                          str(min(bibdocids)))
+        testrec_expected_xm = testrec_expected_xm.replace('9876543212',
+                                                          str(max(bibdocids)))
+
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
         self.failUnless(records_identical(create_record(inserted_xm)[0], create_record(testrec_expected_xm)[0], ignore_subfield_order=True, ignore_field_order=True))
@@ -4311,10 +4379,12 @@ allow any</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543211</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543212</subfield>
           <subfield code="s">79</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif?subformat=icon</subfield>
           <subfield code="x">icon</subfield>
@@ -4336,6 +4406,16 @@ allow any</subfield>
                                                           str(recid))
         testrec_expected_icon = testrec_expected_icon.replace('123456789',
                                                           str(recid))
+
+        # get the bibdocids of latest file inserted
+        bibdocids = [x.get_bibdocid() for x in BibRecDocs(recid).list_latest_files()]
+        # replace test buffers with real bibdocid of inserted test file:
+
+        testrec_expected_xm = testrec_expected_xm.replace('9876543211',
+                                                          str(min(bibdocids)))
+        testrec_expected_xm = testrec_expected_xm.replace('9876543212',
+                                                          str(max(bibdocids)))
+
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
         self.failUnless(records_identical(create_record(inserted_xm)[0], create_record(testrec_expected_xm)[0], ignore_subfield_order=True, ignore_field_order=True))
@@ -4380,18 +4460,22 @@ allow any</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543211</subfield>
           <subfield code="s">295078</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/9809057.pdf</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543212</subfield>
           <subfield code="s">%(sizeofdemobibdata)s</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/demobibdata.xml</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543213</subfield>
           <subfield code="s">208</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/head.gif</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543214</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif</subfield>
          </datafield>
@@ -4410,6 +4494,17 @@ allow any</subfield>
         testrec_expected_urls = []
         for files in ('site_logo.gif', 'head.gif', '9809057.pdf', 'demobibdata.xml'):
             testrec_expected_urls.append('%(siteurl)s/%(CFG_SITE_RECORD)s/%(recid)s/files/%(files)s' % {'siteurl' : CFG_SITE_URL, 'CFG_SITE_RECORD': CFG_SITE_RECORD, 'files' : files, 'recid' : recid})
+
+        # replace test buffers with real bibdocid of inserted test files:
+        bibdocids = dict((x.get_full_name(), x.get_bibdocid()) for x in BibRecDocs(recid).list_latest_files())
+        testrec_expected_xm = testrec_expected_xm.replace('9876543211',
+                                                          str(bibdocids.get('9809057.pdf')))
+        testrec_expected_xm = testrec_expected_xm.replace('9876543212',
+                                                          str(bibdocids.get('demobibdata.xml')))
+        testrec_expected_xm = testrec_expected_xm.replace('9876543213',
+                                                          str(bibdocids.get('head.gif')))
+        testrec_expected_xm = testrec_expected_xm.replace('9876543214',
+                                                          str(bibdocids.get('site_logo.gif')))
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
 
@@ -4461,6 +4556,7 @@ allow any</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">987654321</subfield>
           <subfield code="s">79</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif</subfield>
          </datafield>
@@ -4483,6 +4579,13 @@ allow any</subfield>
         recs = bibupload.xml_marc_to_records(test_to_correct)
         bibupload.bibupload_records(recs, opt_mode='correct')[0]
         self.check_record_consistency(recid)
+
+        # get the bibdocid of latest file inserted
+        # only ony file is added so we don't have to additionally check
+        # if it's really the last file added
+        bibdocid = BibRecDocs(recid).list_latest_files()[0].get_bibdocid()
+        testrec_expected_xm = testrec_expected_xm.replace('987654321',
+                                                          str(bibdocid))
 
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
@@ -4560,23 +4663,28 @@ allow any</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543211</subfield>
           <subfield code="s">35</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/line.gif</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543212</subfield>
           <subfield code="s">626</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/line.png</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543213</subfield>
           <subfield code="s">432</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/rss.png</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543214</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif</subfield>
           <subfield code="y">a second description</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543215</subfield>
           <subfield code="s">786</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.png</subfield>
           <subfield code="y">another second description</subfield>
@@ -4616,6 +4724,19 @@ allow any</subfield>
         recs = bibupload.xml_marc_to_records(test_to_correct)
         bibupload.bibupload(recs[0], opt_mode='correct')
         self.check_record_consistency(recid)
+
+        # replace test buffers with real bibdocid of inserted test file:
+        bibdocids = dict((x.get_full_name(), x.get_bibdocid()) for x in BibRecDocs(recid).list_latest_files())
+        testrec_expected_xm = testrec_expected_xm.replace('9876543211',
+                                                          str(bibdocids.get('line.gif')))
+        testrec_expected_xm = testrec_expected_xm.replace('9876543212',
+                                                          str(bibdocids.get('line.png')))
+        testrec_expected_xm = testrec_expected_xm.replace('9876543213',
+                                                          str(bibdocids.get('rss.png')))
+        testrec_expected_xm = testrec_expected_xm.replace('9876543214',
+                                                          str(bibdocids.get('site_logo.gif')))
+        testrec_expected_xm = testrec_expected_xm.replace('9876543215',
+                                                          str(bibdocids.get('site_logo.png')))
 
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
@@ -4659,6 +4780,7 @@ allow any</subfield>
         <controlfield tag="001">123456789</controlfield>
         <controlfield tag="003">SzGeCERN</controlfield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">987654321</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif</subfield>
           <subfield code="y">a description</subfield>
@@ -4678,6 +4800,12 @@ allow any</subfield>
         recs = bibupload.xml_marc_to_records(test_to_correct)
         bibupload.bibupload(recs[0], opt_mode='correct')
 
+        # get the bibdocid of latest file inserted
+        bibdocid = BibRecDocs(recid).list_latest_files()[0].get_bibdocid()
+        # replace test buffers with real bibdocid of inserted test file:
+
+        testrec_expected_xm = testrec_expected_xm.replace('987654321',
+                                                          str(bibdocid))
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
         self.failUnless(records_identical(create_record(inserted_xm)[0], create_record(testrec_expected_xm)[0], ignore_subfield_order=True, ignore_field_order=True))
@@ -4729,11 +4857,13 @@ allow any</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543211</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif</subfield>
           <subfield code="y">a description</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543212</subfield>
           <subfield code="s">786</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.png</subfield>
           <subfield code="y">another second description</subfield>
@@ -4760,6 +4890,14 @@ allow any</subfield>
         err, recid, msg = bibupload.bibupload(recs[0], opt_mode='append')
         self.check_record_consistency(recid)
 
+        # get the bibdocids of latest file inserted
+        bibdocids = [x.get_bibdocid() for x in BibRecDocs(recid).list_latest_files()]
+        # replace test buffers with real bibdocid of inserted test file:
+
+        testrec_expected_xm = testrec_expected_xm.replace('9876543211',
+                                                          str(min(bibdocids)))
+        testrec_expected_xm = testrec_expected_xm.replace('9876543212',
+                                                          str(max(bibdocids)))
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
         self.failUnless(try_url_download(testrec_expected_url))
@@ -4931,6 +5069,7 @@ allow any</subfield>
         <controlfield tag="001">123456789</controlfield>
          <datafield tag="FFT" ind1=" " ind2=" ">
           <subfield code="a">%(siteurl)s/img/head.gif</subfield>
+          <subfield code="c">Copyright Holder||1234</subfield>
           <subfield code="n">site_logo</subfield>
           <subfield code="m">patata</subfield>
           <subfield code="d">Next Try</subfield>
@@ -4949,7 +5088,13 @@ allow any</subfield>
           <subfield code="a">Test, John</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
+         <datafield tag="542" ind1=" " ind2=" ">
+          <subfield code="8">987654321</subfield>
+          <subfield code="d">Copyright Holder</subfield>
+          <subfield code="g">1234</subfield>
+         </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">987654321</subfield>
           <subfield code="s">208</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/patata.gif</subfield>
           <subfield code="y">Next Try</subfield>
@@ -4979,6 +5124,15 @@ allow any</subfield>
         recs = bibupload.xml_marc_to_records(test_to_correct)
         bibupload.bibupload_records(recs, opt_mode='correct')
         self.check_record_consistency(recid)
+
+        # get the bibdocid of latest file inserted
+        # only ony file is added so we don't have to additionally check
+        # if it's really the last file added
+        bibdocid = BibRecDocs(recid).list_latest_files()[0].get_bibdocid()
+        # replace test buffers with real bibdocid of inserted test file:
+
+        testrec_expected_xm = testrec_expected_xm.replace('987654321',
+                                                          str(bibdocid))
 
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
@@ -5028,6 +5182,7 @@ allow any</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">987654321</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/patata.gif</subfield>
           <subfield code="y">Try</subfield>
@@ -5056,6 +5211,10 @@ allow any</subfield>
         bibupload.bibupload_records(recs, opt_mode='correct')[0]
         self.check_record_consistency(recid)
 
+        # get the bibdocid of latest file inserted
+        bibdocid = BibRecDocs(recid).list_latest_files()[0].get_bibdocid()
+        testrec_expected_xm = testrec_expected_xm.replace('987654321',
+                                                          str(bibdocid))
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
 
@@ -5096,6 +5255,7 @@ allow any</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">987654321</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif?subformat=icon</subfield>
           <subfield code="x">icon</subfield>
@@ -5123,6 +5283,11 @@ allow any</subfield>
         bibupload.bibupload_records(recs, opt_mode='append')[0]
         self.check_record_consistency(recid)
 
+        # get the bibdocid of latest file inserted
+        bibdocid = BibRecDocs(recid).list_latest_files()[0].get_bibdocid()
+        testrec_expected_xm = testrec_expected_xm.replace('987654321',
+                                                          str(bibdocid))
+
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
         self.failUnless(records_identical(create_record(inserted_xm)[0], create_record(testrec_expected_xm)[0], ignore_subfield_order=True, ignore_field_order=True))
@@ -5139,6 +5304,16 @@ allow any</subfield>
          <datafield tag="100" ind1=" " ind2=" ">
           <subfield code="a">Test, John</subfield>
           <subfield code="u">Test University</subfield>
+         </datafield>
+         <datafield tag="540" ind1=" " ind2=" ">
+          <subfield code="a">General License</subfield>
+          <subfield code="b">www.license.url.com</subfield>
+         </datafield>
+         <datafield tag="542" ind1=" " ind2=" ">
+          <subfield code="d">General Copyright Holder</subfield>
+          <subfield code="e">jekyll@cds.cern.ch</subfield>
+          <subfield code="f">CopyrightMessage</subfield>
+          <subfield code="g">2000</subfield>
          </datafield>
          <datafield tag="FFT" ind1=" " ind2=" ">
           <subfield code="a">%(siteurl)s/img/site_logo.gif</subfield>
@@ -5163,6 +5338,7 @@ allow any</subfield>
         <controlfield tag="001">123456789</controlfield>
          <datafield tag="FFT" ind1=" " ind2=" ">
           <subfield code="a">%(siteurl)s/img/loading.gif</subfield>
+          <subfield code="l">License||www.license.url.com||license body</subfield>
           <subfield code="n">site_logo</subfield>
           <subfield code="m">patata</subfield>
           <subfield code="f">.gif</subfield>
@@ -5181,7 +5357,24 @@ allow any</subfield>
           <subfield code="a">Test, John</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
+         <datafield tag="540" ind1=" " ind2=" ">
+          <subfield code="a">General License</subfield>
+          <subfield code="b">www.license.url.com</subfield>
+         </datafield>
+         <datafield tag="540" ind1=" " ind2=" ">
+          <subfield code="8">987654321</subfield>
+          <subfield code="a">License</subfield>
+          <subfield code="b">www.license.url.com</subfield>
+          <subfield code="u">license body</subfield>
+         </datafield>
+         <datafield tag="542" ind1=" " ind2=" ">
+          <subfield code="d">General Copyright Holder</subfield>
+          <subfield code="e">jekyll@cds.cern.ch</subfield>
+          <subfield code="f">CopyrightMessage</subfield>
+          <subfield code="g">2000</subfield>
+         </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">987654321</subfield>
           <subfield code="s">9427</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/patata.gif</subfield>
          </datafield>
@@ -5208,6 +5401,10 @@ allow any</subfield>
         recs = bibupload.xml_marc_to_records(test_to_correct)
         bibupload.bibupload_records(recs, opt_mode='correct')[0]
         self.check_record_consistency(recid)
+        # get the bibdocid of latest file inserted
+        bibdocid = BibRecDocs(recid).list_latest_files()[0].get_bibdocid()
+        testrec_expected_xm = testrec_expected_xm.replace('987654321',
+                                                          str(bibdocid))
 
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
@@ -5269,10 +5466,12 @@ allow any</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543211</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">9876543212</subfield>
           <subfield code="s">208</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/head.gif</subfield>
          </datafield>
@@ -5303,7 +5502,14 @@ allow any</subfield>
         bibupload.bibupload_records(recs, opt_mode='correct')
         self.check_record_consistency(recid)
 
+        # get the bibdocid of latest file inserted
+        bibdocids = [x.get_bibdocid() for x in BibRecDocs(recid).list_latest_files()]
+        # replace test buffers with real bibdocid of inserted test file:
 
+        testrec_expected_xm = testrec_expected_xm.replace('9876543211',
+                                                          str(min(bibdocids)))
+        testrec_expected_xm = testrec_expected_xm.replace('9876543212',
+                                                          str(max(bibdocids)))
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
         self.failUnless(try_url_download(testrec_expected_url))
@@ -5371,6 +5577,7 @@ allow any</subfield>
           <subfield code="%(email_code)s">jekyll@cds.cern.ch</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">987654321</subfield>
           <subfield code="s">171</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif</subfield>
          </datafield>
@@ -5400,6 +5607,13 @@ allow any</subfield>
         recs = bibupload.xml_marc_to_records(test_to_correct)
         bibupload.bibupload_records(recs, opt_mode='correct')
         self.check_record_consistency(recid)
+
+        # get the bibdocid of latest file inserted
+        # only ony file is added so we don't have to additionally check
+        # if it's really the last file added
+        bibdocid = BibRecDocs(recid).list_latest_files()[0].get_bibdocid()
+        testrec_expected_xm = testrec_expected_xm.replace('987654321',
+                                                          str(bibdocid))
 
         # revert test record with new FFT:
         recs = bibupload.xml_marc_to_records(test_to_revert)
@@ -5484,6 +5698,7 @@ allow any</subfield>
           <subfield code="%(email_code)s">jekyll@cds.cern.ch</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">987654321</subfield>
           <subfield code="s">208</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/head.gif</subfield>
          </datafield>
@@ -5513,6 +5728,13 @@ allow any</subfield>
         recs = bibupload.xml_marc_to_records(test_to_replace)
         bibupload.bibupload_records(recs, opt_mode='replace')
         self.check_record_consistency(recid)
+
+        # get the bibdocid of latest file inserted
+        # only ony file is added so we don't have to additionally check
+        # if it's really the last file added
+        bibdocid = BibRecDocs(recid).list_latest_files()[0].get_bibdocid()
+        testrec_expected_xm = testrec_expected_xm.replace('987654321',
+                                                          str(bibdocid))
 
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
@@ -5585,6 +5807,7 @@ allow any</subfield>
           <subfield code="u">Test University</subfield>
          </datafield>
          <datafield tag="856" ind1="4" ind2=" ">
+          <subfield code="8">987654321</subfield>
           <subfield code="s">2032</subfield>
           <subfield code="u">%(siteurl)s/%(CFG_SITE_RECORD)s/123456789/files/site_logo.gif</subfield>
          </datafield>
@@ -5608,6 +5831,13 @@ allow any</subfield>
                                                           str(recid))
         testrec_expected_url2 = testrec_expected_url2.replace('123456789',
                                                           str(recid))
+
+        # get the bibdocid of latest file inserted
+        # only ony file is added so we don't have to additionally check
+        # if it's really the last file added
+        bibdocid = BibRecDocs(recid).list_latest_files()[0].get_bibdocid()
+        testrec_expected_xm = testrec_expected_xm.replace('987654321',
+                                                          str(bibdocid))
         # compare expected results:
         inserted_xm = print_record(recid, 'xm')
         self.failUnless(records_identical(create_record(inserted_xm)[0], create_record(testrec_expected_xm)[0], ignore_subfield_order=True, ignore_field_order=True))

--- a/modules/bibupload/lib/bibupload_revisionverifier_regression_tests.py
+++ b/modules/bibupload/lib/bibupload_revisionverifier_regression_tests.py
@@ -1114,7 +1114,7 @@ class RevisionVerifierHistoryOfAffectedFields(GenericBibUploadTest):
         """Checks if corrected record has affected fields in hstRECORD table"""
         query = "SELECT affected_fields from hstRECORD where id_bibrec=12 ORDER BY job_date DESC"
         res = run_sql(query)
-        self.assertEqual(res[0][0], "005__%,8564_%,909C0%,909C1%,909C5%,909CO%,909CS%")
+        self.assertEqual(res[0][0], "005__%,540__%,542__%,8564_%,909C0%,909C1%,909C5%,909CO%,909CS%")
 
 
     def test_append_to_record_affected_tags(self):

--- a/modules/websearch/lib/websearch_regression_tests.py
+++ b/modules/websearch/lib/websearch_regression_tests.py
@@ -1297,8 +1297,8 @@ class WebSearchSearchEnginePythonAPITest(InvenioXmlTestCase):
 000000085 695__ $$9LANL EDS$$aHigh Energy Physics - Theory
 000000085 700__ $$aPorrati, Massimo
 000000085 700__ $$aZaffaroni, A
-000000085 8564_ $$s112828$$u%(siteurl)s/record/85/files/0212181.ps.gz
-000000085 8564_ $$s151257$$u%(siteurl)s/record/85/files/0212181.pdf
+000000085 8564_ $$874$$s112828$$u%(siteurl)s/record/85/files/0212181.ps.gz
+000000085 8564_ $$874$$s151257$$u%(siteurl)s/record/85/files/0212181.pdf
 000000085 859__ $$falberto.zaffaroni@mib.infn.it
 000000085 909C4 $$c289-293$$pPhys. Lett. B$$v561$$y2003
 000000085 916__ $$sn$$w200251
@@ -1345,8 +1345,8 @@ class WebSearchSearchEnginePythonAPITest(InvenioXmlTestCase):
 000000001 65017 $$2SzGeCERN$$aExperiments and Tracks
 000000001 6531_ $$aLEP
 000000001 8560_ $$fneil.calder@cern.ch
-000000001 8564_ $$s1585244$$u%(siteurl)s/record/1/files/0106015_01.jpg
-000000001 8564_ $$s20954$$u%(siteurl)s/record/1/files/0106015_01.gif?subformat=icon$$xicon
+000000001 8564_ $$81$$s1585244$$u%(siteurl)s/record/1/files/0106015_01.jpg
+000000001 8564_ $$81$$s20954$$u%(siteurl)s/record/1/files/0106015_01.gif?subformat=icon$$xicon
 000000001 909C0 $$o0003717PHOPHO
 000000001 909C0 $$y2000
 000000001 909C0 $$b81
@@ -1520,10 +1520,12 @@ class WebSearchSearchEnginePythonAPITest(InvenioXmlTestCase):
     <subfield code="a">Zaffaroni, A</subfield>
   </datafield>
   <datafield tag="856" ind1="4" ind2=" ">
+    <subfield code="8">74</subfield>
     <subfield code="s">112828</subfield>
     <subfield code="u">%(siteurl)s/record/85/files/0212181.ps.gz</subfield>
   </datafield>
   <datafield tag="856" ind1="4" ind2=" ">
+    <subfield code="8">74</subfield>
     <subfield code="s">151257</subfield>
     <subfield code="u">%(siteurl)s/record/85/files/0212181.pdf</subfield>
   </datafield>
@@ -1739,10 +1741,12 @@ class WebSearchSearchEnginePythonAPITest(InvenioXmlTestCase):
     <subfield code="f">neil.calder@cern.ch</subfield>
   </datafield>
   <datafield tag="856" ind1="4" ind2=" ">
+    <subfield code="8">1</subfield>
     <subfield code="s">1585244</subfield>
     <subfield code="u">%(siteurl)s/record/1/files/0106015_01.jpg</subfield>
   </datafield>
   <datafield tag="856" ind1="4" ind2=" ">
+    <subfield code="8">1</subfield>
     <subfield code="s">20954</subfield>
     <subfield code="u">%(siteurl)s/record/1/files/0106015_01.gif?subformat=icon</subfield>
     <subfield code="x">icon</subfield>
@@ -2108,8 +2112,8 @@ class WebSearchSearchEngineWebAPITest(InvenioTestCase):
 000000085 695__ $$9LANL EDS$$aHigh Energy Physics - Theory
 000000085 700__ $$aPorrati, Massimo
 000000085 700__ $$aZaffaroni, A
-000000085 8564_ $$s112828$$u%(siteurl)s/record/85/files/0212181.ps.gz
-000000085 8564_ $$s151257$$u%(siteurl)s/record/85/files/0212181.pdf
+000000085 8564_ $$874$$s112828$$u%(siteurl)s/record/85/files/0212181.ps.gz
+000000085 8564_ $$874$$s151257$$u%(siteurl)s/record/85/files/0212181.pdf
 000000085 859__ $$falberto.zaffaroni@mib.infn.it
 000000085 909C4 $$c289-293$$pPhys. Lett. B$$v561$$y2003
 000000085 916__ $$sn$$w200251
@@ -2156,8 +2160,8 @@ class WebSearchSearchEngineWebAPITest(InvenioTestCase):
 000000001 65017 $$2SzGeCERN$$aExperiments and Tracks
 000000001 6531_ $$aLEP
 000000001 8560_ $$fneil.calder@cern.ch
-000000001 8564_ $$s1585244$$u%(siteurl)s/record/1/files/0106015_01.jpg
-000000001 8564_ $$s20954$$u%(siteurl)s/record/1/files/0106015_01.gif?subformat=icon$$xicon
+000000001 8564_ $$81$$s1585244$$u%(siteurl)s/record/1/files/0106015_01.jpg
+000000001 8564_ $$81$$s20954$$u%(siteurl)s/record/1/files/0106015_01.gif?subformat=icon$$xicon
 000000001 909C0 $$o0003717PHOPHO
 000000001 909C0 $$y2000
 000000001 909C0 $$b81
@@ -2318,10 +2322,12 @@ Zaffaroni, A
     <subfield code="a">Zaffaroni, A</subfield>
   </datafield>
   <datafield tag="856" ind1="4" ind2=" ">
+    <subfield code="8">74</subfield>
     <subfield code="s">112828</subfield>
     <subfield code="u">%(siteurl)s/record/85/files/0212181.ps.gz</subfield>
   </datafield>
   <datafield tag="856" ind1="4" ind2=" ">
+    <subfield code="8">74</subfield>
     <subfield code="s">151257</subfield>
     <subfield code="u">%(siteurl)s/record/85/files/0212181.pdf</subfield>
   </datafield>
@@ -2537,10 +2543,12 @@ Zaffaroni, A
     <subfield code="f">neil.calder@cern.ch</subfield>
   </datafield>
   <datafield tag="856" ind1="4" ind2=" ">
+    <subfield code="8">1</subfield>
     <subfield code="s">1585244</subfield>
     <subfield code="u">%(siteurl)s/record/1/files/0106015_01.jpg</subfield>
   </datafield>
   <datafield tag="856" ind1="4" ind2=" ">
+    <subfield code="8">1</subfield>
     <subfield code="s">20954</subfield>
     <subfield code="u">%(siteurl)s/record/1/files/0106015_01.gif?subformat=icon</subfield>
     <subfield code="x">icon</subfield>
@@ -2861,8 +2869,8 @@ class WebSearchRecordWebAPITest(InvenioTestCase):
 000000085 695__ $$9LANL EDS$$aHigh Energy Physics - Theory
 000000085 700__ $$aPorrati, Massimo
 000000085 700__ $$aZaffaroni, A
-000000085 8564_ $$s112828$$u%(siteurl)s/record/85/files/0212181.ps.gz
-000000085 8564_ $$s151257$$u%(siteurl)s/record/85/files/0212181.pdf
+000000085 8564_ $$874$$s112828$$u%(siteurl)s/record/85/files/0212181.ps.gz
+000000085 8564_ $$874$$s151257$$u%(siteurl)s/record/85/files/0212181.pdf
 000000085 859__ $$falberto.zaffaroni@mib.infn.it
 000000085 909C4 $$c289-293$$pPhys. Lett. B$$v561$$y2003
 000000085 916__ $$sn$$w200251
@@ -2962,10 +2970,12 @@ class WebSearchRecordWebAPITest(InvenioTestCase):
     <subfield code="a">Zaffaroni, A</subfield>
   </datafield>
   <datafield tag="856" ind1="4" ind2=" ">
+    <subfield code="8">74</subfield>
     <subfield code="s">112828</subfield>
     <subfield code="u">%(siteurl)s/record/85/files/0212181.ps.gz</subfield>
   </datafield>
   <datafield tag="856" ind1="4" ind2=" ">
+    <subfield code="8">74</subfield>
     <subfield code="s">151257</subfield>
     <subfield code="u">%(siteurl)s/record/85/files/0212181.pdf</subfield>
   </datafield>


### PR DESCRIPTION
- Adds possibility to add copyright and license for each file (separate
  from copyright and license for whole record (closes #1684)
- Modifies the filter_field_instances function in bibrecord:
  - Adds new mode to filter_mode that allows to filter all fields
    without specific subfield
- Adds functions (inside bibupload) to synchronize MARC for 542 and 540
  field with copyright and licenses from BibDocs, whenever bibupload
  with "FIX-MARC" field is run
- Adds subfield $8 to 8564 MARC field, that stores the id of a BibDoc
- FFT now modifies the copyright and license:
  - Added functions to bibupload, so when FFT is uploaded, it also
    allows to modify the copyright and license
- Fixed the regression tests (bibupload, websearch) after adding the
  subfield $8 to the 856 field

Signed-off-by: Sebastian Witowski sebastian.witowski@cern.ch
