### PR TITLE
bibcirculation: Change ILL/purchase e-mail

### DIFF
--- a/modules/bibcirculation/lib/bibcirculation_config.py
+++ b/modules/bibcirculation/lib/bibcirculation_config.py
@@ -376,7 +376,7 @@ else:
         }
 
 if CFG_CERN_SITE == 1:
-    CFG_BIBCIRCULATION_ILLS_EMAIL = 'CERN External loans<external.loans@cern.ch>'
+    CFG_BIBCIRCULATION_ILLS_EMAIL = 'CERN External loans<lib.acq@cern.ch>'
     CFG_BIBCIRCULATION_LIBRARIAN_EMAIL = 'CERN Library Desk<library.desk@cern.ch>'
     CFG_BIBCIRCULATION_LOANS_EMAIL = 'CERN Lib loans<lib.loans@cern.ch>'
 else:


### PR DESCRIPTION
* Changes the 'CFG_BIBCIRCULATION_ILLS_EMAIL' parameter from
  'external.loans@cern.ch' to 'lib.acq@cern.ch'

Signed-off-by: Martin Vesper <martin.vesper@cern.ch>