### PR TITLE
WebSearch: fix for collection names with slashes

### DIFF
--- a/modules/miscutil/lib/upgrades/invenio_2015_04_15_collection_names_with_slashes.py
+++ b/modules/miscutil/lib/upgrades/invenio_2015_04_15_collection_names_with_slashes.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Check collection table and warn user about collection names with slashes."""
+
+from invenio.dbquery import run_sql
+
+depends_on = ['invenio_release_1_2_0']
+
+
+def info():
+    """Return upgrade recipe information."""
+    return "Warns user about collection names with slashes."
+
+
+def do_upgrade():
+    """Carry out the upgrade."""
+    res = run_sql("SELECT name FROM collection WHERE name LIKE '%/%'")
+    for row in res:
+        print "WARNING: Collection '%s' contains forward slashes" \
+            " which is not recommended." % row[0]
+        print "WARNING: You may safely continue, but we recommend" \
+            " changing this collection name to avoid slashes."
+
+
+def estimate():
+    """Estimate running time of upgrade in seconds (optional)."""
+    return 1
+
+
+def pre_upgrade():
+    """Pre-upgrade checks."""
+    pass  # because slashes would still work
+
+
+def post_upgrade():
+    """Post-upgrade checks."""
+    pass

--- a/modules/websearch/lib/websearch_webcoll.py
+++ b/modules/websearch/lib/websearch_webcoll.py
@@ -1,5 +1,5 @@
 # This file is part of Invenio.
-# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
+# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -308,7 +308,7 @@ class Collection:
         # open file:
         dirname = "%s/collections" % (CFG_CACHEDIR)
         mymkdir(dirname)
-        fullfilename = dirname + "/%s.html" % filename
+        fullfilename = dirname + "/%s.html" % filename.replace('/', '___SLASH___')
         try:
             os.umask(022)
             f = open(fullfilename, "wb")
@@ -927,8 +927,9 @@ def perform_display_collection(colID, colname, aas, ln, em, show_help_boxes):
     em - code to display just part of the page
     show_help_boxes - whether to show the help boxes or not"""
     # check and update cache if necessary
-    cachedfile = open("%s/collections/%s-ln=%s.html" %
-                      (CFG_CACHEDIR, colname, ln), "rb")
+    cachedfile = open(r"%s/collections/%s-ln=%s.html" %
+                      (CFG_CACHEDIR, colname.replace('/', '___SLASH___'), ln),
+                      "rb")
     try:
         data = cPickle.load(cachedfile)
     except ValueError:


### PR DESCRIPTION
* FIX Collection names containing slashes are now supported again.
  However we recommend not to use slashes in collection names; if
  slashes were wanted for aesthetic reasons, they can be added in
  visible collection translations.  (closes #2902)

* Adds upgrade recipe to check collection names for slashes and warn the
  user about them.  (Soft warning only, since names-with-slashes will
  work more or less fine as of this patch.)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>