### PR TITLE
indexer: deprecated WTForms extension removal

### DIFF
--- a/.kwalitee.yml
+++ b/.kwalitee.yml
@@ -119,3 +119,6 @@ components:
 - version
 - webhooks
 - workflows
+
+excludes:
+- (.)+/legacy/(.)+

--- a/invenio/modules/indexer/admin.py
+++ b/invenio/modules/indexer/admin.py
@@ -32,9 +32,10 @@ from invenio.utils.datastructures import LazyDict
 from werkzeug.local import LocalProxy
 
 from wtforms import HiddenField
-from wtforms.ext.sqlalchemy.fields import QuerySelectMultipleField
 from wtforms.fields import BooleanField
 from wtforms.fields import SelectField
+
+from wtforms_sqlalchemy.fields import QuerySelectMultipleField
 
 from .models import IdxINDEX
 from .utils import load_tokenizers
@@ -78,8 +79,7 @@ class IdxINDEXAdmin(ModelView):
             label=_("Knowledge base name"),
             choices=LocalProxy(
                 lambda:
-                [('', _('-None-'))]
-                +
+                [('', _('-None-'))] +
                 [(k, k) for k in [(x[0]+','+x[1]) for x in itertools.product(
                     kapi.get_all_kb_names(),
                     ['exact', 'leading_to_comma', 'leading_to_number']
@@ -90,8 +90,7 @@ class IdxINDEXAdmin(ModelView):
             label=_("Stemming language"),
             choices=LocalProxy(
                 lambda:
-                [('', _('-None-'))]
-                +
+                [('', _('-None-'))] +
                 [(k, k) for k in get_stemming_language_map()]
             )
         ),

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,8 @@ install_requires = [
     "unidecode>=0.04.1",
     "workflow>=1.2.0",
     "WTForms>=2.0.1",
-    "wtforms-alchemy>=0.12.6,<0.13.1"
+    "wtforms-alchemy>=0.12.6,<0.13.1",
+    "wtforms-sqlalchemy>=0.1"
 ]
 
 


### PR DESCRIPTION
* Uses wtforms_sqlalchemy instead of wtforms.ext.sqlalchemy deprecated
  extension. (closes #2620)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>