### PR TITLE
search: portalbox text overflow fix

### DIFF
--- a/invenio/modules/search/static/css/search/searchbar.css
+++ b/invenio/modules/search/static/css/search/searchbar.css
@@ -1,6 +1,6 @@
 /*
  * This file is part of Invenio.
- * Copyright (C) 2014 CERN.
+ * Copyright (C) 2014, 2015 CERN.
  *
  * Invenio is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -101,6 +101,11 @@ values copied from bootstrap ones for higher than xs size counterparts -> to be 
   width: 1%;
 }
 
+/* fix portalbox text overflow (see issue#3023 */
+.panel-body {
+  word-wrap: break-word;
+}
+
 /*
   too keep searchbar with buttons in one line
 */
@@ -120,6 +125,4 @@ values copied from bootstrap ones for higher than xs size counterparts -> to be 
   #searchform-input-group {
     width: 915px;
   }
-}
-
 }


### PR DESCRIPTION
* FIX Fixes portalbox text overflow and fixes a syntax error.
  (closes #3023)

* Adds collections as qualified component for kwalitee.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>