### PR TITLE
global: invenio.config deprecation

### DIFF
--- a/invenio/base/i18n.py
+++ b/invenio/base/i18n.py
@@ -42,6 +42,8 @@ import babel
 
 from flask_babel import gettext, lazy_gettext
 
+from invenio.base.globals import cfg
+
 # Placemark for the i18n function
 _ = lazy_gettext
 
@@ -62,18 +64,17 @@ def wash_language(ln):
 
     Return it in case of success, return the default language otherwise.
     """
-    from invenio.config import CFG_SITE_LANG, CFG_SITE_LANGS
     if not ln:
-        return CFG_SITE_LANG
+        return cfg['CFG_SITE_LANG']
     if isinstance(ln, list):
         ln = ln[0]
     ln = ln.replace('-', '_')
-    if ln in CFG_SITE_LANGS:
+    if ln in cfg['CFG_SITE_LANGS']:
         return ln
-    elif ln[:2] in CFG_SITE_LANGS:
+    elif ln[:2] in cfg['CFG_SITE_LANGS']:
         return ln[:2]
     else:
-        return CFG_SITE_LANG
+        return cfg['CFG_SITE_LANG']
 
 
 def wash_languages(lns):
@@ -81,15 +82,14 @@ def wash_languages(lns):
 
     Return it in case of success, return the default language otherwise.
     """
-    from invenio.config import CFG_SITE_LANG, CFG_SITE_LANGS
     for ln in lns:
         if ln:
             ln = ln.replace('-', '_')
-            if ln in CFG_SITE_LANGS:
+            if ln in cfg['CFG_SITE_LANGS']:
                 return ln
-            elif ln[:2] in CFG_SITE_LANGS:
+            elif ln[:2] in cfg['CFG_SITE_LANGS']:
                 return ln[:2]
-    return CFG_SITE_LANG
+    return cfg['CFG_SITE_LANG']
 
 
 def language_list_long(enabled_langs_only=True):
@@ -103,7 +103,7 @@ def language_list_long(enabled_langs_only=True):
     translations in webdoc sources or bibformat templates.
     """
     if enabled_langs_only:
-        from invenio.config import CFG_SITE_LANGS
+        CFG_SITE_LANGS = cfg['CFG_SITE_LANGS']
     else:
         from invenio.base.config import CFG_SITE_LANGS
 

--- a/invenio/base/scripts/demosite.py
+++ b/invenio/base/scripts/demosite.py
@@ -29,11 +29,8 @@ import warnings
 
 import pkg_resources
 
-from itertools import count
-
 from invenio.base.utils import run_py_func
 from invenio.ext.script import Manager
-from invenio.modules.scheduler.models import SchTASK
 
 
 warnings.warn("Use of `inveniomanage demosite populate` is being deprecated. "

--- a/invenio/ext/email/backends/__init__.py
+++ b/invenio/ext/email/backends/__init__.py
@@ -24,7 +24,7 @@ CFG_SITE_ADMIN_EMAIL.
 
 __revision__ = "$Id$"
 
-from invenio.config import CFG_SITE_ADMIN_EMAIL
+from invenio.base.globals import cfg
 
 
 def adminonly_class(Backend):
@@ -40,7 +40,7 @@ def adminonly_class(Backend):
 #%s
 #--------------------------------------------------------------
 #%s""" % (','.join(m.recipients()), m.body)
-                m.to = [CFG_SITE_ADMIN_EMAIL]
+                m.to = [cfg['CFG_SITE_ADMIN_EMAIL']]
                 m.cc = []
                 m.bcc = []
                 if 'Cc' in m.extra_headers:

--- a/invenio/ext/script/__init__.py
+++ b/invenio/ext/script/__init__.py
@@ -104,7 +104,7 @@ def check_for_software_updates(flash_message=False):
     :return: True if you have latest version, else False if you need to upgrade
              or None if server was not reachable.
     """
-    from invenio.config import CFG_VERSION
+    from invenio.version import __version__ as invenio_version
     from invenio.base.i18n import _
     try:
         find = re.compile('Invenio v[0-9]+.[0-9]+.[0-9]+(\-rc[0-9])?'
@@ -134,7 +134,7 @@ def check_for_software_updates(flash_message=False):
         version1 = submatch.search(version)
         web_version = version1.group().split(".")
 
-        local_version = CFG_VERSION.split(".")
+        local_version = invenio_version.split(".")
 
         if (web_version[0] > local_version[0] or
                 web_version[0] == local_version[0] and

--- a/invenio/ext/sqlalchemy/utils.py
+++ b/invenio/ext/sqlalchemy/utils.py
@@ -189,9 +189,7 @@ def test_sqla_connection():
         inspector.get_table_names()
     except OperationalError as err:
         from invenio.utils.text import wrap_text_in_a_box
-        from invenio.config import CFG_DATABASE_HOST, \
-            CFG_DATABASE_PORT, CFG_DATABASE_NAME, CFG_DATABASE_USER, \
-            CFG_DATABASE_PASS
+        from invenio.base.globals import cfg
         print(" [ERROR]")
         print(wrap_text_in_a_box("""\
 DATABASE CONNECTIVITY ERROR:
@@ -211,12 +209,13 @@ instance configuration file (invenio.cfg).
 If the problem is of different nature, then please inspect
 the above error message and fix the problem before continuing.""" % {
             'errmsg': err.args[0],
-            'dbname': CFG_DATABASE_NAME,
-            'dbhost': CFG_DATABASE_HOST,
-            'dbport': CFG_DATABASE_PORT,
-            'dbuser': CFG_DATABASE_USER,
-            'dbpass': CFG_DATABASE_PASS,
-            'webhost': (CFG_DATABASE_HOST == 'localhost' and 'localhost' or
+            'dbname': cfg['CFG_DATABASE_NAME'],
+            'dbhost': cfg['CFG_DATABASE_HOST'],
+            'dbport': cfg['CFG_DATABASE_PORT'],
+            'dbuser': cfg['CFG_DATABASE_USER'],
+            'dbpass': cfg['CFG_DATABASE_PASS'],
+            'webhost': (cfg['CFG_DATABASE_HOST'] == 'localhost' and
+                        'localhost' or
                         os.popen('hostname -f', 'r').read().strip()),
         }))
         sys.exit(1)

--- a/invenio/legacy/search_engine/__init__.py
+++ b/invenio/legacy/search_engine/__init__.py
@@ -155,6 +155,11 @@ def create_navtrail_links(cc=CFG_SITE_NAME, aas=0, ln=CFG_SITE_LANG, self_p=1, t
 from invenio_search.washers import *
 
 
+# FIXME remove from master in 66ad8455 commit
+def get_collection_reclist(coll, recreate_cache_if_needed=True):
+    """Return hitset of recIDs that belong to the collection 'coll'."""
+    return intbitset()
+
 def get_coll_ancestors(coll):
     "Returns a list of ancestors for collection 'coll'."
     coll_ancestors = []

--- a/invenio/modules/jsonalchemy/jsonext/functions/is_local_url.py
+++ b/invenio/modules/jsonalchemy/jsonext/functions/is_local_url.py
@@ -17,14 +17,16 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
+"""Is local url."""
+
 
 def is_local_url(url):
     """Check if the current url is local using CFG_SITE_URL."""
     import re
-    from invenio.config import CFG_SITE_URL, CFG_SITE_SECURE_URL
-
+    from invenio.base.globals import cfg
     try:
-        if re.match(CFG_SITE_URL, url) or re.match(CFG_SITE_SECURE_URL, url):
+        if re.match(cfg['CFG_SITE_URL'], url) or \
+                re.match(cfg['CFG_SITE_SECURE_URL'], url):
             return True
     except:
         pass

--- a/invenio/modules/scheduler/tasklets/bst_notify_url.py
+++ b/invenio/modules/scheduler/tasklets/bst_notify_url.py
@@ -26,9 +26,7 @@ import urlparse
 import urllib2
 import time
 
-from invenio.config import \
-     CFG_SITE_ADMIN_EMAIL, \
-     CFG_SITE_NAME
+from invenio.base.globals import cfg
 from invenio.legacy.bibsched.bibtask import write_message, \
      task_sleep_now_if_required
 from invenio.ext.email import send_email
@@ -107,14 +105,14 @@ def bst_notify_url(url, data=None,
         write_message("Notifying by email %(admin_emails)s" % \
                       {'admin_emails': str(admin_emails)})
         subject = "%(CFG_SITE_NAME)s could not contact %(url)s" % \
-                  {'CFG_SITE_NAME': CFG_SITE_NAME,
+                  {'CFG_SITE_NAME': cfg['CFG_SITE_NAME'],
                    'url': url}
         content = """\n%(CFG_SITE_NAME)s unsuccessfully tried to contact %(url)s.
 
 Number of attempts: %(attempt_times)i. No further attempts will be made.
 
 """ % \
-                  {'CFG_SITE_NAME': CFG_SITE_NAME,
+                  {'CFG_SITE_NAME': cfg['CFG_SITE_NAME'],
                    'url': url,
                    'attempt_times': attempt_times}
         if data:
@@ -123,7 +121,7 @@ Number of attempts: %(attempt_times)i. No further attempts will be made.
                       {'data': data[:max_data_length],
                        'extension': len(data) > max_data_length and ' [...]' or ''}
         # Send email. If sending fails, we will stop the queue
-        return send_email(fromaddr=CFG_SITE_ADMIN_EMAIL,
+        return send_email(fromaddr=cfg['CFG_SITE_ADMIN_EMAIL'],
                           toaddr=admin_emails,
                           subject=subject,
                           content=content)

--- a/invenio/modules/scheduler/tasklets/bst_twitter_fetcher.py
+++ b/invenio/modules/scheduler/tasklets/bst_twitter_fetcher.py
@@ -36,11 +36,10 @@ import os
 import sys
 import tempfile
 import time
-import sys
 
 # Here are some good Invenio APIs
 
-from invenio.config import CFG_TMPDIR
+from invenio.base.globals import cfg
 
 # BibRecord -> to create MARCXML records
 from invenio.legacy.bibrecord import record_add_field, record_xml_output
@@ -149,7 +148,7 @@ def bst_twitter_fetcher(query):
     @param user: the user
     """
     ## We prepare a temporary MARCXML file to upload.
-    fd, name = tempfile.mkstemp(suffix='.xml', prefix='tweets', dir=CFG_TMPDIR)
+    fd, name = tempfile.mkstemp(suffix='.xml', prefix='tweets', dir=cfg['CFG_TMPDIR'])
     tweets = get_tweets(query)
     if tweets:
         os.write(fd, """<collection>\n""")

--- a/invenio/modules/sequencegenerator/texkey.py
+++ b/invenio/modules/sequencegenerator/texkey.py
@@ -20,6 +20,7 @@
 """Texkey."""
 
 import os
+from invenio.base.globals import cfg
 
 import random
 
@@ -27,7 +28,6 @@ import string
 
 import time
 
-from invenio.config import CFG_TMPSHAREDDIR, CFG_VERSION
 from invenio.legacy.search_engine import get_record as get_bibrecord
 from invenio.legacy.bibrecord import create_record, \
     field_get_subfield_values, print_rec, record_add_field, \
@@ -217,7 +217,7 @@ def submit_task(to_submit, mode, sequence_id):
     :rtype: int
     """
     (temp_fd, temp_path) = mkstemp(prefix=PREFIX,
-                                   dir=CFG_TMPSHAREDDIR)
+                                   dir=cfg['CFG_TMPSHAREDDIR'])
     temp_file = os.fdopen(temp_fd, 'w')
     temp_file.write('<?xml version="1.0" encoding="UTF-8"?>')
     temp_file.write('<collection>')
@@ -362,7 +362,7 @@ def main():
               authorization_msg="Texkey generator task submission",
               description=DESCRIPTION,
               help_specific_usage=HELP_MESSAGE,
-              version="Invenio v%s" % CFG_VERSION,
+              version="Invenio v%s" % cfg['CFG_VERSION'],
               specific_params=("", []),
               # task_submit_elaborate_specific_parameter_fnc=parse_option,
               # task_submit_check_options_fnc=check_options,

--- a/invenio/modules/textminer/testsuite/test_textminer_documents.py
+++ b/invenio/modules/textminer/testsuite/test_textminer_documents.py
@@ -40,8 +40,8 @@ except ImportError:
 from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
 
 def expected_response():
-    from invenio.config import CFG_INSPIRE_SITE
-    if CFG_INSPIRE_SITE:
+    from invenio.base.globals import cfg
+    if cfg['CFG_INSPIRE_SITE']:
         EXPECTED_RESPONSE = """<record>
       <controlfield tag="001">1</controlfield>
       <datafield tag="999" ind1="C" ind2="5">
@@ -189,8 +189,8 @@ class DocExtractTest(InvenioTestCase):
 
     @unittest.skipUnless(HAS_REQUESTS, 'no request')
     def test_upload(self):
-        from invenio.config import CFG_SITE_URL, CFG_ETCDIR
-        url = CFG_SITE_URL + '/textmining/api/extract-references-pdf'
+        from invenio.base.globals import cfg
+        url = cfg['CFG_SITE_URL'] + '/textmining/api/extract-references-pdf'
 
         pdf = open(pkg_resources.resource_filename(
             'invenio.modules.textminer.testsuite',
@@ -203,17 +203,17 @@ class DocExtractTest(InvenioTestCase):
 
     @unittest.skipUnless(HAS_REQUESTS, 'no request')
     def test_url(self):
-        from invenio.config import CFG_SITE_URL
-        url = CFG_SITE_URL + '/textmining/api/extract-references-pdf-url'
+        from invenio.base.globals import cfg
+        url = cfg['CFG_SITE_URL'] + '/textmining/api/extract-references-pdf-url'
 
-        pdf = CFG_SITE_URL + '/textmining/example.pdf'
+        pdf = cfg['CFG_SITE_URL'] + '/textmining/example.pdf'
         response = requests.post(url, data={'url': pdf})
         compare_references(self, response.content, expected_response())
 
     @unittest.skipUnless(HAS_REQUESTS, 'no request')
     def test_txt(self):
-        from invenio.config import CFG_SITE_URL
-        url = CFG_SITE_URL + '/textmining/api/extract-references-txt'
+        from invenio.base.globals import cfg
+        url = cfg['CFG_SITE_URL'] + '/textmining/api/extract-references-txt'
 
         pdf = open(pkg_resources.resource_filename(
             'invenio.modules.textminer.testsuite',

--- a/invenio/utils/filedownload.py
+++ b/invenio/utils/filedownload.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
-"""
-File handling utilities.
+
+"""File handling utilities.
 
 Main API usage:
     >>> from filedownloadutils import download_url
@@ -35,35 +35,39 @@ import tempfile
 import shutil
 import sys
 
+from invenio.base.globals import cfg
 from invenio.utils.url import make_invenio_opener
 
 URL_OPENER = make_invenio_opener('filedownloadutils')
 
-from invenio.config import (CFG_TMPSHAREDDIR,
-                            CFG_BIBUPLOAD_FFT_ALLOWED_LOCAL_PATHS)
 
 #: block size when performing I/O.
 CFG_FILEUTILS_BLOCK_SIZE = 1024 * 8
 
 
 class InvenioFileDownloadError(Exception):
+
     """A generic download exception."""
+
     def __init__(self, msg, code=None):
+        """Init."""
         Exception.__init__(self, msg)
         self.code = code
 
 
 class InvenioFileCopyError(Exception):
+
     """A generic file copy exception."""
+
     pass
 
 
 def download_url(url, content_type=None, download_to_file=None,
                  retry_count=10, timeout=10.0):
-    """
-    Will download a file from given URL (either local or external) to the
-    desired path (or generate one if none is given). Local files are copied
-    directly.
+    """Will download a file from given URL (either local or external).
+
+    Save it to the desired path (or generate one if none is given).
+    Local files are copied directly.
 
     The function will retry a number of times based on retry_count (default 10)
     parameter and sleeps a number of seconds based on given timeout
@@ -76,27 +80,28 @@ def download_url(url, content_type=None, download_to_file=None,
     that the desired content_type is equal to the content-type of returned
     file.
 
-    @param url: where the file lives on the interwebs
-    @type url: string
+    :param url: where the file lives on the interwebs
+    :type url: string
 
-    @param content_type: desired content_type to check for in external URLs.
+    :param content_type: desired content_type to check for in external URLs.
                          (optional)
-    @type content_type: string
+    :type content_type: string
 
-    @param download_to_file: where the file should live after download.
+    :param download_to_file: where the file should live after download.
                              (optional)
-    @type download_to_file: string
+    :type download_to_file: string
 
-    @param retry_count: number of times to retry. Defaults to 10.
+    :param retry_count: number of times to retry. Defaults to 10.
                         (optional)
-    @type retry_count: int
+    :type retry_count: int
 
-    @param timeout: number of seconds to sleep between attempts.
+    :param timeout: number of seconds to sleep between attempts.
                     Defaults to 10.0 seconds. (optional)
-    @type timeout: float
+    :type timeout: float
 
-    @return: the path of the downloaded/copied file
-    @raise InvenioFileDownloadError: raised upon URL/HTTP errors, file errors or wrong format
+    :return: the path of the downloaded/copied file
+    :raise InvenioFileDownloadError: raised upon URL/HTTP errors, file errors
+        or wrong format
     """
     if not download_to_file:
         download_to_file = safe_mkstemp(suffix=".tmp",
@@ -120,30 +125,30 @@ def download_url(url, content_type=None, download_to_file=None,
 
 def download_external_url(url, download_to_file, content_type=None,
                           retry_count=10, timeout=10.0, verbose=False):
-    """
-    Download a url (if it corresponds to a remote file) and return a
-    local url to it. If format is specified, a check will be performed
-    in order to make sure that the format of the downloaded file is equal
-    to the expected format.
+    """Download a url (if it corresponds to a remote file).
 
-    @param url: the URL to download
-    @type url: string
+    It returns a local url to it. If format is specified, a check will be
+    performed in order to make sure that the format of the downloaded file is
+    equal to the expected format.
 
-    @param download_to_file: the path to download the file to
-    @type download_to_file: string
+    :param url: the URL to download
+    :type url: string
 
-    @param content_type: the content_type of the file (optional)
-    @type content_type: string
+    :param download_to_file: the path to download the file to
+    :type download_to_file: string
 
-    @param retry_count: max number of retries for downloading the file
-    @type retry_count: int
+    :param content_type: the content_type of the file (optional)
+    :type content_type: string
 
-    @param timeout: time to sleep in between attemps
-    @type timeout: int
+    :param retry_count: max number of retries for downloading the file
+    :type retry_count: int
 
-    @return: the path to the download local file
-    @rtype: string
-    @raise StandardError: if the download failed
+    :param timeout: time to sleep in between attemps
+    :type timeout: int
+
+    :return: the path to the download local file
+    :rtype: string
+    :raise StandardError: if the download failed
     """
     error_str = ""
     error_code = None
@@ -215,9 +220,9 @@ def download_external_url(url, download_to_file, content_type=None,
 
 
 def finalize_download(url, download_to_file, content_type, request):
-    """
-    Finalizes the download operation by doing various checks, such as format
-    type, size check etc.
+    """Finalize the download operation by doing various checks.
+
+    Checks such as format type, size check etc.
     """
     # If format is given, a format check is performed.
     if content_type and content_type not in request.headers['content-type']:
@@ -250,18 +255,17 @@ def finalize_download(url, download_to_file, content_type, request):
 
 
 def download_local_file(filename, download_to_file):
-    """
-    Copies a local file to Invenio's temporary directory.
+    """Copie a local file to Invenio's temporary directory.
 
-    @param filename: the name of the file to copy
-    @type filename: string
+    :param filename: the name of the file to copy
+    :type filename: string
 
-    @param download_to_file: the path to save the file to
-    @type download_to_file: string
+    :param download_to_file: the path to save the file to
+    :type download_to_file: string
 
-    @return: the path of the temporary file created
-    @rtype: string
-    @raise StandardError: if something went wrong
+    :return: the path of the temporary file created
+    :rtype: string
+    :raise StandardError: if something went wrong
     """
     # Try to copy.
     try:
@@ -271,8 +275,8 @@ def download_local_file(filename, download_to_file):
                   % (path, os.path.normpath(path))
             raise InvenioFileCopyError(msg)
 
-        allowed_path_list = CFG_BIBUPLOAD_FFT_ALLOWED_LOCAL_PATHS
-        allowed_path_list.append(CFG_TMPSHAREDDIR)
+        allowed_path_list = cfg['CFG_BIBUPLOAD_FFT_ALLOWED_LOCAL_PATHS']
+        allowed_path_list.append(cfg['CFG_TMPSHAREDDIR'])
         for allowed_path in allowed_path_list:
             if path.startswith(allowed_path):
                 shutil.copy(path, download_to_file)
@@ -299,11 +303,13 @@ def is_url_a_local_file(url):
 
 
 def safe_mkstemp(suffix, prefix='filedownloadutils_'):
-    """Create a temporary filename that don't have any '.' inside a part
-    from the suffix."""
+    """Create a temporary filename that don't have any '.' inside.
+
+    It skip the suffix.
+    """
     tmpfd, tmppath = tempfile.mkstemp(suffix=suffix,
                                       prefix=prefix,
-                                      dir=CFG_TMPSHAREDDIR)
+                                      dir=cfg['CFG_TMPSHAREDDIR'])
     # Close the file and leave the responsability to the client code to
     # correctly open/close it.
     os.close(tmpfd)
@@ -315,23 +321,24 @@ def safe_mkstemp(suffix, prefix='filedownloadutils_'):
         os.remove(tmppath)
         tmpfd, tmppath = tempfile.mkstemp(suffix=suffix,
                                           prefix=prefix,
-                                          dir=CFG_TMPSHAREDDIR)
+                                          dir=cfg['CFG_TMPSHAREDDIR'])
         os.close(tmpfd)
     return tmppath
 
 
 def open_url(url, headers=None):
-    """
-    Opens a URL. If headers are passed as argument, no check is performed and
-    the URL will be opened.
+    """Open a URL.
 
-    @param url: the URL to open
-    @type url: string
+    If headers are passed as argument, no check is performed and the URL will
+    be opened.
 
-    @param headers: the headers to use
-    @type headers: dictionary
+    :param url: the URL to open
+    :type url: string
 
-    @return: a file-like object as returned by urllib2.urlopen.
+    :param headers: the headers to use
+    :type headers: dictionary
+
+    :return: a file-like object as returned by urllib2.urlopen.
     """
     request = urllib2.Request(url)
     if headers:


### PR DESCRIPTION
* Replaces usage of invenio.config with invenio.base.globals:cfg.
  (addresses #3106)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>