### PR TITLE
global: unicode literals for bundles

### DIFF
--- a/invenio/base/bundles.py
+++ b/invenio/base/bundles.py
@@ -60,6 +60,8 @@
     asynchronously the module that must be bundles using ``r.js``.
 """
 
+from __future__ import unicode_literals
+
 import mimetypes
 
 from invenio.ext.assets import Bundle, RequireJSFilter

--- a/invenio/ext/jasmine/bundles.py
+++ b/invenio/ext/jasmine/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,8 +19,10 @@
 
 """Bundles for Jasmine test runner."""
 
+from __future__ import unicode_literals
+
+from invenio.base.bundles import invenio as _i, jquery as _j
 from invenio.ext.assets import Bundle, RequireJSFilter
-from invenio.base.bundles import jquery as _j, invenio as _i
 
 jasmine_js = Bundle(
     # es5-shim is needed by PhantomJS

--- a/invenio/modules/accounts/bundles.py
+++ b/invenio/modules/accounts/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,9 +19,10 @@
 
 """Accounts bundles."""
 
-from invenio.ext.assets import Bundle, RequireJSFilter
+from __future__ import unicode_literals
 
-from invenio.base.bundles import styles as _styles, jquery as _j, invenio as _i
+from invenio.base.bundles import invenio as _i, jquery as _j, styles as _styles
+from invenio.ext.assets import Bundle, RequireJSFilter
 
 # The underscore makes it "hidden" for the bundle collector.
 _styles.contents += ("css/accounts/login.css",)

--- a/invenio/modules/annotations/bundles.py
+++ b/invenio/modules/annotations/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,11 +19,12 @@
 
 """Annotations bundles."""
 
-from invenio.ext.assets import Bundle
+from __future__ import unicode_literals
 
+from invenio.ext.assets import Bundle
+from invenio.modules.comments.bundles import css as _commentscss, \
+    js as _commentsjs
 from invenio.modules.previewer.bundles import pdftk as _pdftk
-from invenio.modules.comments.bundles import (js as _commentsjs,
-                                              css as _commentscss)
 
 
 _pdftk.contents += ("js/annotations/pdf_notes_helpers.js",)

--- a/invenio/modules/comments/bundles.py
+++ b/invenio/modules/comments/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,6 +18,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Comments bundles."""
+
+from __future__ import unicode_literals
 
 from invenio.ext.assets import Bundle
 

--- a/invenio/modules/communities/bundles.py
+++ b/invenio/modules/communities/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,6 +18,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Communities bundles."""
+
+from __future__ import unicode_literals
 
 from invenio.ext.assets import Bundle
 

--- a/invenio/modules/deposit/bundles.py
+++ b/invenio/modules/deposit/bundles.py
@@ -19,6 +19,8 @@
 
 """Deposit bundles."""
 
+from __future__ import unicode_literals
+
 from invenio.base.bundles import invenio as _i, jquery as _j
 from invenio.ext.assets import Bundle, RequireJSFilter
 

--- a/invenio/modules/editor/bundles.py
+++ b/invenio/modules/editor/bundles.py
@@ -19,6 +19,8 @@
 
 """Editor bundles."""
 
+from __future__ import unicode_literals
+
 from invenio.ext.assets import Bundle
 
 js = Bundle(

--- a/invenio/modules/formatter/bundles.py
+++ b/invenio/modules/formatter/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,6 +18,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Formatter bundles."""
+
+from __future__ import unicode_literals
 
 from invenio.ext.assets import Bundle
 

--- a/invenio/modules/groups/bundles.py
+++ b/invenio/modules/groups/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,8 +19,10 @@
 
 """Group bundles."""
 
+from __future__ import unicode_literals
+
+from invenio.base.bundles import invenio as _i, jquery as _j
 from invenio.ext.assets import Bundle, RequireJSFilter
-from invenio.base.bundles import jquery as _j, invenio as _i
 
 js = Bundle(
     'js/groups/init.js',

--- a/invenio/modules/messages/bundles.py
+++ b/invenio/modules/messages/bundles.py
@@ -19,6 +19,8 @@
 
 """Messages bundles."""
 
+from __future__ import unicode_literals
+
 from invenio.base.bundles import invenio as _i, jquery as _j, styles as _styles
 from invenio.ext.assets import Bundle, RequireJSFilter
 

--- a/invenio/modules/previewer/bundles.py
+++ b/invenio/modules/previewer/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,9 @@
 
 """Previewer bundles."""
 
-from invenio.ext.assets import Bundle, RequireJSFilter, CleanCSSFilter
+from __future__ import unicode_literals
+
+from invenio.ext.assets import Bundle, CleanCSSFilter, RequireJSFilter
 
 
 pdfjs = Bundle(

--- a/invenio/modules/records/bundles.py
+++ b/invenio/modules/records/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,6 +18,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Records bundles."""
+
+from __future__ import unicode_literals
 
 from invenio.ext.assets import Bundle, RequireJSFilter
 

--- a/invenio/modules/search/bundles.py
+++ b/invenio/modules/search/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,8 +19,10 @@
 
 """Search bundles."""
 
+from __future__ import unicode_literals
+
+from invenio.base.bundles import invenio as _i, jquery as _j
 from invenio.ext.assets import Bundle, RequireJSFilter
-from invenio.base.bundles import jquery as _j, invenio as _i
 
 js = Bundle(
     'js/search/init.js',

--- a/invenio/modules/tags/bundles.py
+++ b/invenio/modules/tags/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,9 +19,10 @@
 
 """Tags bundles."""
 
-from invenio.ext.assets import Bundle
+from __future__ import unicode_literals
 
 from invenio.base.bundles import styles as _css
+from invenio.ext.assets import Bundle
 
 
 _css.contents.append("css/tags/popover.css")

--- a/invenio/modules/workflows/bundles.py
+++ b/invenio/modules/workflows/bundles.py
@@ -19,6 +19,8 @@
 
 """Workflows bundles."""
 
+from __future__ import unicode_literals
+
 from invenio.base.bundles import invenio as _i, jquery as _j
 from invenio.ext.assets import Bundle, CleanCSSFilter, RequireJSFilter
 


### PR DESCRIPTION
* Forces unicode literals on all bundles. (addresses #2967)

* PEP8/257 code style improvements.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>