### PR TITLE
WebStyle: HttpOnly cookie attribute

### DIFF
--- a/modules/websession/lib/session.py
+++ b/modules/websession/lib/session.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 ## This file is part of Invenio.
-## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010 CERN.
+## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -271,7 +271,7 @@ class InvenioSession(dict):
         @return: a session cookie.
         @rtpye: {mod_python.Cookie.Cookie}
         """
-        cookie = Cookie(CFG_WEBSESSION_COOKIE_NAME, self._sid)
+        cookie = Cookie(CFG_WEBSESSION_COOKIE_NAME, self._sid, HttpOnly=True)
         cookie.path = '/'
 
         if self._remember_me:

--- a/modules/webstyle/lib/webinterface_handler_wsgi_utils.py
+++ b/modules/webstyle/lib/webinterface_handler_wsgi_utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ## This file is part of Invenio.
-## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010 CERN.
+## Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -191,8 +191,10 @@ class Cookie(object):
         # The attribute _valid_attr is provided by the metaclass 'metaCookie'.
         for name in self._valid_attr:
             if hasattr(self, name):
-                if name in ("secure", "discard", "httponly"):
+                if name in ("secure", "discard"):
                     result.append(name)
+                elif name == "httponly":
+                    result.append("HttpOnly")
                 else:
                     result.append("%s=%s" % (name, getattr(self, name)))
         # pylint: enable=E1101


### PR DESCRIPTION
* SECURITY Adds back the `HttpOnly` cookie attribute in order to better
  protect against potential XSS vulnerabilities.  (closes #3064)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>