### PR TITLE
global: `run_py_func` list argv

### DIFF
--- a/invenio/base/utils.py
+++ b/invenio/base/utils.py
@@ -300,7 +300,7 @@ def run_py_func(manager_run, command_line, passthrough=False):
         else:
             sys.argv = shlex.split(command_line)
     else:
-        sys.argv = command_line
+        sys.argv = list(command_line)  # argv should be mutable
 
     exit_code = None
     try:


### PR DESCRIPTION
* Have `run_py_func` always set `sys.argv` to a list, as some
  applications may want to manipulate it.

Signed-off-by: Dimitrios Semitsoglou-Tsiapos <dsemitso@cern.ch>