### PR TITLE
legacy: fix of inveniogc when using redis sessions

### DIFF
--- a/invenio/legacy/websession/inveniogc.py
+++ b/invenio/legacy/websession/inveniogc.py
@@ -1,7 +1,7 @@
 # -*- mode: python; coding: utf-8; -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2007, 2008, 2010, 2011, 2012, 2014 CERN.
+# Copyright (C) 2007, 2008, 2010, 2011, 2012, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -42,6 +42,7 @@ from invenio.modules.access.mailcookie import mail_cookie_gc
 from invenio.legacy.bibdocfile.api import BibDoc
 from invenio.legacy.bibsched.cli import gc_tasks
 from invenio.legacy.websubmit.config import CFG_WEBSUBMIT_TMP_VIDEO_PREFIX
+from invenio.modules.upgrader.api import op
 from invenio.utils.date import convert_datestruct_to_datetext
 from intbitset import intbitset
 
@@ -330,7 +331,7 @@ def clean_sessions():
     """
     Deletes expired sessions only.
     """
-    if not CFG_INSPIRE_SITE:
+    if op.has_table('session') and not CFG_INSPIRE_SITE:
         deleted_sessions = 0
         timelimit = convert_datestruct_to_datetext(time.gmtime())
         write_message("Deleting expired sessions since %s" % (timelimit,))


### PR DESCRIPTION
* FIX Fixes inveniogc crash when mysql is NOT used to store sessions.
  (closes #3205)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>