### PR TITLE
WIP global: application factory refactoring

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -8,6 +8,7 @@
 -e git+git://github.com/lepture/flask-wtf.git#egg=Flask-WTF
 
 -e git+git://github.com/inveniosoftware/dictdiffer.git#egg=dictdiffer
+-e git+git://github.com/inveniosoftware/flask-appfactory.git#egg=flask-appfactory
 -e git+git://github.com/inveniosoftware/flask-breadcrumbs.git#egg=flask-breadcrumbs
 -e git+git://github.com/inveniosoftware/flask-iiif.git#egg=flask-iiif
 -e git+git://github.com/inveniosoftware/flask-menu.git#egg=flask-menu

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ install_requires = [
     "fixture>=1.5",
     "Flask>=0.10.1",
     "Flask-Admin>=1.1.0",
+    "Flask-AppFactory>=0.1.0",
     "Flask-Assets>=0.10",
     "Flask-Babel>=0.9",
     "Flask-Breadcrumbs>=0.2",


### PR DESCRIPTION
* BETTER Changes to use Flask-AppFactory for creating the Flask
  application factory.

* Removes legacy blueprint /testing.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>