### PR TITLE
elasticsearch: disable multicast

### DIFF
--- a/elasticsearch-docker.yml
+++ b/elasticsearch-docker.yml
@@ -16,5 +16,6 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 cluster.name: invenio
+discovery.zen.ping.multicast.enabled: false
 http.port: 9200
 http.publish_port: 9200

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -318,7 +318,7 @@ network.host: 127.0.0.1
 #
 # 1. Disable multicast discovery (enabled by default):
 #
-#discovery.zen.ping.multicast.enabled: false
+discovery.zen.ping.multicast.enabled: false
 #
 # 2. Configure an initial list of master nodes in the cluster
 #    to perform discovery when new nodes (master or data) are started:


### PR DESCRIPTION
See [the official documentation](https://www.elastic.co/guide/en/elasticsearch/guide/current/_important_configuration_changes.html#_prefer_unicast_over_multicast) for more information on what this setting does.

We were having some troubles with records that were going missing or being added after seemingly random amounts of time. We discovered that our instances of elasticsearch were being joined into a single cluster by this feature, and we were creating and deleting records ourselves.