### PR TITLE
global: refactoring import from sqlalchemy_utils

### DIFF
--- a/invenio/modules/oauth2server/models.py
+++ b/invenio/modules/oauth2server/models.py
@@ -22,6 +22,7 @@
 from __future__ import absolute_import
 
 from flask import current_app
+
 from flask_login import current_user
 
 from invenio.base.i18n import _
@@ -31,7 +32,7 @@ from invenio.ext.sqlalchemy import db
 
 import six
 
-from sqlalchemy_utils import URLType
+from sqlalchemy_utils.types import URLType
 from sqlalchemy_utils.types.encrypted import AesEngine, EncryptedType
 
 from werkzeug.security import gen_salt

--- a/invenio/modules/oauth2server/upgrades/oauth2server_2014_02_17_initial.py
+++ b/invenio/modules/oauth2server/upgrades/oauth2server_2014_02_17_initial.py
@@ -17,22 +17,26 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
+"""Upgrade recipe."""
+
 import warnings
 
-from sqlalchemy import *
 from invenio.ext.sqlalchemy import db
-from sqlalchemy_utils import URLType
 from invenio.modules.upgrader.api import op
+
+from sqlalchemy_utils.types import URLType
+
 
 depends_on = []
 
 
 def info():
+    """Info."""
     return "Tables for oauth2server"
 
 
 def do_upgrade():
-    """ Implement your upgrades here  """
+    """Implement your upgrades here."""
     if not op.has_table('oauth2CLIENT'):
         op.create_table(
             'oauth2CLIENT',
@@ -68,7 +72,8 @@ def do_upgrade():
             db.Column('_scopes', db.Text(), nullable=True),
             db.Column('is_personal', db.Boolean(), nullable=True),
             db.Column('is_internal', db.Boolean(), nullable=True),
-            db.ForeignKeyConstraint(['client_id'], ['oauth2CLIENT.client_id'], ),
+            db.ForeignKeyConstraint(
+                ['client_id'], ['oauth2CLIENT.client_id'],),
             db.ForeignKeyConstraint(['user_id'], ['user.id'], ),
             db.PrimaryKeyConstraint('id'),
             db.UniqueConstraint('access_token'),
@@ -85,5 +90,7 @@ def do_upgrade():
     #     unique=True
     # )
 
+
 def estimate():
+    """Estimate."""
     return 1


### PR DESCRIPTION
* Modifies imports to directly import the types required.
  (addresses #3163) (addresses kvesteri/sqlalchemy-utils#145)

* PEP8/257 code style improvements.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>