### PR TITLE
access: usedeposit action addition

### DIFF
--- a/invenio/modules/access/local_config.py
+++ b/invenio/modules/access/local_config.py
@@ -133,6 +133,7 @@ DEF_ROLES = ((SUPERADMINROLE, 'superuser with all rights', 'deny any'),
              ('paperattributionlinkviewers', 'Users who can see attribution links in the search', 'allow all'),
              ('authorlistusers', 'Users who can user Authorlist tools', 'deny all'),
              ('holdingpenusers', 'Users who can view Holding Pen', 'deny all'),
+             ('depositusers', 'Users who can use a deposit type', 'allow any'),
              )
 
 
@@ -240,6 +241,7 @@ DEF_AUTHS = (('basketusers', 'usebaskets', {}),
              ('claimpaperoperators', 'claimpaper_change_own_data', {}),
              ('claimpaperoperators', 'claimpaper_change_others_data', {}),
              ('holdingpenusers', 'viewholdingpen', {}),
+             ('depositusers', 'usedeposit', {}),
              )
 
 

--- a/invenio/modules/deposit/acl.py
+++ b/invenio/modules/deposit/acl.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""List the access actions used for authorization."""
+
+from invenio.ext.principal import Action
+
+
+class usedeposit(Action):
+
+    """Enable using a deposit type."""
+
+    optional = True
+
+    allowedkeywords = ['type']
+
+
+__all__ = ("usedeposit",)

--- a/invenio/modules/deposit/cache.py
+++ b/invenio/modules/deposit/cache.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Implementation of allowed deposit type caching."""
+
+from .acl import usedeposit
+from .registry import deposit_types
+
+
+def get_authorized_deposition_types(user_info):
+    """Return a list of allowed deposition types for a certain user."""
+    from invenio.modules.access.engine import acc_authorize_action
+
+    return {
+        key for key in deposit_types.mapping().keys()
+        if acc_authorize_action(user_info, usedeposit.name, type=key)[0] == 0
+    }

--- a/invenio/modules/deposit/testsuite/test_type_simplerecord.py
+++ b/invenio/modules/deposit/testsuite/test_type_simplerecord.py
@@ -39,9 +39,10 @@ class SimpleRecordTest(DepositionTestCase):
     def setUp(self):
         """Setup."""
         self.clear('simple')
-        from invenio.modules.deposit.form import WebDepositForm
-        from invenio.modules.deposit import fields
+        from invenio.ext.login import UserInfo
         from invenio.modules.deposit import field_widgets
+        from invenio.modules.deposit import fields
+        from invenio.modules.deposit.form import WebDepositForm
         from invenio.modules.deposit.types import SimpleRecordDeposition
 
         class SimpleRecordTestForm(WebDepositForm):
@@ -80,6 +81,7 @@ class SimpleRecordTest(DepositionTestCase):
                 self.assert_process_metadata(deposition, metadata)
 
         self.register(simple)
+        UserInfo(1, force=True)
 
     def tearDown(self):
         """Teardown."""


### PR DESCRIPTION
* NEW Adds usedeposit action which enables per user access
  restrictions for different deposit types.  (closes #2724)

* Requires running `webaccessadmin -u admin -c -a -D` command.

Signed-off-by: Jan Stypka <jan.stypka@cern.ch>
Reviewed-by: Jiri Kuncar <jiri.kuncar@cern.ch>