### PR TITLE
global: noscript warning addition

### DIFF
--- a/invenio/base/templates/page_base.html
+++ b/invenio/base/templates/page_base.html
@@ -124,6 +124,14 @@
           </div>
         {% endif %}
       {% endblock title %}
+      {% block noscript %}
+      <noscript>
+        <div class="alert alert-warning">
+          <strong>{{ _("Warning") }}</strong> {{ _('This page requires to have JavaScript enabled.') }}
+          {{ _('Please enable JavaScript on your browser.') }}
+        </div>
+      </noscript>
+      {% endblock %}
       {{ flashed_messages() }}
       {%- block body %}
         {{ body }}


### PR DESCRIPTION
* NEW Adds 'noscript' block to the page template to warn users with
  disabled JavaScript on their browser.  (closes #1039)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>