### PR TITLE
access: fix cookie creation with PostgreSQL

### DIFF
--- a/invenio/ext/sqlalchemy/types/legacyinteger.py
+++ b/invenio/ext/sqlalchemy/types/legacyinteger.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2011, 2012, 2013, 2014 CERN.
+# Copyright (C) 2011, 2012, 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,8 +19,8 @@
 
 """Platform-independent Integer type."""
 
-from sqlalchemy.types import TypeDecorator, Integer
 from sqlalchemy.dialects.mysql import INTEGER
+from sqlalchemy.types import Integer, TypeDecorator
 
 
 class LegacyInteger(TypeDecorator):
@@ -46,3 +46,7 @@ class LegacyInteger(TypeDecorator):
                                                    unsigned=self.unsigned))
         else:
             return dialect.type_descriptor(Integer)
+
+    def process_result_value(self, value, dialect):
+        """Cast to long python variable."""
+        return long(value)

--- a/invenio/modules/access/testsuite/test_cookie.py
+++ b/invenio/modules/access/testsuite/test_cookie.py
@@ -37,7 +37,7 @@ class TestAccMailCookie(InvenioTestCase):
 
     def tearDown(self):
         """Tear down."""
-        self.delete_objects(self.data)
+        pass
 
     def test_mail_cookie(self):
         """Test mail cookie creation."""
@@ -51,6 +51,25 @@ class TestAccMailCookie(InvenioTestCase):
         self.assertEqual(ret.data[0], 'mail_activation')
 
         self.data = [ret]
+
+        self.delete_objects(self.data)
+
+    def test_cookie_record_id_is_long(self):
+        """Test if cookie id is a long."""
+        from invenio.modules.access.models import AccMAILCOOKIE
+
+        cookie = AccMAILCOOKIE(
+            kind='mail_activation',
+            onetime=0,
+            _data="test",
+            status="W"
+        )
+        self.create_objects([cookie])
+        load_cookie = AccMAILCOOKIE.query.get(cookie.id)
+
+        assert isinstance(load_cookie.id, long)
+
+        self.delete_objects([cookie])
 
 
 TEST_SUITE = make_test_suite(TestAccMailCookie)


### PR DESCRIPTION
* Fixes cookie creation with PostgreSQL. (closes #3318)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>