### PR TITLE
misc: problems with deposit, problems with docker

### DIFF
--- a/invenio/modules/deposit/templates/deposit/completed_base.html
+++ b/invenio/modules/deposit/templates/deposit/completed_base.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -47,7 +47,6 @@
     </small>
     <hr />
     {{format_record(recID=sip.metadata['recid'], xml_record=sip.package, of='hd')|safe}}
-    {{format_record(recID=sip.metadata['recid'], xml_record=sip.package, of='hdinfo')|safe}}
 
     </div>
     <div class="col-md-4">

--- a/scripts/docker_devboot.sh
+++ b/scripts/docker_devboot.sh
@@ -89,6 +89,8 @@ CFG_WEBDIR = u'/home/invenio/var/www'
 CFG_WEBSUBMIT_BIBCONVERTCONFIGDIR = u'/home/invenio/etc/bibconvert/config'
 CFG_WEBSUBMIT_COUNTERSDIR = u'/home/invenio/var/data/submit/counters'
 CFG_WEBSUBMIT_STORAGEDIR = u'/home/invenio/var/data/submit/storage'
+
+DEPOSIT_STORAGEDIR = u'/home/invenio/var/data/deposit/storage'
 EOF
 
         # load dev config

--- a/scripts/docker_devboot.sh
+++ b/scripts/docker_devboot.sh
@@ -91,6 +91,8 @@ CFG_WEBSUBMIT_COUNTERSDIR = u'/home/invenio/var/data/submit/counters'
 CFG_WEBSUBMIT_STORAGEDIR = u'/home/invenio/var/data/submit/storage'
 
 DEPOSIT_STORAGEDIR = u'/home/invenio/var/data/deposit/storage'
+
+DEBUG = True
 EOF
 
         # load dev config


### PR DESCRIPTION
A "catch them all" PR to fix some problems I have found while playing around with our demosite. They are rebased against `main-2.0`. The `deposit: leftover cleanup` seems to be critical for the 2.1 release, because without it the affected template will produce an exception at master (= will be 2.1).