### PR TITLE
travis: unittest2 requirements fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ install:
   - "sudo a2enmod rewrite"
   - "sudo mkdir /etc/apache2/ssl"
   - "sudo /usr/sbin/make-ssl-cert generate-default-snakeoil /etc/apache2/ssl/apache.pem"
+  - "travis_retry pip install unittest2"
   - "travis_retry pip install -r requirements.txt --quiet"
   - "travis_retry pip install -r .travis-$REQUIREMENTS-requirements.txt --allow-all-external --quiet"
   - "travis_retry pip install -e .[docs] --quiet --process-dependency-links"


### PR DESCRIPTION
* FIX Fixes TypeError error on markupsafe library. (closes #2862)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>