### PR TITLE
workflows: fix PostgreSQL model compatibility

### DIFF
--- a/invenio/modules/workflows/engine.py
+++ b/invenio/modules/workflows/engine.py
@@ -29,7 +29,7 @@ from uuid import uuid1 as new_uuid
 
 from invenio.ext.sqlalchemy import db
 
-from six import iteritems, reraise
+from six import iteritems, reraise, text_type
 from six.moves import cPickle
 
 from workflow.engine import (
@@ -130,7 +130,7 @@ class BibWorkflowEngine(GenericWorkflowEngine):
                                        module_name=module_name, uuid=uuid)
                 self.save(status=WorkflowStatus.NEW)
 
-        if self.db_obj.uuid not in self.log.name:
+        if text_type(self.db_obj.uuid) not in self.log.name:
             db_handler_obj = BibWorkflowLogHandler(BibWorkflowEngineLog,
                                                    "uuid")
             self.log = get_logger(logger_name="workflow.%s" % self.db_obj.uuid,

--- a/invenio/modules/workflows/testsuite/test_workflows.py
+++ b/invenio/modules/workflows/testsuite/test_workflows.py
@@ -21,13 +21,17 @@
 
 from __future__ import absolute_import
 
-import random
-import time
 import logging
 
-from ..registry import WorkflowsRegistry
+import random
+
+import time
+
 from flask_registry import ImportPathRegistry
+
 from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+
+from ..registry import WorkflowsRegistry
 
 TEST_PACKAGES = [
     'invenio.modules.*',
@@ -106,7 +110,8 @@ distances from it.
     def tearDown(self):
         """ Clean up created objects."""
         from invenio.modules.workflows.models import Workflow
-        Workflow.get(Workflow.module_name == "unit_tests").delete()
+        self.delete_objects(
+            Workflow.get(Workflow.module_name == "unit_tests").all())
         self.cleanup_registries()
 
     def test_halt(self):
@@ -117,7 +122,8 @@ distances from it.
         from invenio.modules.workflows.models import (BibWorkflowObjectLog,
                                                       ObjectVersion)
 
-        halt_engine = lambda obj, eng: eng.halt("Test")
+        def halt_engine(obj, eng):
+            return eng.halt("Test")
 
         class HaltTest(object):
             workflow = [halt_engine]
@@ -142,8 +148,11 @@ distances from it.
         from invenio.modules.workflows.models import (BibWorkflowObjectLog,
                                                       ObjectVersion)
 
-        always_true = lambda obj, eng: True
-        halt_engine = lambda obj, eng: eng.halt("Test")
+        def always_true(obj, eng):
+            return True
+
+        def halt_engine(obj, eng):
+            return eng.halt("Test")
 
         class BranchTest(object):
             workflow = [
@@ -445,8 +454,9 @@ distances from it.
                                                       ObjectVersion)
 
         initial_data = 20
-        obj_init = BibWorkflowObject(id_workflow=11,
-                                     version=ObjectVersion.INITIAL)
+        obj_init = BibWorkflowObject(
+            id_workflow=None,
+            version=ObjectVersion.INITIAL)
         obj_init.set_data(initial_data)
         obj_init.save()
 
@@ -644,7 +654,8 @@ class TestWorkflowTasks(WorkflowTasksTestCase):
     def tearDown(self):
         """Clean up tests."""
         from invenio.modules.workflows.models import Workflow
-        Workflow.get(Workflow.module_name == "unit_tests").delete()
+        self.delete_objects(
+            Workflow.get(Workflow.module_name == "unit_tests").all())
         self.cleanup_registries()
 
     def test_logic_tasks_restart(self):

--- a/invenio/modules/workflows/testsuite/test_workflows_delayed.py
+++ b/invenio/modules/workflows/testsuite/test_workflows_delayed.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,9 +19,10 @@
 
 """Test for delayed workflows."""
 
-from invenio.testsuite import make_test_suite, run_test_suite
-from ...workflows.testsuite.test_workflows import WorkflowTasksTestCase
 from invenio.celery import celery
+from invenio.testsuite import make_test_suite, run_test_suite
+
+from ...workflows.testsuite.test_workflows import WorkflowTasksTestCase
 
 
 class WorkflowDelayedTest(WorkflowTasksTestCase):
@@ -36,7 +37,8 @@ class WorkflowDelayedTest(WorkflowTasksTestCase):
     def tearDown(self):
         """ Clean up created objects."""
         from invenio.modules.workflows.models import Workflow
-        Workflow.get(Workflow.module_name == "unit_tests").delete()
+        self.delete_objects(
+            Workflow.get(Workflow.module_name == "unit_tests").all())
         self.cleanup_registries()
 
     def test_workflow_delay(self):
@@ -95,7 +97,8 @@ class WorkflowDelayedTest(WorkflowTasksTestCase):
         """Deep test of celery worker."""
         from ..workers.worker_celery import (celery_run, celery_restart,
                                              celery_continue)
-        from invenio.modules.workflows.utils import BibWorkflowObjectIdContainer
+        from invenio.modules.workflows.utils import \
+            BibWorkflowObjectIdContainer
         from invenio.modules.workflows.models import (BibWorkflowObject,
                                                       get_default_extra_data)
 

--- a/invenio/modules/workflows/testsuite/test_workflows_model.py
+++ b/invenio/modules/workflows/testsuite/test_workflows_model.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2013, 2014, 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Unit tests for workflows models."""
+
+from __future__ import absolute_import
+
+from invenio.ext.sqlalchemy import db
+from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+
+
+class TestWorkflowModels(InvenioTestCase):
+
+    """Test meant for testing the models available."""
+
+    def setUp(self):
+        """Setup tests."""
+        from invenio.modules.workflows.models import BibWorkflowObject, \
+            Workflow
+        from uuid import uuid1 as new_uuid
+
+        self.workflow = Workflow(name='test_workflow', uuid=new_uuid(),
+                                 id_user=0, module_name="Unknown")
+        self.bibworkflowobject = BibWorkflowObject(workflow=self.workflow)
+
+        self.create_objects([self.workflow, self.bibworkflowobject])
+
+    def tearDown(self):
+        """Clean up tests."""
+        self.delete_objects([self.workflow, self.bibworkflowobject])
+
+    def test_deleting_workflow(self):
+        """Test deleting workflow."""
+        from invenio.modules.workflows.models import BibWorkflowObject, \
+            Workflow
+        bwo_id = self.bibworkflowobject.id
+
+        # delete workflow
+        Workflow.delete(self.workflow.uuid)
+
+        # assert bibworkflowobject is deleted
+        self.assertFalse(
+            db.session.query(
+                BibWorkflowObject.query.filter(
+                    BibWorkflowObject.id == bwo_id).exists()).scalar())
+
+    def test_deleting_bibworkflowobject(self):
+        """Test deleting workflowobject."""
+        from invenio.modules.workflows.models import Workflow
+        w_uuid = self.workflow.uuid
+
+        # delete bibworkflowobject
+        self.bibworkflowobject.delete(self.bibworkflowobject.id)
+
+        # assert workflow is not deleted
+        self.assertTrue(
+            db.session.query(
+                Workflow.query.filter(
+                    Workflow.uuid == w_uuid).exists()).scalar())
+
+
+TEST_SUITE = make_test_suite(TestWorkflowModels)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)

--- a/invenio/modules/workflows/testsuite/test_workflows_others.py
+++ b/invenio/modules/workflows/testsuite/test_workflows_others.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -21,6 +21,7 @@
 """ Test for workflow not fitting in other categories."""
 
 from invenio.testsuite import make_test_suite, run_test_suite
+
 from .test_workflows import WorkflowTasksTestCase
 
 
@@ -35,7 +36,8 @@ class WorkflowOthers(WorkflowTasksTestCase):
     def tearDown(self):
         """ Clean up created objects."""
         from invenio.modules.workflows.models import Workflow
-        Workflow.get(Workflow.module_name == "unit_tests").delete()
+        self.delete_objects(
+            Workflow.get(Workflow.module_name == "unit_tests").all())
         self.cleanup_registries()
 
     def test_result_abstraction(self):
@@ -67,7 +69,8 @@ class WorkflowOthers(WorkflowTasksTestCase):
             start("@thisisnotatrueworkflow@", ["my_false_data"],
                   random_kay_args="value")
         except Exception as e:
-            from invenio.modules.workflows.errors import WorkflowDefinitionError
+            from invenio.modules.workflows.errors import \
+                WorkflowDefinitionError
             self.assertTrue(isinstance(e, WorkflowDefinitionError))
 
     def test_workflows_exceptions(self):

--- a/invenio/modules/workflows/upgrades/workflows_2015_06_05_resize_uuid_columns.py
+++ b/invenio/modules/workflows/upgrades/workflows_2015_06_05_resize_uuid_columns.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Upgrade recipe."""
+
+from invenio.ext.sqlalchemy import db
+from invenio.modules.upgrader.api import op
+
+depends_on = [u'workflows_2014_08_12_initial']
+
+
+def info():
+    """Info message."""
+    return "Resize uuid columns on workflows tables."
+
+
+def do_upgrade():
+    """Implement your upgrades here."""
+    with op.batch_alter_table("bwlWORKFLOW") as batch_op:
+        batch_op.alter_column(
+            column_name='uuid',
+            type_=db.UUID(), nullable=False
+        )
+    with op.batch_alter_table("bwlOBJECT") as batch_op:
+        batch_op.alter_column(
+            column_name='id_workflow',
+            type_=db.UUID(), nullable=True
+        )
+    with op.batch_alter_table("bwlWORKFLOWLOGGING") as batch_op:
+        batch_op.alter_column(
+            column_name='id_object',
+            type_=db.UUID(), nullable=False
+        )
+
+
+def estimate():
+    """Estimate running time of upgrade in seconds (optional)."""
+    return 1
+
+
+def pre_upgrade():
+    """Run pre-upgrade checks (optional)."""
+    pass
+
+
+def post_upgrade():
+    """Run post-upgrade checks (optional)."""
+    pass


### PR DESCRIPTION
* Fixes UUID usage on bwlWORKFLOW, bwlWORKFLOWLOGGING tables.
  (closes #3217)

* Defines a delete cascade action for BibWorkflowObject and
  BibWorkflowObjectLog if you delete a Workflow.

* Fixes testsuite to properly clean the database after ending.
  (closes #3147)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>