### PR TITLE
legacy: ANSI_QUOTES setting on second try

### DIFF
--- a/invenio/legacy/dbquery_mysql.py
+++ b/invenio/legacy/dbquery_mysql.py
@@ -286,6 +286,7 @@ def run_sql(sql, param=None, n=0, with_desc=False, with_dict=False,
         try:
             db = _db_login(dbhost, relogin=1)
             cur = db.cursor()
+            cur.execute("SET SESSION sql_mode = %s", ['ANSI_QUOTES'])
             gc.disable()
             rc = cur.execute(sql, param)
             gc.enable()


### PR DESCRIPTION
* FIX Sets the ANSI_QUOTES setting also on the second attempt
  to connect to the database in case of a lost connection.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>