### PR TITLE
records: port of BibDocFile serving

### DIFF
--- a/invenio/modules/documents/utils.py
+++ b/invenio/modules/documents/utils.py
@@ -78,8 +78,8 @@ def _get_document(uuid):
         return path
 
 
-def _get_legacy_bibdoc(recid, filename=None):
-    """Get the the fullpath of legacy bibdocfile.
+def _get_legacy_bibdocs(recid, filename=None):
+    """Get all fullpaths of legacy bibdocfile.
 
     :param int recid: The record id
     :param str filename: A specific filename
@@ -88,12 +88,23 @@ def _get_legacy_bibdoc(recid, filename=None):
     """
     from invenio.ext.login import current_user
     from invenio.legacy.bibdocfile.api import BibRecDocs
-    paths = [
+    return [
         (bibdoc.fullpath, bibdoc.is_restricted(current_user))
         for bibdoc in BibRecDocs(recid).list_latest_files(list_hidden=False)
         if not bibdoc.subformat and not filename or
         bibdoc.name + bibdoc.superformat == filename
     ]
+
+
+def _get_legacy_bibdoc(recid, filename=None):
+    """Get the fullpath of legacy bibdocfile.
+
+    :param int recid: The record id
+    :param str filename: A specific filename
+    :returns: bibdocfile full path and access rights
+    :rtype: tuple
+    """
+    paths = _get_legacy_bibdocs(recid, filename=filename)
     try:
         path = paths[0]
     except IndexError:

--- a/invenio/modules/records/views.py
+++ b/invenio/modules/records/views.py
@@ -231,6 +231,14 @@ def file(recid, filename):
             return send_file(file_, mimetype='application/octet-stream',
                              attachment_filename=filename)
         return send_file(document['uri'])
+
+    from invenio.modules.documents.utils import _get_legacy_bibdocs
+    for fullpath, permission in _get_legacy_bibdocs(recid, filename=filename):
+        if not permission:
+            error = 401
+            continue
+        return send_file(fullpath)
+
     abort(error)
 
 


### PR DESCRIPTION
* NOTE Ports basic BibDocFile serving including access right checks.
  (closes #3160)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>

--
This commit brings back only limited support for BibDocFile serving. Do you have any critical use-cases that are missing?

cc @lnielsen @tiborsimko @egabancho @kaplun