### PR TITLE
installation: fix mysql install steps for CentOS 7

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -87,8 +87,22 @@ Setting up MySQL Server requires you to give some credentials for the root
 user. You will need the root password later on and we will refer to it as
 ``$MYSQL_ROOT``.
 
+If you are on CentOS 7, the mysql-server package is not available in the
+default repository. First we need to add the official YUM repository provided
+by Oracle. The YUM repository configuration can be downloaded from the `MySQL
+website <http://dev.mysql.com/downloads/repo/yum/>`_. Choose the desired
+distribution (Red Hat Enterprise Linux 7 / Oracle Linux 7 for CentOS 7) and
+click Download.
+The download link can be retrieved without registering for an Oracle account.
+Locate the "No thanks, just start my download" link and pass the link URL as a
+parameter to rpm.
+
 .. code-block:: console
 
+    # only needed with CentOS version >= 7
+    $ sudo rpm -Uvh http://dev.mysql.com/get/mysql-community-release...
+
+    # for every CentOS version
     $ sudo yum install mysql-server
     $ sudo service mysqld status
     mysqld is stopped


### PR DESCRIPTION
* Add a step describing how to install mysql on CentOS 7 because it
  does not have mysql-server package by default.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>