### PR TITLE
global: deprecation of external authentication

### DIFF
--- a/invenio/legacy/external_authentication/__init__.py
+++ b/invenio/legacy/external_authentication/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,8 +19,14 @@
 
 """External user authentication for Invenio."""
 
-__revision__ = \
-    "$Id$"
+import warnings
+
+from invenio.utils.deprecation import RemovedInInvenio21Warning
+
+warnings.warn(
+    "External authentication pluugins have been deprecated. Please use "
+    "'invenio.modules.oauthclient' or Flask-SSO instead.",
+    RemovedInInvenio21Warning)
 
 
 class InvenioWebAccessExternalAuthError(Exception):


### PR DESCRIPTION
* NOTE External authentication methods are being deprecated. Please use
  `invenio.modules.oauthclient` or Flask-SSO instead.  (addresses #1083)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>