### PR TITLE
documents: fix Flask-Login import

### DIFF
--- a/invenio/modules/documents/documentext/fields/base.cfg
+++ b/invenio/modules/documents/documentext/fields/base.cfg
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -77,7 +77,7 @@ creator:
     Internal user identifier.
     """
     schema:
-        {'creator': {'type': 'integer', 'required': True, 'default': lambda: __import__('flask').ext.login.current_user.get_id() }}
+        {'creator': {'type': 'integer', 'required': True, 'default': lambda: __import__('flask_login').current_user.get_id() }}
 
 deleted:
     """ Is file deleted? """


### PR DESCRIPTION
As discussed on Hangouts/Gitter, running `nosetests invenio/modules/documents/testsuite/test_api.py` is currently broken due to a broken import in `invenio/modules/documents/documentext/fields/base.cfg`, similar to https://github.com/inveniosoftware/invenio/commit/0875c0570b99f77af5a715ed35857c506b6e8bbf.

