### PR TITLE
global: editorconfig fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,8 @@ root = true
 [*]
 indent_style = space
 end_of_line = lf
-insert_final_newline = false
-trim_trailing_whitespace = false
+insert_final_newline = true
+trim_trailing_whitespace = true
 charset = utf-8
 
 # Python files


### PR DESCRIPTION
* Reverts change that was accidentally done by mistake in 0c9ffff.

Signed-off-by: Marco Neumann <marco@crepererum.net>

Rebased against: `main-2.0`
See https://github.com/inveniosoftware/cookiecutter-invenio-module/pull/13