### PR TITLE
admin: fix select2 by adding bundle

### DIFF
--- a/invenio/base/bundles.py
+++ b/invenio/base/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -127,6 +127,13 @@ invenio = Bundle(
     output="invenio.js",
     filters=RequireJSFilter(exclude=[jquery]),
     weight=90
+)
+
+admin = Bundle(
+    "js/admin.js",
+    output="admin.js",
+    filters=RequireJSFilter(exclude=[jquery]),
+    weight=50
 )
 
 # less.js is only used when the following configuration is set:

--- a/invenio/base/static/js/admin.js
+++ b/invenio/base/static/js/admin.js
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2015 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * Invenio is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Invenio; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+require([
+  "jquery",
+  "select2",
+  ], function() {
+  // loading select2 module for the not require.js ready scripts
+  // everywhere.
+})

--- a/invenio/base/static/js/settings.js
+++ b/invenio/base/static/js/settings.js
@@ -52,6 +52,7 @@ require.config({
     "searchtypeahead-configuration": "js/search/default_typeahead_configuration",
     "jasmine-events": "js/jasmine/events_checker",
     "jasmine-initialization": "js/jasmine/initialization_checker",
+    "select2": "vendor/select2/select2.min",
   },
   shim: {
     jquery: {
@@ -148,6 +149,10 @@ require.config({
     },
     "jasmine-initialization": {
       deps: ["jasmine-boot"],
+    },
+    select2: {
+      deps: ["jquery"],
+      exports: "select2"
     },
   }
 });

--- a/invenio/base/templates/admin_base.html
+++ b/invenio/base/templates/admin_base.html
@@ -20,23 +20,19 @@
 {% extends "page.html" %}
 
 {%- block css -%}{% block head_css %}<link href="{{ url_for('admin.static', filename='css/admin.css') }}" rel="stylesheet">{% endblock %}{%- endblock css -%}
+{%- bundle "admin.js" %}
 
 {% block header %}
-    {%- include "base/scripts.html" %}
-    {{ super() }}
-    {% block head_meta %}{% endblock -%}
-    {% block head_tail %}{% endblock -%}
-{% endblock header -%}
-
-{% block pagefooteradd -%}
-    {{ super() }}
-{% endblock pagefooteradd -%}
+  {%- include "base/scripts.html" %}
+  {{ super() }}
+  {% block head_meta %}{% endblock -%}
+  {% block head_tail %}{% endblock -%}
+{%- endblock header %}
 {%- block _bottom_assets %}
-    {{ super() }}
-    <script src="{{ url_for('admin.static', filename='vendor/select2/select2.min.js') }}" type="text/javascript"></script>
-    {% block tail %}{% endblock -%}
-{%- endblock _bottom_assets %}
-
+  {# The legacy page requires that the scripts are loaded from the <head>
+   # rather than at the bottom of the page.
+   #}
+{%- endblock %}
 
 {% block page_body %}
 <div class="container">


### PR DESCRIPTION
* FIX Adds `admin.js` bundle that loads `select2.js` library on `/admin`
  pages.  (closes #2690) (closes #2781)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>