### PR TITLE
installation: latest h5py version

### DIFF
--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -2,7 +2,8 @@
 # import numpy in their setup.py, which means they have to be
 # installed in a second step.
 gnuplot-py==1.8
-h5py==2.0.1
+cython
+h5py
 
 # Following packages are optional (if you do development you probably want to install them):
 pylint
@@ -12,7 +13,6 @@ selenium
 winpdb
 mock
 ipython
-cython
 nose
 nosexcover
 flake8


### PR DESCRIPTION
* FIX Releases constraint on using an old version of `h5py` that was
  anyway no longer available on PyPI.

* Also moves `cython` before `h5py` so that `h5py` can be compiled.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
Reviewed-by: Jiri Kuncar <jiri.kuncar@cern.ch>