### PR TITLE
deposit: fixes for JSON-based records

### DIFF
--- a/invenio/modules/deposit/helpers.py
+++ b/invenio/modules/deposit/helpers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -80,14 +80,14 @@ def deposition_record(record, form_classes, pre_process_load=None,
     )
 
 
-def make_record(values, is_dump=True):
+def make_record(values, is_dump=None):
     """
     Export recjson from drafts
     """
-    if is_dump:
-        record = Record(json=values, master_format='marc')
-    else:
-        record = Record(master_format='marc')
-        for k, v in six.iteritems(values):
-            record[k] = v
-    return record
+    if is_dump is not None:
+        import warnings
+        warnings.warn(
+            "Usage of `is_dump` parameter is deprecated and has no effect.",
+            category=UserWarning
+        )
+    return Record(data=values)

--- a/invenio/modules/deposit/templates/deposit/completed_base.html
+++ b/invenio/modules/deposit/templates/deposit/completed_base.html
@@ -46,7 +46,7 @@
              x_contact='<a href="mailto:{email}">{email}</a>'.format(email=config.CFG_SITE_SUPPORT_EMAIL)|safe) }}
     </small>
     <hr />
-    {{format_record(recID=sip.metadata['recid'], xml_record=sip.package, of='hd')|safe}}
+    {{format_record(sip.metadata, of='hd')|safe}}
 
     </div>
     <div class="col-md-4">

--- a/invenio/modules/deposit/types/simplerecord.py
+++ b/invenio/modules/deposit/types/simplerecord.py
@@ -25,8 +25,8 @@ from invenio.modules.formatter import format_record
 from invenio.modules.deposit.tasks import render_form, \
     create_recid, \
     prepare_sip, \
-    finalize_record_sip, \
-    upload_record_sip, \
+    dump_record_sip, \
+    store_record, \
     prefill_draft, \
     process_sip_metadata, \
     hold_for_approval
@@ -44,18 +44,18 @@ class SimpleRecordDeposition(DepositionType):
         # Create the submission information package by merging form data
         # from all drafts (in this case only one draft exists).
         prepare_sip(),
+        # Dump unmodified SIP
+        dump_record_sip(),
         # Process metadata to match your JSONAlchemy record model. This will
         # call process_sip_metadata() on your subclass.
         process_sip_metadata(),
         # Reserve a new record id, so that we can provide proper feedback to
         # user before the record has been uploaded.
         create_recid(),
-        # Generate MARC based on metadata dictionary.
-        finalize_record_sip(is_dump=False),
         # Hold the deposition for admin approval
         hold_for_approval(),
-        # Seal the SIP and write MARCXML file and call bibupload on it
-        upload_record_sip(),
+        # Finally create the record
+        store_record(),
     ]
 
     hold_for_upload = False

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -17,3 +17,4 @@
 -e git+git://github.com/inveniosoftware/flask-registry.git#egg=flask-registry
 -e git+git://github.com/inveniosoftware/flask-iiif.git#egg=flask-iiif
 -e git+git://github.com/inveniosoftware/invenio-query-parser.git#egg=invenio-query-parser
+-e git+git://github.com/inveniosoftware/invenio-records.git#egg=invenio-records


### PR DESCRIPTION
* Adds invenio-records the devel requirements.

* INCOMPATIBLE Reworks the default (i.e. example/simple) workflow for
  deposit. SIPs are now sealed and dumped after we collected all form
  data and before make ANY further modification to the deposit. This
  also holds for adding the default collection information to the
  deposit. Further analysis and work is required to make this process
  standard compliant (e.g. splitting SIP, DIP, ...). Dumped SIPs are
  now in JSON (was XML).

Signed-off-by: Marco Neumann <marco@crepererum.net>

NOTE: This is currently only working when using the devel (i.e. unreleased) version of invenio-records. Keep this in mind when building Docker images for interactive testing. (reminder: there is an ENV-flag to control the dependency installation similar to our Travis setup). 