### PR TITLE
search: new Query class

### DIFF
--- a/invenio/legacy/oairepository/server.py
+++ b/invenio/legacy/oairepository/server.py
@@ -69,7 +69,7 @@ from invenio.legacy.oairepository.config import CFG_OAI_REPOSITORY_GLOBAL_SET_SP
 from invenio.legacy.search_engine import record_exists, get_all_restricted_recids, \
     search_unit_in_bibxxx, get_record
 from invenio.modules.formatter import format_record
-from invenio.modules.search.api import SearchEngine
+from invenio.modules.search.api import Query
 from invenio.utils.date import localtime_to_utc, utc_to_localtime
 from invenio.utils.html import X, EscapedXMLString
 
@@ -590,7 +590,7 @@ def oai_get_recid(identifier):
     record if multiple recids matches but some of them are deleted (e.g. in
     case of merging). Returns None if no record matches."""
     if identifier:
-        recids = SearchEngine('{f}:"{p}"'.format(
+        recids = Query('{f}:"{p}"'.format(
             f=CFG_OAI_ID_FIELD, p=identifier)
         ).search()
         if recids:

--- a/invenio/legacy/search_engine/__init__.py
+++ b/invenio/legacy/search_engine/__init__.py
@@ -322,8 +322,8 @@ def search_pattern(req=None, p=None, f=None, m=None, ap=0, of="id", verbose=0,
        This function is suitable as a mid-level API.
     """
     if f is None:
-        from invenio.modules.search.api import SearchEngine
-        results = SearchEngine(p).search()
+        from invenio.modules.search.api import Query
+        results = Query(p).search()
     else:
         results = search_unit(p, f, m, wl=wl)
     import warnings
@@ -667,11 +667,11 @@ def perform_request_search(req=None, cc=CFG_SITE_NAME, c=None, p="", f="", rg=No
     import warnings
     warnings.warn('Deprecated perform_request_search({}).'.format(str(kwargs)),
                   stacklevel=2)
-    from invenio.modules.search.api import SearchEngine
+    from invenio.modules.search.api import Query
     p = create_add_to_search_pattern(p, p1, f1, m1, "")
     p = create_add_to_search_pattern(p, p2, f2, m2, op1)
     p = create_add_to_search_pattern(p, p3, f3, m3, op2)
-    return SearchEngine(p).search(collection=cc)
+    return Query(p).search(collection=cc)
 
 
 def prs_wash_arguments(req=None, cc=CFG_SITE_NAME, c=None, p="", f="", rg=CFG_WEBSEARCH_DEF_RECORDS_IN_GROUPS,

--- a/invenio/modules/collections/recordext/functions/get_record_collections.py
+++ b/invenio/modules/collections/recordext/functions/get_record_collections.py
@@ -21,7 +21,7 @@
 
 from six import iteritems
 
-from invenio.modules.search.api import SearchEngine
+from invenio.modules.search.api import Query
 from invenio.utils.datastructures import LazyDict
 
 COLLECTIONS_DELETED_RECORDS = '{dbquery} AND NOT collection:"DELETED"'

--- a/invenio/modules/formatter/template_context_functions/tfn_get_fulltext_snippets.py
+++ b/invenio/modules/formatter/template_context_functions/tfn_get_fulltext_snippets.py
@@ -29,8 +29,8 @@ from invenio.modules.search.cache import get_pattern_from_cache
 @cache.memoize(timeout=5)
 def get_fulltext_terms_from_search_pattern(search_pattern):
     """Return fulltext terms from search pattern."""
-    from invenio.modules.search.api import SearchEngine
-    return SearchEngine(search_pattern).terms(keywords=['fulltext'])
+    from invenio.modules.search.api import Query
+    return Query(search_pattern).terms(keywords=['fulltext'])
 
 
 def template_context_function(id_bibrec, pattern, qid, current_user):

--- a/invenio/modules/records/utils.py
+++ b/invenio/modules/records/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -38,10 +38,10 @@ from .api import get_record
 
 def get_unique_record_json(param):
     """API to query records from the database."""
-    from invenio.modules.search.api import SearchEngine
+    from invenio.modules.search.api import Query
     data, query = {}, {}
     data['status'] = 'notfound'
-    recid = SearchEngine(param).search()
+    recid = Query(param).search()
     if len(recid) == 1:
         query = get_record(recid[0]).dumps(clean=True)
         data['status'] = 'success'

--- a/invenio/modules/search/api.py
+++ b/invenio/modules/search/api.py
@@ -29,9 +29,13 @@ from .walkers.match_unit import MatchUnit
 from .walkers.terms import Terms
 
 
-class SearchEngine(object):
+class Query(object):
 
-    """Search engine implemetation."""
+    """Search engine implemetation.
+
+    .. versionadded:: 2.1
+       New search and match API.
+    """
 
     def __init__(self, query):
         """Initialize with search query."""

--- a/invenio/modules/search/views/search.py
+++ b/invenio/modules/search/views/search.py
@@ -68,7 +68,7 @@ from invenio.modules.search.registry import facets
 from invenio.utils.pagination import Pagination
 
 from .. import receivers
-from ..api import SearchEngine
+from ..api import Query
 from ..cache import get_search_query_id
 from ..forms import EasySearchForm
 from ..models import Field
@@ -316,8 +316,7 @@ def rss(collection, p, jrec, so, rm):
     rg = int(argd['rg'])
 
     qid = get_search_query_id(**argd)
-    searcher = SearchEngine(p)
-    recids = searcher.search(collection=collection.name)
+    recids = Query(p).search(collection=collection.name)
 
     ctx = dict(
         records=len(recids),
@@ -368,8 +367,7 @@ def search(collection, p, of, ot, so, sf, sp, rm):
     collection_breadcrumbs(collection)
 
     qid = get_search_query_id(p=p, cc=collection.name)
-    searcher = SearchEngine(p)
-    recids = searcher.search(collection=collection.name)
+    recids = Query(p).search(collection=collection.name)
     records = len(recids)
     recids = sort_and_rank_records(recids, so=so, rm=rm, sf=sf,
                                    sp=sp, p=p, of='id', rg=rg, jrec=jrec)


### PR DESCRIPTION
* Renames SearchEngine class to Query that better describes its
  function.

* NEW Adds new API for querying records.

* INCOMPATIBLE Removes support for legacy `perform_request_search` and
  `search_unit` API functions.

Reviewed-by: Tibor Simko <tibor.simko@cern.ch>
Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>