### PR TITLE
deposit: MintedDOIValidator fix

### DIFF
--- a/invenio/modules/deposit/testsuite/test_deposit_validators.py
+++ b/invenio/modules/deposit/testsuite/test_deposit_validators.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Unit tests for deposit module validators."""
+
+from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+
+from wtforms.validators import StopValidation, ValidationError
+
+
+class Field(object):
+
+    def __init__(self, old_doi, new_doi):
+        self.object_data = old_doi
+        self.data = new_doi
+
+
+class Form(object):
+    pass
+
+
+LOCAL_DOI_PREFIX = "10.5072"
+REMOTE_DOI_PREFIX = "10.7777"
+
+
+class MintedDOIValidatorTest(InvenioTestCase):
+    """Test MitedDOIValidator."""
+
+    def test_doi_new(self):
+        from invenio.modules.deposit.validation_utils import MintedDOIValidator
+
+        validator = MintedDOIValidator()
+        field = Field("", LOCAL_DOI_PREFIX + "/test.77777")
+        field2 = Field("", REMOTE_DOI_PREFIX + "/test.77777")
+        form = Form()
+
+        with self.assertRaises(StopValidation):
+            validator(form, field)
+        with self.assertRaises(StopValidation):
+            validator(form, field2)
+
+    def test_matching_doi(self):
+        from invenio.modules.deposit.validation_utils import MintedDOIValidator
+
+        validator = MintedDOIValidator()
+        field = Field(
+            LOCAL_DOI_PREFIX + "/test.77777",
+            LOCAL_DOI_PREFIX + "/test.77777")
+        field2 = Field(
+            REMOTE_DOI_PREFIX + "/test.77777",
+            REMOTE_DOI_PREFIX + "/test.77777")
+        form = Form()
+
+        with self.assertRaises(StopValidation):
+            validator(form, field)
+        with self.assertRaises(StopValidation):
+            validator(form, field2)
+
+    def test__different_doi_(self):
+        from invenio.modules.deposit.validation_utils import MintedDOIValidator
+
+        validator = MintedDOIValidator()
+        field = Field(
+            LOCAL_DOI_PREFIX + "/test.12345",
+            LOCAL_DOI_PREFIX + "/test.77777")
+        field2 = Field(
+            REMOTE_DOI_PREFIX + "/test.12345",
+            REMOTE_DOI_PREFIX + "/test.77777")
+        form = Form()
+
+        with self.assertRaises(ValidationError):
+            validator(form, field)
+        with self.assertRaises(ValidationError):
+            validator(form, field2)
+
+
+TEST_SUITE = make_test_suite(MintedDOIValidatorTest)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)

--- a/invenio/modules/deposit/validation_utils.py
+++ b/invenio/modules/deposit/validation_utils.py
@@ -42,13 +42,16 @@ class ListLength(object):
     :param element_filter: Callable used to filter the list prior to testing
         the number of elements. Useful to remove empty elements.
     """
+
     def __init__(self, min_num=None, max_num=None,
                  element_filter=lambda x: True):
+        """Initialize the validator."""
         self.min = min_num
         self.max = max_num
         self.element_filter = element_filter
 
     def __call__(self, form, field):
+        """Validate."""
         test_list = []
         if self.min or self.max:
             test_list = filter(self.element_filter, field.data)
@@ -76,11 +79,13 @@ class RequiredIf(object):
     """Require field if value of another field is set to a certain value."""
 
     def __init__(self, other_field_name, values, message=None):
+        """Initialize the validator."""
         self.other_field_name = other_field_name
         self.values = values
         self.message = message
 
     def __call__(self, form, field):
+        """Validate."""
         try:
             other_field = getattr(form, self.other_field_name)
             other_val = other_field.data
@@ -107,6 +112,7 @@ class NotRequiredIf(RequiredIf):
     """Do not require field if another field contains a certain value."""
 
     def __call__(self, form, field):
+        """Validate."""
         try:
             other_field = getattr(form, self.other_field_name)
             other_val = other_field.data
@@ -119,17 +125,23 @@ class NotRequiredIf(RequiredIf):
 
 
 class Unchangeable(object):
+
+    """Unchangeable validator."""
+
     def __call__(self, form, field):
+        """Validate."""
         field.data = field.object_data
 
 
 def number_validate(form, field, submit=False,
                     error_message='It must be a number!'):
+    """Number validator."""
     value = field.data or ''
     if value == "" or value.isspace():
         return
 
     def is_number(s):
+        """Decide whether argument is a number."""
         try:
             float(s)
             return True
@@ -184,13 +196,14 @@ class DOISyntaxValidator(object):
 
 
 class InvalidDOIPrefix(object):
-    """
-    Validates if DOI
-    """
+
+    """Validates if DOI."""
+
     def __init__(self, prefix='10.5072', message=None,
                  message_testing=None):
-        """
-        @param doi_prefix: DOI prefix, e.g. 10.5072
+        """Initialize validator.
+
+        :param doi_prefix: DOI prefix, e.g. 10.5072
         """
         self.doi_prefix = prefix
         # Remove trailing slash
@@ -198,9 +211,9 @@ class InvalidDOIPrefix(object):
             self.doi_prefix = self.doi_prefix[:-1]
 
         if not message_testing:
-            self.message_testing = "The prefix 10.5072 is invalid. The prefix" \
-                "is only used for testing purposes, and no DOIs with this " \
-                "prefix are attached to any meaningful content."
+            self.message_testing = "The prefix 10.5072 is invalid. The " \
+                "prefix is only used for testing purposes, and no DOIs with " \
+                "this prefix are attached to any meaningful content."
         if not message:
             self.message = 'The prefix %(prefix)s is ' \
                 'administered automatically by %(CFG_SITE_NAME)s.'
@@ -213,6 +226,7 @@ class InvalidDOIPrefix(object):
         self.message_testing = self.message_testing % ctx
 
     def __call__(self, form, field):
+        """Validate."""
         value = field.data
 
         # Defined prefix
@@ -226,12 +240,13 @@ class InvalidDOIPrefix(object):
 
 
 class MintedDOIValidator(object):
-    """
-    Validates if DOI
-    """
+
+    """Validates if DOI."""
+
     def __init__(self, prefix='10.5072', message=None):
-        """
-        @param doi_prefix: DOI prefix, e.g. 10.5072
+        """Initialize validator.
+
+        :param doi_prefix: DOI prefix, e.g. 10.5072
         """
         self.doi_prefix = prefix
         # Remove trailing slash
@@ -248,22 +263,18 @@ class MintedDOIValidator(object):
         self.message = self.message % ctx
 
     def __call__(self, form, field):
-        if field.object_data and \
-           field.object_data.startswith("%s/" % self.doi_prefix):
-            # We have a DOI and it's our own DOI.
-            if field.data != field.object_data:
+        """Validate."""
+        if field.object_data and field.data != field.object_data:
                 raise ValidationError(self.message)
-            else:
-                raise StopValidation()
-        else:
-            raise ValidationError(self.message)
+        raise StopValidation()
 
 
 class PreReservedDOI(object):
-    """
-    Validate that user did not edit pre-reserved DOI.
-    """
+
+    """Validate that user did not edit pre-reserved DOI."""
+
     def __init__(self, field_name, message=None, prefix='10.5072'):
+        """Initialize the validator."""
         self.field_name = field_name
         self.message = message or 'You are not allowed to edit a ' \
                                   'pre-reserved DOI. Click the Pre-reserve ' \
@@ -271,6 +282,7 @@ class PreReservedDOI(object):
         self.prefix = prefix
 
     def __call__(self, form, field):
+        """Validate."""
         attr_value = getattr(form, self.field_name).data
         if isinstance(attr_value, dict):
             attr_value = attr_value['doi']
@@ -283,10 +295,11 @@ class PreReservedDOI(object):
 
 
 class PidValidator(object):
-    """
-    Validate that value is a persistent identifier understood by us.
-    """
+
+    """Validate that value is a persistent identifier understood by us."""
+
     def __init__(self, message=None):
+        """Initialize the validator."""
         self.message = message or "Not a valid persistent identifier"
 
     def __call__(self, form, field):


### PR DESCRIPTION
* FIX Fixes MintedDOIValidator, so that it correctly checks if DOI was
  already minted for the specific upload. (addresses zenodo/zenodo#285)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>