### PR TITLE
legacy: fix six import in bibsort

### DIFF
--- a/invenio/legacy/bibsort/engine.py
+++ b/invenio/legacy/bibsort/engine.py
@@ -19,6 +19,7 @@
 
 """BibSort Engine"""
 
+import six
 import sys
 import time
 


### PR DESCRIPTION
When running `$ inveniomanage demosite populate --packages=invenio_demosite.base` we get several errors, among which a missing `six` import: https://gist.github.com/jacquerie/1f9453605570fe762b73#file-invenio-demosite-log-L3954-L3992.