### PR TITLE
legacy: dbquery exception handling

### DIFF
--- a/invenio/legacy/dbquery_mysql.py
+++ b/invenio/legacy/dbquery_mysql.py
@@ -43,6 +43,8 @@ from flask import current_app
 from invenio.base.globals import cfg
 from invenio.utils.datastructures import LazyDict
 
+from MySQLdb import OperationalError as MySQLdbOperationalError
+
 from thread import get_ident
 
 from sqlalchemy.exc import InterfaceError, OperationalError
@@ -275,7 +277,7 @@ def run_sql(sql, param=None, n=0, with_desc=False, with_dict=False,
         gc.disable()
         rc = cur.execute(sql, param)
         gc.enable()
-    except (OperationalError, InterfaceError):
+    except (OperationalError, MySQLdbOperationalError, InterfaceError):
         # unexpected disconnect, bad malloc error, etc
         # FIXME: now reconnect is always forced, we may perhaps want to ping()
         # first?
@@ -287,7 +289,7 @@ def run_sql(sql, param=None, n=0, with_desc=False, with_dict=False,
             gc.disable()
             rc = cur.execute(sql, param)
             gc.enable()
-        except (OperationalError, InterfaceError):
+        except (OperationalError, MySQLdbOperationalError, InterfaceError):
             # unexpected disconnect, bad malloc error, etc
             raise
 
@@ -361,14 +363,14 @@ def run_sql_many(query, params, limit=None, run_on_slave=False):
             gc.disable()
             rc = cur.executemany(query, params[i:i + limit])
             gc.enable()
-        except (OperationalError, InterfaceError):
+        except (OperationalError, MySQLdbOperationalError, InterfaceError):
             try:
                 db = _db_login(dbhost, relogin=1)
                 cur = db.cursor()
                 gc.disable()
                 rc = cur.executemany(query, params[i:i + limit])
                 gc.enable()
-            except (OperationalError, InterfaceError):
+            except (OperationalError, MySQLdbOperationalError, InterfaceError):
                 raise
         # collect its result:
         if r is None:


### PR DESCRIPTION
* FIX Catches also any `MySQLdb.OperationalError` coming from legacy
  MySQL queries using `run_sql()`. (addresses #3089)

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>

As promised in https://github.com/inveniosoftware/invenio/issues/3089#issuecomment-106484781