### PR TITLE
knowledge: temporary knowledge creation removal

### DIFF
--- a/invenio/modules/knowledge/api.py
+++ b/invenio/modules/knowledge/api.py
@@ -574,9 +574,6 @@ def get_kbd_values(kbname, searchwith=""):
     :param kbname:     name of the knowledge base
     :param searchwith: a term to search with
     """
-    from invenio.legacy import search_engine
-
-    # first check that the kb in question is dynamic
     kb = get_kb_by_name(kbname)
     kbid = kb.id
     if not kbid:
@@ -586,8 +583,19 @@ def get_kbd_values(kbname, searchwith=""):
         return []
     if kbtype != 'd':
         return []
+    return get_kbd_values_by_def(kb.kbdefs.to_dict(), searchwith)
+
+
+def get_kbd_values_by_def(confdict, searchwith=""):
+    """Return a list of values by searching a dynamic kb.
+
+    :param confdict: dictionary with keys "field", "expression"
+    and "collection" name
+    :param searchwith: a term to search with
+    """
+    from invenio.legacy import search_engine
+
     # get the configuration so that we see what the field is
-    confdict = kb.kbdefs.to_dict()
     if not confdict:
         return []
     if 'field' not in confdict:
@@ -640,9 +648,7 @@ def get_kbd_values_json(kbname, searchwith=""):
 
 def get_kbd_values_for_bibedit(tag, collection="", searchwith="",
                                expression=""):
-    """Dynamically create a dynamic KB for a specific search; then destroy it.
-
-    This probably isn't the method you want.
+    """Get list of kbd values for bibedit.
 
     Example1: tag=100__a : return values of 100__a
     Example2: tag=100__a, searchwith=Jill: return values of 100__a that match
@@ -662,17 +668,9 @@ def get_kbd_values_for_bibedit(tag, collection="", searchwith="",
                        if present, '%' is substituted with /searcwith/.
                        If absent, /searchwith/ is searched for in /tag/.
     """
-    dkbname = "tmp_dynamic_"+tag+'_'+expression
-    kb_id = add_kb(kb_name=dkbname, kb_type='dynamic')
-    # get the kb name since it may be catenated by a number
-    # in case there are concurrent calls.
-    kb_name = get_kb_name(kb_id)
-    add_kb_mapping(kb_name, tag, expression, collection)
-    # now, get stuff
-    myvalues = get_kbd_values(kb_name, searchwith)
-    # the tmp dyn kb is now useless, delete it
-    delete_kb(kb_name)
-    return myvalues
+    return get_kbd_values_by_def(dict(
+        field=tag, expression=expression, collection=collection
+    ), searchwith)
 
 
 def get_kbt_items(taxonomyfilename, templatefilename, searchwith=""):


### PR DESCRIPTION
* Relaxes constrictions on dynamic search function that
  force us to create temporary knowledge.
  (closes #698)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>