### PR TITLE
travis: speed up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ services:
   - mongodb
   - elasticsearch
 
+sudo: false
+
 language: python
 
 cache:
@@ -42,9 +44,16 @@ python:
 #  - "2.6"
   - "2.7"
 
+addons:
+  apt:
+    packages:
+      - apache2
+      - git
+      - liblzma-dev
+      - nodejs
+      - poppler-utils
+
 before_install:
-  - "sudo add-apt-repository -y ppa:chris-lea/node.js"
-  - "sudo apt-get update"
   - "travis_retry pip install --upgrade pip"
   - "travis_retry pip install mock"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
@@ -52,35 +61,21 @@ before_install:
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
 
 install:
-  - "sudo apt-get -qy install apache2 libapache2-mod-wsgi libapache2-mod-xsendfile ssl-cert poppler-utils git subversion nodejs --fix-missing"
-  - "sudo a2enmod actions"
-  - "sudo a2enmod version || echo ':('"
-  - "sudo a2enmod rewrite"
-  - "sudo mkdir /etc/apache2/ssl"
-  - "sudo /usr/sbin/make-ssl-cert generate-default-snakeoil /etc/apache2/ssl/apache.pem"
   - "travis_retry pip install unittest2"
-  - "travis_retry pip install invenio_records"
-  - "travis_retry pip install -r .travis-$REQUIREMENTS-requirements.txt --allow-all-external --quiet"
-  - "travis_retry pip install -e .[$REXTRAS] --quiet --process-dependency-links"
+  - "travis_retry pip install -r .travis-$REQUIREMENTS-requirements.txt --allow-all-external"
+  - "travis_retry pip install -e .[$REXTRAS] --process-dependency-links"
   - "python setup.py compile_catalog"
-  - "sudo su -c \"npm update\""
-  - "sudo su -c \"npm install --silent -g bower less clean-css uglify-js requirejs\""
+  - "npm update"
+  - "npm install --silent -g bower less clean-css uglify-js requirejs"
   # All the step below this points are solely for test purposes, don't use them
   # to setup your invenio installation. Please do RTFM instead (INSTALL.rst).
   - "./scripts/setup_devmode.sh"
 
 before_script:
   - "inveniomanage apache create-config"
-  - "sudo ln -s $VIRTUAL_ENV/var/invenio.base-instance/apache/invenio-apache-vhost.conf /etc/apache2/sites-enabled/invenio.conf"
-  - "sudo ln -s $VIRTUAL_ENV/var/invenio.base-instance/apache/invenio-apache-vhost-ssl.conf /etc/apache2/sites-enabled/invenio-ssl.conf"
-  - "sudo /usr/sbin/a2dissite *default* || echo ':('"
-  - "sudo /usr/sbin/a2enmod ssl" # enable SSL module
-  - "sudo apachectl configtest && sudo service apache2 restart || echo 'Apache failed ...'"
   - "inveniomanage database init --yes-i-know || echo ':('"
   - "inveniomanage database create --quiet || echo ':('"
-#  - "inveniomanage demosite populate --yes-i-know"
 
 script:
   - "sphinx-build -qnNW docs docs/_build/html"
   - "python setup.py test"
-#  - "wget -O /dev/null http://localhost"


### PR DESCRIPTION
* Redesigns .travis.yml to use the new container-based infrastructure.
  This lowers the waiting time for the queue, gives us the ability to
  use caches for apt and pip and improves testing time down to ~15min.
  We are not allowed too use `sudo` any more but we should need it,
  because Apache is not tested anyway.

Signed-off-by: Marco Neumann <marco@crepererum.net>