### PR TITLE
global: fix alembic dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ class _install_lib(install_lib):  # noqa
 
 
 install_requires = [
-    "alembic>=0.6.6",
+    "alembic>=0.6.6,<0.7",
     "Babel>=1.3",
     "bagit>=1.5.1",
     "BeautifulSoup>=3.2.1",


### PR DESCRIPTION
* FIX Fixes upgrader and database creation by limiting alembic
  version to <0.7.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>

PS: I chose the same version limit as in invenio-upgrader.