### PR TITLE
access: usedeposit action addition

### DIFF
--- a/invenio/modules/access/local_config.py
+++ b/invenio/modules/access/local_config.py
@@ -133,6 +133,7 @@ DEF_ROLES = ((SUPERADMINROLE, 'superuser with all rights', 'deny any'),
              ('paperattributionlinkviewers', 'Users who can see attribution links in the search', 'allow all'),
              ('authorlistusers', 'Users who can user Authorlist tools', 'deny all'),
              ('holdingpenusers', 'Users who can view Holding Pen', 'deny all'),
+             ('depositusers', 'Users who can use a deposit type', 'allow any'),
              )
 
 
@@ -240,6 +241,7 @@ DEF_AUTHS = (('basketusers', 'usebaskets', {}),
              ('claimpaperoperators', 'claimpaper_change_own_data', {}),
              ('claimpaperoperators', 'claimpaper_change_others_data', {}),
              ('holdingpenusers', 'viewholdingpen', {}),
+             ('depositusers', 'usedeposit', {}),
              )
 
 

--- a/invenio/modules/deposit/acl.py
+++ b/invenio/modules/deposit/acl.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""List the access actions used for authorization."""
+
+from invenio.ext.principal import Action
+
+
+class usedeposit(Action):
+
+    """Enable using a deposit type."""
+
+    optional = True
+
+    allowedkeywords = ['type']
+
+
+__all__ = ("usedeposit",)

--- a/invenio/modules/deposit/cache.py
+++ b/invenio/modules/deposit/cache.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Implementation of allowed deposit type caching."""
+
+from .acl import usedeposit
+from .registry import deposit_types
+
+
+def get_authorized_deposition_types(user_info):
+    """Return a list of allowed deposition types for a certain user."""
+    from invenio.modules.access.engine import acc_authorize_action
+
+    return {
+        key for key in deposit_types.mapping().keys()
+        if acc_authorize_action(user_info, usedeposit.name, type=key)[0] == 0
+    }

--- a/invenio/modules/deposit/models.py
+++ b/invenio/modules/deposit/models.py
@@ -23,87 +23,114 @@ Classes for wrapping BibWorkflowObject and friends to make it easier to
 work with the data attributes.
 """
 
-from uuid import uuid4
 import json
 import os
 from datetime import datetime
+
+from uuid import uuid4
+
 from dateutil.tz import tzutc
 
-from sqlalchemy.orm.exc import NoResultFound
-from werkzeug.datastructures import MultiDict
-from werkzeug.utils import secure_filename
-from flask import redirect, render_template, flash, url_for, request, \
-    session, current_app
+from flask import current_app, flash, redirect, render_template, request, \
+    session, url_for
 from flask_login import current_user
 from flask_restful import fields, marshal
-from invenio.ext.restful import UTCISODateTime
+
 from invenio.base.helpers import unicodifier
+from invenio.ext.restful import UTCISODateTime
 
 from invenio.ext.sqlalchemy import db
-from invenio.modules.workflows.models import BibWorkflowObject, Workflow, \
-    ObjectVersion
 from invenio.modules.workflows.engine import WorkflowStatus
+from invenio.modules.workflows.models import BibWorkflowObject, ObjectVersion, \
+    Workflow
+
+from sqlalchemy.orm.exc import NoResultFound
+
+from werkzeug.datastructures import MultiDict
+from werkzeug.utils import secure_filename
 
 from .form import CFG_FIELD_FLAGS, DataExporter
 from .signals import file_uploaded
-from .storage import Storage, DepositionStorage
+from .storage import DepositionStorage, Storage
 
 
 #
 # Exceptions
 #
 class DepositionError(Exception):
+
     """Base class for deposition errors."""
+
     pass
 
 
 class InvalidDepositionType(DepositionError):
+
     """Raise when a deposition type cannot be found."""
+
     pass
 
 
 class InvalidDepositionAction(DepositionError):
+
     """Raise when deposition is in an invalid state for action."""
+
     pass
 
 
 class DepositionDoesNotExists(DepositionError):
+
     """Raise when a deposition does not exists."""
+
     pass
 
 
 class DraftDoesNotExists(DepositionError):
+
     """Raise when a draft does not exists."""
+
     pass
 
 
 class FormDoesNotExists(DepositionError):
+
     """Raise when a draft does not exists."""
+
     pass
 
 
 class FileDoesNotExists(DepositionError):
+
     """Raise when a draft does not exists."""
+
     pass
 
 
 class DepositionNotDeletable(DepositionError):
+
     """Raise when a deposition cannot be deleted."""
+
     pass
 
 
 class FilenameAlreadyExists(DepositionError):
+
     """Raise when an identical filename is already present in a deposition."""
+
     pass
 
 
 class ForbiddenAction(DepositionError):
+
     """Raise when action on a deposition, draft or file is not authorized."""
+
     pass
 
 
 class InvalidApiAction(DepositionError):
+
     """Raise when an invalid API action is requested."""
+
     pass
 
 
@@ -111,7 +138,9 @@ class InvalidApiAction(DepositionError):
 # Helpers
 #
 class FactoryMixin(object):
+
     """Mix-in class to help create objects from persisted object state."""
+
     @classmethod
     def factory(cls, state, *args, **kwargs):
         obj = cls(*args, **kwargs)
@@ -123,6 +152,7 @@ class FactoryMixin(object):
 # Primary classes
 #
 class DepositionType(object):
+
     """
     A base class for the deposition types to ensure certain
     properties are defined on each type.
@@ -133,6 +163,7 @@ class DepositionType(object):
     you can override the render_error(), render_step() and render_completed()
     methods.
     """
+
     workflow = []
     """ Workflow definition """
 
@@ -521,8 +552,22 @@ class DepositionType(object):
         """ Return a name for this class """
         return self.get_identifier()
 
+    @classmethod
+    def all_authorized(cls, user_info=None):
+        """
+        Return a dict of deposit types that the current user
+        is allowed to view.
+        """
+        user_info = user_info or current_user
+
+        all_types = cls.all()
+        auth_types = user_info.get('precached_allowed_deposition_types', set())
+
+        return {key: all_types[key] for key in auth_types if key in all_types}
+
 
 class DepositionFile(FactoryMixin):
+
     """
     Represents an uploaded file
 
@@ -565,6 +610,7 @@ class DepositionFile(FactoryMixin):
         d.delete()
 
     """
+    
     def __init__(self, uuid=None, backend=None):
         self.uuid = uuid or str(uuid4())
         self._backend = backend


### PR DESCRIPTION
* NEW Adds usedeposit action which enables per user access
  restrictions for different deposit types. (closes #2724)

* Requires running `webaccessadmin -u admin -c -a -D` command.

Signed-off-by: Jan Stypka <jan.stypka@cern.ch>

cc @jmartinm @jalavik 