### PR TITLE
base: apache 2.4 config syntax fix

### DIFF
--- a/invenio/base/templates/invenio-apache-vhost.tpl
+++ b/invenio/base/templates/invenio-apache-vhost.tpl
@@ -68,7 +68,7 @@ WSGIPythonHome {{pythonhome}}
         DocumentRoot {{ config.COLLECT_STATIC_ROOT }}
         <Directory {{ config.COLLECT_STATIC_ROOT }}>
            DirectorySlash Off
-           Options FollowSymLinks MultiViews -Indexes
+           Options +FollowSymLinks +MultiViews -Indexes
            AllowOverride None
            <IfVersion >= 2.4>
            Require all granted


### PR DESCRIPTION
* Fixes syntax error in generated Apache virtual host
  configuration.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>