### PR TITLE
search: response recids fix

### DIFF
--- a/invenio/modules/search/api.py
+++ b/invenio/modules/search/api.py
@@ -95,7 +95,7 @@ class Results(object):
             body={
                 'size': 9999999,
                 'fields': ['control_number'],
-                'query': self.query
+                'query': self.body.get("query")
             }
         )
         return intbitset([int(r['_id']) for r in results['hits']['hits']])


### PR DESCRIPTION
* Fixes an exception when calling `Results.recids`. (closes #3335)

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>