### PR TITLE
global: on pip installed via brew no sudo required

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -169,9 +169,9 @@ Now, it is time to start installing the prerequisites.
 
 .. code-block:: console
 
-    $ brew install python --framework -- universal
-    $ sudo pip install virtualenv
-    $ sudo pip install virtualenvwrapper
+    $ brew install python --framework --universal
+    $ pip install virtualenv
+    $ pip install virtualenvwrapper
     # edit the Bash profile
     $ $EDITOR ~/.bash_profile
 


### PR DESCRIPTION
* Removes `sudo` from `pip` command because brew directories belong to the user, so no `sudo` is required to execute any command that writes to them (such as `pip` for example).

* Removes the extra space from the `-- universal` argument in line 172.

Also please consider removing the `--framework` argument in line 172, as it seems that is no longer included in the python formula options (so it's just ignored by brew).