### PR TITLE
installation: SQLAlchemy-Utils>=0.30

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ install_requires = [
     "six>=1.7.2",
     "Sphinx",
     "SQLAlchemy>=0.9.8,<1.0",
-    "SQLAlchemy-Utils[encrypted]>=0.28.2,<0.30",
+    "SQLAlchemy-Utils[encrypted]>=0.30",
     "unidecode",
     "workflow>=1.2.0",
     "WTForms>=2.0.1",


### PR DESCRIPTION
* Updates required version for SQLAlchemy-Utils. (closes #3039)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>