### PR TITLE
global: jinja2hacks deprecation and usage warning

### DIFF
--- a/invenio/ext/template/__init__.py
+++ b/invenio/ext/template/__init__.py
@@ -152,6 +152,12 @@ def setup_app(app):
     def test_not_empty(v):
         return v is not None and v != ''
 
+    @app.template_filter('u')
+    def tounicode(value):
+        if isinstance(value, str):
+            return value.decode('utf8')
+        return value
+
     @app.template_filter('prefix')
     def _prefix(value, prefix=''):
         return prefix + value if test_not_empty(value) else ''


### PR DESCRIPTION
* NOTE Adds deprecation warning for `invenio.ext.jinja2hacks` and all detected non-ascii strings usage in templates mainly coming from legacy (1.x) modules.  (addresses #2862)

Reviewed-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>