### PR TITLE
WebAccess: FireRole documentation fix

### DIFF
--- a/modules/webaccess/doc/admin/webaccess-admin-guide.webdoc
+++ b/modules/webaccess/doc/admin/webaccess-admin-guide.webdoc
@@ -1119,7 +1119,7 @@ II. Example - connecting role and user</a>
 
     Example of role definition:
         allow not email /.*@gmail.com/,/.*@hotmail.com/
-        deny group badguys
+        deny group "badguys"
         allow remote_ip "127.0.0.0/24"
         deny all
 


### PR DESCRIPTION
* FIX Improves the WebAccess FireRole documentation by providing
  corrected example on how to use groups in FireRole definitions.
  (closes #3107)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>
Reported-by: Theodoros Theodoropoulos <theod@physics.auth.gr>