### PR TITLE
jinja2hacks: only warnings in DEBUG mode

### DIFF
--- a/invenio/ext/jinja2hacks.py
+++ b/invenio/ext/jinja2hacks.py
@@ -113,7 +113,7 @@ def utf8escape(s):
     """
     if isinstance(s, str):
         warnings.warn("Convert string '{0}' in template to unicode.".format(s),
-                      RuntimeWarning, stacklevel=3)
+                      DeprecationWarning, stacklevel=3)
         return jinja2_escape(s.decode('utf8'))
     return jinja2_escape(s)
 # Ensure function name is identical to replaced function.
@@ -136,6 +136,6 @@ class Markup(jinja2_Markup):
             encoding = 'utf8'
             warnings.warn(
                 "Convert string '{0}' in template to unicode.".format(base),
-                RuntimeWarning, stacklevel=3)
+                DeprecationWarning, stacklevel=3)
         return jinja2_Markup.__new__(cls, base=base, encoding=encoding,
                                      errors=errors)


### PR DESCRIPTION
* BETTER Changes the hacks to only triggers warnings from non-unicode
  strings in jinja templates when in DEBUG mode to avoid taking a
  performance hit in production. This is important until the data model
  is only represented in Unicode.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>

CC @lnielsen