### PR TITLE
installation: Flask-Admin git url fix

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -4,7 +4,7 @@
 -e git+git://github.com/mitsuhiko/itsdangerous.git#egg=itsdangerous
 -e git+git://github.com/jek/blinker.git#egg=blinker
 -e git+git://github.com/mitsuhiko/flask.git#egg=flask
--e git+git://github.com/mrjoes/flask-admin.git#egg=Flask-Admin
+-e git+git://github.com/flask-admin/flask-admin.git#egg=Flask-Admin
 -e git+git://github.com/lepture/flask-wtf.git#egg=Flask-WTF
 
 -e git+git://github.com/inveniosoftware/dictdiffer.git#egg=dictdiffer


### PR DESCRIPTION
* Fixes the repository url of Flask-Admin because it moves from
  mrjoes/flask-admin to flask-admin/flask-admin. (closes #3049)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>