### PR TITLE
tags: fix PostgreSQL compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,3 @@ invenio/base/translations/*/LC_MESSAGES/messages.mo
 missing
 node_modules/
 org.eclipse.core.resources.prefs
-tags

--- a/invenio/modules/tags/api.py
+++ b/invenio/modules/tags/api.py
@@ -21,10 +21,13 @@
 """API for the tags."""
 
 from flask_login import current_user
-from sqlalchemy.exc import DBAPIError
+
 from invenio.ext.sqlalchemy import db
 from invenio.modules.accounts.models import Usergroup
-import invenio.modules.tags.errors as tags_errors
+from invenio.modules.tags import errors as tags_errors
+
+from sqlalchemy.exc import DBAPIError
+
 from .models import WtgTAG, WtgTAGRecord
 
 
@@ -146,7 +149,7 @@ def update_tag_of_user(uid, tag_name, dictionary_to_update):
         raise tags_errors.TagOwnerError(
             "The tag's owner id does not match the given id")
     # initialize variables to default values
-    usergroup_id = 0
+    usergroup_id = None
     group_rights = WtgTAG.ACCESS_LEVELS['View']
     show_in_description = True
     # get the values that user uploaded

--- a/invenio/modules/tags/models.py
+++ b/invenio/modules/tags/models.py
@@ -132,8 +132,7 @@ class WtgTAG(db.Model, Serializable):
 
     # Owner
     id_user = db.Column(db.Integer(15, unsigned=True),
-                        db.ForeignKey(User.id),
-                        server_default='0')
+                        db.ForeignKey(User.id), nullable=True)
 
     # Access rights of owner
     user_access_rights = db.Column(db.Integer(2, unsigned=True),
@@ -141,11 +140,11 @@ class WtgTAG(db.Model, Serializable):
                                    default=ACCESS_OWNER_DEFAULT)
 
     # Group
-    # equal to 0 for private tags
+    # equal to NULL for private tags
     id_usergroup = db.Column(
         db.Integer(15, unsigned=True),
         db.ForeignKey(Usergroup.id),
-        server_default='0')
+        nullable=True)
 
     # Group access rights
     group_access_rights = db.Column(

--- a/invenio/modules/tags/testsuite/test_tags_restful.py
+++ b/invenio/modules/tags/testsuite/test_tags_restful.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -20,13 +20,15 @@
 """Test tags REST API."""
 
 from __future__ import print_function
+
 from collections import OrderedDict
+
 from datetime import datetime
-from dateutil.tz import tzutc
+
 from invenio.base.wrappers import lazy_import
-from invenio.testsuite import make_test_suite, run_test_suite
-from invenio.ext.restful.utils import APITestCase
 from invenio.ext.restful import validation_errors
+from invenio.ext.restful.utils import APITestCase
+from invenio.testsuite import make_test_suite, run_test_suite
 
 
 db = lazy_import('invenio.ext.sqlalchemy.db')
@@ -40,7 +42,8 @@ class TestTagsRestfulAPI(APITestCase):
         """Run before each test."""
         from invenio.modules.accounts.models import User
 
-        self.user_a = User(email='user_a@example.com', nickname='user_a')
+        self.user_a = User(email='tag_user_a@example.com',
+                           nickname='tag_user_a')
         self.user_a.password = "iamusera"
 
         try:
@@ -53,13 +56,8 @@ class TestTagsRestfulAPI(APITestCase):
 
     def tearDown(self):
         """Run after every test."""
-        from invenio.modules.accounts.models import User
-
         self.remove_oauth_token()
-        User.query.filter(User.nickname.in_([
-            self.user_a.nickname,
-        ])).delete(synchronize_session=False)
-        db.session.commit()
+        self.delete_objects([self.user_a])
 
     def test_405_methods_tagslistresource(self):
         """Test methods that return 405."""
@@ -122,7 +120,7 @@ class TestTagsRestfulAPI(APITestCase):
         ordered_json_answer = OrderedDict(
             sorted(answer.json.items(), key=lambda t: t[0])
         )
-        #query the created tag
+        # query the created tag
         retrieved_tag = WtgTAG.query.filter(
             WtgTAG.name == data[data.keys()[0]]).first()
         expected_result = dict(
@@ -222,8 +220,8 @@ class TestTagsRestfulAPI(APITestCase):
                     code=validation_errors['INCORRECT_TYPE']['error_code'],
                     message=(
                         validation_errors['INCORRECT_TYPE']['error_mesg'] +
-                        ": " + "'" + ordered_to_update.keys()[1] + "' "
-                        + "must be of boolean type"
+                        ": " + "'" + ordered_to_update.keys()[1] + "' " +
+                        "must be of boolean type"
                     ),
                     field=ordered_to_update.keys()[1],
                 ),
@@ -232,8 +230,8 @@ class TestTagsRestfulAPI(APITestCase):
                           ['error_code']),
                     message=(
                         validation_errors['VALUE_OUT_OF_BOUNDS']
-                        ['error_mesg'] + " : " + "unallowed value "
-                        + str(ordered_to_update[ordered_to_update.keys()[0]])
+                        ['error_mesg'] + " : " + "unallowed value " +
+                        str(ordered_to_update[ordered_to_update.keys()[0]])
                     ),
                     field=ordered_to_update.keys()[0],
                 )
@@ -501,7 +499,7 @@ class TestTagsRestfulAPI(APITestCase):
                 sorted(tag_representation.items(), key=lambda t: t[0])
             )
             ordered_created_tags.append(ordered_tag_repr)
-        #now query DB
+        # now query DB
         get_answer = self.get(
             'recordlisttagresource',
             user_id=self.user_a.id,

--- a/invenio/modules/tags/upgrades/tags_2015_06_05_id_usergroup_nullable_on_tags.py
+++ b/invenio/modules/tags/upgrades/tags_2015_06_05_id_usergroup_nullable_on_tags.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Upgrade recipe."""
+
+from invenio.ext.sqlalchemy import db
+from invenio.modules.upgrader.api import op
+
+
+depends_on = [u'tags_2014_08_22_initial']
+
+
+def info():
+    """Info message."""
+    return "Set id_usergroup nullable on table wtgTAG."
+
+
+def do_upgrade():
+    """Implement your upgrades here."""
+    with op.batch_alter_table("wtgTAG") as batch_op:
+        batch_op.alter_column(
+            column_name='id_usergroup',
+            type_=db.Integer(15, unsigned=True),
+            nullable=True
+        )
+        batch_op.alter_column(
+            column_name='id_user',
+            type_=db.Integer(15, unsigned=True),
+            nullable=True
+        )
+
+
+def estimate():
+    """Estimate running time of upgrade in seconds (optional)."""
+    return 1
+
+
+def pre_upgrade():
+    """Run pre-upgrade checks (optional)."""
+    pass
+
+
+def post_upgrade():
+    """Run post-upgrade checks (optional)."""
+    pass


### PR DESCRIPTION
* Removes default value and sets nullable on usergroup id and user id
  column on tag table. (addresses #3218) (closes #3246)

* Fixes testsuite to properly clean the database after ending.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>