### PR TITLE
search: author search and collection results

### DIFF
--- a/invenio/modules/indexer/models.py
+++ b/invenio/modules/indexer/models.py
@@ -132,6 +132,11 @@ class IdxINDEX(db.Model):
         """Return correct word index."""
         return globals().get('IdxWORD{:02d}F'.format(self.id))
 
+    @property
+    def pairf(self):
+        """Return correct pair index."""
+        return globals().get('IdxPAIR{:02d}F'.format(self.id))
+
 
 class IdxINDEXIdxINDEX(db.Model):
 

--- a/invenio/modules/search/searchext/units/author.py
+++ b/invenio/modules/search/searchext/units/author.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Author search unit."""
+
+from invenio.legacy.bibindex.engine_utils import author_name_requires_phrase_search
+from invenio.modules.search.searchext.engines.native import default_search_unit
+
+
+def search_unit(p, f, m, wl=None):
+    """Special author field handler."""
+    if author_name_requires_phrase_search(p):
+        m = 'a'
+    return default_search_unit(p, f, m, wl)

--- a/invenio/modules/search/searchext/units/authorityauthor.py
+++ b/invenio/modules/search/searchext/units/authorityauthor.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Authority author search unit."""
+
+from invenio.modules.search.searchext.units.author import search_unit

--- a/invenio/modules/search/searchext/units/exactauthor.py
+++ b/invenio/modules/search/searchext/units/exactauthor.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Exact author search unit."""
+
+from invenio.modules.search.searchext.units.author import search_unit

--- a/invenio/modules/search/searchext/units/exactfirstauthor.py
+++ b/invenio/modules/search/searchext/units/exactfirstauthor.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Exact first author search unit."""
+
+from invenio.modules.search.searchext.units.author import search_unit

--- a/invenio/modules/search/searchext/units/firstauthor.py
+++ b/invenio/modules/search/searchext/units/firstauthor.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""First author search unit."""
+
+from invenio.modules.search.searchext.units.author import search_unit

--- a/invenio/modules/search/searchext/units/subject.py
+++ b/invenio/modules/search/searchext/units/subject.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Subject search unit."""
+
+from invenio.modules.search.searchext.engines.native import default_search_unit
+
+
+def search_unit(p, f, m, wl=None):
+    """Search subject always in phrase index."""
+    return default_search_unit(p, f, 'a', wl)

--- a/invenio/modules/search/walkers/search_unit.py
+++ b/invenio/modules/search/walkers/search_unit.py
@@ -20,13 +20,14 @@
 """Implement AST vistor."""
 
 from intbitset import intbitset
+
 from invenio_query_parser.ast import (
-    AndOp, KeywordOp, OrOp,
-    NotOp, Keyword, Value,
+    AndOp, DoubleQuotedValue, EmptyQuery,
+    GreaterOp, Keyword,
+    KeywordOp, NotOp, OrOp,
+    RangeOp, RegexValue,
     SingleQuotedValue,
-    DoubleQuotedValue,
-    RegexValue, RangeOp,
-    ValueQuery, EmptyQuery
+    Value, ValueQuery,
 )
 from invenio_query_parser.visitor import make_visitor
 
@@ -64,6 +65,11 @@ class SearchUnit(object):
     @visitor(ValueQuery)
     def visit(self, node, op):
         return search_unit(**op)
+
+    @visitor(GreaterOp)
+    def visit(self, node, op):
+        op["p"] = "{0}->".format(op["p"])
+        return op
 
     @visitor(Keyword)
     def visit(self, node):


### PR DESCRIPTION
Here is a bundle of fixes to the new search structure I did with @jirikuncar 

Basically it fixes the default author search to return the correct result if you only search for the lastname (as one word), and that records without any collections do not display in search results.