### PR TITLE
installation: Python path in Apache virtual hosts

### DIFF
--- a/modules/miscutil/lib/inveniocfg.py
+++ b/modules/miscutil/lib/inveniocfg.py
@@ -890,6 +890,7 @@ NameVirtualHost %(vhost_ip_address)s:80
 %(listen_directive)s
 %(wsgi_socket_directive)s
 %(xsendfile_directive)s
+WSGIPythonHome %(wsgi_python_home)s
 WSGIRestrictStdout Off
 <Files *.pyc>
    deny from all
@@ -932,6 +933,7 @@ WSGIRestrictStdout Off
        'wsgidir': os.path.join(conf.get('Invenio', 'CFG_PREFIX'), 'var', 'www-wsgi'),
        'vhost_ip_address': vhost_ip_address_needed and _detect_ip_address(conf) or '*',
        'listen_directive': listen_directive_needed and 'Listen 80' or '#Listen 80',
+       'wsgi_python_home': sys.prefix,
        'wsgi_socket_directive': (wsgi_socket_directive_needed and \
                                 'WSGISocketPrefix ' or '#WSGISocketPrefix ') + \
               conf.get('Invenio', 'CFG_PREFIX') + os.sep + 'var' + os.sep + 'run',


### PR DESCRIPTION
* BETTER Apache virtual environments are now created with appropriate
  `WSGIPythonHome` directive so that it would be easier to run Invenio
  from within Python virtual environments.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
Reviewed-by: Jiri Kuncar <jiri.kuncar@cern.ch>