### PR TITLE
accounts: verification email is not being sent fix

### DIFF
--- a/invenio/modules/accounts/models.py
+++ b/invenio/modules/accounts/models.py
@@ -70,7 +70,7 @@ class User(db.Model):
     password_salt = db.Column(db.String(255))
     password_scheme = db.Column(db.String(50), nullable=False, index=True)
 
-    note = db.Column(db.String(255), nullable=True)
+    _note = db.Column(db.String(255), name="note", nullable=True)
     given_names = db.Column(db.String(255), nullable=False, server_default='')
     family_name = db.Column(db.String(255), nullable=False, server_default='')
     settings = db.Column(db.MutableDict.as_mutable(db.MarshalBinary(
@@ -83,6 +83,16 @@ class User(db.Model):
 
     PROFILE_FIELDS = ['nickname', 'email', 'family_name', 'given_names']
     """List of fields that can be updated with update_profile."""
+
+    @hybrid_property
+    def note(self):
+        """Return the note."""
+        return self._note
+
+    @note.setter
+    def note(self, note):
+        """Set the note."""
+        self._note = str(note)
 
     @hybrid_property
     def password(self):

--- a/invenio/modules/accounts/testsuite/test_accounts_user.py
+++ b/invenio/modules/accounts/testsuite/test_accounts_user.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2006, 2007, 2008, 2010, 2011, 2013 CERN.
+# Copyright (C) 2006, 2007, 2008, 2010, 2011, 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,15 +19,30 @@
 
 """Unit tests for the user handling library."""
 
-# Note: unit tests located here were moved to the regression test
-# suite.  Keeping this file here with empty test case set in order to
-# overwrite any previously installed file.  Also, keeping TEST_SUITE
-# empty so that `inveniocfg --run-unit-tests' would not complain.
+from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
 
-#from invenio.base.wrappers import lazy_import
-from invenio.testsuite import make_test_suite, run_test_suite  # , InvenioTestCase
 
-TEST_SUITE = make_test_suite()
+class UserTestCase(InvenioTestCase):
+    """Test User class."""
+
+    def test_note_is_converted_to_string(self):
+        from invenio.modules.accounts.models import User
+        u = User(email="test@test.pl", password="")
+        u.note = 2
+        self.assertTrue(isinstance(u.note, str))
+
+    def test_verify_email_works_with_numbers_and_strings(self):
+        from invenio.modules.accounts.models import User
+        u = User(email="test@test.pl", password="")
+        u.note = 2
+        self.assertTrue(u.verify_email())
+
+        u2 = User(email="test2@test2.pl", password="")
+        u2.note = "2"
+        self.assertTrue(u2.verify_email())
+
+
+TEST_SUITE = make_test_suite(UserTestCase)
 
 if __name__ == "__main__":
     run_test_suite(TEST_SUITE)


### PR DESCRIPTION
* Corrects conditions on when to sent an email. (addresses
  zenodo/zenodo#275)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>