### PR TITLE
oauthclient: orcid login default nickname

### DIFF
--- a/invenio/modules/oauthclient/contrib/orcid.py
+++ b/invenio/modules/oauthclient/contrib/orcid.py
@@ -121,8 +121,12 @@ REMOTE_SANDBOX_APP['params'].update(dict(
 
 def account_info(remote, resp):
     """Retrieve remote account information used to find local user."""
-    account_info = dict(external_id=resp.get("orcid"), external_method="orcid")
-    return account_info
+    orcid = resp.get("orcid")
+    return dict(
+        external_id=orcid,
+        external_method="orcid",
+        nickname=orcid,
+    )
 
 
 def disconnect_handler(remote, *args, **kwargs):


### PR DESCRIPTION
* BETTER Adds ORCID id as default nickname when a user first logs in
  through ORCID. (addresses #3272)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>