### PR TITLE
access: superadmin role fix

### DIFF
--- a/invenio/modules/access/config.py
+++ b/invenio/modules/access/config.py
@@ -21,3 +21,4 @@ from __future__ import unicode_literals
 
 CFG_EXTERNAL_AUTH_USING_SSO = False
 CFG_EXTERNAL_AUTH_LOGOUT_SSO = None
+CFG_SUPERADMINROLE_ID = 1

--- a/invenio/modules/access/control.py
+++ b/invenio/modules/access/control.py
@@ -24,6 +24,8 @@ from __future__ import print_function
 
 import urlparse
 
+from flask import current_app
+
 from intbitset import intbitset
 
 from invenio.config import CFG_SITE_ADMIN_EMAIL, CFG_SITE_LANG, CFG_SITE_RECORD
@@ -45,18 +47,6 @@ from invenio.modules.access.models import AccACTION, AccAuthorization, \
 from six import iteritems
 
 from sqlalchemy.exc import ProgrammingError
-
-
-CFG_SUPERADMINROLE_ID = 0
-try:
-    id_tmp = run_sql("""SELECT id FROM "accROLE" WHERE name=%s""",
-                     (SUPERADMINROLE, ))
-    if id_tmp:
-        CFG_SUPERADMINROLE_ID = int(id_tmp[0][0])
-except Exception:
-    pass
-
-# ACTIONS
 
 
 def acc_add_action(name_action='', description='', optional='no',
@@ -1480,7 +1470,7 @@ def acc_find_possible_roles(name_action, always_add_superadmin=True,
         id_action=id_action)).fetchall())
 
     if always_add_superadmin:
-        roles.add(CFG_SUPERADMINROLE_ID)
+        roles.add(current_app.config.get("CFG_SUPERADMINROLE_ID", 1))
 
     # Unpack arguments
     if batch_args:
@@ -1610,7 +1600,7 @@ def acc_find_possible_actions(id_role, id_action):
         # action without arguments"
         if run_sql(
             """SELECT "id_accROLE"
-               FROM ""accROLE_accACTION_accARGUMENT"
+               FROM "accROLE_accACTION_accARGUMENT"
                WHERE "id_accROLE" = %s AND "id_accACTION"  = %s AND
                      "id_accARGUMENT" = 0 AND argumentlistid = 0""",
                 (id_role, id_action)):


### PR DESCRIPTION
* FIX Sets the superadmin role ID properly when elaborating access
  authorizations. Previously it was masked behind an application
  context exception. (closes #3184)

* NOTE The default access role ID for the superadmin user is 1, but
  it can be configured via CFG_SUPERADMINROLE_ID.

* Removes a double wrong quote in `acc_find_possible_actions()`.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>