### PR TITLE
legacy: oaiharvest resumptionToken fix

### DIFF
--- a/invenio/legacy/oaiharvest/getter.py
+++ b/invenio/legacy/oaiharvest/getter.py
@@ -122,9 +122,9 @@ def OAI_Session(server, script, http_param_dict , method="POST", output="",
 
         # FIXME We should NOT use regular expressions to parse XML. This works
         # for the time being to escape namespaces.
-        rt_obj = re.search('<.*resumptionToken.*>(.+)</.*resumptionToken.*>',
+        rt_obj = re.search('<.*resumptionToken.*>(.*)</.*resumptionToken.*>',
             harvested_data, re.DOTALL)
-        if rt_obj is not None and rt_obj != "":
+        if rt_obj is not None and rt_obj.group(1) != "":
             http_param_dict = http_param_resume(http_param_dict, rt_obj.group(1))
             i = i + 1
         else:


### PR DESCRIPTION
* FIX Fixes the parsing of resumptiontoken in incoming OAI-PMH XML
  which could fail when the resumptiontoken was empty.

This issue was observed with arXiv harvesting at least where resumptiontoken are received in the following way:

`<resumptionToken cursor="1000" completeListSize="2092">866116|2001</resumptionToken>`

and when reaching the last "page":
`<resumptionToken cursor="2000" completeListSize="2092"></resumptionToken>`

This is the master PR, there is also one upcoming for legacy.

@aw-bib 