### PR TITLE
indexer: fix for term washing

### DIFF
--- a/invenio/legacy/bibindex/engine_washer.py
+++ b/invenio/legacy/bibindex/engine_washer.py
@@ -121,6 +121,7 @@ def remove_stopwords(word, stopwords_kb=None):
             return ""
     return word
 
+
 def length_check(word):
     """Returns word after length check.
 
@@ -131,12 +132,12 @@ def length_check(word):
         return ""
     return word
 
+
 def wash_index_term(term, max_char_length=50, lower_term=True):
-    """
-    Return washed form of the index term TERM that would be suitable
-    for storing into idxWORD* tables.  I.e., lower the TERM if
-    LOWER_TERM is True, and truncate it safely to MAX_CHAR_LENGTH
-    UTF-8 characters (meaning, in principle, 4*MAX_CHAR_LENGTH bytes).
+    """Return washed form of the index term TERM for storing into idxWORD* tables.
+
+    I.e., lower the TERM if LOWER_TERM is True, and truncate it safely to
+    MAX_CHAR_LENGTH UTF-8 characters (meaning, in principle, 4*MAX_CHAR_LENGTH bytes).
 
     The function works by an internal conversion of TERM, when needed,
     from its input Python UTF-8 binary string format into Python
@@ -149,9 +150,11 @@ def wash_index_term(term, max_char_length=50, lower_term=True):
     column in idxINDEX* tables.
     """
     if lower_term:
-        washed_term = unicode(term, 'utf-8').lower()
-    else:
+        washed_term = lower_index_term(term)
+    elif not isinstance(term, unicode):
         washed_term = unicode(term, 'utf-8')
+    else:
+        washed_term = term
     if len(washed_term) <= max_char_length:
         # no need to truncate the term, because it will fit
         # nicely even if it uses four-byte UTF-8 characters
@@ -159,6 +162,7 @@ def wash_index_term(term, max_char_length=50, lower_term=True):
     else:
         # truncate the term in a safe position:
         return washed_term[:max_char_length].encode('utf-8')
+
 
 def wash_author_name(p):
     """

--- a/invenio/legacy/bibindex/engine_washer.py
+++ b/invenio/legacy/bibindex/engine_washer.py
@@ -66,16 +66,20 @@ re_latex_uppercase_c = re.compile("\\\\['uc]\\{?C\\}?")
 re_latex_uppercase_n = re.compile("\\\\[c'~^vu]\\{?N\\}?")
 
 def lower_index_term(term):
-    """
-    Return safely lowered index term TERM.  This is done by converting
-    to UTF-8 first, because standard Python lower() function is not
-    UTF-8 safe.  To be called by both the search engine and the
-    indexer when appropriate (e.g. before stemming).
+    """Return safely lowered index term TERM.
+
+    This is done by converting to unicode string, if not already,
+    and use it's lower() function. Standard Python lower() function is not
+    UTF-8 safe.
 
     In case of problems with UTF-8 compliance, this function raises
     UnicodeDecodeError, so the client code may want to catch it.
     """
-    return unicode(term, 'utf-8').lower().encode('utf-8')
+    try:
+        return unicode(term, 'utf-8').lower()
+    except TypeError:
+        # term is already Unicode
+        return term.lower()
 
 latex_markup_re = re.compile(r"\\begin(\[.+?\])?\{.+?\}|\\end\{.+?}|\\\w+(\[.+?\])?\{(?P<inside1>.*?)\}|\{\\\w+ (?P<inside2>.*?)\}")
 def remove_latex_markup(phrase):

--- a/invenio/modules/indexer/testsuite/test_indexer_engine.py
+++ b/invenio/modules/indexer/testsuite/test_indexer_engine.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2004, 2005, 2006, 2007, 2008, 2010, 2011, 2013, 2014 CERN.
+# Copyright (C) 2004, 2005, 2006, 2007, 2008, 2010, 2011, 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,65 +19,72 @@
 
 """Unit tests for the indexing engine."""
 
-__revision__ = \
-    "$Id$"
-
 from invenio.base.wrappers import lazy_import
-from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
+from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+
 bibindex_engine = lazy_import('invenio.legacy.bibindex.engine')
-load_tokenizers = lazy_import('invenio.legacy.bibindex.engine_utils.load_tokenizers')
+load_tokenizers = lazy_import(
+    'invenio.legacy.bibindex.engine_utils.load_tokenizers')
 list_union = lazy_import('invenio.legacy.bibindex.engine_utils.list_union')
-get_values_recursively = lazy_import('invenio.legacy.bibindex.engine_utils.get_values_recursively')
+get_values_recursively = lazy_import(
+    'invenio.legacy.bibindex.engine_utils.get_values_recursively')
 
 
 class TestListSetOperations(InvenioTestCase):
+
     """Tests for list set operations."""
 
     def test_list_union(self):
-        """bibindex engine utils - list union"""
+        """bibindex engine utils - list union."""
         self.assertEqual([1, 2, 3, 4],
                          list_union([1, 2, 3],
                                     [1, 3, 4]))
 
     def test_list_unique(self):
-        """bibindex engine - list unique"""
+        """bibindex engine - list unique."""
         self.assertEqual([1, 2, 3],
                          bibindex_engine.list_unique([1, 2, 3, 3, 1, 2]))
 
 
-
 class TestWashIndexTerm(InvenioTestCase):
+
     """Tests for washing index terms, useful for both searching and indexing."""
 
     def test_wash_index_term_short(self):
-        """bibindex engine - wash index term, short word"""
+        """bibindex engine - wash index term, short word."""
         self.assertEqual("ellis",
                          bibindex_engine.wash_index_term("ellis"))
 
     def test_wash_index_term_long(self):
-        """bibindex engine - wash index term, long word"""
-        self.assertEqual(50*"e",
-                         bibindex_engine.wash_index_term(1234*"e"))
+        """bibindex engine - wash index term, long word."""
+        self.assertEqual(50 * "e",
+                         bibindex_engine.wash_index_term(1234 * "e"))
 
     def test_wash_index_term_case(self):
-        """bibindex engine - wash index term, lower the case"""
+        """bibindex engine - wash index term, lower the case."""
         self.assertEqual("ellis",
                          bibindex_engine.wash_index_term("Ellis"))
 
     def test_wash_index_term_unicode(self):
-        """bibindex engine - wash index term, unicode"""
+        """bibindex engine - wash index term, unicode."""
         self.assertEqual("ελληνικό αλφάβητο",
-          bibindex_engine.wash_index_term("Ελληνικό αλφάβητο"))
+                         bibindex_engine.wash_index_term("Ελληνικό αλφάβητο"))
+
+    def test_wash_index_term_unicode_for_real(self):
+        """bibindex engine - wash index term, unicode string."""
+        self.assertEqual("ellis",
+                         bibindex_engine.wash_index_term(u"ellis"))
 
 
 class TestGetWordsFromPhrase(InvenioTestCase):
+
     """Tests for getting words from phrase."""
 
     def setUp(self):
         self._TOKENIZERS = load_tokenizers()
 
     def test_easy_phrase(self):
-        """bibindex engine - getting words from `word1 word2' phrase"""
+        """bibindex engine - getting words from `word1 word2' phrase."""
         test_phrase = 'word1 word2'
         l_words_expected = ['word1', 'word2']
         tokenizer = self._TOKENIZERS["BibIndexDefaultTokenizer"]()
@@ -86,9 +93,10 @@ class TestGetWordsFromPhrase(InvenioTestCase):
         self.assertEqual(l_words_obtained, l_words_expected)
 
     def test_stemming_phrase(self):
-        """bibindex engine - getting stemmed words from l'anthropologie"""
+        """bibindex engine - getting stemmed words from l'anthropologie."""
         test_phrase = "l'anthropologie"
-        l_words_not_expected = ['anthropolog', 'l', "l'anthropolog", "l'anthropologi"]
+        l_words_not_expected = [
+            'anthropolog', 'l', "l'anthropolog", "l'anthropologi"]
         l_words_expected = ['anthropologi', 'l', "l'anthropologi"]
         tokenizer = self._TOKENIZERS["BibIndexDefaultTokenizer"]('en')
         l_words_obtained = tokenizer.tokenize_for_words(test_phrase)
@@ -97,23 +105,25 @@ class TestGetWordsFromPhrase(InvenioTestCase):
         self.assertEqual(l_words_obtained, l_words_expected)
 
     def test_remove_stopwords_phrase(self):
-        """bibindex engine - test for removing stopwords from 'theory of' """
+        """bibindex engine - test for removing stopwords from 'theory of'."""
         test_phrase = 'theory of'
-        tokenizer = self._TOKENIZERS["BibIndexDefaultTokenizer"](remove_stopwords='stopwords.kb')
+        tokenizer = self._TOKENIZERS["BibIndexDefaultTokenizer"](
+            remove_stopwords='stopwords.kb')
         words_obtained = tokenizer.tokenize_for_words(test_phrase)
         words_expected = ['theory']
         self.assertEqual(words_expected, words_obtained)
 
     def test_stemming_and_remove_stopwords_phrase(self):
-        """bibindex engine - test for removing stopwords and stemming from 'beams of photons' """
+        """bibindex engine - test for removing stopwords and stemming from 'beams of photons'."""
         test_phrase = 'beams of photons'
-        tokenizer = self._TOKENIZERS["BibIndexDefaultTokenizer"]('en', remove_stopwords='stopwords.kb')
+        tokenizer = self._TOKENIZERS["BibIndexDefaultTokenizer"](
+            'en', remove_stopwords='stopwords.kb')
         words_obtained = tokenizer.tokenize_for_words(test_phrase)
-        words_expected = ['beam','photon']
+        words_expected = ['beam', 'photon']
         self.assertEqual(words_expected, words_obtained)
 
     def test_dashed_phrase(self):
-        """bibindex engine - getting words from `word1-word2' phrase"""
+        """bibindex engine - getting words from `word1-word2' phrase."""
         test_phrase = 'word1-word2'
         l_words_expected = ['word1', 'word1-word2', 'word2']
         tokenizer = self._TOKENIZERS["BibIndexDefaultTokenizer"]()
@@ -122,16 +132,17 @@ class TestGetWordsFromPhrase(InvenioTestCase):
         self.assertEqual(l_words_obtained, l_words_expected)
 
     def test_arXiv_good(self):
-        """bibindex engine - getting words from `arXiv:1007.5048' phrase"""
+        """bibindex engine - getting words from `arXiv:1007.5048' phrase."""
         test_phrase = 'arXiv:1007.5048'
-        l_words_expected = ['1007', '1007.5048', '5048', 'arxiv', 'arxiv:1007.5048']
+        l_words_expected = [
+            '1007', '1007.5048', '5048', 'arxiv', 'arxiv:1007.5048']
         tokenizer = self._TOKENIZERS["BibIndexDefaultTokenizer"]()
         l_words_obtained = tokenizer.tokenize_for_words(test_phrase)
         l_words_obtained.sort()
         self.assertEqual(l_words_obtained, l_words_expected)
 
     def test_arXiv_bad(self):
-        """bibindex engine - getting words from `arXiv:1xy7.5z48' phrase"""
+        """bibindex engine - getting words from `arXiv:1xy7.5z48' phrase."""
         test_phrase = 'arXiv:1xy7.5z48'
         l_words_expected = ['1xy7', '5z48', 'arxiv', 'arxiv:1xy7.5z48']
         tokenizer = self._TOKENIZERS["BibIndexDefaultTokenizer"]()
@@ -141,125 +152,129 @@ class TestGetWordsFromPhrase(InvenioTestCase):
 
 
 class TestGetPairsFromPhrase(InvenioTestCase):
+
     """Tests for getting pairs from phrase."""
 
     def setUp(self):
         self._TOKENIZERS = load_tokenizers()
 
     def test_remove_stopwords_phrase_first(self):
-        """bibindex engine - getting pairs from phrase with stopwords removed first"""
+        """bibindex engine - getting pairs from phrase with stopwords removed first."""
         test_phrase = 'Matrices on a point as the theory of everything'
-        tokenizer = self._TOKENIZERS["BibIndexDefaultTokenizer"](remove_stopwords='stopwords.kb')
+        tokenizer = self._TOKENIZERS["BibIndexDefaultTokenizer"](
+            remove_stopwords='stopwords.kb')
         pairs_obtained = tokenizer.tokenize_for_pairs(test_phrase)
         pairs_expected = ['matrices theory']
         self.assertEqual(pairs_expected, pairs_obtained)
 
     def test_remove_stopwords_phrase_second(self):
-        """bibindex engine - getting pairs from phrase with stopwords removed second"""
+        """bibindex engine - getting pairs from phrase with stopwords removed second."""
         test_phrase = 'Nonlocal action for long-distance'
-        tokenizer = self._TOKENIZERS["BibIndexDefaultTokenizer"](remove_stopwords='stopwords.kb')
+        tokenizer = self._TOKENIZERS["BibIndexDefaultTokenizer"](
+            remove_stopwords='stopwords.kb')
         pairs_obtained = tokenizer.tokenize_for_pairs(test_phrase)
         pairs_expected = ['nonlocal action', 'long distance', 'action long']
         self.assertEqual(pairs_expected, pairs_obtained)
 
 
 class TestGetWordsFromDateTag(InvenioTestCase):
+
     """Tests for getting words for date-like tag."""
 
     def setUp(self):
         self._TOKENIZERS = load_tokenizers()
 
     def test_dateindex_yyyy(self):
-        """bibindex engine - index date-like tag, yyyy"""
+        """bibindex engine - index date-like tag, yyyy."""
         tokenizer = self._TOKENIZERS["BibIndexYearTokenizer"]()
         self.assertEqual(["2010"],
                          tokenizer.get_words_from_date_tag("2010"))
 
     def test_dateindex_yyyy_mm(self):
-        """bibindex engine - index date-like tag, yyyy-mm"""
+        """bibindex engine - index date-like tag, yyyy-mm."""
         tokenizer = self._TOKENIZERS["BibIndexYearTokenizer"]()
         self.assertEqual(["2010-03", "2010"],
                          tokenizer.get_words_from_date_tag("2010-03"))
 
     def test_dateindex_yyyy_mm_dd(self):
-        """bibindex engine - index date-like tag, yyyy-mm-dd"""
+        """bibindex engine - index date-like tag, yyyy-mm-dd."""
         tokenizer = self._TOKENIZERS["BibIndexYearTokenizer"]()
         self.assertEqual(["2010-03-08", "2010", "2010-03", ],
                          tokenizer.get_words_from_date_tag("2010-03-08"))
 
     def test_dateindex_freetext(self):
-        """bibindex engine - index date-like tag, yyyy-mm-dd"""
+        """bibindex engine - index date-like tag, yyyy-mm-dd."""
         tokenizer = self._TOKENIZERS["BibIndexYearTokenizer"]()
         self.assertEqual(["dd", "mon", "yyyy"],
                          tokenizer.get_words_from_date_tag("dd mon yyyy"))
 
 
 class TestGetAuthorFamilyNameWords(InvenioTestCase):
+
     """Tests for getting family name words from author names."""
 
     def setUp(self):
         self._TOKENIZERS = load_tokenizers()
 
     def test_authornames_john_doe(self):
-        """bibindex engine - get author family name words for John Doe"""
+        """bibindex engine - get author family name words for John Doe."""
         tokenizer = self._TOKENIZERS["BibIndexAuthorTokenizer"]()
-        self.assertEqual(['doe',],
+        self.assertEqual(['doe', ],
                          tokenizer.get_author_family_name_words_from_phrase('John Doe'))
 
     def test_authornames_doe_john(self):
-        """bibindex engine - get author family name words for Doe, John"""
+        """bibindex engine - get author family name words for Doe, John."""
         tokenizer = self._TOKENIZERS["BibIndexAuthorTokenizer"]()
-        self.assertEqual(['doe',],
+        self.assertEqual(['doe', ],
                          tokenizer.get_author_family_name_words_from_phrase('Doe, John'))
 
     def test_authornames_campbell_wilson(self):
-        """bibindex engine - get author family name words for Campbell-Wilson, D"""
+        """bibindex engine - get author family name words for Campbell-Wilson, D."""
         tokenizer = self._TOKENIZERS["BibIndexAuthorTokenizer"]()
         self.assertEqual(['campbell', 'wilson', 'campbell-wilson'],
                          tokenizer.get_author_family_name_words_from_phrase('Campbell-Wilson, D'))
 
 
 class TestGetValuesFromRecjson(InvenioTestCase):
-    """Tests for get_values_recursively function which finds values for tokenization
-       in recjson record"""
+
+    """Tests for get_values_recursively function which finds values for tokenization in recjson record."""
 
     @classmethod
     def setUp(self):
-        self.dict1 = {'all': {'vehicles': {'cars':{'car1':('flat tyre', 'windscreen'),
-                                                   'car2':('engine',)
-                                                  },
-                                           'planes':['Airplane', 'x,y - plane'],
-                                           'ufo':{}
-                                          },
+        self.dict1 = {'all': {'vehicles': {'cars': {'car1': ('flat tyre', 'windscreen'),
+                                                    'car2': ('engine',)
+                                                    },
+                                           'planes': ['Airplane', 'x,y - plane'],
+                                           'ufo': {}
+                                           },
                               'people': ['Frank', 'Theodor', 'Richard'],
                               'vikings': ['Odin', 'Eric'],
-                             }
+                              }
                       }
-        self.dict2 = {'all': {'name':([(['name1', 'name2', {'name3': 'name4'}], )], )} }
+        self.dict2 = {
+            'all': {'name': ([(['name1', 'name2', {'name3': 'name4'}], )], )}}
 
     def test_dict1_all_fields(self):
-        """bibindex termcollectors - get_field_values - complicated field"""
+        """bibindex termcollectors - get_field_values - complicated field."""
         fields = self.dict1
-        phrases =[]
+        phrases = []
         get_values_recursively(fields['all'], phrases)
         self.assertEqual(phrases, ['engine', 'flat tyre', 'windscreen', 'Airplane', 'x,y - plane',
                                    'Odin', 'Eric', 'Frank', 'Theodor', 'Richard'])
 
     def test_dict1_subfield(self):
-        """bibindex termcollectors - get_field_values - simple field"""
+        """bibindex termcollectors - get_field_values - simple field."""
         fields = self.dict1
-        phrases =[]
+        phrases = []
         get_values_recursively(fields['all']['people'], phrases)
         self.assertEqual(phrases, ['Frank', 'Theodor', 'Richard'])
 
-
     def test_dict2_all_fields(self):
-        """bibindex termcollectors - get_field_values - nested field"""
+        """bibindex termcollectors - get_field_values - nested field."""
         fields = self.dict2
-        phrases =[]
+        phrases = []
         get_values_recursively(fields['all'], phrases)
         self.assertEqual(phrases, ['name1', 'name2', 'name4'])
-
 
 
 TEST_SUITE = make_test_suite(TestListSetOperations,

--- a/invenio/modules/indexer/testsuite/test_indexer_engine_washer.py
+++ b/invenio/modules/indexer/testsuite/test_indexer_engine_washer.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Unit tests for the indexing engine washer."""
+
+from invenio.base.wrappers import lazy_import
+from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+
+engine_washer = lazy_import('invenio.legacy.bibindex.engine_washer')
+
+
+class TestWashers(InvenioTestCase):
+
+    """Test for washer operations."""
+
+    def test_lower_term_washer(self):
+        """Bibindex engine washer - lower term."""
+        self.assertEqual(
+            engine_washer.lower_index_term("test"),
+            u"test"
+        )
+        self.assertEqual(
+            engine_washer.lower_index_term("Test"),
+            u"test"
+        )
+
+    def test_lower_term_washer_encoding(self):
+        """Bibindex engine washer - lower term encoding."""
+        self.assertEqual(
+            engine_washer.lower_index_term(u"test"),
+            u"test"
+        )
+        self.assertEqual(
+            engine_washer.lower_index_term("Über"),
+            u"über"
+        )
+        self.assertEqual(
+            engine_washer.lower_index_term(u"Über"),
+            u"über"
+        )
+
+TEST_SUITE = make_test_suite(TestWashers)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)

--- a/invenio/modules/indexer/tokenizers/BibIndexCJKTokenizer.py
+++ b/invenio/modules/indexer/tokenizers/BibIndexCJKTokenizer.py
@@ -16,9 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
-"""BibIndexCJKTokenizer: makes search in collections with CJK papers and publications more reliable
-   If phrase has characters from CJK language set tokenizer will treat it diffrently than phrase without these chars.
-   CJK Tokenizer splits CJK words into single characters (it adds space between every two CJK characters).
+
+"""BibIndexCJKTokenizer: makes search in collections with CJK papers and publications more reliable.
+
+If phrase has characters from CJK language set tokenizer will treat it
+differently than phrase without these chars.
+
+CJK Tokenizer splits CJK words into single characters (it adds space between every two CJK characters).
 """
 
 import re
@@ -26,7 +30,8 @@ import re
 from invenio.modules.indexer.tokenizers.BibIndexDefaultTokenizer import BibIndexDefaultTokenizer
 
 is_character_from_CJK_set = re.compile(u'[\u3400-\u4DBF\u4E00-\u9FFF]')
-special_CJK_punctuation = re.compile(u'[\uff1a,\uff0c,\u3001,\u3002,\u201c,\u201d]')
+special_CJK_punctuation = re.compile(
+    u'[\uff1a,\uff0c,\u3001,\u3002,\u201c,\u201d]')
 
 
 def is_from_CJK_set_single_character_match(char):
@@ -61,28 +66,29 @@ def is_non_CJK_expression(word):
 
 
 class BibIndexCJKTokenizer(BibIndexDefaultTokenizer):
-    """A phrase is split into CJK characters.
-       CJK is Chinese, Japanese and Korean unified character set.
-       It means that for example, phrase: '据信，新手机更轻'
-       will be split into: ['据', '信', '新', '手', '机', '更', '轻']"""
 
-    def __init__(self, stemming_language = None, remove_stopwords = False, remove_html_markup = False, remove_latex_markup = False):
-        """Initialisation"""
+    u"""A phrase is split into CJK characters.
+
+    CJK is Chinese, Japanese and Korean unified character set.
+    It means that for example, phrase: '据信，新手机更轻'
+    will be split into: ['据', '信', '新', '手', '机', '更', '轻']"""
+
+    def __init__(self, stemming_language=None, remove_stopwords=False, remove_html_markup=False, remove_latex_markup=False):
+        """Initialisation."""
         BibIndexDefaultTokenizer.__init__(self, stemming_language,
-                                                remove_stopwords,
-                                                remove_html_markup,
-                                                remove_latex_markup)
-
+                                          remove_stopwords,
+                                          remove_html_markup,
+                                          remove_latex_markup)
 
     def tokenize_for_words_default(self, phrase):
-        """Default tokenize_for_words inherited from default tokenizer"""
+        """Default tokenize_for_words inherited from default tokenizer."""
         return super(BibIndexCJKTokenizer, self).tokenize_for_words(phrase)
 
-
     def tokenize_for_words(self, phrase):
-        """
-        Splits phrase into words with additional spaces
-        between CJK characters to enhance search for CJK papers and stuff.
+        """Split phrase into words with additional spaces between CJK characters.
+
+        Will enhance search for CJK papers.
+
         If there is no single CJK character in whole phrase it behaves the standard way:
         it splits phrase into words with use of BibIndexDefaultTokenizer's tokenize_for_words.
 
@@ -93,14 +99,15 @@ class BibIndexCJKTokenizer(BibIndexDefaultTokenizer):
         @rtype: list of string
         """
         if is_there_any_CJK_character_in_text(phrase):
-            #remove special CJK punctuation
+            # remove special CJK punctuation
             phrase = special_CJK_punctuation.sub("", phrase)
-            #first, we split our phrase with default word tokenizer to make it easier later
+            # first, we split our phrase with default word tokenizer to make it
+            # easier later
             words = self.tokenize_for_words_default(phrase)
-            #list for keeping CJK chars and non-CJK words
+            # list for keeping CJK chars and non-CJK words
             chars = []
-            #every CJK word splits into a set of single characters
-            #for example: "春眠暁覚" into ['春','眠','暁','覚']
+            # every CJK word splits into a set of single characters
+            # for example: "春眠暁覚" into ['春','眠','暁','覚']
             for word in words:
                 if is_from_CJK_set_full_match(word):
                     chars.extend(word)
@@ -124,9 +131,10 @@ class BibIndexCJKTokenizer(BibIndexDefaultTokenizer):
         else:
             return self.tokenize_for_words_default(phrase)
 
-
     def tokenize_for_pairs(self, phrase):
+        """Do nothing."""
         return []
 
     def tokenize_for_phrases(self, phrase):
+        """Do nothing."""
         return []

--- a/invenio/modules/indexer/tokenizers/BibIndexCJKTokenizer.py
+++ b/invenio/modules/indexer/tokenizers/BibIndexCJKTokenizer.py
@@ -96,12 +96,11 @@ class BibIndexCJKTokenizer(BibIndexDefaultTokenizer):
             #remove special CJK punctuation
             phrase = special_CJK_punctuation.sub("", phrase)
             #first, we split our phrase with default word tokenizer to make it easier later
-            pre_tokenized = self.tokenize_for_words_default(phrase)
+            words = self.tokenize_for_words_default(phrase)
             #list for keeping CJK chars and non-CJK words
             chars = []
             #every CJK word splits into a set of single characters
             #for example: "春眠暁覚" into ['春','眠','暁','覚']
-            words = [ word.decode("utf8") for word in pre_tokenized]
             for word in words:
                 if is_from_CJK_set_full_match(word):
                     chars.extend(word)


### PR DESCRIPTION
* FIX Avoids an exception from happening when passing a unicode string
  to the BibIndex engine washer. (closes #2981)

* Adds a unit test to cover this case.

Co-authored-by: Eamonn Maguire <eamonn.maguire@cern.ch>
Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>