### PR TITLE
global: maximum oauthlib requirement

### DIFF
--- a/invenio/modules/knowledge/testsuite/test_knowledge_restful.py
+++ b/invenio/modules/knowledge/testsuite/test_knowledge_restful.py
@@ -172,13 +172,7 @@ class TestKnowledgeRestfulAPI(APITestCase):
             user_id=1,
         )
 
-        answer = get_answer.json
-
-        expected_result = dict(
-            status=404,
-        )
-
-        assert answer['status'] == expected_result['status']
+        assert get_answer.status_code == 404
 
     def test_get_knwkb_mappings(self):
         """Test the return of list of mappings."""

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,9 @@ install_requires = [
     "MySQL-python>=1.2.5",
     "numpy>=1.7",
     "nydus>=0.10.8",
+    # FIXME new oauthlib release after 0.7.2 has some compatible problems with
+    # the used Flask-Oauthlib version.
+    "oauthlib==0.7.2",
     "passlib>=1.6.2",
     # pyparsing>=2.0.2 has a new api and is not compatible yet
     "pyparsing>=2.0.1,<2.0.2",


### PR DESCRIPTION
* Fixes a maximum version requirement for oauthlib. (closes #3379)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>