### PR TITLE
access: restrict access per object

### DIFF
--- a/invenio/modules/access/bases.py
+++ b/invenio/modules/access/bases.py
@@ -61,6 +61,16 @@ def AclFactory(obj=''):
             functionality,
             e.g. :class:`~invenio.modules.records.bases:DocumentsHooks`
 
+        .. note::
+
+                If the object has embed restrictions it will override the
+                access right of the parent. For example in
+                :class:`~invenio.modules.documents.api:Document` and
+                :class:`~invenio.modules.records.api:Record` the `Document`
+                will override the `Record` restriction which means if the
+                `Record` is restricted and the `Document` is open the user
+                will have access to the file.
+
             :param user_info: an instance of
                 :class:`~invenio.ext.login.legacy_user.UserInfo`
                 (default: :class:`flask_login.current_user`)
@@ -86,7 +96,7 @@ def AclFactory(obj=''):
             except AttributeError:
                 pass
 
-            if is_authorized[0] != 0:
+            if is_authorized[0] != 0 and not any(restriction.values()):
                 return is_authorized
 
             for auth_type, auth_value in six.iteritems(restriction):

--- a/invenio/modules/access/testsuite/test_document_restrictions.py
+++ b/invenio/modules/access/testsuite/test_document_restrictions.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Test for document access restrictions."""
+
+from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+
+
+class DocumentRestrictionsTest(InvenioTestCase):
+
+    """Test document access restrictions."""
+
+    def setUp(self):
+        """Run before the test."""
+        from invenio.modules.documents.api import Document
+        self.document = Document.create({'title': 'Test restrictions'})
+
+    def tearDown(self):
+        """Run after the tests."""
+        self.document = None
+
+    def test_documet_access_open(self):
+        """Test the document if it's open to everyone by default."""
+        self.assertEqual(
+            self.document.is_authorized()[0],
+            0
+        )
+
+    def test_document_no_access_for_specific_user(self):
+        """The the document access only for specific user."""
+        self.document['restriction']['email'] = "fake@cern.ch"
+        authorize = self.document.is_authorized(
+            user_info=dict(email='happy@cern.ch', uid=2222)
+        )
+        self.assertEqual(
+            authorize[0],
+            1
+        )
+
+    def test_document_has_access_for_specific_user(self):
+        """The the document access only for specific user."""
+        self.document['restriction']['email'] = "happy@cern.ch"
+        authorize = self.document.is_authorized(
+            user_info=dict(email='happy@cern.ch', uid=2222)
+        )
+        self.assertEqual(
+            authorize[0],
+            0
+        )
+
+TEST_SUITE = make_test_suite(DocumentRestrictionsTest,)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
* NEW Adds the ability to restrict access per object independently from
  the parent.

Reviewed-by: Jiri Kuncar <jiri.kuncar@cern.ch>
Reviewed-by: Esteban J. G. Gabancho <esteban.gabancho@gmail.com>
Signed-off-by: Harris Tzovanakis <me@drjova.com>