### PR TITLE
template: adds test 'list'

### DIFF
--- a/invenio/ext/template/__init__.py
+++ b/invenio/ext/template/__init__.py
@@ -231,4 +231,8 @@ def setup_app(app):
         )
         return rv
 
+    @app.template_test('list')
+    def _is_list(value):
+        return isinstance(value, list)
+
     return app


### PR DESCRIPTION
* Jinja2 lacks a test to check if a variable is a list. `iterable`
  is not sufficient, as it will return true for strings.
  (closes #3227)

Signed-off-by: Øystein Blixhavn <oystein@blixhavn.no>