### PR TITLE
docs: fix missing dependencies

### DIFF
--- a/docs/getting-started/overlay.rst
+++ b/docs/getting-started/overlay.rst
@@ -61,9 +61,10 @@ solely required for development purposes.
     $ python --version
     Python 2.7.5+
     $ sudo apt-get update
-    $ sudo apt-get install build-essential redis-server \
+    $ sudo apt-get install build-essential git redis-server \
                            libmysqlclient-dev libxml2-dev libxslt-dev \
                            libjpeg-dev libfreetype6-dev libtiff-dev \
+                           libffi-dev libssl-dev \
                            software-properties-common python-dev \
                            virtualenvwrapper
     $ sudo pip install -U virtualenvwrapper pip


### PR DESCRIPTION
The list at http://invenio.readthedocs.org/en/latest/getting-started/first-steps.html also includes `subversion`. Is that needed?
