### PR TITLE
docs: update node installation instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     apt-get -qy install --fix-missing --no-install-recommends \
         curl \
         && \
-    curl -sL https://deb.nodesource.com/setup | bash -
+    curl -sL https://deb.nodesource.com/setup_0.10 | bash -
 
 # install requirements from repos
 # also clean up apt

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -51,13 +51,12 @@ refer to it as ``$MYSQL_ROOT``.
 2.1.2. Node.js
 ++++++++++++++
 
-`node.js <http://nodejs.org/>`_ and `npm <https://www.npmjs.org/>`_ from Ubuntu
-are troublesome so we recommend you to install them from Chris Lea's PPA.
+`node.js <http://nodejs.org/>`_ and `npm <https://www.npmjs.org/>`_ can be
+installed using NodeSource's script.
 
 .. code-block:: console
 
-    $ sudo add-apt-repository ppa:chris-lea/node.js
-    $ sudo apt-get update
+    $ curl -sL https://deb.nodesource.com/setup_0.10 | sudo bash -
     $ sudo apt-get install nodejs
 
 2.2. Centos / RHEL

--- a/docs/getting-started/overlay.rst
+++ b/docs/getting-started/overlay.rst
@@ -73,8 +73,7 @@ solely required for development purposes.
     $ sudo apt-get install mysql-server
 
     # Install Node.js
-    $ sudo add-apt-repository ppa:chris-lea/node.js
-    $ sudo apt-get update
+    $ curl -sL https://deb.nodesource.com/setup_0.10 | sudo bash -
     $ sudo apt-get install nodejs
 
 The virtual environment


### PR DESCRIPTION
Chris Lea's PPA has been deprecated since March 2015: https://nodesource.com/blog/nodejs-v012-iojs-and-the-nodesource-linux-repositories#the-nodesource-linux-repositories.

Also includes a defensive change for the Dockerfile, so that if in the future the version downloaded from `https://deb.nodesource.com/setup` changes we won't have problems.