### PR TITLE
global: InnoDB for MySQL

### DIFF
--- a/invenio/ext/sqlalchemy/__init__.py
+++ b/invenio/ext/sqlalchemy/__init__.py
@@ -140,22 +140,22 @@ class SQLAlchemy(FlaskSQLAlchemy):
         engine = app.config.get('CFG_DATABASE_TYPE', 'mysql')
         self.Model = get_model_type(self.Model)
         if engine == 'mysql':
-            # Override MySQL parameters to force MyISAM engine
+            # Override MySQL parameters to force InnoDB engine
             mysql_parameters = {'keep_existing': True,
                                 'extend_existing': False,
-                                'mysql_engine': 'MyISAM',
+                                'mysql_engine': 'InnoDB',
                                 'mysql_charset': 'utf8',
                                 'sql_mode': 'ansi_quotes'}
 
             original_table = self.Table
 
-            def table_with_myisam(*args, **kwargs):
+            def table_with_innodb(*args, **kwargs):
                 """Use same MySQL parameters that are used for ORM models."""
                 new_kwargs = dict(mysql_parameters)
                 new_kwargs.update(kwargs)
                 return original_table(*args, **new_kwargs)
 
-            self.Table = table_with_myisam
+            self.Table = table_with_innodb
             self.Model.__table_args__ = mysql_parameters
 
         _include_sqlalchemy(self, engine=engine)

--- a/invenio/modules/access/control.py
+++ b/invenio/modules/access/control.py
@@ -356,7 +356,7 @@ def acc_update_role(id_role=0, name_role='', dummy=0, description='',
 
 # CONNECTIONS BETWEEN USER AND ROLE
 
-def acc_add_user_role(id_user=0, id_role=0, email='', name_role='',
+def acc_add_user_role(id_user=None, id_role=None, email='', name_role='',
                       expiration='9999-12-31 23:59:59'):
     """Add a new entry to table user_accROLE and returns it.
 
@@ -369,11 +369,11 @@ def acc_add_user_role(id_user=0, id_role=0, email='', name_role='',
     id_role = id_role or acc_get_role_id(name_role=name_role)
 
     # check if the id_role exists
-    if id_role and not acc_get_role_name(id_role=id_role):
+    if not id_role or (id_role and not acc_get_role_name(id_role=id_role)):
         return 0
 
     # check that the user actually exist
-    if not acc_get_user_email(id_user=id_user):
+    if not id_user or (id_user and not acc_get_user_email(id_user=id_user)):
         return 0
 
     # control if existing entry

--- a/invenio/modules/collections/models.py
+++ b/invenio/modules/collections/models.py
@@ -716,7 +716,7 @@ class FacetCollection(db.Model):
     __tablename__ = 'facet_collection'
 
     id = db.Column(db.Integer, primary_key=True)
-    id_collection = db.Column(db.Integer, db.ForeignKey(Collection.id))
+    id_collection = db.Column(db.MediumInteger(9, unsigned=True), db.ForeignKey(Collection.id))
     order = db.Column(db.Integer)
     facet_name = db.Column(db.String(80))
 

--- a/invenio/modules/collections/upgrades/collections_2015_07_14_innodb.py
+++ b/invenio/modules/collections/upgrades/collections_2015_07_14_innodb.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Fixes foreign key relationship."""
+
+from invenio.ext.sqlalchemy import db
+
+from invenio.modules.upgrader.api import op
+
+
+depends_on = ['invenio_2015_03_03_tag_value']
+
+
+def info():
+    """Return upgrade recipe information."""
+    return "Fixes foreign key relationship."
+
+
+def do_upgrade():
+    """Carry out the upgrade."""
+    op.alter_column(
+        table_name='facet_collection',
+        column_name='id_collection',
+        type_=db.MediumInteger(9, unsigned=True)
+    )
+
+
+def estimate():
+    """Estimate running time of upgrade in seconds (optional)."""
+    return 1
+
+
+def pre_upgrade():
+    """Pre-upgrade checks."""
+    pass
+
+
+def post_upgrade():
+    """Post-upgrade checks."""
+    pass

--- a/invenio/modules/knowledge/models.py
+++ b/invenio/modules/knowledge/models.py
@@ -285,7 +285,7 @@ class KnwKBRVAL(db.Model):
     m_value = db.Column(
         db.Text().with_variant(mysql.TEXT(30), 'mysql'),
         nullable=False)
-    id_knwKB = db.Column(db.MediumInteger(8), db.ForeignKey(KnwKB.id),
+    id_knwKB = db.Column(db.MediumInteger(8, unsigned=True), db.ForeignKey(KnwKB.id),
                          nullable=False, server_default='0',
                          primary_key=True)
     kb = db.relationship(

--- a/invenio/modules/knowledge/upgrades/knowledge_2015_07_14_innodb.py
+++ b/invenio/modules/knowledge/upgrades/knowledge_2015_07_14_innodb.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Fixes foreign key relationship."""
+
+from invenio.ext.sqlalchemy import db
+
+from invenio.modules.upgrader.api import op
+
+
+depends_on = ['invenio_2015_03_03_tag_value']
+
+
+def info():
+    """Return upgrade recipe information."""
+    return "Fixes foreign key relationship."
+
+
+def do_upgrade():
+    """Carry out the upgrade."""
+    op.alter_column(
+        table_name='knwKBRVAL',
+        column_name='id_knwKB',
+        type_=db.MediumInteger(8, unsigned=True),
+        existing_nullable=False,
+        existing_server_default='0'
+    )
+
+
+def estimate():
+    """Estimate running time of upgrade in seconds (optional)."""
+    return 1
+
+
+def pre_upgrade():
+    """Pre-upgrade checks."""
+    pass
+
+
+def post_upgrade():
+    """Post-upgrade checks."""
+    pass

--- a/invenio/modules/oaiharvester/models.py
+++ b/invenio/modules/oaiharvester/models.py
@@ -21,8 +21,10 @@
 
 from invenio.ext.sqlalchemy import db
 from invenio.ext.sqlalchemy.utils import session_manager
-from invenio_records.models import Record as Bibrec
+
 from invenio.modules.scheduler.models import SchTASK
+
+from invenio_records.models import Record as Bibrec
 
 
 def get_default_arguments():
@@ -100,7 +102,7 @@ class OaiHARVESTLOG(db.Model):
         db.MediumInteger(8, unsigned=True),
         db.ForeignKey(Bibrec.id), nullable=False, server_default='0'
     )
-    bibupload_task_id = db.Column(db.Integer(11), db.ForeignKey(SchTASK.id),
+    bibupload_task_id = db.Column(db.Integer(15, unsigned=True), db.ForeignKey(SchTASK.id),
                                   nullable=False, server_default='0',
                                   primary_key=True)
     oai_id = db.Column(db.String(40), nullable=False, server_default='',

--- a/invenio/modules/oaiharvester/upgrades/oaiharvester_2015_07_14_innodb.py
+++ b/invenio/modules/oaiharvester/upgrades/oaiharvester_2015_07_14_innodb.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Fixes foreign key relationship."""
+
+from invenio.ext.sqlalchemy import db
+
+from invenio.modules.upgrader.api import op
+
+
+depends_on = ['invenio_2015_03_03_tag_value']
+
+
+def info():
+    """Return upgrade recipe information."""
+    return "Fixes foreign key relationship."
+
+
+def do_upgrade():
+    """Carry out the upgrade."""
+    op.alter_column(
+        table_name='oaiHARVESTLOG',
+        column_name='bibupload_task_id',
+        type_=db.MediumInteger(15, unsigned=True),
+        existing_nullable=False,
+        existing_server_default='0'
+    )
+
+
+def estimate():
+    """Estimate running time of upgrade in seconds (optional)."""
+    return 1
+
+
+def pre_upgrade():
+    """Pre-upgrade checks."""
+    pass
+
+
+def post_upgrade():
+    """Post-upgrade checks."""
+    pass

--- a/invenio/modules/oauth2server/models.py
+++ b/invenio/modules/oauth2server/models.py
@@ -301,7 +301,7 @@ class Token(db.Model):
     """Object ID."""
 
     client_id = db.Column(
-        db.String(40), db.ForeignKey('oauth2CLIENT.client_id'),
+        db.String(255), db.ForeignKey('oauth2CLIENT.client_id'),
         nullable=False,
     )
     """Foreign key to client application."""
@@ -315,7 +315,7 @@ class Token(db.Model):
     """SQLAlchemy relationship to client application."""
 
     user_id = db.Column(
-        db.Integer, db.ForeignKey('user.id'), nullable=True
+        db.Integer(15, unsigned=True), db.ForeignKey('user.id'), nullable=True
     )
     """Foreign key to user."""
 

--- a/invenio/modules/oauth2server/upgrades/oauth2server_2015_07_14_innodb.py
+++ b/invenio/modules/oauth2server/upgrades/oauth2server_2015_07_14_innodb.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Fixes foreign key relationship."""
+
+from invenio.ext.sqlalchemy import db
+
+from invenio.modules.upgrader.api import op
+
+
+depends_on = ['invenio_2015_03_03_tag_value']
+
+
+def info():
+    """Return upgrade recipe information."""
+    return "Fixes foreign key relationship."
+
+
+def do_upgrade():
+    """Carry out the upgrade."""
+    op.alter_column(
+        table_name='oauth2TOKEN',
+        column_name='client_id',
+        type_=db.String(255),
+        existing_nullable=False
+    )
+    op.alter_column(
+        table_name='oauth2TOKEN',
+        column_name='user_id',
+        type_=db.Integer(15, unsigned=True),
+        existing_nullable=False
+    )
+
+
+def estimate():
+    """Estimate running time of upgrade in seconds (optional)."""
+    return 1
+
+
+def pre_upgrade():
+    """Pre-upgrade checks."""
+    pass
+
+
+def post_upgrade():
+    """Post-upgrade checks."""
+    pass

--- a/invenio/modules/upgrader/upgrades/invenio_2015_07_14_innodb.py
+++ b/invenio/modules/upgrader/upgrades/invenio_2015_07_14_innodb.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Upgrades MySQL database to InnoDB."""
+
+from invenio.legacy.dbquery import run_sql
+
+
+depends_on = [
+    'collections_2015_07_14_innodb',
+    'knowledge_2015_07_14_innodb',
+    'oaiharvester_2015_07_14_innodb',
+    'oauth2server_2015_07_14_innodb'
+]
+
+
+def info():
+    """Return upgrade recipe information."""
+    return "Upgrades MySQL database to InnoDB."
+
+
+def do_upgrade():
+    """Carry out the upgrade."""
+    from flask import current_app
+    if current_app.config.get('CFG_DATABASE_TYPE') == 'mysql':
+        run_sql(
+            "SELECT CONCAT('ALTER TABLE ',TABLE_NAME,' ENGINE=InnoDB;')"
+            " FROM INFORMATION_SCHEMA.TABLES"
+            " WHERE ENGINE='MyISAM'"
+            " AND table_schema = %s",
+            (current_app.config.get('CFG_DATABASE_NAME'),)
+        )
+
+
+def estimate():
+    """Estimate running time of upgrade in seconds (optional)."""
+    return 1
+
+
+def pre_upgrade():
+    """Pre-upgrade checks."""
+    pass
+
+
+def post_upgrade():
+    """Post-upgrade checks."""
+    pass


### PR DESCRIPTION
* INCOMPATIBLE Sets default MySQL storage engine to `InnoDB` (was
  `MyISAM`).

* Fixes models that have invalid foreign key types (affects
  collections, knowledge, oaiharvester, oauth2server).

* Fixes bug in access rule creation, caused by the fact that Python
  evaluates `0` to `False`.

Signed-off-by: Marco Neumann <marco@crepererum.net>