### PR TITLE
messages: jQuery-Timepicker-Addon fix

### DIFF
--- a/invenio/base/static/js/settings.js
+++ b/invenio/base/static/js/settings.js
@@ -1,6 +1,6 @@
 /*
  * This file is part of Invenio.
- * Copyright (C) 2014 CERN.
+ * Copyright (C) 2014, 2015 CERN.
  *
  * Invenio is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -21,6 +21,7 @@ require.config({
   baseUrl: "/",
   paths: {
     jquery: "vendors/jquery/dist/jquery",
+    "jquery.ui": "vendors/jquery-ui/jquery-ui",
     ui: "vendors/jquery-ui/ui",
     "jqueryui-timepicker": "vendors/jqueryui-timepicker-addon/dist",
     "jquery-form": "vendors/jquery-form/jquery.form",

--- a/invenio/modules/messages/bundles.py
+++ b/invenio/modules/messages/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,9 +19,8 @@
 
 """Messages bundles."""
 
+from invenio.base.bundles import invenio as _i, jquery as _j, styles as _styles
 from invenio.ext.assets import Bundle, RequireJSFilter
-
-from invenio.base.bundles import styles as _styles, jquery as _j, invenio as _i
 
 _styles.contents.append(
     "vendors/jqueryui-timepicker-addon/dist/jquery-ui-timepicker-addon.css"
@@ -34,6 +33,6 @@ js = Bundle(
     filters=RequireJSFilter(exclude=[_j, _i]),
     bower={
         "jquery-ui": "~1.11",
-        "jqueryui-timepicker-addon": "latest"
+        "jqueryui-timepicker-addon": "1.5.2"
     }
 )


### PR DESCRIPTION
* FIX Sets a defined version to use for jQuery-Timepicker-Addon instead
  of automatically use latest.

* FIX Defines a path for jquery.ui required by jQuery-Timepicker-Addon.
  (closes #2910)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>