### PR TITLE
deposit: datetimepicker version bump

### DIFF
--- a/invenio/modules/deposit/bundles.py
+++ b/invenio/modules/deposit/bundles.py
@@ -35,7 +35,7 @@ js = Bundle(
         "plupload": "latest",
         "ckeditor": "latest",
         "flight": "latest",
-        "eonasdan-bootstrap-datetimepicker": "3.1.3",
+        "eonasdan-bootstrap-datetimepicker": "4.14.30",
     }
 )
 

--- a/invenio/modules/deposit/static/js/deposit/form.js
+++ b/invenio/modules/deposit/static/js/deposit/form.js
@@ -57,7 +57,6 @@ define(function(require, exports, module) {
         autocomplete_url: "",
         datepicker_options: {
           format: "YYYY-MM-DD",
-          pickTime: false,
         },
 
         // Selectors

--- a/invenio/modules/deposit/templates/deposit/run_base.html
+++ b/invenio/modules/deposit/templates/deposit/run_base.html
@@ -118,7 +118,6 @@
             datepicker_element: '.datepicker',
             datepicker_options: {
                 format: "YYYY-MM-DD",
-                pickTime: false
             }
           },
 


### PR DESCRIPTION
* Updates eonasdan-bootstrap-datetimepicker to 4.14.30

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>