### PR TITLE
accounts: fix typo in `repeat_email_validator`

### DIFF
--- a/invenio/modules/accounts/forms.py
+++ b/invenio/modules/accounts/forms.py
@@ -87,7 +87,7 @@ def repeat_email_validator(form, field):
         raise StopValidation()
 
     if field.data != form.email.data:
-        raise ValidationError(_("Email addresses does not match."))
+        raise ValidationError(_("Email addresses do not match."))
 
 
 def password_validator(form, field):


### PR DESCRIPTION
Signed-off-by: Ioannis Tsanaktsidis <ioannis.tsanaktsidis@cern.ch>