### PR TITLE
installation: database init for any host

### DIFF
--- a/invenio/base/scripts/database.py
+++ b/invenio/base/scripts/database.py
@@ -86,6 +86,9 @@ def init(user='root', password='', yes_i_know=False):
             (cmd_prefix + '-e "GRANT ALL PRIVILEGES ON '
              '{CFG_DATABASE_NAME}.* TO {CFG_DATABASE_USER}@localhost '
              'IDENTIFIED BY {CFG_DATABASE_PASS}"'),
+            (cmd_prefix + '-e "GRANT ALL PRIVILEGES ON '
+             '{CFG_DATABASE_NAME}.* TO {CFG_DATABASE_USER}@\'%\' '
+             'IDENTIFIED BY {CFG_DATABASE_PASS}"'),
             cmd_admin_prefix + 'flush-privileges'
         ]
         for cmd in cmds:


### PR DESCRIPTION
* BETTER Adds default priviledges for database user to access from any
  host.

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>

--
cc @hachreak @crepererum 

PS: It's going to `maint-2.0`.