### PR TITLE
installation: allow only valid names for database

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -460,8 +460,8 @@ the following commands.
 
     (invenio)$ inveniomanage config set CFG_EMAIL_BACKEND flask_email.backends.console.Mail
     (invenio)$ inveniomanage config set CFG_BIBSCHED_PROCESS_USER $USER
-    (invenio)$ inveniomanage config set CFG_DATABASE_NAME $BRANCH
-    (invenio)$ inveniomanage config set CFG_DATABASE_USER $BRANCH
+    (invenio)$ inveniomanage config set CFG_DATABASE_NAME `echo $BRANCH | sed -e 's/[^A-Za-z0-9]//g'`
+    (invenio)$ inveniomanage config set CFG_DATABASE_USER `echo $BRANCH | sed -e 's/[^A-Za-z0-9]//g'`
     (invenio)$ inveniomanage config set CFG_SITE_URL http://localhost:4000
     (invenio)$ inveniomanage config set CFG_SITE_SECURE_URL http://localhost:4000
 


### PR DESCRIPTION
INSTALL.rst used $BRANCH for the database name which might end up to be invalid e.g. for maint-2.1 like branches. Remove all non characters and numbers from the name so it will read maint21 in this example.

Closes #3303