### PR TITLE
deposit: maximum files count per upload

### DIFF
--- a/invenio/modules/deposit/config.py
+++ b/invenio/modules/deposit/config.py
@@ -61,3 +61,6 @@ DEPOSIT_MAX_UPLOAD_SIZE = 104857600
 
 DEPOSIT_DROPBOX_API_KEY = None
 """API key DropBox Saver widget."""
+
+DEPOSIT_MAX_UPLOAD_FILES_COUNT = 100
+"""Maximum files count."""

--- a/invenio/modules/deposit/static/js/deposit/uploader/uploaders/dropboxuploader.js
+++ b/invenio/modules/deposit/static/js/deposit/uploader/uploaders/dropboxuploader.js
@@ -1,6 +1,6 @@
 /*
  * This file is part of Invenio.
- * Copyright (C) 2014 CERN.
+ * Copyright (C) 2014, 2015 CERN.
  *
  * Invenio is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -29,6 +29,7 @@ define(function(require) {
 
         this.attributes({
             dropbox_url: "http://httpbin.org/post",
+            max_files_count: null,
             preupload_hooks: {}
         });
 
@@ -40,6 +41,15 @@ define(function(require) {
         var options = {
 
             success: function(files) {
+                if (self.attr.max_files_count && (Object.keys(dropboxFiles).length + files.length > self.attr.max_files_count)) {
+                    var maxFilesToAdd = self.attr.max_files_count - Object.keys(dropboxFiles).length;
+                    while (files.length > maxFilesToAdd) {
+                        files.pop();
+                    }
+                    self.trigger('uploaderError', {
+                        message: "Max files count exceeded."
+                    });
+                }
                 var newFiles = {};
                 files.forEach(function(file) {
                     if (dropboxFiles[file.name] === undefined) {

--- a/invenio/modules/deposit/static/js/deposit/uploader/uploaders/pluploader.js
+++ b/invenio/modules/deposit/static/js/deposit/uploader/uploaders/pluploader.js
@@ -31,6 +31,7 @@ define(function(require) {
             url: "http://httpbin.org/post",
             drop_element: null,
             max_file_size: null,
+            max_files_count: null,
             preupload_hooks: {},
             filters: {prevent_duplicates: true}
         });
@@ -79,6 +80,13 @@ define(function(require) {
              */
 
             PlUploader.bind('FilesAdded', function(up, files) {
+                if (that.attr.max_files_count && (up.files.length > that.attr.max_files_count)) {
+                    up.removeFile(files[files.length-1]);
+                    files.pop();
+                    that.trigger('uploaderError', {
+                        message: "Max files count exceeded."
+                    });
+                }
                 files = $.map(files, function(file) {
                     return {
                         id: file.id,

--- a/invenio/modules/deposit/templates/deposit/run_base.html
+++ b/invenio/modules/deposit/templates/deposit/run_base.html
@@ -137,11 +137,13 @@
           pluploader: {
             url: '{{ url_for('.upload_file', deposition_type=deposition_type, uuid=uuid) }}',
             max_file_size: '{{config.DEPOSIT_MAX_UPLOAD_SIZE|default('10mb')}}',
+            max_files_count: {{config.DEPOSIT_MAX_UPLOAD_FILES_COUNT|default('null')}},
             drop_element: $('#field-plupload_file')[0]
           }{% if config.DEPOSIT_DROPBOX_API_KEY %},
 
           dropboxuploader: {
-            dropbox_url: '{{ url_for('.upload_url', deposition_type=deposition_type, uuid=uuid) }}'
+            dropbox_url: '{{ url_for('.upload_url', deposition_type=deposition_type, uuid=uuid) }}',
+            max_files_count: {{config.DEPOSIT_MAX_UPLOAD_FILES_COUNT|default('null')}}
           }{% endif %}
         };
 


### PR DESCRIPTION
* NEW Adds configuration variable `DEPOSIT_MAX_UPLOAD_FILES_COUNT`
  (specified in deposit module config file), which gives one
  a possibility to limit number of files per upload.

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>