### PR TITLE
access: fix foreign key declaration

### DIFF
--- a/invenio/modules/access/control.py
+++ b/invenio/modules/access/control.py
@@ -31,7 +31,7 @@ from intbitset import intbitset
 from invenio.config import CFG_SITE_ADMIN_EMAIL, CFG_SITE_LANG, CFG_SITE_RECORD
 from invenio.ext import principal
 from invenio.ext.sqlalchemy import db
-from invenio.legacy.dbquery import run_sql
+from invenio.legacy.dbquery import run_sql, truncate_table
 from invenio.modules.access.firerole import (
     acc_firerole_check_user, compile_role_definition, deserialize,
     load_role_definition, serialize
@@ -349,7 +349,7 @@ def acc_update_role(id_role=0, name_role='', dummy=0, description='',
 
     return run_sql("""UPDATE "accROLE" SET description = %s,
         firerole_def_ser = %s, firerole_def_src = %s
-        WHERE id = %s""", (description, firerole_def_ser,
+        WHERE id = %s""", (description, bytearray(firerole_def_ser or ""),
                            firerole_def_src, id_role))
 
 
@@ -1804,11 +1804,11 @@ def acc_delete_all_settings():
     from invenio.ext.sqlalchemy import db
     db.session.commit()
 
-    run_sql("""TRUNCATE "accROLE" """)
-    run_sql("""TRUNCATE "accACTION" """)
-    run_sql("""TRUNCATE "accARGUMENT" """)
-    run_sql("""TRUNCATE "user_accROLE" """)
-    run_sql("""TRUNCATE "accROLE_accACTION_accARGUMENT" """)
+    truncate_table("accROLE")
+    truncate_table("accACTION")
+    truncate_table("accARGUMENT")
+    truncate_table("user_accROLE")
+    truncate_table("accROLE_accACTION_accARGUMENT")
 
     return 1
 

--- a/invenio/modules/access/firerole.py
+++ b/invenio/modules/access/firerole.py
@@ -225,10 +225,10 @@ def acc_firerole_extract_emails(firerole_def_obj):
                         authorized_emails.add(
                             expr[:-len(' [CERN]')].lower().strip() + ':cern.ch')
                         emails = run_sql(
-                            "SELECT user.email FROM usergroup JOIN "
+                            """SELECT "user".email FROM usergroup JOIN """
                             "user_usergroup ON "
                             "usergroup.id=user_usergroup.id_usergroup "
-                            "JOIN user ON user.id=user_usergroup.id_user "
+                            """JOIN "user" ON "user".id=user_usergroup.id_user """
                             "WHERE usergroup.name=%s", (expr, ))
                     for email in emails:
                         authorized_emails.add(email[0].lower().strip())
@@ -241,7 +241,7 @@ def acc_firerole_extract_emails(firerole_def_obj):
                 for reg_p, expr in expressions_list:
                     if reg_p:
                         continue
-                    email = run_sql("SELECT email FROM user WHERE id=%s",
+                    email = run_sql("""SELECT email FROM "user" WHERE id=%s""",
                                     (expr, ))
                     if email:
                         authorized_emails.add(email[0][0].lower().strip())

--- a/invenio/modules/access/models.py
+++ b/invenio/modules/access/models.py
@@ -19,15 +19,15 @@
 
 """Access database models."""
 
-# General imports.
 from cPickle import dumps, loads
 
 from datetime import datetime, timedelta
 
-from invenio.base.wrappers import lazy_import
 from invenio.ext.passlib.hash import mysql_aes_decrypt, mysql_aes_encrypt
 from invenio.ext.sqlalchemy import db
 from invenio.ext.sqlalchemy.utils import session_manager
+from invenio.modules.access.local_config import CFG_ACC_ACTIVITIES_URLS, \
+    SUPERADMINROLE
 from invenio.modules.accounts.models import User
 from invenio.utils.hash import md5
 
@@ -35,13 +35,8 @@ from random import random
 
 from sqlalchemy.orm import validates
 
-from .errors import \
-    InvenioWebAccessMailCookieDeletedError, InvenioWebAccessMailCookieError
-
-SUPERADMINROLE = lazy_import(
-    'invenio.modules.access.local_config.SUPERADMINROLE')
-CFG_ACC_ACTIVITIES_URLS = lazy_import(
-    'invenio.modules.access.local_config.CFG_ACC_ACTIVITIES_URLS')
+from .errors import InvenioWebAccessMailCookieDeletedError, \
+    InvenioWebAccessMailCookieError
 
 
 class AccACTION(db.Model):
@@ -185,14 +180,23 @@ class AccAuthorization(db.Model):
     id_accACTION = db.Column(db.Integer(15, unsigned=True),
                              db.ForeignKey(AccACTION.id), nullable=True,
                              index=True)
-    _id_accARGUMENT = db.Column(db.Integer(15), db.ForeignKey(AccARGUMENT.id),
-                                nullable=True, name="id_accARGUMENT",
-                                index=True)
+    _id_accARGUMENT = db.Column(db.Integer(15), nullable=True,
+                                name="id_accARGUMENT", index=True)
     argumentlistid = db.Column(db.MediumInteger(8), nullable=True)
 
     role = db.relationship(AccROLE, backref='authorizations')
     action = db.relationship(AccACTION, backref='authorizations')
-    argument = db.relationship(AccARGUMENT, backref='authorizations')
+    argument = db.relationship(
+        AccARGUMENT, backref='authorizations',
+        primaryjoin=db.and_(
+            AccARGUMENT.id == _id_accARGUMENT,
+            _id_accARGUMENT != -1,
+            _id_accARGUMENT is not None
+        ),
+        foreign_keys=_id_accARGUMENT,
+        uselist=False,
+        cascade="all, delete",
+    )
 
     @db.hybrid_property
     def id_accARGUMENT(self):


### PR DESCRIPTION
* Fixes sql queries to improve standard compliance and compatibility:
  "RLIKE", quoting. (addresses #3214)

* Fixes problem of assignement of -1 to a foreign key, removing foreign
  key and shaping relationship to exclude -1 value. (closes #3099)

* PEP8/257 code style improvements.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>