### PR TITLE
accounts: admin user fixture addition

### DIFF
--- a/invenio/ext/legacy/__init__.py
+++ b/invenio/ext/legacy/__init__.py
@@ -21,38 +21,29 @@
 from __future__ import print_function
 
 import os
+
 import sys
 
 from flask import (abort, current_app, g, render_template, request,
                    send_from_directory, url_for)
-from flask_admin.menu import MenuLink
-from werkzeug.exceptions import HTTPException
-from werkzeug.wrappers import BaseResponse
 
-from .request_class import LegacyRequest
+from flask_admin.menu import MenuLink
+
 from invenio.base import signals
 from invenio.base.scripts.database import create, recreate
 from invenio.base.utils import run_py_func
 
+from werkzeug.exceptions import HTTPException
+from werkzeug.wrappers import BaseResponse
+
+from .request_class import LegacyRequest
+
 
 def cli_cmd_reset(sender, yes_i_know=False, drop=True, **kwargs):
     """Reset legacy values."""
-    from invenio.ext.sqlalchemy import db
-    from invenio.modules.accounts.models import User
-    # from invenio.legacy.inveniocfg import cli_cmd_reset_sitename
-    # from invenio.legacy.inveniocfg import cli_cmd_reset_fieldnames
     from invenio.legacy.bibsort.daemon import main as bibsort
     from invenio.modules.access.scripts.webaccessadmin import main as \
         webaccessadmin
-
-    # FIXME refactor fixtures so these calls are not needed
-    # cli_cmd_reset_sitename(conf)
-    User.query.filter_by(id=1).delete()
-    siteadminemail = current_app.config.get('CFG_SITE_ADMIN_EMAIL')
-    u = User(id=1, email=siteadminemail, password='', note=1, nickname='admin')
-    db.session.add(u)
-    db.session.commit()
-    # cli_cmd_reset_fieldnames(conf)
 
     for cmd in (
         (webaccessadmin, "webaccessadmin -u admin -c -a -D"),

--- a/invenio/modules/accounts/fixtures.py
+++ b/invenio/modules/accounts/fixtures.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""User fixtures."""
+
+from fixture import DataSet
+
+from flask import current_app
+
+
+class UserData(DataSet):
+
+    """User data."""
+
+    class admin:
+        id = 1
+        email = current_app.config.get('CFG_SITE_ADMIN_EMAIL')
+        password = ''
+        note = '1'
+        nickname = 'admin'


### PR DESCRIPTION
* NOTE Moves admin user creation from legacy extension to accounts
  fixture. It resolves a problem with next value of the serial id
  on PostgreSQL. (closes #3216)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>