### PR TITLE
assets: fix deepcopy of webassets.filter.options

### DIFF
--- a/invenio/ext/assets/extensions.py
+++ b/invenio/ext/assets/extensions.py
@@ -133,6 +133,16 @@ class BundleExtension(Extension):
                         bundle.extra.update(rel="stylesheet")
                     bundles.append((bundle.weight, bundle))
 
+            from webassets.filter import option
+
+            def option__deepcopy__(value, memo):
+                """Custom deepcopy implementation for ``option`` class."""
+                return option(copy.deepcopy(value[0]),
+                              copy.deepcopy(value[1]),
+                              copy.deepcopy(value[2]))
+
+            option.__deepcopy__ = option__deepcopy__
+
             for _, bundle in sorted(bundles):
                 # A little bit of madness to read the "/" at the
                 # beginning of the assets in ran in debug mode as well as

--- a/invenio/ext/assets/extensions.py
+++ b/invenio/ext/assets/extensions.py
@@ -21,11 +21,16 @@
 
 import copy
 import os
-import six
-from flask import current_app, _request_ctx_stack
+
+from flask import _request_ctx_stack, current_app
+
 from flask_assets import Environment, FlaskResolver
+
 from jinja2 import nodes
 from jinja2.ext import Extension
+
+import six
+
 from webassets.bundle import is_url
 
 from . import registry
@@ -232,7 +237,7 @@ class InvenioResolver(FlaskResolver):
             else:
                 abspath = super(InvenioResolver, self) \
                     .search_env_directory(ctx, item)
-        except:  # FIXME do not catch all!
+        except Exception:  # FIXME do not catch all!
             # If a file is missing in production (non-debug mode), we want
             # to not break and will use /dev/null instead. The exception
             # is caught and logged.


### PR DESCRIPTION
* FIX Implements `__deepcopy__` method for `webassets.filter.option` in
  order to fix unexpected behavior of the `option` class contructor.
  (addresses #2777) (fixes #2864) (closes #2921)

Reviewed-by: Javier Martin <javier.martin.montull@cern.ch>
Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>