### PR TITLE
global: legacy code exclusion from kwalitee checks

### DIFF
--- a/.kwalitee.yml
+++ b/.kwalitee.yml
@@ -119,3 +119,6 @@ components:
 - version
 - webhooks
 - workflows
+
+excludes:
+- (.)+/legacy/(.)+


### PR DESCRIPTION
* Excludes legacy code from kwalitee checks. (closes #3022)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>