### PR TITLE
base: url rewrite rule for '/admin' to '/admin/'

### DIFF
--- a/invenio/base/templates/invenio-apache-vhost.tpl
+++ b/invenio/base/templates/invenio-apache-vhost.tpl
@@ -1,6 +1,6 @@
 {#
 # This file is part of Invenio.
-# Copyright (C) 2013 CERN.
+# Copyright (C) 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -100,6 +100,9 @@ WSGIPythonHome {{pythonhome}}
         RewriteEngine on
         RewriteCond {{ config.COLLECT_STATIC_ROOT }}%{REQUEST_FILENAME} !-f
         RewriteCond {{ config.COLLECT_STATIC_ROOT }}%{REQUEST_FILENAME} !-d
+        {#- Temporary manual handling of /admin, to work around the presence of
+            a folder admin/ in root #}
+        RewriteRule ^admin$ {{ script_alias}}/admin/ [PT,L]
         RewriteRule ^(.*)$ {{ script_alias }}$1 [PT,L]
     {% endblock wsgi -%}
     {%- block xsendfile_directive %}


### PR DESCRIPTION
* FIX Adds rewrite rule in Apache site configuration to avoid problems
  with loading '/admin' url without trailing slash that attempts to
  serve the static directory of the same name.  (closes #2470)

* NOTE Recreate Apache site configurations using new template.
  Run following command `inveniomanage apache create-config`.

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>

--
@dset0x  I have backported your commit (094b603971a3331b993b215a861772a204f1ad38).