### PR TITLE
legacy: print_record import fix

### DIFF
--- a/invenio/legacy/search_engine/__init__.py
+++ b/invenio/legacy/search_engine/__init__.py
@@ -597,8 +597,8 @@ def print_record(recID, format='hb', ot='', ln=CFG_SITE_LANG, decompress=zlib.de
     method or a certain sort field was selected, keep it selected in
     any dynamic search links that may be printed.
     """
-    from invenio.modules.formatter import api
-    return api.format_record(
+    from invenio.modules.formatter import format_record
+    return format_record(
         recID, of=format, ln=ln, verbose=verbose,
         search_pattern=search_pattern
     ) if record_exists(recID) != 0 else ""


### PR DESCRIPTION
* FIX Fixes a broken import in the `print_record()` function
  of search_engine.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>