### PR TITLE
formatter: translated output format names

### DIFF
--- a/invenio/modules/formatter/registry.py
+++ b/invenio/modules/formatter/registry.py
@@ -20,12 +20,17 @@
 """Implement registries for formatter."""
 
 import os
-import yaml
 
-from flask_registry import PkgResourcesDirDiscoveryRegistry, \
-    ModuleAutoDiscoveryRegistry, RegistryProxy
+from flask_registry import (
+    ModuleAutoDiscoveryRegistry,
+    PkgResourcesDirDiscoveryRegistry,
+    RegistryProxy,
+)
+
 from invenio.ext.registry import ModuleAutoDiscoverySubRegistry
 from invenio.utils.datastructures import LazyDict
+
+import yaml
 
 format_elements = RegistryProxy(
     'format_elements',
@@ -93,7 +98,7 @@ def create_output_formats_lookup():
 
     for f in output_formats_files:
         of = os.path.basename(f).lower()
-        data = {}
+        data = {'names': {}}
         if of.endswith('.yml'):
             of = of[:-4]
             with open(f, 'r') as f:

--- a/invenio/modules/search/templates/search/results_base.html
+++ b/invenio/modules/search/templates/search/results_base.html
@@ -180,7 +180,7 @@
                  href="{{ url_for('search.search', **used_args) }}{{ '#'+request.form.get('filter','')|default('', true) }}"
                  class="{{ ' active' if active }}">
                 <i class="pull-right icon {{ ' glyphicon glyphicon-ok' if of==i.code }}"></i>
-                {{ i.name }}
+                {{ i.names.get(g.ln, i.name) }}
               </a></li>
             {%- endfor -%}
             <!-- dropdown menu links -->
@@ -230,7 +230,9 @@
             <div class="form-group">
               <select name="of" class="col-md-2 form-control">
               {%- for i in export_formats -%}
-                <option value="{{ i.code }}"{{ ' selected' if request.args.get('of','hb')==i.code }}>{{ i.name }}</option>
+                <option value="{{ i.code }}"{{ ' selected' if request.args.get('of','hb')==i.code }}>
+                  {{ i.names.get(g.ln, i.name) }}
+                </option>
               {%- endfor -%}
               </select>
             </div>


### PR DESCRIPTION
* BETTER Improves support for translated output format names on search
  results page.  (closes #2429)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>