### PR TITLE
docs: --process-dependency-links removal

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -382,7 +382,7 @@ Installing Invenio.
 .. code-block:: console
 
     (invenio)$ cdvirtualenv src/invenio
-    (invenio)$ pip install --process-dependency-links -e .[development]
+    (invenio)$ pip install -e .[development]
 
 Some modules may require specific dependencies listed as ``extras``. Pick the
 ones you need. E.g. to add `images` support, we can do as follow:


### PR DESCRIPTION
* Removes reference to --process-dependency-links when
  installing Invenio as it is no longer needed. (closes #3401)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>