### PR TITLE
email: fix type mismatch

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Active contributors:
 * Annette Holtkamp <annette.holtkamp@cern.ch>
 * Cornelia Plott <c.plott@fz-juelich.de>
 * Cristian Bacchi <cristian.bacchi@gmail.com>
+* Dan Michael O. Heggø <danmichaelo@gmail.com>
 * Daniel Lovasko <daniel.lovasko@cern.ch>
 * Dimitrios Semitsoglou-Tsiapos <dsemitso@cern.ch>
 * Esteban J. G. Gabancho <esteban.jose.garcia.gabancho@cern.ch>


### PR DESCRIPTION
This fixes the following error (and a few more in the same method):
```
Traceback (most recent call last):
[…]
  File "/home/danmichael/.virtualenvs/redodo3/vendor/invenio/invenio/ext/email/__init__.py", line 284, in send_email
    quoted_body = '> ' + '> '.join(body.splitlines(True))
AttributeError: 'EmailMessage' object has no attribute 'splitlines'
```
