### PR TITLE
global: fix CFG_TMPSHAREDDIR variable name

### DIFF
--- a/invenio/modules/workflows/models.py
+++ b/invenio/modules/workflows/models.py
@@ -698,7 +698,7 @@ class BibWorkflowObject(db.Model):
         Warning: Currently assumes non-binary content.
         """
         if directory is None:
-            directory = cfg['CFG_TMPSHAREDIR']
+            directory = cfg['CFG_TMPSHAREDDIR']
         tmp_fd, filename = tempfile.mkstemp(dir=directory,
                                             prefix=prefix,
                                             suffix=suffix)


### PR DESCRIPTION
* Fixes CFG_TMPSHAREDDIR variable's name.

* Fixes direct_xml_output varible definition. (closes #3221)

* PEP8/257 code style improvements.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>