### PR TITLE
RFC global: namespace package for modules

### DIFF
--- a/invenio/__init__.py
+++ b/invenio/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -28,3 +28,6 @@ protocol and uses MARC21 as its underlying bibliographic standard.
 
 # Version information
 from .version import __version__
+
+# namespace package
+__import__("pkg_resources").declare_namespace(__name__)

--- a/invenio/modules/__init__.py
+++ b/invenio/modules/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013 CERN.
+# Copyright (C) 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,3 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Modules that are used to compose an Invenio installation."""
+
+# namespace package
+__import__("pkg_resources").declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -259,6 +259,9 @@ setup(
     description='Invenio digital library framework',
     long_description=__doc__,
     packages=packages,
+    namespace_packages=[
+        'invenio.modules',
+    ],
     package_dir={'invenio_docs': 'docs'},
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
* Adds `invenio.modules` as a namespace packages. This simplifies the
  transition for external modules until we have proper entry points. The
  setuptools hack is required until we use a python version with PEP
  0420 (3.3). This might break module autocompletion for some tools,
  e.g. iPython.

Signed-off-by: Marco Neumann <marco@crepererum.net>

See https://github.com/inveniosoftware/cookiecutter-invenio-module/pull/12 for a usage example.