### PR TITLE
accounts: localized site name for user email

### DIFF
--- a/invenio/modules/accounts/forms.py
+++ b/invenio/modules/accounts/forms.py
@@ -87,7 +87,7 @@ def repeat_email_validator(form, field):
         raise StopValidation()
 
     if field.data != form.email.data:
-        raise ValidationError(_("Email addresses does not match."))
+        raise ValidationError(_("Email addresses do not match."))
 
 
 def password_validator(form, field):

--- a/invenio/modules/accounts/helpers.py
+++ b/invenio/modules/accounts/helpers.py
@@ -21,7 +21,7 @@
 
 from datetime import timedelta
 
-from flask import render_template, url_for
+from flask import g, render_template, url_for
 
 from invenio.base.globals import cfg
 from invenio.base.i18n import _
@@ -59,6 +59,8 @@ def send_account_activation_email(user):
         cfg.get('CFG_SITE_SUPPORT_EMAIL'),
         user.email,
         _("Account registration at %(sitename)s",
-          sitename=cfg['CFG_SITE_NAME']),
+          sitename=cfg["CFG_SITE_NAME_INTL"].get(getattr(g, 'ln',
+                                                 cfg['CFG_SITE_LANG']),
+                                                 cfg['CFG_SITE_NAME'])),
         render_template("accounts/emails/activation.tpl", **ctx)
     )


### PR DESCRIPTION
* BETTER When contacting users, use the localized site name.
  (addresses #3273)