### PR TITLE
base: url rewrite not to serve directories

### DIFF
--- a/invenio/base/templates/invenio-apache-vhost.tpl
+++ b/invenio/base/templates/invenio-apache-vhost.tpl
@@ -68,7 +68,7 @@ WSGIPythonHome {{pythonhome}}
         DocumentRoot {{ config.COLLECT_STATIC_ROOT }}
         <Directory {{ config.COLLECT_STATIC_ROOT }}>
            DirectorySlash Off
-           Options FollowSymLinks MultiViews
+           Options FollowSymLinks MultiViews -Indexes
            AllowOverride None
            <IfVersion >= 2.4>
            Require all granted
@@ -99,10 +99,6 @@ WSGIPythonHome {{pythonhome}}
 
         RewriteEngine on
         RewriteCond {{ config.COLLECT_STATIC_ROOT }}%{REQUEST_FILENAME} !-f
-        RewriteCond {{ config.COLLECT_STATIC_ROOT }}%{REQUEST_FILENAME} !-d
-        {#- Temporary manual handling of /admin, to work around the presence of
-            a folder admin/ in root #}
-        RewriteRule ^admin$ {{ script_alias}}/admin/ [PT,L]
         RewriteRule ^(.*)$ {{ script_alias }}$1 [PT,L]
     {% endblock wsgi -%}
     {%- block xsendfile_directive %}


### PR DESCRIPTION
* FIX Drops support for serving directories in Apache site configuration
  to avoid problems with loading '/admin' url without trailing slash
  that attempts to serve the static directory of the same name. (closes
  #2470) (invalidates #2943)

* NOTE Recreate Apache site configurations using new template.
  Run following command: `inveniomanage apache create-config`.

---

This is awaiting to be tested on some `maint` flavor.
Critical fix. #2943 breaks all static files. (at least on `master` it does.)