### PR TITLE
previewer: proper files extension resolution

### DIFF
--- a/invenio/modules/previewer/views.py
+++ b/invenio/modules/previewer/views.py
@@ -20,8 +20,10 @@
 """Implementation of Blueprint for previewers."""
 
 import itertools
+import os
 
-from flask import Blueprint, request, current_app
+from flask import Blueprint, current_app, request
+
 from flask_breadcrumbs import default_breadcrumb_root
 
 from invenio.base.globals import cfg
@@ -47,12 +49,13 @@ def preview(recid):
     for f in itertools.chain(get_record_documents(recid, filename),
                              get_record_files(recid, filename)):
         if f.name + f.superformat == filename or filename is None:
+            extension = os.path.splitext(f.name + f.superformat)[1]
             ordered = previewers.keys()
             if "CFG_PREVIEW_PREFERENCE" in cfg and \
-               f.superformat in cfg["CFG_PREVIEW_PREFERENCE"]:
+               extension in cfg["CFG_PREVIEW_PREFERENCE"]:
                 from collections import OrderedDict
                 ordered = OrderedDict.fromkeys(
-                    cfg["CFG_PREVIEW_PREFERENCE"][f.superformat] +
+                    cfg["CFG_PREVIEW_PREFERENCE"][extension] +
                     ordered).keys()
 
             try:


### PR DESCRIPTION
* Extracts only the file extension in case
  of multiple dots in one file. (closes zenodo/zenodo#205)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>