### PR TITLE
travis: apt and pip cache activation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ services:
 
 language: python
 
+cache:
+  - apt
+  - pip
+
 env:
   - REQUIREMENTS=lowest REXTRAS=docs
   - REQUIREMENTS=release REXTRAS=docs


### PR DESCRIPTION
* Enables cache configuration on travis for apt and pip packages.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>