### PR TITLE
global: unicode literals for config

### DIFF
--- a/invenio/base/scripts/config.py
+++ b/invenio/base/scripts/config.py
@@ -19,7 +19,7 @@
 
 """Command line script to manage configuration operations."""
 
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import ast
 import errno
@@ -68,7 +68,7 @@ def get_conf():
     """Prepare configuration."""
     try:
         from invenio.config import CFG_ETCDIR
-    except:
+    except Exception:
         CFG_ETCDIR = None
     from invenio.legacy.inveniocfg import prepare_conf
 
@@ -118,7 +118,8 @@ def set_(name, value, filename='invenio.cfg'):
     with current_app.open_instance_resource(filename, 'a') as config_file:
         print(name, '=', pformat(value), file=config_file)
 
-set_.__name__ = 'set'
+# See http://bugs.python.org/issue7688
+set_.__name__ = str('set')
 manager.command(set_)
 
 
@@ -138,7 +139,8 @@ def list_():
     for key, value in current_app.config.items():
         print(key, '=', pformat(value))
 
-list_.__name__ = 'list'
+# See http://bugs.python.org/issue7688
+list_.__name__ = str('list')
 manager.command(list_)
 
 

--- a/invenio/celery/config.py
+++ b/invenio/celery/config.py
@@ -20,6 +20,8 @@
 
 """Default configuration for Celery."""
 
+from __future__ import unicode_literals
+
 
 def default_config(config):
     """Default configuration."""
@@ -32,8 +34,8 @@ def default_config(config):
     # The Invenio Celery loader automatically takes care of loading tasks
     # defined in *_tasks.py files in 'invenio' package.
     config.setdefault("CELERY_INCLUDE", [
-        #"invenio.celery.tasks",
-        #"invenio.modules.workflows.workers.worker_celery",
+        # "invenio.celery.tasks",
+        # "invenio.modules.workflows.workers.worker_celery",
     ])
 
     # Result backend

--- a/invenio/ext/template/config.py
+++ b/invenio/ext/template/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,6 +19,7 @@
 
 """Jinja2 configuration."""
 
+from __future__ import unicode_literals
 
 JINJA2_EXTENSIONS = [
     'invenio.ext.template.extensions:LangExtension',

--- a/invenio/legacy/authorlist/config.py
+++ b/invenio/legacy/authorlist/config.py
@@ -15,6 +15,8 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
+from __future__ import unicode_literals
+
 import re
 
 EMPTY                       = re.compile('^\s*$')

--- a/invenio/legacy/bibauthority/config.py
+++ b/invenio/legacy/bibauthority/config.py
@@ -15,6 +15,8 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
+from __future__ import unicode_literals
+
 # CFG_BIBAUTHORITY_RECORD_CONTROL_NUMBER_FIELD
 # the authority record field containing the authority record control number
 CFG_BIBAUTHORITY_RECORD_CONTROL_NUMBER_FIELD = '035__a'

--- a/invenio/legacy/bibcirculation/config.py
+++ b/invenio/legacy/bibcirculation/config.py
@@ -21,6 +21,8 @@
 bibcirculation config file
 """
 
+from __future__ import unicode_literals
+
 __revision__ = "$Id$"
 
 from invenio.config import CFG_CERN_SITE, \

--- a/invenio/legacy/bibclassify/config.py
+++ b/invenio/legacy/bibclassify/config.py
@@ -29,6 +29,8 @@ local configuration file names 'bibclassify_config_local.py' that
 contains the changes to apply.
 """
 
+from __future__ import unicode_literals
+
 import re
 import logging
 import sys

--- a/invenio/legacy/bibdocfile/config.py
+++ b/invenio/legacy/bibdocfile/config.py
@@ -15,6 +15,8 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
+from __future__ import unicode_literals
+
 import re
 
 try:

--- a/invenio/legacy/bibingest/config.py
+++ b/invenio/legacy/bibingest/config.py
@@ -16,7 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
 """Ingestion database configuration."""
+
+from __future__ import unicode_literals
 
 __revision__ = "$Id$"
 

--- a/invenio/legacy/bibmatch/config.py
+++ b/invenio/legacy/bibmatch/config.py
@@ -16,6 +16,9 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """BibMatch Configuration."""
+
+from __future__ import unicode_literals
+
 import logging
 import logging.handlers
 from invenio.config import CFG_TMPDIR

--- a/invenio/legacy/bibsword/config.py
+++ b/invenio/legacy/bibsword/config.py
@@ -19,6 +19,8 @@
 Forward to ArXiv.org source code
 '''
 
+from __future__ import unicode_literals
+
 from invenio.modules.formatter.api import get_tag_from_name
 
 #Maximal time to keep the stored XML Service doucment before reloading it in sec

--- a/invenio/legacy/bibupload/config.py
+++ b/invenio/legacy/bibupload/config.py
@@ -21,6 +21,8 @@
 BibUpload Engine configuration.
 """
 
+from __future__ import unicode_literals
+
 __revision__ = "$Id$"
 
 CFG_BIBUPLOAD_CONTROLFIELD_TAGS = ['001', '002', '003', '004',

--- a/invenio/legacy/elmsubmit/config.py
+++ b/invenio/legacy/elmsubmit/config.py
@@ -17,6 +17,8 @@
 
 """ElmSubmit configuration parameters."""
 
+from __future__ import unicode_literals
+
 __revision__ = "$Id$"
 
 import pkg_resources

--- a/invenio/legacy/oaiharvest/config.py
+++ b/invenio/legacy/oaiharvest/config.py
@@ -17,6 +17,8 @@
 
 """OAI Harvest Configuration."""
 
+from __future__ import unicode_literals
+
 __revision__ = "$Id$"
 
 

--- a/invenio/legacy/oairepository/config.py
+++ b/invenio/legacy/oairepository/config.py
@@ -17,6 +17,8 @@
 
 """OAI Repository Configuration."""
 
+from __future__ import unicode_literals
+
 # Maximum number of records to put in a single bibupload
 CFG_OAI_REPOSITORY_MARCXML_SIZE = 1000
 

--- a/invenio/legacy/refextract/config.py
+++ b/invenio/legacy/refextract/config.py
@@ -19,6 +19,8 @@
 
 """RefExtract configuration"""
 
+from __future__ import unicode_literals
+
 import pkg_resources
 from invenio.config import CFG_VERSION
 

--- a/invenio/legacy/webjournal/config.py
+++ b/invenio/legacy/webjournal/config.py
@@ -19,6 +19,9 @@
 """
 WebJournal exceptions classes
 """
+
+from __future__ import unicode_literals
+
 import cgi
 from invenio.config import \
      CFG_SITE_URL, \

--- a/invenio/legacy/weblinkback/config.py
+++ b/invenio/legacy/weblinkback/config.py
@@ -19,6 +19,8 @@
 
 """WebLinkback - Configuration Parameters"""
 
+from __future__ import unicode_literals
+
 CFG_WEBLINKBACK_STATUS = {'APPROVED': 'approved',
                           'PENDING': 'pending',
                           'REJECTED': 'rejected',

--- a/invenio/legacy/websearch_external_collections/config.py
+++ b/invenio/legacy/websearch_external_collections/config.py
@@ -21,6 +21,8 @@
 
 """External collection configuration file."""
 
+from __future__ import unicode_literals
+
 __revision__ = "$Id$"
 
 from invenio.config import CFG_WEBSEARCH_EXTERNAL_COLLECTION_SEARCH_TIMEOUT, \

--- a/invenio/legacy/webstat/config.py
+++ b/invenio/legacy/webstat/config.py
@@ -19,6 +19,8 @@
 
 """Invenio WebStat Configuration."""
 
+from __future__ import unicode_literals
+
 __revision__ = "$Id$"
 
 import pkg_resources

--- a/invenio/legacy/websubmit/config.py
+++ b/invenio/legacy/websubmit/config.py
@@ -17,6 +17,8 @@
 
 """Invenio Submission Web Interface config file."""
 
+from __future__ import unicode_literals
+
 __revision__ = "$Id$"
 
 import re

--- a/invenio/modules/access/config.py
+++ b/invenio/modules/access/config.py
@@ -1,5 +1,5 @@
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -15,7 +15,9 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""Invenio Access Control Config. """
+"""Invenio Access Control Config."""
+
+from __future__ import unicode_literals
 
 CFG_EXTERNAL_AUTH_USING_SSO = False
 CFG_EXTERNAL_AUTH_LOGOUT_SSO = None

--- a/invenio/modules/accounts/config.py
+++ b/invenio/modules/accounts/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,5 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Account config."""
+
+from __future__ import unicode_literals
 
 CFG_ACCOUNT_MIN_PASSWORD_LENGTH = 6

--- a/invenio/modules/annotations/config.py
+++ b/invenio/modules/annotations/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -17,7 +17,12 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
+"""Annotation config."""
+
+from __future__ import unicode_literals
+
 from invenio.base import config
+
 
 ANNOTATIONS_ENGINE = ('invenio.modules.jsonalchemy.jsonext.engines.'
                       'mongodb_pymongo:MongoDBStorage')

--- a/invenio/modules/apikeys/config.py
+++ b/invenio/modules/apikeys/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,6 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Apikey config."""
+
+from __future__ import unicode_literals
 
 CFG_WEB_API_KEY_ENABLE_SIGNATURE = True
 

--- a/invenio/modules/archiver/config.py
+++ b/invenio/modules/archiver/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,6 +18,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Archiver configuration."""
+
+from __future__ import unicode_literals
 
 import os
 

--- a/invenio/modules/authors/config.py
+++ b/invenio/modules/authors/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,6 +18,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Default configuration of the authors module."""
+
+from __future__ import unicode_literals
 
 # Stores all types of acceptable identifiers types.
 # `authorid` is the only internal and the only required Invenio author

--- a/invenio/modules/baskets/config.py
+++ b/invenio/modules/baskets/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,6 +18,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """WebBasket configuration parameters."""
+
+from __future__ import unicode_literals
 
 __revision__ = "$Id$"
 

--- a/invenio/modules/cloudconnector/config.py
+++ b/invenio/modules/cloudconnector/config.py
@@ -19,9 +19,11 @@
 
 """Configuration for all cloud services and general cloudutils config."""
 
-from werkzeug import secure_filename
+from __future__ import unicode_literals
 
 from invenio.base.config import CFG_SITE_NAME
+
+from werkzeug import secure_filename
 
 # General configuration
 CLOUDCONNECTOR_ROWS_PER_PAGE = 10

--- a/invenio/modules/comments/config.py
+++ b/invenio/modules/comments/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013 CERN.
+# Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -21,6 +21,8 @@
 
 """WebComment configuration parameters."""
 
+from __future__ import unicode_literals
+
 __revision__ = "$Id$"
 
 CFG_WEBCOMMENT_ACTION_CODE = {
@@ -30,22 +32,30 @@ CFG_WEBCOMMENT_ACTION_CODE = {
     'REPORT_ABUSE': 'A'
 }
 
+
 # Exceptions: errors
 class InvenioWebCommentError(Exception):
+
     """A generic error for WebComment."""
+
     def __init__(self, message):
         """Initialisation."""
         self.message = message
+
     def __str__(self):
         """String representation."""
         return repr(self.message)
 
+
 # Exceptions: warnings
 class InvenioWebCommentWarning(Exception):
+
     """A generic warning for WebComment."""
+
     def __init__(self, message):
         """Initialisation."""
         self.message = message
+
     def __str__(self):
         """String representation."""
         return repr(self.message)

--- a/invenio/modules/communities/config.py
+++ b/invenio/modules/communities/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -17,7 +17,9 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""Communities configuration variables."""
+"""Community configuration variables."""
+
+from __future__ import unicode_literals
 
 from datetime import timedelta
 

--- a/invenio/modules/deposit/config.py
+++ b/invenio/modules/deposit/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -17,6 +17,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Default configuration of deposit module."""
+
+from __future__ import unicode_literals
 
 import os
 import sys

--- a/invenio/modules/documentation/config.py
+++ b/invenio/modules/documentation/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,6 +18,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Configuration of documentation module.
+
+from __future__ import unicode_literals
 
 **Configuration**
 

--- a/invenio/modules/documents/config.py
+++ b/invenio/modules/documents/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -17,12 +17,10 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""
-    invenio.modules.documents.config
-    --------------------------------
+"""Defines configuration options for documents."""
 
-    Defines configuration options for documents.
-"""
+from __future__ import unicode_literals
+
 from invenio.base import config
 
 DOCUMENTS_ENGINE = ('invenio.modules.jsonalchemy.jsonext.engines.sqlalchemy'

--- a/invenio/modules/editor/config.py
+++ b/invenio/modules/editor/config.py
@@ -1,5 +1,5 @@
 # This file is part of Invenio.
-# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,6 +16,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """BibEdit Configuration."""
+
+from __future__ import unicode_literals
 
 # CFG_BIBEDIT_FILENAME - default filename for BibEdit files.
 CFG_BIBEDIT_FILENAME = "bibedit_record"
@@ -88,33 +90,33 @@ CFG_BIBEDIT_REQUESTS_UNTIL_SAVE = 3
 # by the Ajax engine.
 
 CFG_BIBEDIT_AJAX_RESULT_CODES_REV = {
-    #TODO: all the result codes should be accessible through the constants rather than
-    #      a direct number ! some parts of the bibedit_engine.py are not readable because
-    #      of using the numbers
-    #      The dictionary is convenient at this place because it can be imported with one command
-    #      unlike a number of constants
+    # TODO: all the result codes should be accessible through the constants
+    #       rather than a direct number ! some parts of the bibedit_engine.py
+    #       are not readable because of using the numbers
+    #       The dictionary is convenient at this place because it can be
+    #       imported with one command unlike a number of constants
     'record_submitted': 4,
     'editor_modifications_changed': 33,
-    'disabled_hp_changeset' : 34,
-    'added_positioned_subfields' : 35,
-    'autosuggestion_scanned' : 36,
-    'error_rec_locked_by_user' : 104,
-    'error_rec_locked_by_queue' : 105,
-    'server_error' : 111,
+    'disabled_hp_changeset': 34,
+    'added_positioned_subfields': 35,
+    'autosuggestion_scanned': 36,
+    'error_rec_locked_by_user': 104,
+    'error_rec_locked_by_queue': 105,
+    'server_error': 111,
     'error_physical_copies_exist': 112,
     'cache_updated_with_references': 114,
-    'textmarc_parsing_error' : 115,
-    'tableview_change_success' : 116,
+    'textmarc_parsing_error': 115,
+    'tableview_change_success': 116,
     'error_no_doi_specified': 117,
     'error_crossref_record_not_found': 118,
     'error_crossref_malformed_doi': 119,
-    'error_crossref_no_account' : 120,
-    'ticket_closed' : 121,
+    'error_crossref_no_account': 120,
+    'ticket_closed': 121,
     'error_ticket_closed': 122,
-    'ticket_opened' : 123,
+    'ticket_opened': 123,
     'error_ticket_opened': 124,
     'error_rt_connection': 125,
-    'ticket_created' : 126,
+    'ticket_created': 126,
     'error_ticket_created': 127
 }
 
@@ -166,7 +168,7 @@ CFG_BIBEDIT_AJAX_RESULT_CODES = {
 }
 
 CFG_BIBEDIT_MSG = {
-    "not_authorised" : "You are not authorised to submit a record into the given \
+    "not_authorised": "You are not authorised to submit a record into the given \
                         collection. Please, review the collection tags."
 }
 # CFG_BIBEDIT_MAX_SEARCH_RESULTS
@@ -180,23 +182,27 @@ CFG_BIBEDIT_TAG_FORMAT = 'MARC'
 # <CFG_BIBEDIT_FILENAME>_<RECID>_<UID>_<CFG_BIBEDIT_TO_MERGE_SUFFIX>.xml
 CFG_BIBEDIT_TO_MERGE_SUFFIX = 'merge'
 
-# CFG_BIBEDIT_AUTOSUGGEST_TAGS - for which tags the editor should try to autosuggest values
-# This is "safe" to have configured since it does not rely to a particular existing KB
+# CFG_BIBEDIT_AUTOSUGGEST_TAGS - for which tags the editor should try to
+# autosuggest values
+# This is "safe" to have configured since it does not rely to a particular
+# existing KB
 CFG_BIBEDIT_AUTOSUGGEST_TAGS = ['100__a']
 
-# CFG_BIBEDIT_AUTOCOMPLETE_TAGS_KBS - a dictionary whose keys are tags and values kb names
+# CFG_BIBEDIT_AUTOCOMPLETE_TAGS_KBS - a dictionary whose keys are tags and
+# values kb names
 # This is better left empty when in doubt
-CFG_BIBEDIT_AUTOCOMPLETE_TAGS_KBS = {} # { '65017a': 'SISC-65017a---65017a' }
+CFG_BIBEDIT_AUTOCOMPLETE_TAGS_KBS = {}  # { '65017a': 'SISC-65017a---65017a' }
 
-# CFG_BIBEDIT_KEYWORD_TAXONOMY - the name of the taxonomy DB that holds the taxonomy file used
+# CFG_BIBEDIT_KEYWORD_TAXONOMY - the name of the taxonomy DB that holds the
+# taxonomy file usead
 # for getting the keywords. Use only if you have a taxonomy KB.
-CFG_BIBEDIT_KEYWORD_TAXONOMY = "" #'HEP.RDF'
+CFG_BIBEDIT_KEYWORD_TAXONOMY = ""  # 'HEP.RDF'
 
-#what tag is used for keywords
-CFG_BIBEDIT_KEYWORD_TAG = "" # '6531_a'
+# what tag is used for keywords
+CFG_BIBEDIT_KEYWORD_TAG = ""  # '6531_a'
 
-#what label inside the RDF file contains the term
-CFG_BIBEDIT_KEYWORD_RDFLABEL = "" #'prefLabel'
+# what label inside the RDF file contains the term
+CFG_BIBEDIT_KEYWORD_RDFLABEL = ""  # 'prefLabel'
 
 # CFG_BIBEDIT_DOI_LOOKUP_FIELD - for which tag bibedit should add a link
 # to a DOI name resolver
@@ -216,10 +222,11 @@ CFG_BIBEDIT_DISPLAY_AUTHOR_TAGS = ['100', '700']
 
 # CFG_BIBEDIT_EXCLUDE_CURATOR_TAGS - which tags to be excluded in the
 # curator view
-CFG_BIBEDIT_EXCLUDE_CURATOR_TAGS = ['035', '041', '520', '540', '595', '650', '653', '690', '695', '856']
+CFG_BIBEDIT_EXCLUDE_CURATOR_TAGS = ['035', '041', '520', '540', '595', '650',
+                                    '653', '690', '695', '856']
 
-# CFG_BIBEDIT_AUTHOR_DISPLAY_THRESHOLD - if number of authors is higher than this number
-# they will be hidden by default
+# CFG_BIBEDIT_AUTHOR_DISPLAY_THRESHOLD - if number of authors is higher than
+# this number they will be hidden by default
 CFG_BIBEDIT_AUTHOR_DISPLAY_THRESHOLD = 200
 
 # CFG_BIBEDIT_SHOW_HOLDING_PEN_REMOVED_FIELDS -- whether to show or not
@@ -248,7 +255,8 @@ CFG_BIBEDIT_INTERNAL_DOI_PROTECTION_LEVEL = 2
 #     fixed(boolean): the results are displayed in a dropdown list and
 #                     the user can't provide any search term,
 #                     when set to true, searchChars setting must be set to 0.
-#     searchMethod(string: startsWith,contains): the method used to filter results
+#     searchMethod(string: startsWith,contains): the method used to filter
+#                                                results
 #     searchChars(int): sets after how many given chars from user,
 #                       autocomplete search function is called
 #     preload(boolean): sets whether Knowledge Base's data are retrieved
@@ -259,7 +267,8 @@ CFG_BIBEDIT_INTERNAL_DOI_PROTECTION_LEVEL = 2
 #     CFG_BIBEDIT_AUTOCOMPLETE = {
 #          'COMMON' : {
 #               '100__u' : { 'kb' : 'InstitutionsCollection', 'fixed' : False,
-#               'searchMethod' : 'startsWith', 'searchChars' : 2, 'preload' : False },
+#               'searchMethod' : 'startsWith', 'searchChars' : 2, 'preload' :
+#               False },
 #          }
 #     }
 CFG_BIBEDIT_AUTOCOMPLETE = {'COMMON': {}}

--- a/invenio/modules/encoder/config.py
+++ b/invenio/modules/encoder/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2011 CERN.
+# Copyright (C) 2011, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -17,68 +17,83 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""Bibencode configuration submodule"""
+"""Bibencode configuration submodule."""
 
-__revision__ = "$Id$"
+from __future__ import unicode_literals
 
 import invenio.config
+
 import pkg_resources
+
 import re
 
 from six import iteritems
 
-#-----------------------#
-# General Configuration #
-#-----------------------#
+__revision__ = "$Id$"
+
+# -----------------------#
+# General Configuration  #
+# -----------------------#
 
 # The command for probing with FFMPEG
-CFG_BIBENCODE_FFMPEG_PROBE_COMMAND = invenio.config.CFG_PATH_FFPROBE + " %s -loglevel verbose -show_format -show_streams"
+CFG_BIBENCODE_FFMPEG_PROBE_COMMAND = invenio.config.CFG_PATH_FFPROBE + \
+    " %s -loglevel verbose -show_format -show_streams"
 
 # The command for probing with MEDIAINFO
-CFG_BIBENCODE_MEDIAINFO_COMMAND = invenio.config.CFG_PATH_MEDIAINFO + " %s -f --Output=XML"
+CFG_BIBENCODE_MEDIAINFO_COMMAND = invenio.config.CFG_PATH_MEDIAINFO + \
+    " %s -f --Output=XML"
 
 # Image extraction base command
-CFG_BIBENCODE_FFMPEG_EXTRACT_COMMAND = invenio.config.CFG_PATH_FFMPEG + " -ss %.2f -i %s -r 1 -vframes 1 -f image2 -s %s %s"
+CFG_BIBENCODE_FFMPEG_EXTRACT_COMMAND = invenio.config.CFG_PATH_FFMPEG + \
+    " -ss %.2f -i %s -r 1 -vframes 1 -f image2 -s %s %s"
 
 # Commands for multipass encoding
 # In the first pass, you can dump the output to /dev/null and ignore audio
-# CFG_BIBENCODE_FFMPEG_COMMAND_PASS_1 = "ffmpeg -i %s -y -loglevel verbose -vcodec %s -pass 1 -passlogfile %s -an -f rawvideo -b %s -s %s %s /dev/null"
-# CFG_BIBENCODE_FFMPEG_COMMAND_PASS_2 = "ffmpeg -i %s -y -loglevel verbose -vcodec %s -pass 2 -passlogfile %s -acodec %s -b %s -ab %s -s %s %s %s"
-CFG_BIBENCODE_FFMPEG_PASSLOGFILE_PREFIX = invenio.config.CFG_LOGDIR + "/bibencode2pass-%s-%s"
+# CFG_BIBENCODE_FFMPEG_COMMAND_PASS_1 = "ffmpeg -i %s -y -loglevel verbose
+# -vcodec %s -pass 1 -passlogfile %s -an -f rawvideo -b %s -s %s %s /dev/null"
+# CFG_BIBENCODE_FFMPEG_COMMAND_PASS_2 = "ffmpeg -i %s -y -loglevel verbose
+# -vcodec %s -pass 2 -passlogfile %s -acodec %s -b %s -ab %s -s %s %s %s"
+CFG_BIBENCODE_FFMPEG_PASSLOGFILE_PREFIX = invenio.config.CFG_LOGDIR + \
+    "/bibencode2pass-%s-%s"
 
 # Path to the encoding logfiles
 # Filenames will later be substituted with process specific information
-CFG_BIBENCODE_FFMPEG_ENCODING_LOG = invenio.config.CFG_LOGDIR + "/bibencode_%s.log"
+CFG_BIBENCODE_FFMPEG_ENCODING_LOG = invenio.config.CFG_LOGDIR + \
+    "/bibencode_%s.log"
 
 # Path to probing logiles
-CFG_BIBENCODE_FFMPEG_PROBE_LOG = invenio.config.CFG_LOGDIR + "/bibencode_probe_%s.log"
+CFG_BIBENCODE_FFMPEG_PROBE_LOG = invenio.config.CFG_LOGDIR + \
+    "/bibencode_probe_%s.log"
 
 # The pattern for the encoding status specific string in the FFmpeg output
-CFG_BIBENCODE_FFMPEG_ENCODE_TIME = re.compile("^.+time=(\d\d:\d\d:\d\d.\d\d).+$")
+CFG_BIBENCODE_FFMPEG_ENCODE_TIME = re.compile(
+    "^.+time=(\d\d:\d\d:\d\d.\d\d).+$")
 
-# The pattern for the configuration string with information about compiling options
-CFD_BIBENCODE_FFMPEG_OUT_RE_CONFIGURATION = re.compile("(--enable-[a-z0-9\-]*)")
+# The pattern for the configuration string with information about compiling
+# options
+CFD_BIBENCODE_FFMPEG_OUT_RE_CONFIGURATION = re.compile(
+    "(--enable-[a-z0-9\-]*)")
 
 # The minimum ffmpeg compile options for BibEncode to work correctly
 CFG_BIBENCODE_FFMPEG_CONFIGURATION_REQUIRED = (
-                '--enable-gpl',
-                '--enable-version3',
-                '--enable-nonfree',
-                '--enable-libfaac',
-                ## '--enable-libfdk-aac',
-                '--enable-libtheora',
-                '--enable-libvorbis',
-                '--enable-libvpx',
-                '--enable-libx264',
-                ## '--enable-funky'
-                )
+    '--enable-gpl',
+    '--enable-version3',
+    '--enable-nonfree',
+    '--enable-libfaac',
+    # '--enable-libfdk-aac',
+    '--enable-libtheora',
+    '--enable-libvorbis',
+    '--enable-libvpx',
+    '--enable-libx264',
+    # '--enable-funky'
+)
 
 # Path to the directory for transcoded files
 CFG_BIBENCODE_TARGET_DIRECTORY = invenio.config.CFG_TMPDIR + "/"
 
-#------------------------#
-# Metadata Configuration #
-#------------------------#
+# ------------------------#
+# Metadata Configuration  #
+# ------------------------#
 
 # Template for key-value pairs that can be used with FFMPEG to set metadata.
 # Not all keys are represented in every video container format.
@@ -90,70 +105,88 @@ CFG_BIBENCODE_TARGET_DIRECTORY = invenio.config.CFG_TMPDIR + "/"
 # The FFMPEG argument structure is:
 # -metadata key1="value1" -metadata key2="value2 ...
 CFG_BIBENCODE_FFMPEG_METADATA_TEMPLATE = {
-                   'title': None,
-                   'author': None,
-                   'album_artist': None,
-                   'album': None,
-                   'grouping': None,
-                   'composer': None,
-                   'year': None,
-                   'track': None,
-                   'comment': None,
-                   'genre': None,
-                   'copyright': None,
-                   'description': None,
-                   'synopsis': None,
-                   'show': None,
-                   'episode_id': None,
-                   "network": None,
-                   'lyrics': None
-                   }
+    'title': None,
+    'author': None,
+    'album_artist': None,
+    'album': None,
+    'grouping': None,
+    'composer': None,
+    'year': None,
+    'track': None,
+    'comment': None,
+    'genre': None,
+    'copyright': None,
+    'description': None,
+    'synopsis': None,
+    'show': None,
+    'episode_id': None,
+    "network": None,
+    'lyrics': None
+}
 
 #  Duration: 00:02:28.58, start: 0.000000, bitrate: 9439 kb/s
-#                                                                       timcode       start?              bitrate
-CFG_BIBENCODE_FFMPEG_RE_VIDEOINFO_DURATION = re.compile("^\s*Duration: (.*?), start: (\d+\.\d+), bitrate: (\d+?) kb\/s$")
+#                   timcode       start?              bitrate
+CFG_BIBENCODE_FFMPEG_RE_VIDEOINFO_DURATION = re.compile(
+    "^\s*Duration: (.*?), start: (\d+\.\d+), bitrate: (\d+?) kb\/s$")
 
-#    Stream #0.0(eng): Video: h264 (Main), yuv420p, 1920x1056, 9338 kb/s, 23.98 fps, 23.98 tbr, 2997 tbn, 5994 tbc
-#    Stream #0.1(eng): Video: wmv3, yuv420p, 1440x1080, 9500 kb/s, 25 tbr, 1k tbn, 1k tbc
-#                                                                   number     language         codec               color   resolution  bitrate    fps       tbr       tbn      tbc
-CFG_BIBENCODE_FFMPEG_RE_VIDEOINFO_VSTREAM = re.compile("^\s*Stream #(\d+.\d+)\(?(\w+)?\)?: Video: ([a-zA-Z0-9\(\) ]*), (\w+), (\d+x\d+), (\d+) kb\/s, (.+) fps, (.+) tbr, (.+) tbn, (.+) tbc$")
+#    Stream #0.0(eng): Video: h264 (Main), yuv420p, 1920x1056, 9338 kb/s, 23.98
+#    fps, 23.98 tbr, 2997 tbn, 5994 tbc
+#    Stream #0.1(eng): Video: wmv3, yuv420p, 1440x1080, 9500 kb/s, 25 tbr, 1k
+#    tbn, 1k tbc
+#                  number     language           codec
+#    color   resolution  bitrate    fps       tbr       tbn      tbc
+CFG_BIBENCODE_FFMPEG_RE_VIDEOINFO_VSTREAM = re.compile(
+    "^\s*Stream #(\d+.\d+)\(?(\w+)?\)?: Video: ([a-zA-Z0-9\(\) ]*), "
+    "(\w+), (\d+x\d+), (\d+) kb\/s, (.+) fps, (.+) tbr, (.+) tbn, (.+) tbc$")
 
 #    Stream #0.0(eng): Audio: wmav2, 44100 Hz, 2 channels, s16, 320 kb/s
 #    Stream #0.1(eng): Audio: aac, 44100 Hz, stereo, s16, 97 kb/s
-#                                                                    number    language         codec              samplerate   channels      bit-depth   bitrate
-CFG_BIBENCODE_FFMPEG_RE_VIDEOINFO_ASTREAM = re.compile("^\s*Stream #(\d+.\d+)\(?(\w+)?\)?: Audio: ([a-zA-Z0-9\(\) ]*), (\d+) Hz, ([a-zA-Z0-9 ]+), (\w+), (\d+) kb\/s$")
+#    number    language         codec              samplerate
+#    channels      bit-depth   bitrate
+CFG_BIBENCODE_FFMPEG_RE_VIDEOINFO_ASTREAM = re.compile(
+    "^\s*Stream #(\d+.\d+)\(?(\w+)?\)?: Audio: ([a-zA-Z0-9\(\) ]*), "
+    "(\d+) Hz, ([a-zA-Z0-9 ]+), (\w+), (\d+) kb\/s$")
 
 # FFMPEG command for setting metadata
 # This will create a copy of the master and write the metadata there
-CFG_BIBENCODE_FFMPEG_METADATA_SET_COMMAND = "ffmpeg -y -i %s -acodec copy -vcodec copy %s"
+CFG_BIBENCODE_FFMPEG_METADATA_SET_COMMAND = "ffmpeg -y -i %s " + \
+    "-acodec copy -vcodec copy %s"
 
 # FFMPEG metadata argument template
 # had to remove '-metadata ' in front because of issues with command splitting
 CFG_BIBENCODE_FFMPEG_METADATA_ARGUMENT = "%s=\"%s\""
 
 # File containing mappings from ffprobe and mediainfo to pbcore
-CFG_BIBENCODE_PBCORE_MAPPINGS = pkg_resources.resource_filename('invenio.modules.encoder','pbcore_mappings.json')
+CFG_BIBENCODE_PBCORE_MAPPINGS = pkg_resources.resource_filename(
+    'invenio.modules.encoder', 'pbcore_mappings.json')
 
 # XSLT Template from PBCORE to MARCXML
-CFG_BIBENCODE_PBCORE_MARC_XSLT = pkg_resources.resource_filename('invenio.modules.encoder','pbcore_to_marc_nons.xsl')
+CFG_BIBENCODE_PBCORE_MARC_XSLT = pkg_resources.resource_filename(
+    'invenio.modules.encoder', 'pbcore_to_marc_nons.xsl')
 
-CFG_BIBENCODE_ASPECT_RATIO_MARC_FIELD  = "951__x"
+CFG_BIBENCODE_ASPECT_RATIO_MARC_FIELD = "951__x"
+
 
 # Metadata Patterns for parsing
 def create_metadata_re_dict():
-    """ Creates a dictionary with Regex patterns from the metadata template dictionary
+    """Create a dictionary with Regex patterns.
+
+    Creates a dictionary with Regex patterns from the metadata template
+    dictionary.
     """
     metadata_re_dictionary = {}
     for key, value in iteritems(CFG_BIBENCODE_FFMPEG_METADATA_TEMPLATE):
-        metadata_re_dictionary[key] = re.compile("^\s*%s\s*:\s(((\S*)\s*(\S*))*)$" % key)
+        metadata_re_dictionary[key] = re.compile(
+            "^\s*%s\s*:\s(((\S*)\s*(\S*))*)$" % key)
     return metadata_re_dictionary
 CFG_BIBENCODE_FFMPEG_METADATA_RE_DICT = create_metadata_re_dict()
 
-#----------------------#
+# ---------------------#
 # Parameter Validation #
-#----------------------#
+# ---------------------#
 
-CFG_BIBENCODE_VALID_MODES = ['encode', 'extract', 'meta', 'batch', 'daemon', 'cdsmedia']
+CFG_BIBENCODE_VALID_MODES = ['encode', 'extract', 'meta', 'batch',
+                             'daemon', 'cdsmedia']
 
 CFG_BIBENCODE_FFMPEG_VALID_SIZES = [
     'sqcif', 'qcif', 'cif', '4cif', '16cif', 'qqvga', 'qvga', 'vga', 'svga',
@@ -212,26 +245,33 @@ CFG_BIBENCODE_FFMPEG_VALID_ACODECS = [
     'libmp3lame', 'libvorbis', 'wma1', 'wma2', 'libfaac'
     ]
 
-#------------------------#
+# -----------------------#
 # Profiles Configuration #
-#------------------------#
+# -----------------------#
 
-CFG_BIBENCODE_PROFILES_ENCODING = pkg_resources.resource_filename('invenio.modules.encoder','encoding_profiles.json')
-CFG_BIBENCODE_PROFILES_ENCODING_LOCAL = pkg_resources.resource_filename('invenio.modules.encoder','encoding_profiles_local.json')
-CFG_BIBENCODE_PROFILES_EXTRACT = pkg_resources.resource_filename('invenio.modules.encoder','extract_profiles.json')
-CFG_BIBENCODE_PROFILES_EXTRACT_LOCAL = pkg_resources.resource_filename('invenio.modules.encoder','extract_profiles_local.json')
-CFG_BIBENCODE_TEMPLATE_BATCH_SUBMISSION = pkg_resources.resource_filename('invenio.modules.encoder','batch_template_submission.json')
+CFG_BIBENCODE_PROFILES_ENCODING = pkg_resources.resource_filename(
+    'invenio.modules.encoder', 'encoding_profiles.json')
+CFG_BIBENCODE_PROFILES_ENCODING_LOCAL = pkg_resources.resource_filename(
+    'invenio.modules.encoder', 'encoding_profiles_local.json')
+CFG_BIBENCODE_PROFILES_EXTRACT = pkg_resources.resource_filename(
+    'invenio.modules.encoder', 'extract_profiles.json')
+CFG_BIBENCODE_PROFILES_EXTRACT_LOCAL = pkg_resources.resource_filename(
+    'invenio.modules.encoder', 'extract_profiles_local.json')
+CFG_BIBENCODE_TEMPLATE_BATCH_SUBMISSION = pkg_resources.resource_filename(
+    'invenio.modules.encoder', 'batch_template_submission.json')
 
-#----------------------#
+# ---------------------#
 # Daemon Configuration #
-#----------------------#
+# ---------------------#
 
-CFG_BIBENCODE_DAEMON_DIR_NEWJOBS = invenio.config.CFG_TMPSHAREDDIR + '/bibencode/jobs'
-CFG_BIBENCODE_DAEMON_DIR_OLDJOBS = invenio.config.CFG_TMPSHAREDDIR + '/bibencode/jobs/done'
+CFG_BIBENCODE_DAEMON_DIR_NEWJOBS = invenio.config.CFG_TMPSHAREDDIR + \
+    '/bibencode/jobs'
+CFG_BIBENCODE_DAEMON_DIR_OLDJOBS = invenio.config.CFG_TMPSHAREDDIR + \
+    '/bibencode/jobs/done'
 
-#-------------------#
+# ------------------#
 # WebSubmit Support #
-#-------------------#
+# ------------------#
 
 CFG_BIBENCODE_WEBSUBMIT_ASPECT_SAMPLE_FNAME = 'aspect_sample_.jpg'
 CFG_BIBENCODE_WEBSUBMIT_ASPECT_SAMPLE_DIR = 'aspect_samples'

--- a/invenio/modules/formatter/config.py
+++ b/invenio/modules/formatter/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2006, 2007, 2008, 2010, 2011, 2014 CERN.
+# Copyright (C) 2006, 2007, 2008, 2010, 2011, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -21,22 +21,29 @@
 
 """BibFormat configuration parameters."""
 
-__revision__ = "$Id$"
+from __future__ import unicode_literals
 
 import os
+
 import pkg_resources
 
 from invenio.config import CFG_ETCDIR
 
+__revision__ = "$Id$"
+
+
 # Paths to main formats directories
 CFG_BIBFORMAT_TEMPLATES_DIR = "format_templates"
-CFG_BIBFORMAT_TEMPLATES_PATH = pkg_resources.resource_filename('invenio.modules.formatter', CFG_BIBFORMAT_TEMPLATES_DIR)
-CFG_BIBFORMAT_JINJA_TEMPLATE_PATH = os.path.join(CFG_ETCDIR, 'templates', CFG_BIBFORMAT_TEMPLATES_DIR)
-CFG_BIBFORMAT_OUTPUTS_PATH = pkg_resources.resource_filename('invenio.modules.formatter', 'output_formats')
+CFG_BIBFORMAT_TEMPLATES_PATH = pkg_resources.resource_filename(
+    'invenio.modules.formatter', CFG_BIBFORMAT_TEMPLATES_DIR)
+CFG_BIBFORMAT_JINJA_TEMPLATE_PATH = os.path.join(
+    CFG_ETCDIR, 'templates', CFG_BIBFORMAT_TEMPLATES_DIR)
+CFG_BIBFORMAT_OUTPUTS_PATH = pkg_resources.resource_filename(
+    'invenio.modules.formatter', 'output_formats')
 
 # CFG_BIBFORMAT_HIDDEN_TAGS -- list of MARC tags that
 # are not shown to users not having cataloging authorizations.
-CFG_BIBFORMAT_HIDDEN_TAGS = [595,]
+CFG_BIBFORMAT_HIDDEN_TAGS = [595, ]
 
 # File extensions of formats
 CFG_BIBFORMAT_FORMAT_TEMPLATE_EXTENSION = "bft"
@@ -48,8 +55,10 @@ CFG_BIBFORMAT_FORMAT_OUTPUT_EXTENSION = "bfo"
 # of these in a db table
 CFG_BIBFORMAT_CACHED_FORMATS = []
 
-assert CFG_BIBFORMAT_FORMAT_TEMPLATE_EXTENSION != CFG_BIBFORMAT_FORMAT_JINJA_TEMPLATE_EXTENSION, \
-    "CFG_BIBFORMAT_FORMAT_TEMPLATE_EXTENSION and CFG_BIBFORMAT_FORMAT_JINJA_TEMPLATE_EXTENSION must be different"
+assert CFG_BIBFORMAT_FORMAT_TEMPLATE_EXTENSION != \
+    CFG_BIBFORMAT_FORMAT_JINJA_TEMPLATE_EXTENSION, \
+    "CFG_BIBFORMAT_FORMAT_TEMPLATE_EXTENSION and " +\
+    "CFG_BIBFORMAT_FORMAT_JINJA_TEMPLATE_EXTENSION must be different"
 
 assert len(CFG_BIBFORMAT_FORMAT_TEMPLATE_EXTENSION) == 3, \
     "CFG_BIBFORMAT_FORMAT_TEMPLATE_EXTENSION must be 3 characters long"
@@ -64,6 +73,7 @@ assert len(CFG_BIBFORMAT_FORMAT_OUTPUT_EXTENSION) == 3, \
 
 
 class InvenioBibFormatError(Exception):
+
     """A generic error for BibFormat."""
 
     def __init__(self, message):
@@ -79,6 +89,7 @@ class InvenioBibFormatError(Exception):
 
 
 class InvenioBibFormatWarning(Exception):
+
     """A generic warning for BibFormat."""
 
     def __init__(self, message):

--- a/invenio/modules/groups/config.py
+++ b/invenio/modules/groups/config.py
@@ -1,5 +1,5 @@
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,6 +16,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Groups parameters."""
+
+from __future__ import unicode_literals
 
 """Specify how many suggestion returns for autocomplete fields."""
 GROUPS_AUTOCOMPLETE_LIMIT = 10

--- a/invenio/modules/linkbacks/config.py
+++ b/invenio/modules/linkbacks/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,6 +18,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Linkback configuration."""
+
+from __future__ import unicode_literals
 
 # Enable legacy weblinkback code.
 CFG_WEBLINKBACK_TRACKBACK_ENABLED = 1

--- a/invenio/modules/messages/config.py
+++ b/invenio/modules/messages/config.py
@@ -1,5 +1,5 @@
 # This file is part of Invenio.
-# Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013 CERN.
+# Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -15,12 +15,13 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""
-    WebMessage parameters
+"""WebMessage parameters.
 
     webmessage config file, here you can manage error messages,
     size of messages, quotas, and some db related fields...
 """
+
+from __future__ import unicode_literals
 
 # from invenio.conf:
 

--- a/invenio/modules/multimedia/config.py
+++ b/invenio/modules/multimedia/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -22,6 +22,8 @@
 # 60 seconds * 60 (1 hour) * 24 (1 day) * 2 (2 days)
 
 """Multimedia configuration."""
+
+from __future__ import unicode_literals
 
 MULTIMEDIA_IMAGE_CACHE_TIME = 60 * 60 * 24 * 2
 

--- a/invenio/modules/oaiharvester/config.py
+++ b/invenio/modules/oaiharvester/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,6 +18,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """OAI harvest config."""
+
+from __future__ import unicode_literals
 
 OAIHARVESTER_DEFAULT_NAMESPACE_MAP = {
     None: "http://www.openarchives.org/OAI/2.0/",

--- a/invenio/modules/oauth2server/config.py
+++ b/invenio/modules/oauth2server/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,6 +18,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """OAuth2Server configuration variables."""
+
+from __future__ import unicode_literals
 
 OAUTH2_CACHE_TYPE = 'redis'
 """ Type of cache to use for storing the temporary grant token """

--- a/invenio/modules/oauthclient/config.py
+++ b/invenio/modules/oauthclient/config.py
@@ -175,6 +175,8 @@ a given authorize request.
     )
 """
 
+from __future__ import unicode_literals
+
 OAUTHCLIENT_REMOTE_APPS = {}
 """Configuration of remote applications."""
 

--- a/invenio/modules/pages/config.py
+++ b/invenio/modules/pages/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,6 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Page module config."""
+
+from __future__ import unicode_literals
 
 PAGES_DEFAULT_TEMPLATE = 'pages/default.html'
 PAGES_APPEND_SLASH = True

--- a/invenio/modules/pidstore/config.py
+++ b/invenio/modules/pidstore/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,6 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Pidstore config."""
+
+from __future__ import unicode_literals
 
 PIDSTORE_PROVIDERS = [
     'invenio.modules.pidstore.providers.datacite:DataCite',

--- a/invenio/modules/ranker/config.py
+++ b/invenio/modules/ranker/config.py
@@ -1,5 +1,5 @@
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -14,5 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Ranker config."""
+
+from __future__ import unicode_literals
 
 CFG_BIBRANK_PATH_TO_STOPWORDS_FILE = 'stopwords.kb'

--- a/invenio/modules/records/config.py
+++ b/invenio/modules/records/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,6 +18,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Records configuration."""
+
+from __future__ import unicode_literals
 
 from .models import RecordMetadata as RecordMetadataModel
 

--- a/invenio/modules/scheduler/config.py
+++ b/invenio/modules/scheduler/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,5 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Scheduler config."""
+
+from __future__ import unicode_literals
 
 CFG_BIBSCHED_LOGDIR = "bibsched"

--- a/invenio/modules/search/config.py
+++ b/invenio/modules/search/config.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2010, 2011, 2012, 2013, 2015 CERN.
+# Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2010, 2011, 2012, 2013,
+#               2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,6 +20,8 @@
 
 """Invenio Search Engine config parameters."""
 
+from __future__ import unicode_literals
+
 SEARCH_QUERY_PARSER = 'invenio_query_parser.parser:Main'
 
 SEARCH_QUERY_WALKERS = [
@@ -31,7 +34,7 @@ CFG_EXPERIMENTAL_FEATURES = 0
 # CFG_WEBSEARCH_IDXPAIRS_FIELDS -- a comma separated list of index
 # fields. This list contains all the index fields on which exact
 # phrase search should use idxPairs tables.
-CFG_WEBSEARCH_IDXPAIRS_FIELDS = ['global','abstract','title','caption']
+CFG_WEBSEARCH_IDXPAIRS_FIELDS = ['global', 'abstract', 'title', 'caption']
 
 # CFG_WEBSEARCH_IDXPAIRS_EXACT_SEARCH -- if true, it will eliminate
 # all the false positives when using the word pairs for search.
@@ -51,11 +54,11 @@ CFG_WEBSEARCH_RESULTS_OVERVIEW_MAX_COLLS_TO_PRINT = 10
 CFG_SEARCH_RESULTS_CACHE_PREFIX = "search_results::"
 
 # CERN Site hack
-#CFG_WEBSEARCH_SEARCH_WITHIN = ['title',
-#                               'author',
-#                               'abstract',
-#                               'report number,
-#                               'year']
+# CFG_WEBSEARCH_SEARCH_WITHIN = ['title',
+#                                'author',
+#                                'abstract',
+#                                'report number,
+#                                'year']
 
 CFG_WEBSEARCH_SEARCH_WITHIN = ['title',
                                'author',
@@ -69,7 +72,7 @@ CFG_WEBSEARCH_SEARCH_WITHIN = ['title',
 
 
 CFG_WEBSEACH_MATCHING_TYPES = [
-        {
+    {
         'code': 'a',
         'title': "all of the words",
         'order': 1,
@@ -83,8 +86,8 @@ CFG_WEBSEACH_MATCHING_TYPES = [
             }
             return result;
         """
-        },
-        {
+    },
+    {
         'code': 'o',
         'title': "any of the words",
         'order': 2,
@@ -98,32 +101,32 @@ CFG_WEBSEACH_MATCHING_TYPES = [
             }
             return result;
         """
-        },
-        {
+    },
+    {
         'code': 'e',
         'title': "exact phrase",
         'order': 3,
         'tokenize': """
             return f+'"'+val+'"';
         """
-        },
-        {
+    },
+    {
         'code': 'p',
         'title': "partial phrase",
         'order': 4,
         'tokenize': """
             return f+"'"+val+"'";
         """
-        },
-        {
+    },
+    {
         'code': 'r',
         'title': "regular expression",
         'order': 5,
         'tokenize': """
             return f+'/'+val+'/';
         """
-        }
-    ]
+    }
+]
 
 # CFG_WEBSEARCH_COLLECTION_NAMES_SEARCH -- decides whether search for
 # collection name is enabled (1), disabled (-1) or enabled only for

--- a/invenio/modules/tags/config.py
+++ b/invenio/modules/tags/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # This file is part of CDS Invenio.
-# Copyright (C) 2013 CERN.
+# Copyright (C) 2013, 2015 CERN.
 #
 # CDS Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,7 +16,9 @@
 # along with CDS Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-""" Webtag module configuration. """
+"""Webtag module configuration."""
+
+from __future__ import unicode_literals
 
 # pylint: disable-msg=W0105
 

--- a/invenio/modules/unapi/config.py
+++ b/invenio/modules/unapi/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,6 +18,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """UnAPI service hooks configuration options."""
+
+from __future__ import unicode_literals
 
 # Define enabled format names fo
 UNAPI_FORMAT_MAPPING = {

--- a/invenio/modules/uploader/config.py
+++ b/invenio/modules/uploader/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,6 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Uploader config."""
+
+from __future__ import unicode_literals
 
 UPLOADER_WORKFLOWS = {
     'insert': 'invenio.modules.uploader.workflows.insert:insert'

--- a/invenio/modules/webhooks/config.py
+++ b/invenio/modules/webhooks/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,6 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Webhooks module."""
+
+from __future__ import unicode_literals
 
 WEBHOOKS_DEBUG_RECEIVER_URLS = {}
 """Mapping of receiver id to URL pattern. This allows generating URLs to an

--- a/invenio/utils/plotextractor/config.py
+++ b/invenio/utils/plotextractor/config.py
@@ -1,5 +1,6 @@
+# -*- coding: utf-8 -*-
 # This file is part of Invenio.
-# Copyright (C) 2010, 2011 CERN.
+# Copyright (C) 2010, 2011, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,6 +20,8 @@
 
 """Plotextractor configuration."""
 
+from __future__ import unicode_literals
+
 __revision__ = "$Id$"
 
 # CFG_PLOTEXTRACTOR_DESY_BASE --
@@ -26,4 +29,3 @@ CFG_PLOTEXTRACTOR_DESY_BASE = 'http://www-library.desy.de/preparch/desy/'
 
 # CFG_PLOTEXTRACTOR_DESY_PIECE --
 CFG_PLOTEXTRACTOR_DESY_PIECE = '/desy'
-


### PR DESCRIPTION
* Forces unicode literals on config. (addresses #2967)

* PEP8/257 code style improvements.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>