### PR TITLE
installation: post-release version bump

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -367,6 +367,7 @@ Installing Invenio.
 .. code-block:: console
 
     (invenio)$ cdvirtualenv src/invenio
+    (invenio)$ pip install babel
     (invenio)$ pip install --process-dependency-links -e .[development]
 
 Some modules may require specific dependencies listed as ``extras``. Pick the

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -60,6 +60,7 @@ Bug fixes
 Installation
 ------------
 
+   $ pip install babel
    $ pip install invenio
 
 Documentation

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -60,6 +60,7 @@ Bug fixes
 Installation
 ------------
 
+   $ pip install babel
    $ pip install invenio
 
 Documentation

--- a/invenio/version.py
+++ b/invenio/version.py
@@ -30,7 +30,7 @@ This file is imported by ``invenio.__init__``, and parsed by ``setup.py``.
 # - revision can be set if you want to override the date coming from git.
 #
 # See the doctest below.
-version = (2, 0, 1)
+version = (2, 0, 2, 'dev', 20150320)
 
 
 def build_version(*args):


### PR DESCRIPTION
* Increases version number after the release of Invenio v2.0.1.

* Adds note about `pip install babel` that is still necessary to do
  before installing Invenio from PyPI.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>