### PR TITLE
search: hotfix form typeahead loading

### DIFF
--- a/invenio/modules/search/static/js/search/form.js
+++ b/invenio/modules/search/static/js/search/form.js
@@ -1,6 +1,6 @@
 /*
  * This file is part of Invenio.
- * Copyright (C) 2014 CERN.
+ * Copyright (C) 2014, 2015 CERN.
  *
  * Invenio is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -21,6 +21,7 @@
 define([
     'jquery',
     'searchtypeahead-configuration',
+    'typeahead',
     'js/search/typeahead',
 ], function($, getParserConf, Bloodhound) {
     "use strict";


### PR DESCRIPTION
* Hotfixes loading of typeahead.js library.  (closes #2559)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>