### PR TITLE
installation: Babel required in package setup

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -367,7 +367,6 @@ Installing Invenio.
 .. code-block:: console
 
     (invenio)$ cdvirtualenv src/invenio
-    (invenio)$ pip install babel
     (invenio)$ pip install --process-dependency-links -e .[development]
 
 Some modules may require specific dependencies listed as ``extras``. Pick the

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -60,7 +60,6 @@ Bug fixes
 Installation
 ------------
 
-   $ pip install babel
    $ pip install invenio
 
 Documentation

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -60,7 +60,6 @@ Bug fixes
 Installation
 ------------
 
-   $ pip install babel
    $ pip install invenio
 
 Documentation

--- a/setup.py
+++ b/setup.py
@@ -218,6 +218,10 @@ tests_require = [
     "unittest2>=0.5",
 ]
 
+setup_requires = [
+    'Babel>=1.3',
+]
+
 # Add `tests` dependencies to `extras_require` so that developers
 # could install test dependencies also with pip:
 extras_require["tests"] = tests_require
@@ -321,6 +325,7 @@ setup(
             "inveniomanage = invenio.base.setuptools:InvenioManageCommand",
         ]
     },
+    setup_requires=setup_requires,
     install_requires=install_requires,
     extras_require=extras_require,
     classifiers=[


### PR DESCRIPTION
* FIX Adds Babel as setup requirements for installing compile_catalog
  command.

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>