### PR TITLE
legacy: deprecation warnings addition

### DIFF
--- a/invenio/legacy/__init__.py
+++ b/invenio/legacy/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013 CERN.
+# Copyright (C) 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,3 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+import warnings
+
+warnings.warn("'invenio.legacy' modules are being deprecated. "
+              "Please check our roadmap for specific modules.",
+              PendingDeprecationWarning)

--- a/invenio/legacy/bibcirculation/__init__.py
+++ b/invenio/legacy/bibcirculation/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+import warnings
+
+from invenio.utils.deprecation import RemovedInInvenio22Warning
+
+warnings.warn("BibCirculation will be removed in 2.2. Please check "
+              "new Invenio-Circulation package.",
+              RemovedInInvenio22Warning)

--- a/invenio/legacy/bibdocfile/__init__.py
+++ b/invenio/legacy/bibdocfile/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013 CERN.
+# Copyright (C) 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,3 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+import warnings
+
+from invenio.utils.deprecation import RemovedInInvenio23Warning
+
+warnings.warn("BibDocFile will be removed in 2.3. Please check "
+              "'invenio.modules.documents' module.",
+              RemovedInInvenio23Warning)

--- a/invenio/legacy/bibedit/__init__.py
+++ b/invenio/legacy/bibedit/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+import warnings
+
+from invenio.utils.deprecation import RemovedInInvenio22Warning
+
+warnings.warn("BibEdit will be removed in 2.2. Please check "
+              "'invenio.modules.editor' module.",
+              RemovedInInvenio22Warning)

--- a/invenio/legacy/elmsubmit/__init__.py
+++ b/invenio/legacy/elmsubmit/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+import warnings
+
+from invenio.utils.deprecation import RemovedInInvenio22Warning
+
+warnings.warn("ElmSubmit will be removed in 2.2.", RemovedInInvenio22Warning)

--- a/invenio/legacy/websearch_external_collections/__init__.py
+++ b/invenio/legacy/websearch_external_collections/__init__.py
@@ -22,6 +22,14 @@
 
 __revision__ = "$Id$"
 
+import warnings
+
+from invenio.utils.deprecation import RemovedInInvenio22Warning
+
+warnings.warn("External collection search will be removed in 2.2. Please check "
+              "new Record REST API.",
+              RemovedInInvenio22Warning)
+
 import cgi
 import sys
 from copy import copy

--- a/invenio/legacy/websubmit/__init__.py
+++ b/invenio/legacy/websubmit/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+import warnings
+
+from invenio.utils.deprecation import RemovedInInvenio22Warning
+
+warnings.warn("WebSubmit will be removed in 2.2. Please check "
+              "'invenio.modules.deposition' module.",
+              RemovedInInvenio22Warning)


### PR DESCRIPTION
* INCOMPATIBLE Specifies deprecation warnings for legacy modules
  bibcirculation, bibdocfile, bibedit, elmsubmit,
  websearch_external_collections, and websubmit.

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>