### PR TITLE
WebSearch: no special behaviour for subject index

### DIFF
--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -2458,7 +2458,7 @@ def search_unit(p, f=None, m=None, wl=0, ignore_synonyms=None):
     elif f == 'citedbyexcludingselfcites':
         # we are doing search by the citation count
         hitset = search_unit_citedby_excluding_selfcites(p)
-    elif m == 'a' or m == 'r' or f == 'subject':
+    elif m == 'a' or m == 'r':
         # we are doing either phrase search or regexp search
         if f == 'fulltext':
             # FIXME: workaround for not having phrase index yet


### PR DESCRIPTION
* FIX Removes special behaviour of the "subject" index that was
  hard-coded based on the index name.  Installations should rather
  specify wanted behaviour by means of configurable tokeniser instead.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
Reviewed-by: Jan Aage Lavik <jan.age.lavik@cern.ch>