### PR TITLE
oauthclient: validate oauth users' email

### DIFF
--- a/invenio/modules/oauthclient/handlers.py
+++ b/invenio/modules/oauthclient/handlers.py
@@ -26,10 +26,12 @@ from functools import partial, wraps
 from flask import current_app, flash, redirect, render_template, \
     request, session, url_for
 from flask_login import current_user
-import six
-from werkzeug.utils import import_string
 
 from invenio.base.globals import cfg
+
+import six
+
+from werkzeug.utils import import_string
 
 from .client import oauth, signup_handlers
 from .errors import OAuthClientError, OAuthError, \

--- a/invenio/modules/oauthclient/testsuite/test_contrib_orcid.py
+++ b/invenio/modules/oauthclient/testsuite/test_contrib_orcid.py
@@ -22,16 +22,19 @@
 from __future__ import absolute_import
 
 from flask import session, url_for
-from mock import MagicMock
-from six.moves.urllib_parse import parse_qs, urlparse
 
 import httpretty
 
 from invenio.ext.sqlalchemy import db
+
 from invenio.testsuite import make_test_suite, run_test_suite
 
-from ..contrib.orcid import REMOTE_APP, account_info
+from mock import MagicMock
+
+from six.moves.urllib_parse import parse_qs, urlparse
+
 from .helpers import OAuth2ClientTestCase
+from ..contrib.orcid import REMOTE_APP, account_info
 
 
 class OrcidTestCase(OAuth2ClientTestCase):

--- a/invenio/modules/oauthclient/utils.py
+++ b/invenio/modules/oauthclient/utils.py
@@ -20,11 +20,12 @@
 """Utility methods to help find, authenticate or register a remote user."""
 
 from flask import current_app
+
 from flask_login import logout_user
 
-from invenio.ext.login import authenticate, UserInfo
-from invenio.ext.sqlalchemy import db
+from invenio.ext.login import UserInfo, authenticate
 from invenio.ext.script import generate_secret_key
+from invenio.ext.sqlalchemy import db
 from invenio.modules.accounts.models import User, UserEXT
 
 from .models import RemoteAccount, RemoteToken

--- a/invenio/modules/oauthclient/utils.py
+++ b/invenio/modules/oauthclient/utils.py
@@ -24,7 +24,6 @@ from flask import current_app
 from flask_login import logout_user
 
 from invenio.ext.login import UserInfo, authenticate
-from invenio.ext.script import generate_secret_key
 from invenio.ext.sqlalchemy import db
 from invenio.modules.accounts.models import User, UserEXT
 
@@ -94,7 +93,7 @@ def oauth_register(account_info, form_data=None):
             u = User(
                 nickname=account_info.get('nickname', ''),
                 email=email,
-                password=generate_secret_key(),
+                password=None,
                 note='1',  # Activated - assumes email is validated
             )
 

--- a/invenio/modules/oauthclient/utils.py
+++ b/invenio/modules/oauthclient/utils.py
@@ -23,6 +23,7 @@ from flask import current_app
 
 from flask_login import logout_user
 
+from invenio.base.globals import cfg
 from invenio.ext.login import UserInfo, authenticate
 from invenio.ext.sqlalchemy import db
 from invenio.modules.accounts.models import User, UserEXT
@@ -94,15 +95,23 @@ def oauth_register(account_info, form_data=None):
                 nickname=account_info.get('nickname', ''),
                 email=email,
                 password=None,
-                note='1',  # Activated - assumes email is validated
+                # email has to be validated
+                note='2',
             )
 
             try:
                 db.session.add(u)
                 db.session.commit()
-                return UserInfo(u.id)
             except Exception:
                 current_app.logger.exception("Cannot create user")
+                return None
+
+            # verify the email
+            if cfg['CFG_ACCESS_CONTROL_NOTIFY_USER_ABOUT_NEW_ACCOUNT']:
+                u.verify_email()
+
+            return UserInfo(u.id)
+
     return None
 
 


### PR DESCRIPTION
* FIX users creating their account with oauth process have to validate
  their email too. Previously it was marked as valid from the start.

* FIX a validation email is now sent when users create their account
  with oauth and their email address is not provided by the oauth
  service. (closes #2739)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>