### PR TITLE
assets: removal of LESS_RUN_IN_DEBUG support

### DIFF
--- a/docs/getting-started/overlay.rst
+++ b/docs/getting-started/overlay.rst
@@ -227,7 +227,6 @@ the application).
     (myoverlay)$ inveniomanage config set CFG_SITE_SECURE_URL https://0.0.0.0:4000
     (myoverlay)$ inveniomanage config set DEBUG True
     (myoverlay)$ inveniomanage config set ASSETS_DEBUG True
-    (myoverlay)$ inveniomanage config set LESS_RUN_IN_DEBUG False
 
 
 Database setup

--- a/invenio/base/bundles.py
+++ b/invenio/base/bundles.py
@@ -138,21 +138,6 @@ admin = Bundle(
     weight=50
 )
 
-# less.js is only used when the following configuration is set:
-#
-#  - ASSETS_DEBUG is True
-#  - LESS_RUN_IN_DEBUG is False
-#
-lessjs = Bundle(
-    "vendors/less/dist/less.js",
-    output="less.js",
-    filters="uglifyjs",
-    weight=0,
-    bower={
-        "less": "latest"
-    }
-)
-
 # require.js is only used when:
 #
 #  - ASSETS_DEBUG is True

--- a/invenio/base/templates/base/bundles_base.html
+++ b/invenio/base/templates/base/bundles_base.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -31,9 +31,6 @@
  # modes.
  #}
 {%- if config.get("ASSETS_DEBUG") -%}
-  {%- if not config.get("LESS_RUN_IN_DEBUG") -%}
-    {% bundle "less.js" %}
-  {%- endif -%}
   {%- if not config.get("REQUIREJS_RUN_IN_DEBUG") -%}
     {% bundle "require.js" %}
   {%- endif -%}

--- a/invenio/ext/assets/extensions.py
+++ b/invenio/ext/assets/extensions.py
@@ -21,13 +21,10 @@
 
 import copy
 import os
-import warnings
 
 from flask import _request_ctx_stack, current_app
 
 from flask_assets import Environment, FlaskResolver
-
-from invenio.utils.deprecation import RemovedInInvenio21Warning
 
 from jinja2 import nodes
 from jinja2.ext import Extension
@@ -90,7 +87,6 @@ class BundleExtension(Extension):
 
         # The filters less and requirejs don't have the same behaviour by
         # default. Make sure we are respecting that.
-        app.config.setdefault("LESS_RUN_IN_DEBUG", True)
         app.config.setdefault("REQUIREJS_RUN_IN_DEBUG", False)
         # Fixing some paths as we forced the output directory with the
         # .directory
@@ -121,13 +117,6 @@ class BundleExtension(Extension):
                     _bundles[bundle.output] = bundle
 
             env = current_app.jinja_env.assets_environment
-            # disable the compilation in debug mode iff asked.
-            less_debug = env.debug and \
-                not current_app.config.get("LESS_RUN_IN_DEBUG")
-
-            if less_debug:
-                warnings.warn("LESS_RUN_IN_DEBUG has been deprecated",
-                              RemovedInInvenio21Warning)
 
             requirejs_debug = env.debug and \
                 not current_app.config.get("REQUIREJS_RUN_IN_DEBUG")
@@ -161,11 +150,7 @@ class BundleExtension(Extension):
                     bundle_copy = copy.deepcopy(bundle)
                     bundle_copy.extra.update(static_url_path=static_url_path)
                     if bundle.has_filter("less"):
-                        if less_debug:
-                            bundle_copy.filters = None
-                            bundle_copy.extra.update(rel="stylesheet/less")
-                        else:
-                            bundle_copy.extra.update(static_url_path="")
+                        bundle_copy.extra.update(static_url_path="")
                     if bundle.has_filter("requirejs"):
                         if requirejs_debug:
                             bundle_copy.filters = None


### PR DESCRIPTION
* INCOMPATIBILITY Removes support for runtime compiling of less files in
  debug mode when option LESS_RUN_IN_DEBUG is enabled.  (addresses #2923)

Co-authored-by: Jiri Kuncar <jiri.kuncar@cern.ch>