### PR TITLE
legacy: dbquery import fix

### DIFF
--- a/invenio/legacy/dbquery_mysql.py
+++ b/invenio/legacy/dbquery_mysql.py
@@ -45,8 +45,9 @@ from invenio.utils.datastructures import LazyDict
 
 from thread import get_ident
 
-from werkzeug.utils import cached_property
+from sqlalchemy.exc import InterfaceError, OperationalError
 
+from werkzeug.utils import cached_property
 
 __revision__ = "$Id$"
 


### PR DESCRIPTION
* Fixes imports on dbquery legacy interface. (addresses #3089)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>