### PR TITLE
i18n: message catalogue update and clean-up

### DIFF
--- a/invenio/base/translations/af/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/af/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
 "PO-Revision-Date: 2006-10-12 17:50+0200\n"
 "Last-Translator: Christopher Parker <chris.parker.za@gmail.com>\n"
 "Language-Team: AF <info@invenio-software.org>\n"
@@ -24,7 +24,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -55,8 +55,8 @@ msgstr ""
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -199,7 +199,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr ""
 
@@ -220,17 +220,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -256,45 +256,49 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+msgid "Provided data is not valid"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 msgid "Authorization failure"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 msgid "Please sign in to continue."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 msgid "Authorization failure."
 msgstr ""
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -493,7 +497,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -694,7 +699,8 @@ msgid "The following errors have occurred:"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -711,8 +717,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -794,7 +800,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -836,8 +842,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr ""
@@ -852,8 +858,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr ""
 
@@ -1062,7 +1068,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1111,8 +1118,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1125,25 +1132,23 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1167,13 +1172,14 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1201,9 +1207,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1268,8 +1273,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1277,8 +1282,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1300,9 +1305,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1343,8 +1347,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1399,11 +1403,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1414,11 +1418,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1431,8 +1435,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1522,8 +1526,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1542,29 +1546,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1573,9 +1577,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr ""
 
@@ -1892,16 +1896,14 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -1921,8 +1923,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2066,8 +2068,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2174,7 +2176,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr ""
 
@@ -2366,8 +2368,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2637,9 +2639,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2690,7 +2691,7 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr ""
 
@@ -2698,8 +2699,8 @@ msgstr ""
 #, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3150,8 +3151,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr ""
 
@@ -3939,8 +3940,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -3958,8 +3959,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4018,17 +4019,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4378,25 +4379,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4455,15 +4456,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4474,10 +4475,10 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4490,15 +4491,15 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4509,7 +4510,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4528,17 +4530,15 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4556,14 +4556,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4614,8 +4613,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4665,8 +4664,8 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -4777,9 +4776,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -4792,8 +4791,8 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -4918,11 +4917,10 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5046,7 +5044,7 @@ msgid "Total"
 msgstr ""
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr ""
 
@@ -5202,8 +5200,8 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5258,56 +5256,56 @@ msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5345,7 +5343,7 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5395,15 +5393,15 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5618,8 +5616,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -5693,8 +5690,8 @@ msgstr ""
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -5708,8 +5705,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr ""
 
@@ -5867,8 +5864,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -5894,8 +5891,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -5906,8 +5903,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -5917,108 +5913,108 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 msgid "No match found, please enter different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6032,11 +6028,11 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
 
@@ -6079,10 +6075,9 @@ msgstr ""
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
 
 #: invenio/legacy/webalert/htmlparser.py:186
@@ -6272,15 +6267,15 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:453
@@ -6338,7 +6333,7 @@ msgstr ""
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6402,7 +6397,7 @@ msgstr ""
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6462,7 +6457,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6484,7 +6480,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6511,7 +6508,8 @@ msgid "You do not have permission to delete this note."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6541,8 +6539,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6562,8 +6560,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6594,8 +6592,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -6665,8 +6663,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
@@ -6692,8 +6689,7 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -6853,8 +6849,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7034,15 +7030,16 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2131
@@ -7052,7 +7049,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr ""
 
@@ -7213,7 +7210,7 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7344,207 +7341,207 @@ msgstr ""
 msgid "Record ID %(x_rec)s does not exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, python-format
 msgid "%(x_nb)i Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, python-format
 msgid "View all %(x_name)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 msgid "Be the first to review this document.</div>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 msgid "Close"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7553,487 +7550,489 @@ msgstr ""
 msgid "Record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, python-format
 msgid "Max %(maxfiles)i files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, python-format
 msgid "Here is review %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, python-format
 msgid "Here is comment %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
+msgstr ""
+
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 msgid "Your comment will be lost."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 msgid "Oldest comment first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 msgid "Latest comment first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 msgid "Group by record, latest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 msgid "Records and comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 msgid "Records only"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 msgid "Comments only"
 msgstr ""
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, python-format
 msgid "%(x_i)s items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 msgid "All items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 msgid "Order by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 msgid "Per page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 msgid "Display options"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8041,98 +8040,98 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 msgid "(in reply to a comment)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, python-format
 msgid "%(x_num)i items found in total"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 msgid "You do not have access to the specified comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 msgid "You cannot report a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 msgid "You are not authorized to use comments."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 msgid "Your Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr ""
@@ -8247,8 +8246,8 @@ msgstr ""
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8312,8 +8311,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8340,8 +8339,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -8515,9 +8514,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8538,8 +8536,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9004,14 +9001,14 @@ msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9141,8 +9138,7 @@ msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3357
@@ -9168,8 +9164,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3832
@@ -9351,7 +9347,8 @@ msgid "in"
 msgstr ""
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr ""
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9440,8 +9437,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9450,8 +9447,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:271
@@ -9468,14 +9465,14 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:327
@@ -9513,8 +9510,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:343
 #, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:346
@@ -9601,10 +9598,9 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:559
@@ -9621,15 +9617,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:573
@@ -9642,10 +9638,10 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:611
@@ -9665,8 +9661,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:636
@@ -9681,22 +9677,22 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:785
@@ -9713,8 +9709,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:799
@@ -9726,8 +9722,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:805
@@ -9738,8 +9734,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:811
@@ -9785,7 +9781,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -9833,15 +9830,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1027
@@ -9877,8 +9874,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -9903,8 +9900,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1228
@@ -9921,24 +9918,24 @@ msgstr ""
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1235
 #, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1267
@@ -10065,8 +10062,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1378
@@ -10285,7 +10282,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2400
@@ -10327,71 +10325,66 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:127
@@ -10400,14 +10393,14 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -10416,8 +10409,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -10429,8 +10422,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -10499,8 +10492,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -10563,8 +10555,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -10627,10 +10618,10 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -10658,8 +10649,8 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:452
 #, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -10834,15 +10825,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:989
@@ -10956,7 +10947,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:707
@@ -10979,37 +10971,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11017,15 +11009,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11089,8 +11081,8 @@ msgstr ""
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11125,8 +11117,8 @@ msgstr ""
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11172,8 +11164,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:366
@@ -11202,8 +11194,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:548
@@ -11252,8 +11244,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1041
@@ -11335,8 +11327,7 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -11473,7 +11464,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -11565,8 +11557,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -11585,8 +11577,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -11627,7 +11619,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -11648,14 +11641,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -11766,10 +11758,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12040,8 +12031,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12188,8 +12179,8 @@ msgstr ""
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -12248,9 +12239,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -12271,8 +12261,8 @@ msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -12338,8 +12328,7 @@ msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -12402,13 +12391,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -12417,9 +12405,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -12581,8 +12569,7 @@ msgstr ""
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -12664,8 +12651,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -12754,8 +12741,8 @@ msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:55
@@ -12845,9 +12832,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -12866,8 +12852,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -12925,8 +12911,7 @@ msgstr ""
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -12963,8 +12948,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13114,8 +13098,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13136,8 +13120,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13153,8 +13137,7 @@ msgstr ""
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -13270,7 +13253,7 @@ msgstr ""
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr ""
 
@@ -13452,8 +13435,8 @@ msgstr ""
 #: invenio/modules/groups/views.py:223
 #, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr ""
 
 #: invenio/modules/groups/views.py:279
@@ -13465,11 +13448,11 @@ msgstr ""
 msgid "Members"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 msgid "Knowledge base name"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 msgid "-None-"
 msgstr ""
@@ -13478,11 +13461,11 @@ msgstr ""
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 msgid "Index fields"
 msgstr ""
 
@@ -13528,7 +13511,7 @@ msgid "Create new record \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
+msgid "Create KB \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
@@ -13665,28 +13648,28 @@ msgstr ""
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -13747,8 +13730,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -14202,8 +14185,7 @@ msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -14451,1706 +14433,3 @@ msgstr ""
 #: invenio/utils/date.py:581
 msgid " years ago"
 msgstr ""
-
-#~ msgid "Export as"
-#~ msgstr ""
-
-#~ msgid "Search Services"
-#~ msgstr ""
-
-#~ msgid "Citation Metrics"
-#~ msgstr ""
-
-#~ msgid "WebSearch Admin Guide"
-#~ msgstr ""
-
-#~ msgid "Submit Guide"
-#~ msgstr ""
-
-#~ msgid "Add to personal basket"
-#~ msgstr ""
-
-#~ msgid "WebSubmit Admin Guide"
-#~ msgstr ""
-
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
-#~ msgid "Quit searching."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
-#~ msgid "Cancel merging"
-#~ msgstr ""
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Your options"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
-
-#~ msgid "Search for a person to assign the paper to"
-#~ msgstr ""
-
-#~ msgid "Select All"
-#~ msgstr ""
-
-#~ msgid "Select None"
-#~ msgstr ""
-
-#~ msgid "Invert Selection"
-#~ msgstr ""
-
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
-#~ msgid "Author Name"
-#~ msgstr ""
-
-#~ msgid "Experiment"
-#~ msgstr ""
-
-#~ msgid "Not assigned"
-#~ msgstr ""
-
-#~ msgid "No status information found."
-#~ msgstr ""
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
-
-#~ msgid "Review Transaction"
-#~ msgstr ""
-
-#~ msgid "On all pages"
-#~ msgstr ""
-
-#~ msgid "With selected do"
-#~ msgstr ""
-
-#~ msgid "View name variants"
-#~ msgstr ""
-
-#~ msgid "The author has an internal ID!"
-#~ msgstr ""
-
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
-#~ msgid "Not provided"
-#~ msgstr ""
-
-#~ msgid "Not available"
-#~ msgstr ""
-
-#~ msgid "No comments"
-#~ msgstr ""
-
-#~ msgid "Not Available"
-#~ msgstr ""
-
-#~ msgid " Delete this ticket"
-#~ msgstr ""
-
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
-#~ msgid "No title available"
-#~ msgstr ""
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
-
-#~ msgid "Select name for"
-#~ msgstr ""
-
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
-#~ msgid "Paper title: "
-#~ msgstr ""
-
-#~ msgid "Ignore"
-#~ msgstr ""
-
-#~ msgid "The following names have been automatically chosen:"
-#~ msgstr ""
-
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
-#~ msgid "Selected name on paper"
-#~ msgstr ""
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
-
-#~ msgid "Please provide your information"
-#~ msgstr ""
-
-#~ msgid "Please provide your first name"
-#~ msgstr ""
-
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
-#~ msgid "Your last name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
-#~ msgid "Your eMail:"
-#~ msgstr ""
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
-
-#~ msgid "!Delete the entire request!"
-#~ msgstr ""
-
-#~ msgid "Mark as your documents"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
-#~ msgid "Mark as their documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ their documents"
-#~ msgstr ""
-
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
-#~ msgid "Create new profile"
-#~ msgstr ""
-
-#~ msgid "Create a new Person"
-#~ msgstr ""
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
-
-#~ msgid "Add to merge list"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
-#~ msgid "Recent Papers"
-#~ msgstr ""
-
-#~ msgid "Publication List "
-#~ msgstr ""
-
-#~ msgid "Showing the"
-#~ msgstr ""
-
-#~ msgid "most recent documents:"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
-#~ msgid "Manage your profile"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
-
-#~ msgid "Choose your profile"
-#~ msgstr ""
-
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
-#~ msgid "Manage publication list"
-#~ msgstr ""
-
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
-#~ msgid "add external id"
-#~ msgstr ""
-
-#~ msgid "delete selected ids"
-#~ msgstr ""
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
-
-#~ msgid "suggest missing ids"
-#~ msgstr ""
-
-#~ msgid "Choose system"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr ""
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
-#~ msgid "Fatal: You are not allowed to access this functionality."
-#~ msgstr ""
-
-#~ msgid "Claim this paper"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "You have %i tickets."
-#~ msgstr ""
-
-#~ msgid "The publication date of this book is %s."
-#~ msgstr ""
-
-#~ msgid "You can see your library account %(x_url_open)shere%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid "%i items found."
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
-#~ msgid "Unweighted %s keywords:"
-#~ msgstr ""
-
-#~ msgid "Weighted %s keywords:"
-#~ msgstr ""
-
-#~ msgid "Unknown type: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file named %s already exists. Please choose another name."
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Record #%i"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
-#~ msgid "Revision"
-#~ msgstr ""
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Could not find format element named %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s could not be found."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
-
-#~ msgid "Output format with code %s could not be found."
-#~ msgstr ""
-
-#~ msgid "Could not find output format named %s."
-#~ msgstr ""
-
-#~ msgid "Could not find a fresh name for output format %s."
-#~ msgstr ""
-
-#~ msgid "Modify Template Attributes"
-#~ msgstr ""
-
-#~ msgid "Template Editor"
-#~ msgstr ""
-
-#~ msgid "Check Dependencies"
-#~ msgstr ""
-
-#~ msgid "Update Format Attributes"
-#~ msgstr ""
-
-#~ msgid "Show Documentation"
-#~ msgstr ""
-
-#~ msgid "Hide Documentation"
-#~ msgstr ""
-
-#~ msgid "Last Modification Date"
-#~ msgstr ""
-
-#~ msgid "Manage Output Formats"
-#~ msgstr ""
-
-#~ msgid "Manage Format Templates"
-#~ msgstr ""
-
-#~ msgid "Format Elements Documentation"
-#~ msgstr ""
-
-#~ msgid "Add New Format Template"
-#~ msgstr ""
-
-#~ msgid "Check Format Templates Extensively"
-#~ msgstr ""
-
-#~ msgid "Code"
-#~ msgstr ""
-
-#~ msgid "Add New Output Format"
-#~ msgstr ""
-
-#~ msgid "menu"
-#~ msgstr ""
-
-#~ msgid "Close Output Format"
-#~ msgstr ""
-
-#~ msgid "Rules"
-#~ msgstr ""
-
-#~ msgid "Modify Output Format Attributes"
-#~ msgstr ""
-
-#~ msgid "Remove Rule"
-#~ msgstr ""
-
-#~ msgid "Add New Rule"
-#~ msgstr ""
-
-#~ msgid "No problem found with format"
-#~ msgstr ""
-
-#~ msgid "An error has been found"
-#~ msgstr ""
-
-#~ msgid "The following errors have been found"
-#~ msgstr ""
-
-#~ msgid "BibFormat Admin"
-#~ msgstr ""
-
-#~ msgid "Test with record:"
-#~ msgstr ""
-
-#~ msgid "Enter a search query here."
-#~ msgstr ""
-
-#~ msgid "No Record Found for %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
-#~ msgid "Template \"%s\" does not exist at line %s."
-#~ msgstr ""
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
-
-#~ msgid "Output format %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
-#~ msgid "Format template %s calls undefined element \"%s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
-
-#~ msgid "Error in format element %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Show all %i authors"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
-
-#~ msgid "Restricted Output Format"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Rules"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Output Format"
-#~ msgstr ""
-
-#~ msgid "Cannot create output format"
-#~ msgstr ""
-
-#~ msgid "Format template %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Element %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Test Format Element %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Output Format %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Element"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Element %s"
-#~ msgstr ""
-
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
-#~ msgid "Format Validation"
-#~ msgstr ""
-
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid "Your rule: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Download history:"
-#~ msgstr ""
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid "Cannot send error request, %s parameter missing."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Not Set"
-#~ msgstr ""
-
-#~ msgid "never"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Your account on '%s' has been activated"
-#~ msgstr ""
-
-#~ msgid "Your account earlier created on '%s' has been activated:"
-#~ msgstr ""
-
-#~ msgid "Account created on '%s'"
-#~ msgstr ""
-
-#~ msgid "An account has been created for you on '%s':"
-#~ msgstr ""
-
-#~ msgid "Account rejected on '%s'"
-#~ msgstr ""
-
-#~ msgid "Your request for an account has been rejected on '%s':"
-#~ msgstr ""
-
-#~ msgid "Username/Email: %s"
-#~ msgstr ""
-
-#~ msgid "Account deleted on '%s'"
-#~ msgstr ""
-
-#~ msgid "Your account on '%s' has been deleted:"
-#~ msgstr ""
-
-#~ msgid "You already have an alert named %s."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been added to your profile."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been successfully updated."
-#~ msgstr ""
-
-#~ msgid "You have defined %s alerts."
-#~ msgstr ""
-
-#~ msgid "Here are the %s most popular searches."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display searches"
-#~ msgstr ""
-
-#~ msgid "%s, personalize"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Set a new alert"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Modify alert settings"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display alerts"
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
-
-#~ msgid "times"
-#~ msgstr ""
-
-#~ msgid "Papers"
-#~ msgstr ""
-
-#~ msgid "No Keywords"
-#~ msgstr ""
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
-
-#~ msgid "No Subject categories"
-#~ msgstr ""
-
-#~ msgid "Subject categories"
-#~ msgstr ""
-
-#~ msgid "No Collaborations"
-#~ msgstr ""
-
-#~ msgid "Collaborations"
-#~ msgstr ""
-
-#~ msgid "unknown affiliation"
-#~ msgstr ""
-
-#~ msgid "No Affiliations"
-#~ msgstr ""
-
-#~ msgid "Affiliations"
-#~ msgstr ""
-
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
-#~ msgid "Citations%s"
-#~ msgstr ""
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
-
-#~ msgid "No Publication Graph"
-#~ msgstr ""
-
-#~ msgid "<strong> Publications list </strong>"
-#~ msgstr ""
-
-#~ msgid "No publications available"
-#~ msgstr ""
-
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "Sorry, you do not have sufficient rights to add record #%i."
-#~ msgstr ""
-
-#~ msgid "%i matching items"
-#~ msgstr ""
-
-#~ msgid "%i items have been successfully added to your basket"
-#~ msgstr ""
-
-#~ msgid "Adding %i items to your baskets"
-#~ msgstr ""
-
-#~ msgid "%i users are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "%i user groups are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "You have set %i alerts on this basket."
-#~ msgstr ""
-
-#~ msgid "%i items"
-#~ msgstr ""
-
-#~ msgid "%i notes"
-#~ msgstr ""
-
-#~ msgid "%i subscribers"
-#~ msgstr ""
-
-#~ msgid "Record %i"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s does not exist in the database."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is an invalid ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "Showing the latest %i comments:"
-#~ msgstr ""
-
-#~ msgid "Sorry, the record %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "Sorry, %s is not a valid ID value."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s"
-#~ msgstr ""
-
-#~ msgid "Readers found the following %s reviews to be most helpful."
-#~ msgstr ""
-
-#~ msgid "View all %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s comments"
-#~ msgstr ""
-
-#~ msgid "Note: Your nickname, %s, will be displayed as author of this comment."
-#~ msgstr ""
-
-#~ msgid "Max %i files"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Note: Your nickname, %s, will be "
-#~ "displayed as the author of this "
-#~ "review."
-#~ msgstr ""
-
-#~ msgid "View all %s reported comments"
-#~ msgstr ""
-
-#~ msgid "View all %s reported reviews"
-#~ msgstr ""
-
-#~ msgid "This review has been reported %i times"
-#~ msgstr ""
-
-#~ msgid "This comment has been reported %i times"
-#~ msgstr ""
-
-#~ msgid "Here are the reported reviews of user %s"
-#~ msgstr ""
-
-#~ msgid "Here are the reported comments of user %s"
-#~ msgstr ""
-
-#~ msgid "Here is review %s"
-#~ msgstr ""
-
-#~ msgid "Here is comment %s"
-#~ msgstr ""
-
-#~ msgid "Here are all reviews for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "Here are all comments for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "%s items"
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid "%i items found in total"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "%s View your previously submitted comments"
-#~ msgstr ""
-
-#~ msgid "Comment ID %s does not exist."
-#~ msgstr ""
-
-#~ msgid "Record ID %s does not exist."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your message is too long, please "
-#~ "shorten it. Maximum size allowed is "
-#~ "%i characters."
-#~ msgstr ""
-
-#~ msgid "Group %s does not exist."
-#~ msgstr ""
-
-#~ msgid "User %s does not exist."
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
-#~ msgid "There are no records referring to %s."
-#~ msgstr ""
-
-#~ msgid "There are no records modified by %s."
-#~ msgstr ""
-
-#~ msgid "There are no records cited by %s."
-#~ msgstr ""
-
-#~ msgid "No word index is available for %s."
-#~ msgstr ""
-
-#~ msgid "No phrase index is available for %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Search term %s did not match any"
-#~ " record. Nearest terms in any "
-#~ "collection are:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, %s does not seem to be "
-#~ "a valid sort option. The records "
-#~ "will not be sorted."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, sorting is allowed on sets "
-#~ "of up to %d records only. Using"
-#~ " default sort order."
-#~ msgstr ""
-
-#~ msgid "The record %d replaces it."
-#~ msgstr ""
-
-#~ msgid "%s results found"
-#~ msgstr ""
-
-#~ msgid "%s seconds"
-#~ msgstr ""
-
-#~ msgid "Search %s records for"
-#~ msgstr ""
-
-#~ msgid "Cited by %i records"
-#~ msgstr ""
-
-#~ msgid "%s records found"
-#~ msgstr ""
-
-#~ msgid "Search took %s seconds."
-#~ msgstr ""
-
-#~ msgid "Cited by 1 record"
-#~ msgstr ""
-
-#~ msgid "%i comments"
-#~ msgstr ""
-
-#~ msgid "%i reviews"
-#~ msgstr ""
-
-#~ msgid "Collection %s Not Found"
-#~ msgstr ""
-
-#~ msgid "Sorry, collection %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s."
-#~ msgstr ""
-
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid "Cited by: %s records"
-#~ msgstr ""
-
-#~ msgid "Co-cited with: %s records"
-#~ msgstr ""
-
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
-#~ msgid "No Papers"
-#~ msgstr ""
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
-
-#~ msgid "Citations:"
-#~ msgstr ""
-
-#~ msgid "No Citation Information available"
-#~ msgstr ""
-
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Sorry, DOI %s could not be resolved."
-#~ msgstr ""
-
-#~ msgid "DOI \"%s\" Not Found"
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
-#~ msgid "Discussion"
-#~ msgstr ""
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If you are using a lightweight CERN account you can\n"
-#~ "                %(x_url_open)sreset the password%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Alternatively, you can ask %s to "
-#~ "change your login system from external"
-#~ " to internal."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "%s offers you the possibility to "
-#~ "personalize the interface, to set up "
-#~ "your own personal library of documents,"
-#~ " or to set up an automatic "
-#~ "alert query that would run periodically"
-#~ " and would notify you of search "
-#~ "results by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid "Okay, a password reset link has been emailed to %s."
-#~ msgstr ""
-
-#~ msgid "If you don't own an account yet, please contact %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please do not use valuable passwords "
-#~ "such as your Unix, AFS or NICE "
-#~ "passwords with this service. Your email"
-#~ " address will stay strictly confidential"
-#~ " and will not be disclosed to "
-#~ "any third party. It will be used"
-#~ " to identify you for personal "
-#~ "services of %s. For example, you "
-#~ "may set up an automatic alert "
-#~ "search that will look for new "
-#~ "preprints and will notify you daily "
-#~ "of new arrivals by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "It is not possible to create an"
-#~ " account yourself. Contact %s if you"
-#~ " want an account."
-#~ msgstr ""
-
-#~ msgid "Your alerts"
-#~ msgstr ""
-
-#~ msgid "Your approvals"
-#~ msgstr ""
-
-#~ msgid "Your baskets"
-#~ msgstr ""
-
-#~ msgid "Your comments"
-#~ msgstr ""
-
-#~ msgid "Your groups"
-#~ msgstr ""
-
-#~ msgid "Your loans"
-#~ msgstr ""
-
-#~ msgid "Your submissions"
-#~ msgstr ""
-
-#~ msgid "Your searches"
-#~ msgstr ""
-
-#~ msgid "Administration"
-#~ msgstr ""
-
-#~ msgid "Statistics"
-#~ msgstr ""
-
-#~ msgid "Edit %s members"
-#~ msgstr ""
-
-#~ msgid "Edit group %s"
-#~ msgstr ""
-
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
-#~ msgid "Group: %s"
-#~ msgstr ""
-
-#~ msgid "Group %s: New membership request"
-#~ msgstr ""
-
-#~ msgid "A user wants to join the group %s."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been accepted"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been accepted."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been rejected"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been rejected."
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted"
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted by its administrator."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Your Settings"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown to the external login "
-#~ "system."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The external login method %s does "
-#~ "not support email address based logins."
-#~ "  Please contact the site administrators."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is already in use."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "Sorry, page %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
-#~ msgid "Page %s Not Found"
-#~ msgstr ""
-
-#~ msgid "Please contact %s quoting the following information:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
-
-#~ msgid "Unable to find the submission directory for the action: %s"
-#~ msgstr ""
-
-#~ msgid "Unable to find document type: %s"
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory."
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory. Please fill it in."
-#~ msgstr ""
-
-#~ msgid "Function %s does not exist."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s%s'"
-#~ msgstr ""
-

--- a/invenio/base/translations/ar/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/ar/LC_MESSAGES/messages.po
@@ -16,16 +16,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
 "PO-Revision-Date: 2011-07-10 21:05+0200\n"
 "Last-Translator: Bessem Amira <bessem.amira@cnudst.rnrt.tn>\n"
 "Language-Team: AR <info@invenio-software.org>\n"
-"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n>=3 "
-"&& n<=10 ? 3 : n>=11 && n<=99 ? 4 : 5)\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n>=3 && "
+"n<=10 ? 3 : n>=11 && n<=99 ? 4 : 5)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -56,8 +56,8 @@ msgstr ""
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -200,7 +200,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr ""
 
@@ -221,17 +221,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -257,45 +257,49 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+msgid "Provided data is not valid"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "غير مصرح لك باستخدام السلال."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 msgid "Authorization failure"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 msgid "Please sign in to continue."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 msgid "Authorization failure."
 msgstr ""
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -494,7 +498,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -698,7 +703,8 @@ msgid "The following errors have occurred:"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -715,8 +721,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -798,7 +804,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -840,8 +846,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr ""
@@ -856,8 +862,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr ""
 
@@ -1072,7 +1078,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1123,8 +1130,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1137,25 +1144,23 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1180,13 +1185,14 @@ msgstr "إنشاء السلة"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1215,9 +1221,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1283,8 +1288,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1292,8 +1297,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1315,9 +1320,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1359,8 +1363,8 @@ msgstr "%s العثور على سجلات"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1416,11 +1420,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1431,11 +1435,11 @@ msgstr "نعم"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1448,8 +1452,8 @@ msgstr "رقم"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1541,8 +1545,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1562,29 +1566,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1593,9 +1597,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr ""
 
@@ -1930,16 +1934,14 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -1959,8 +1961,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2104,8 +2106,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2212,7 +2214,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "وصف"
 
@@ -2404,8 +2406,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2676,9 +2678,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "يمكنك إذا رغبت إعادة تسجيل دخولك %(x_url_open)sمن هنا%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2730,7 +2731,7 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr ""
 
@@ -2738,8 +2739,8 @@ msgstr ""
 #, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3192,8 +3193,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr ""
 
@@ -3983,8 +3984,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4002,8 +4003,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4062,17 +4063,17 @@ msgstr "ردمد"
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4423,25 +4424,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4500,15 +4501,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4519,10 +4520,10 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4535,15 +4536,15 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4554,7 +4555,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4573,17 +4575,15 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4601,14 +4601,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4661,8 +4660,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4712,8 +4711,8 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -4824,9 +4823,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -4839,8 +4838,8 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -4967,11 +4966,10 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5095,7 +5093,7 @@ msgid "Total"
 msgstr ""
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr ""
 
@@ -5251,8 +5249,8 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5307,56 +5305,56 @@ msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5395,7 +5393,7 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5445,15 +5443,15 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5669,8 +5667,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -5744,8 +5741,8 @@ msgstr ""
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -5759,8 +5756,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "نتائج البحث"
 
@@ -5918,8 +5915,8 @@ msgstr "لم يتم العثور على بيانات"
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -5947,8 +5944,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -5959,8 +5956,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -5970,111 +5966,111 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr "لم تطابق عبارة البحث  %s أي سجل.أقرب المصطلحات الواردة هي :"
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 msgid "No match found, please enter different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr ". %s لا توجد سجلات تشير إلى"
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "%s لا توجد سجلات استشهد بها ."
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "%s لا توجد سجلات استشهد بها ."
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "%s لا يوجد كشاف كلمات متاح ل."
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "%s لا يوجد كشاف جمل متاح ل ."
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 "لم تطابق عبارة البحث  %(x_term)s في الكشاف %(x_index)s  أي سجل . أقرب "
 "المصطلحات الواردة هي :"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr "لم تطابق عبارة البحث  %s أي سجل.أقرب المصطلحات الواردة هي :"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6088,11 +6084,11 @@ msgstr ""
 msgid "Browse"
 msgstr "تصفح"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
 
@@ -6135,14 +6131,13 @@ msgstr ""
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"قمت بإجراء %(x_nb)s عملية بحث.يوجد %(x_url_open)sقائمة "
-"مفصلة%(x_url_close)s  مع إمكانية (أ) عرض نتائج البحث و (ب) الاشتراك في "
-"خدمة التنبيه التلقائي عبر البريد الالكتروني ."
+"قمت بإجراء %(x_nb)s عملية بحث.يوجد %(x_url_open)sقائمة مفصلة%(x_url_close)s  "
+"مع إمكانية (أ) عرض نتائج البحث و (ب) الاشتراك في خدمة التنبيه التلقائي عبر "
+"البريد الالكتروني ."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6281,8 +6276,8 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"يمكنك إضافة تنبيهات جديدة من %(x_url1_open)sبحوثك%(x_url1_close)s السابقة"
-" ، أو من ضمن البحوث %(x_url2_open)sالأكثر رواجا%(x_url2_close)s."
+"يمكنك إضافة تنبيهات جديدة من %(x_url1_open)sبحوثك%(x_url1_close)s السابقة ، "
+"أو من ضمن البحوث %(x_url2_open)sالأكثر رواجا%(x_url2_close)s."
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6333,18 +6328,19 @@ msgstr "عدد التنبيهات المنشأة : %s ."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
-"لم تقم  بأي بحث حتى الآن. يرجى الانتقال  أولا إلى %(x_url_open)sواجهة "
-"البحث%(x_url_close)s."
+"لم تقم  بأي بحث حتى الآن. يرجى الانتقال  أولا إلى %(x_url_open)sواجهة البحث"
+"%(x_url_close)s."
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
-msgstr "قمت بـ%(x_nb1)s بحث (%(x_nb2)s أسئلة مختلفة) خلال الأيام ال 30 الماضية."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
+msgstr ""
+"قمت بـ%(x_nb1)s بحث (%(x_nb2)s أسئلة مختلفة) خلال الأيام ال 30 الماضية."
 
 #: invenio/legacy/webalert/templates.py:453
 #, fuzzy, python-format
@@ -6401,7 +6397,7 @@ msgstr "عمليات البحث"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6465,7 +6461,7 @@ msgstr "إضفاء الطابع الشخصي على %s، إنشاء تنبيه �
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6525,7 +6521,8 @@ msgstr "إضفاء الطابع الشخصي على %s، عرض التنبيها
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6547,7 +6544,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6574,7 +6572,8 @@ msgid "You do not have permission to delete this note."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6604,8 +6603,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6626,8 +6625,8 @@ msgstr "%s العثور على سجلات"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6660,8 +6659,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -6731,8 +6730,7 @@ msgstr "السلال العمومية"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 "لديك %(x_nb_perso)s سلال شخصية ، ومشترك في %(x_nb_group)s سلال لفرق و "
 "%(x_nb_public)s سلال عمومية لمستخدمين آخرين"
@@ -6760,8 +6758,7 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -6921,8 +6918,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7102,15 +7099,17 @@ msgstr "تقاسم السلة مع فريق جديد"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
-msgstr "تم تسجيل دخولك كزائر، لذا لا يمكن الاحتفاظ بسلالك الخاصة عند نهاية الزيارة"
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
+msgstr ""
+"تم تسجيل دخولك كزائر، لذا لا يمكن الاحتفاظ بسلالك الخاصة عند نهاية الزيارة"
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2131
@@ -7120,7 +7119,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "هذه الوظيفة غير متاحة للمستخدمين الزوار٠"
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "عودة إلى نتائج البحث"
 
@@ -7281,7 +7280,7 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7417,207 +7416,207 @@ msgstr ""
 msgid "Record ID %(x_rec)s does not exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "%i تعليق"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, python-format
 msgid "View all %(x_name)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 msgid "Be the first to review this document.</div>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 msgid "Close"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7626,494 +7625,496 @@ msgstr ""
 msgid "Record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, python-format
 msgid "Max %(maxfiles)i files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr "يمكنك الاطلاع على قائمة %(x_url_open)s تذاكرك%(x_url_close)s"
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "اسم مستعار"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, python-format
 msgid "Here is review %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, python-format
 msgid "Here is comment %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
+msgstr ""
+
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 msgid "Your comment will be lost."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "ضافة تعليقات"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "الأخير أولا"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 msgid "Group by record, latest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "ضافة تعليقات"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "العثور على %s سجل"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 msgid "Comments only"
 msgstr ""
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "%s العثور على سجلات"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 msgid "All items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 #, fuzzy
 msgid "Display"
 msgstr "عرض التنبيهات"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 msgid "Order by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "الصفحة التالية"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "عرض التنبيهات"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8121,100 +8122,100 @@ msgstr "عرض التنبيهات"
 msgid "Refresh"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 msgid "(in reply to a comment)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "%s العثور على سجلات"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 msgid "You do not have access to the specified comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 msgid "You cannot report a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "غير مصرح لك باستخدام السلال."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "استعارتك"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr ""
@@ -8329,8 +8330,8 @@ msgstr ""
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8394,8 +8395,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8422,8 +8423,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -8599,9 +8600,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8623,8 +8623,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9092,14 +9091,14 @@ msgstr "أبحث أيضا :"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9208,8 +9207,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found at least "
 "%(x_nb_records)s records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sنظرة عامة على النتائج :%(x_fmt_close)s العثور على ما لا يقل"
-" عن %(x_nb_records)s سجل في %(x_nb_seconds)s ثانية."
+"%(x_fmt_open)sنظرة عامة على النتائج :%(x_fmt_close)s العثور على ما لا يقل عن "
+"%(x_nb_records)s سجل في %(x_nb_seconds)s ثانية."
 
 #: invenio/legacy/websearch/templates.py:3184
 #, fuzzy
@@ -9236,8 +9235,7 @@ msgstr "إيداعتك"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3357
@@ -9263,8 +9261,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "إنشاء%(x_url1_open)sتنبيه عبر بريدك الإلكتروني%(x_url1_close)s\n"
 "أو الاشتراك في خدمة%(x_url2_open)sRSS%(x_url2_close)s."
@@ -9451,7 +9449,8 @@ msgid "in"
 msgstr "في"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "لم تجد ما تبحث عنه؟ حاول البحث في مصادر معلومات اخرى :"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9494,8 +9493,8 @@ msgid ""
 "You can consult the list of your external groups directly in the "
 "%(x_url_open)sgroups page%(x_url_close)s."
 msgstr ""
-"يمكنك الاطلاع على قائمة فرقك الخارجية  مباشرة من %(x_url_open)sصفحة "
-"الفرق%(x_url_close)s ."
+"يمكنك الاطلاع على قائمة فرقك الخارجية  مباشرة من %(x_url_open)sصفحة الفرق"
+"%(x_url_close)s ."
 
 #: invenio/legacy/websession/templates.py:110
 msgid "External user groups"
@@ -9545,8 +9544,8 @@ msgstr "إجباري"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9556,11 +9555,11 @@ msgstr "إنشاء السلة"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
-"إذا كنت تريد تغيير بريدك الالكتروني أو تعيين لأول مرة إسما مستعارا لك، "
-"يرجى إستعمال الاستمارة التالية"
+"إذا كنت تريد تغيير بريدك الالكتروني أو تعيين لأول مرة إسما مستعارا لك، يرجى "
+"إستعمال الاستمارة التالية"
 
 #: invenio/legacy/websession/templates.py:271
 msgid "Edit login credentials"
@@ -9576,17 +9575,17 @@ msgstr "تسجيل المعطيات الجديدة"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr "بإعتماده كتوقيع للتعليقات و الاستعراضات لا يمكن تغييره لاحقا."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
-"إذا كنت تريد تغيير كلمة المرور ,يرجى إدخال الكلمة القديمة والكلمة الجديدة"
-" أدناه."
+"إذا كنت تريد تغيير كلمة المرور ,يرجى إدخال الكلمة القديمة والكلمة الجديدة "
+"أدناه."
 
 #: invenio/legacy/websession/templates.py:327
 msgid "Old password"
@@ -9623,8 +9622,8 @@ msgstr "تغيير كلمة المرور"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr "يمكنك إذا رغبت إعادة تسجيل دخولك %(x_url_open)sمن هنا%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:346
@@ -9712,10 +9711,9 @@ msgstr "حدد الأسلوب"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:559
@@ -9732,15 +9730,15 @@ msgstr "إرسال رابط إعادة كلمة المرور"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:573
@@ -9753,10 +9751,10 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:611
@@ -9776,8 +9774,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:636
@@ -9792,24 +9790,23 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
-"تم تسجيل دخولك كزائر، لذا لا يمكن الاحتفاظ بتنبيهاتك الخاصة عند نهاية "
-"الزيارة"
+"تم تسجيل دخولك كزائر، لذا لا يمكن الاحتفاظ بتنبيهاتك الخاصة عند نهاية الزيارة"
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:785
@@ -9826,8 +9823,8 @@ msgstr "تنبيهاتك"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 "يمكنك الاطلاع على %(x_url_open)sقائمة المجموعات%(x_url_close)s التي تقوم "
 "بإدارتها أو  التي أنت عضو فيها."
@@ -9841,11 +9838,11 @@ msgstr "الجماعات الخاصة بك"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"يمكنك الاطلاع على قائمة %(x_url_open)sالوثائق التي قمت "
-"بإيداعها%(x_url_close)s والاستفسار عن وضعيتها."
+"يمكنك الاطلاع على قائمة %(x_url_open)sالوثائق التي قمت بإيداعها"
+"%(x_url_close)s والاستفسار عن وضعيتها."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -9855,8 +9852,8 @@ msgstr "إيداعتك"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
 "يمكنك الاطلاع على قائمة %(x_url_open)s الوثائق%(x_url_close)s التي قمت "
 "بالموافقة عليها ."
@@ -9904,7 +9901,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -9952,25 +9950,23 @@ msgstr "إذا كان لديك حساب ، الرجاء تسجيل الدخول 
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"إذا لم يكن لديك حساب ،فيمكنك %(x_url_open)s إنشاء حساب "
-"الآن%(x_url_close)s. "
+"إذا لم يكن لديك حساب ،فيمكنك %(x_url_open)s إنشاء حساب الآن%(x_url_close)s. "
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
 msgid "If you don't own an account yet, please contact %(x_name)s."
 msgstr ""
-"إذا لم يكن لديك حساب ،فيمكنك %(x_url_open)s إنشاء حساب "
-"الآن%(x_url_close)s. "
+"إذا لم يكن لديك حساب ،فيمكنك %(x_url_open)s إنشاء حساب الآن%(x_url_close)s. "
 
 #: invenio/legacy/websession/templates.py:1051
 msgid "Login method:"
@@ -10000,8 +9996,8 @@ msgstr "يمكنك استخدام اسمك المستعار أو عنوان بر
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -10028,8 +10024,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1228
@@ -10046,24 +10042,24 @@ msgstr "تسجيل"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1235
 #, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1267
@@ -10194,8 +10190,8 @@ msgstr "هنا بعض روابط ويب هامة للمشرف :"
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "لمزيد من الأنشطة على المستوى الإشراف، الرجاء الرجوع  %(x_url_open)sلفضاء "
 "الإدارة%(x_url_close)s."
@@ -10416,7 +10412,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2400
@@ -10458,76 +10455,71 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
-"تم تسجيل دخولك كزائر. قد ترغب في%(x_url_open)sالدخول%(x_url_close)s "
-"كمستخدم عادي."
+"تم تسجيل دخولك كزائر. قد ترغب في%(x_url_open)sالدخول%(x_url_close)s كمستخدم "
+"عادي."
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
-"على المستخدم%(x_fmt_open)s الزائر %(x_fmt_close)s%(x_url_open)s "
-"التسجيل%(x_url_close)s أولا ٠"
+"على المستخدم%(x_fmt_open)s الزائر %(x_fmt_close)s%(x_url_open)s التسجيل"
+"%(x_url_close)s أولا ٠"
 
 #: invenio/legacy/websession/webaccount.py:127
 msgid "No queries found"
@@ -10535,16 +10527,16 @@ msgstr "لا وجود لاي استشارات"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 "هذه المجموعة مقيد بحقوق إستغلال. الرجاء تسجيل الدخول بحساب يتمتع بالحقوق "
 "اللازمة ."
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 "هذه الملف مقيد بحقوق إستغلال. الرجاء تسجيل الدخول بحساب يتمتع بالحقوق "
 "اللازمة ."
@@ -10555,8 +10547,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -10568,8 +10560,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -10638,8 +10630,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -10702,8 +10693,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -10766,10 +10756,10 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -10797,8 +10787,8 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:452
 #, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -10973,15 +10963,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:989
@@ -11095,7 +11085,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:707
@@ -11118,37 +11109,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11156,15 +11147,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11228,8 +11219,8 @@ msgstr ""
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11264,8 +11255,8 @@ msgstr "الإيداع"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11312,8 +11303,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:366
@@ -11342,8 +11333,8 @@ msgstr "العودة الى القائمة الرئيسية"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:548
@@ -11392,8 +11383,8 @@ msgstr "الإيداع عدد"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1041
@@ -11475,8 +11466,7 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -11613,7 +11603,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -11705,8 +11696,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -11725,8 +11716,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -11767,7 +11758,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -11788,14 +11780,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -11907,10 +11898,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12190,8 +12180,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12346,8 +12336,8 @@ msgstr "عنوان البريد الإلكتروني %s موجود في قاعد
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -12410,9 +12400,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -12438,8 +12427,8 @@ msgstr "تغيير كلمة المرور"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
 "الرجاء إدخال عنوان بريدك الالكتروني ،الاسم المستعار وكلمة السر المرغوب "
 "فيهما :"
@@ -12510,8 +12499,7 @@ msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -12582,13 +12570,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -12597,9 +12584,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -12765,8 +12752,7 @@ msgstr "المجموعات"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -12852,8 +12838,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -12942,8 +12928,8 @@ msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:55
@@ -13040,9 +13026,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13061,8 +13046,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13096,7 +13081,7 @@ msgid "New community"
 msgstr "عرض التعليقات"
 
 #: invenio/modules/communities/templates/communities/new_base.html:54
-#, fuzzy, python-format
+#, fuzzy
 msgid "Edit community"
 msgstr "%i تعليق"
 
@@ -13126,8 +13111,7 @@ msgstr "استعراض وحيد"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13167,8 +13151,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13332,8 +13315,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13354,8 +13337,8 @@ msgstr "%s لا يوجد كشاف كلمات متاح ل."
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13371,8 +13354,7 @@ msgstr ""
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -13489,7 +13471,7 @@ msgstr ""
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr ""
 
@@ -13679,8 +13661,8 @@ msgstr "إدارة حقوق الفرق"
 #: invenio/modules/groups/views.py:223
 #, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr ""
 
 #: invenio/modules/groups/views.py:279
@@ -13692,11 +13674,11 @@ msgstr "أنت لست مسؤولا في أي مجموعة."
 msgid "Members"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 msgid "Knowledge base name"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 msgid "-None-"
 msgstr ""
@@ -13705,11 +13687,11 @@ msgstr ""
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "في كل الحقول"
@@ -13753,13 +13735,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "%s لا توجد سجلات استشهد بها ."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "%s لا توجد سجلات استشهد بها ."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -13911,28 +13894,28 @@ msgstr "نوع الملف"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -13994,8 +13977,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -14353,7 +14336,7 @@ msgid "Tag name"
 msgstr "اسم التنبيه"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "الاسم المستعار %s هو في قيد الاستعمال."
 
@@ -14497,8 +14480,7 @@ msgstr "استعارتك"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -14701,7 +14683,7 @@ msgid "just now"
 msgstr ""
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s ثانية"
 
@@ -14791,9 +14773,6 @@ msgstr "السنة"
 #~ msgid "HTML brief"
 #~ msgstr "HTML موجز"
 
-#~ msgid ""
-#~ msgstr ""
-
 #~ msgid "Export as"
 #~ msgstr "تصدير بصيغة"
 
@@ -14815,638 +14794,26 @@ msgstr "السنة"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "WebSubmit دليل ادارة"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
-#~ msgid "Quit searching."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
-#~ msgid "Cancel merging"
-#~ msgstr ""
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
-
-#~ msgid "Search for a person to assign the paper to"
-#~ msgstr ""
-
-#~ msgid "Select All"
-#~ msgstr ""
-
-#~ msgid "Select None"
-#~ msgstr ""
-
-#~ msgid "Invert Selection"
-#~ msgstr ""
-
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "مؤلف"
 
 #~ msgid "Experiment"
 #~ msgstr "تجربة"
 
-#~ msgid "Not assigned"
-#~ msgstr ""
-
-#~ msgid "No status information found."
-#~ msgstr ""
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
-
-#~ msgid "Review Transaction"
-#~ msgstr ""
-
-#~ msgid "On all pages"
-#~ msgstr ""
-
-#~ msgid "With selected do"
-#~ msgstr ""
-
-#~ msgid "View name variants"
-#~ msgstr ""
-
-#~ msgid "The author has an internal ID!"
-#~ msgstr ""
-
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
-#~ msgid "Not provided"
-#~ msgstr ""
-
-#~ msgid "Not available"
-#~ msgstr ""
-
-#~ msgid "No comments"
-#~ msgstr ""
-
-#~ msgid "Not Available"
-#~ msgstr ""
-
-#~ msgid " Delete this ticket"
-#~ msgstr ""
-
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "لا يوجد أنواع وثائق متاحة."
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
-
-#~ msgid "Select name for"
-#~ msgstr ""
-
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
-#~ msgid "Paper title: "
-#~ msgstr ""
-
-#~ msgid "Ignore"
-#~ msgstr ""
-
-#~ msgid "The following names have been automatically chosen:"
-#~ msgstr ""
-
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
-#~ msgid "Selected name on paper"
-#~ msgstr ""
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
-
-#~ msgid "Please provide your information"
-#~ msgstr ""
-
-#~ msgid "Please provide your first name"
-#~ msgstr ""
-
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
-#~ msgid "Your last name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
-#~ msgid "Your eMail:"
-#~ msgstr ""
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
-
-#~ msgid "!Delete the entire request!"
-#~ msgstr ""
-
-#~ msgid "Mark as your documents"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
-#~ msgid "Mark as their documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ their documents"
-#~ msgstr ""
-
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
-#~ msgid "Create new profile"
-#~ msgstr ""
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "أضف إلى المستخدمين"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
-#~ msgid "Recent Papers"
-#~ msgstr ""
-
-#~ msgid "Publication List "
-#~ msgstr ""
-
-#~ msgid "Showing the"
-#~ msgstr ""
-
-#~ msgid "most recent documents:"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "إدارة حقوق الفرق"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
-
-#~ msgid "Choose your profile"
-#~ msgstr ""
-
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
-#~ msgid "Manage publication list"
-#~ msgstr ""
-
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
-#~ msgid "add external id"
-#~ msgstr ""
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
-
-#~ msgid "suggest missing ids"
-#~ msgstr ""
-
-#~ msgid "Choose system"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr ""
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
-#~ msgid "Fatal: You are not allowed to access this functionality."
-#~ msgstr ""
-
-#~ msgid "Claim this paper"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "You have %i tickets."
-#~ msgstr ""
-
-#~ msgid "The publication date of this book is %s."
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
-#~ msgid "Unweighted %s keywords:"
-#~ msgstr ""
-
-#~ msgid "Unknown type: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file named %s already exists. Please choose another name."
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Record #%i"
-#~ msgstr ""
 
 #~ msgid "Comparison of:"
 #~ msgstr ": المقارنة"
 
 #~ msgid "Revision"
 #~ msgstr "تنقيح"
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Could not find format element named %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s could not be found."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
-
-#~ msgid "Output format with code %s could not be found."
-#~ msgstr ""
-
-#~ msgid "Could not find output format named %s."
-#~ msgstr ""
-
-#~ msgid "Could not find a fresh name for output format %s."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "تعديل خصائص النموذج"
@@ -15456,9 +14823,6 @@ msgstr "السنة"
 
 #~ msgid "Check Dependencies"
 #~ msgstr "فحص علاقات"
-
-#~ msgid "Update Format Attributes"
-#~ msgstr ""
 
 #~ msgid "Show Documentation"
 #~ msgstr "عرض الوثائق"
@@ -15472,710 +14836,32 @@ msgstr "السنة"
 #~ msgid "Manage Output Formats"
 #~ msgstr "إدارة صيغ العرض"
 
-#~ msgid "Manage Format Templates"
-#~ msgstr ""
-
-#~ msgid "Format Elements Documentation"
-#~ msgstr ""
-
-#~ msgid "Add New Format Template"
-#~ msgstr ""
-
-#~ msgid "Check Format Templates Extensively"
-#~ msgstr ""
-
 #~ msgid "Code"
 #~ msgstr "رمز"
-
-#~ msgid "Add New Output Format"
-#~ msgstr ""
 
 #~ msgid "menu"
 #~ msgstr "القائمة"
 
-#~ msgid "Close Output Format"
-#~ msgstr ""
-
-#~ msgid "Rules"
-#~ msgstr ""
-
-#~ msgid "Modify Output Format Attributes"
-#~ msgstr ""
-
-#~ msgid "Remove Rule"
-#~ msgstr ""
-
-#~ msgid "Add New Rule"
-#~ msgstr ""
-
-#~ msgid "No problem found with format"
-#~ msgstr ""
-
-#~ msgid "An error has been found"
-#~ msgstr ""
-
-#~ msgid "The following errors have been found"
-#~ msgstr ""
-
-#~ msgid "BibFormat Admin"
-#~ msgstr ""
-
-#~ msgid "Test with record:"
-#~ msgstr ""
-
-#~ msgid "Enter a search query here."
-#~ msgstr ""
-
-#~ msgid "No Record Found for %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
-#~ msgid "Template \"%s\" does not exist at line %s."
-#~ msgstr ""
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
-
-#~ msgid "Output format %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
-#~ msgid "Format template %s calls undefined element \"%s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
-
-#~ msgid "Error in format element %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Show all %i authors"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
-
-#~ msgid "Restricted Output Format"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Rules"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Output Format"
-#~ msgstr ""
-
-#~ msgid "Cannot create output format"
-#~ msgstr ""
-
-#~ msgid "Format template %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Element %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Test Format Element %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Output Format %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Element"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Element %s"
-#~ msgstr ""
-
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
-#~ msgid "Format Validation"
-#~ msgstr ""
-
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid "Your rule: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Download history:"
-#~ msgstr ""
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Not Set"
-#~ msgstr ""
-
-#~ msgid "never"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Your account on '%s' has been activated"
-#~ msgstr ""
-
-#~ msgid "Your account earlier created on '%s' has been activated:"
-#~ msgstr ""
-
-#~ msgid "Account created on '%s'"
-#~ msgstr ""
-
-#~ msgid "An account has been created for you on '%s':"
-#~ msgstr ""
-
-#~ msgid "Account rejected on '%s'"
-#~ msgstr ""
-
-#~ msgid "Your request for an account has been rejected on '%s':"
-#~ msgstr ""
-
-#~ msgid "Username/Email: %s"
-#~ msgstr ""
-
-#~ msgid "Account deleted on '%s'"
-#~ msgstr ""
-
-#~ msgid "Your account on '%s' has been deleted:"
-#~ msgstr ""
-
-#~ msgid "You already have an alert named %s."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been added to your profile."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been successfully updated."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display searches"
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
-
-#~ msgid "times"
-#~ msgstr ""
-
-#~ msgid "Papers"
-#~ msgstr ""
-
-#~ msgid "No Keywords"
-#~ msgstr ""
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
-
-#~ msgid "No Subject categories"
-#~ msgstr ""
-
-#~ msgid "Subject categories"
-#~ msgstr ""
-
 #~ msgid "No Collaborations"
 #~ msgstr "المجموعات"
-
-#~ msgid "unknown affiliation"
-#~ msgstr ""
-
-#~ msgid "No Affiliations"
-#~ msgstr ""
 
 #~ msgid "Affiliations"
 #~ msgstr "الإدارة"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
 #~ msgid "Citations%s"
 #~ msgstr "استشهادات"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
-
-#~ msgid "No Publication Graph"
-#~ msgstr ""
-
-#~ msgid "<strong> Publications list </strong>"
-#~ msgstr ""
 
 #~ msgid "No publications available"
 #~ msgstr "لا يوجد أنواع وثائق متاحة."
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "Sorry, you do not have sufficient rights to add record #%i."
-#~ msgstr ""
-
-#~ msgid "%i matching items"
-#~ msgstr ""
-
-#~ msgid "%i items have been successfully added to your basket"
-#~ msgstr ""
-
-#~ msgid "Adding %i items to your baskets"
-#~ msgstr ""
-
-#~ msgid "%i user groups are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "%i items"
-#~ msgstr ""
-
-#~ msgid "%i notes"
-#~ msgstr ""
-
-#~ msgid "%i subscribers"
-#~ msgstr ""
-
-#~ msgid "Record %i"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s does not exist in the database."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is an invalid ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "Showing the latest %i comments:"
-#~ msgstr ""
-
-#~ msgid "Sorry, the record %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "Sorry, %s is not a valid ID value."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s"
-#~ msgstr ""
-
-#~ msgid "Readers found the following %s reviews to be most helpful."
-#~ msgstr ""
-
-#~ msgid "View all %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s comments"
-#~ msgstr ""
-
-#~ msgid "Note: Your nickname, %s, will be displayed as author of this comment."
-#~ msgstr ""
-
-#~ msgid "Max %i files"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Note: Your nickname, %s, will be "
-#~ "displayed as the author of this "
-#~ "review."
-#~ msgstr ""
-
-#~ msgid "View all %s reported comments"
-#~ msgstr ""
-
-#~ msgid "View all %s reported reviews"
-#~ msgstr ""
-
-#~ msgid "This review has been reported %i times"
-#~ msgstr ""
-
-#~ msgid "This comment has been reported %i times"
-#~ msgstr ""
-
-#~ msgid "Here are the reported reviews of user %s"
-#~ msgstr ""
-
-#~ msgid "Here are the reported comments of user %s"
-#~ msgstr ""
-
-#~ msgid "Here is review %s"
-#~ msgstr ""
-
-#~ msgid "Here is comment %s"
-#~ msgstr ""
-
-#~ msgid "Here are all reviews for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "Here are all comments for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "%s View your previously submitted comments"
-#~ msgstr ""
-
-#~ msgid "Comment ID %s does not exist."
-#~ msgstr ""
-
-#~ msgid "Record ID %s does not exist."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your message is too long, please "
-#~ "shorten it. Maximum size allowed is "
-#~ "%i characters."
-#~ msgstr ""
-
-#~ msgid "Group %s does not exist."
-#~ msgstr ""
-
-#~ msgid "User %s does not exist."
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, %s does not seem to be "
-#~ "a valid sort option. The records "
-#~ "will not be sorted."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, sorting is allowed on sets "
-#~ "of up to %d records only. Using"
-#~ " default sort order."
-#~ msgstr ""
-
-#~ msgid "The record %d replaces it."
-#~ msgstr ""
-
-#~ msgid "Cited by 1 record"
-#~ msgstr ""
-
 #~ msgid "%i reviews"
 #~ msgstr " %i استعراض"
-
-#~ msgid "Sorry, collection %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s."
-#~ msgstr ""
-
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid "Cited by: %s records"
-#~ msgstr ""
-
-#~ msgid "Co-cited with: %s records"
-#~ msgstr ""
-
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
-#~ msgid "No Papers"
-#~ msgstr ""
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
-
-#~ msgid "Citations:"
-#~ msgstr ""
-
-#~ msgid "No Citation Information available"
-#~ msgstr ""
-
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Sorry, DOI %s could not be resolved."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
 
 #~ msgid "Discussion"
 #~ msgstr "مناقشة"
 
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If you are using a lightweight CERN account you can\n"
-#~ "                %(x_url_open)sreset the password%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Alternatively, you can ask %s to "
-#~ "change your login system from external"
-#~ " to internal."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "%s offers you the possibility to "
-#~ "personalize the interface, to set up "
-#~ "your own personal library of documents,"
-#~ " or to set up an automatic "
-#~ "alert query that would run periodically"
-#~ " and would notify you of search "
-#~ "results by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid "Okay, a password reset link has been emailed to %s."
-#~ msgstr ""
-
-#~ msgid "If you don't own an account yet, please contact %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please do not use valuable passwords "
-#~ "such as your Unix, AFS or NICE "
-#~ "passwords with this service. Your email"
-#~ " address will stay strictly confidential"
-#~ " and will not be disclosed to "
-#~ "any third party. It will be used"
-#~ " to identify you for personal "
-#~ "services of %s. For example, you "
-#~ "may set up an automatic alert "
-#~ "search that will look for new "
-#~ "preprints and will notify you daily "
-#~ "of new arrivals by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "It is not possible to create an"
-#~ " account yourself. Contact %s if you"
-#~ " want an account."
-#~ msgstr ""
-
 #~ msgid "Your alerts"
 #~ msgstr "تنبيهاتك"
-
-#~ msgid "Your approvals"
-#~ msgstr ""
 
 #~ msgid "Your baskets"
 #~ msgstr "سلالك"
@@ -16189,178 +14875,5 @@ msgstr "السنة"
 #~ msgid "Statistics"
 #~ msgstr "إحصائيات"
 
-#~ msgid "Edit %s members"
-#~ msgstr ""
-
-#~ msgid "Edit group %s"
-#~ msgstr ""
-
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
-#~ msgid "Group: %s"
-#~ msgstr ""
-
-#~ msgid "Group %s: New membership request"
-#~ msgstr ""
-
-#~ msgid "A user wants to join the group %s."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been accepted"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been accepted."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been rejected"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been rejected."
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted"
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted by its administrator."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown to the external login "
-#~ "system."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The external login method %s does "
-#~ "not support email address based logins."
-#~ "  Please contact the site administrators."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "Sorry, page %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
-#~ msgid "Page %s Not Found"
-#~ msgstr ""
-
-#~ msgid "Please contact %s quoting the following information:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
-
-#~ msgid "Unable to find the submission directory for the action: %s"
-#~ msgstr ""
-
-#~ msgid "Unable to find document type: %s"
-#~ msgstr ""
-
 #~ msgid "The field %s is mandatory."
 #~ msgstr "الحقل %s إجباري"
-
-#~ msgid "Function %s does not exist."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s%s'"
-#~ msgstr ""
-

--- a/invenio/base/translations/bg/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/bg/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
 "PO-Revision-Date: 2008-03-27 02:25+0200\n"
 "Last-Translator: Nikolay Dyankov <ndyankov@gmail.com>\n"
 "Language-Team: BG <info@invenio-software.org>\n"
@@ -24,7 +24,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -58,8 +58,8 @@ msgstr "Страници за администриране"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -205,7 +205,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Здравей:"
 
@@ -226,17 +226,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -262,48 +262,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Записът не съществува."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Вие не сте упълномощен да разглеждате тази зона"
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Грешка при регистрация"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Моля, изберете един или повече:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Грешка при регистрация"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -503,7 +508,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -562,8 +568,7 @@ msgstr "Промяна на метода за идентификация"
 #, fuzzy, python-format
 msgid "All fields with %(x_fmt_open)s*%(x_fmt_close)s are mandatory"
 msgstr ""
-"Ако отговорът е %(x_fmt_open)sне%(x_fmt_close)s, трябва да зададете "
-"кошница"
+"Ако отговорът е %(x_fmt_open)sне%(x_fmt_close)s, трябва да зададете кошница"
 
 #: invenio/legacy/batchuploader/templates.py:245
 #: invenio/legacy/batchuploader/templates.py:466
@@ -582,9 +587,9 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"Вие сте влязъл като %(x_user)s. Може да  а) "
-"%(x_url1_open)sизлезете%(x_url1_close)s; б) редактирате  "
-"%(x_url2_open)sнастройките%(x_url2_close)s на вашата сметка."
+"Вие сте влязъл като %(x_user)s. Може да  а) %(x_url1_open)sизлезете"
+"%(x_url1_close)s; б) редактирате  %(x_url2_open)sнастройките%(x_url2_close)s "
+"на вашата сметка."
 
 #: invenio/legacy/batchuploader/templates.py:282
 msgid "No metadata files have been uploaded yet."
@@ -727,7 +732,8 @@ msgid "The following errors have occurred:"
 msgstr "Намерени са следните грешки"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -744,8 +750,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -827,7 +833,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -870,8 +876,8 @@ msgstr "Вашите кошници"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Предишен"
@@ -887,8 +893,8 @@ msgstr "Точки"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Следващ"
 
@@ -903,18 +909,6 @@ msgstr "Следващ"
 #: invenio/legacy/weblinkback/adminlib.py:55
 msgid "Admin Area"
 msgstr "Администриране"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "автор"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
@@ -934,11 +928,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
 msgid "Limit to knowledge bases containing string:"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "успешно изтрит"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -990,16 +979,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
 msgid "Verify BibCheck config file"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Проблем с базата данни"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "файл(а)"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
@@ -1106,7 +1085,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1157,8 +1137,8 @@ msgstr "Създадена е нова сметка в"
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1172,25 +1152,23 @@ msgstr "Преглеждане"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "Създадена е нова сметка в"
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "Създадена е нова сметка в"
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1215,13 +1193,14 @@ msgstr "Създаване на тема"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "Създадена е нова сметка в"
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1253,9 +1232,8 @@ msgstr "моментно състояние:"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "Създадена е нова сметка в"
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1322,8 +1300,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1331,8 +1309,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1354,9 +1332,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "Създадена е нова сметка в"
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1398,8 +1375,8 @@ msgstr "Намерени са %s записа"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1458,11 +1435,11 @@ msgstr "Създадена е нова сметка в"
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1473,11 +1450,11 @@ msgstr "Да"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1490,8 +1467,8 @@ msgstr "Не"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1588,8 +1565,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1609,29 +1586,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1640,9 +1617,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr "Желаният запис не съществува."
 
@@ -2003,16 +1980,14 @@ msgstr "Записът е изтрит."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2033,8 +2008,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2196,8 +2171,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2306,7 +2281,7 @@ msgstr "Действие"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Описание"
 
@@ -2501,8 +2476,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2788,9 +2763,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "Ако желаете, може да  %(x_url_open)sвлезете тук%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2846,7 +2820,7 @@ msgstr "Отхвърляне"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "OK"
 
@@ -2854,8 +2828,8 @@ msgstr "OK"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "Създадена е нова сметка в"
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3328,8 +3302,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "E-mail"
 
@@ -4183,8 +4157,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4202,8 +4176,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4269,17 +4243,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4667,25 +4641,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "Записът е изтрит."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4745,15 +4719,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4765,10 +4739,10 @@ msgstr "Избери тема"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4782,15 +4756,15 @@ msgstr "Правила"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4801,7 +4775,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4820,17 +4795,15 @@ msgstr "Желаният псевдоним %s вече съществува в 
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "Желаният псевдоним %s вече съществува в базата от данни."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4849,14 +4822,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4910,8 +4882,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4966,8 +4938,8 @@ msgstr "Желаният запис не съществува."
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -5087,9 +5059,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -5104,8 +5076,8 @@ msgstr "Запазване на промените"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -5249,11 +5221,10 @@ msgstr "Обратно към резултатите от търсенето"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5389,7 +5360,7 @@ msgid "Total"
 msgstr "изборен"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Избери"
 
@@ -5559,8 +5530,8 @@ msgstr "Изтриване на базата от знания"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5619,56 +5590,56 @@ msgstr "Моля, първо влезте."
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5707,7 +5678,7 @@ msgstr "Зависимости на базата от знания"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5761,15 +5732,15 @@ msgstr "Вашите известия"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5854,7 +5825,8 @@ msgstr "Извинете"
 #: invenio/legacy/errorlib/webinterface.py:130
 #, fuzzy, python-format
 msgid "Cannot send error request, %(x_name)s parameter missing."
-msgstr "Съобщението за грешка не може да бъде изпратено, параметърът %s липсва."
+msgstr ""
+"Съобщението за грешка не може да бъде изпратено, параметърът %s липсва."
 
 #: invenio/legacy/errorlib/webinterface.py:150
 msgid "The error report has been sent."
@@ -5868,8 +5840,8 @@ msgstr "Благодарим Ви за помощта Ви да направим
 #: invenio/legacy/errorlib/webinterface.py:155
 msgid "Use the back button of your browser to return to the previous page."
 msgstr ""
-"Използвайте бутона за навигация назад във вашия браузър за да се върнете "
-"на предишната страница."
+"Използвайте бутона за навигация назад във вашия браузър за да се върнете на "
+"предишната страница."
 
 #: invenio/legacy/errorlib/webinterface.py:158
 msgid "Thank you!"
@@ -5999,8 +5971,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -6078,8 +6049,8 @@ msgstr ""
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6094,8 +6065,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Резултати от търсенето"
 
@@ -6256,8 +6227,8 @@ msgstr "Не бяха намерени стойности."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6283,8 +6254,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6295,42 +6266,41 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
 #, python-format
 msgid "No exact match found for %(x_query1)s, using %(x_query2)s instead..."
 msgstr ""
-"Не беше намерено точно съвпадение за %(x_query1)s, вместо това използваме"
-" %(x_query2)s..."
+"Не беше намерено точно съвпадение за %(x_query1)s, вместо това използваме "
+"%(x_query2)s..."
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
-"Не беше намерено съвпадение в колекцията %(x_collection)s. Други публични"
-" колекции дадоха %(x_url_open)s%(x_nb_hits)d поапдения%(x_url_close)s."
+"Не беше намерено съвпадение в колекцията %(x_collection)s. Други публични "
+"колекции дадоха %(x_url_open)s%(x_nb_hits)d поапдения%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 "Вашата заявка не съвпадна с нито една обща колекция. Ако търсите частен "
 "документ, моля, първо изберете желаната ограничена колекция."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
@@ -6338,99 +6308,99 @@ msgstr ""
 "Вашата заявка не съвпадна с нито една обща колекция. Ако търсите частен "
 "документ, моля, първо изберете желаната ограничена колекция."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
-"Търсенето на %s не съвпадна с нито един запис. Най-близките попадения във"
-" всички колекции са:"
+"Търсенето на %s не съвпадна с нито един запис. Най-близките попадения във "
+"всички колекции са:"
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "Използвайте други думи за търсене."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Има %i кошници"
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Има %i кошници"
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Има %i кошници"
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Индексът за думата не е наличен за"
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Индексът за фразата не е наличен за"
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
-"Търсенето на %(x_term)s в индекса %(x_index)s не съвпадна с нито един "
-"запис. Най-близките до него попадения в коя да е колекция са:"
+"Търсенето на %(x_term)s в индекса %(x_index)s не съвпадна с нито един запис. "
+"Най-близките до него попадения в коя да е колекция са:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr ""
-"Търсенето на %s не съвпадна с нито един запис. Най-близките попадения във"
-" всички колекции са:"
+"Търсенето на %s не съвпадна с нито един запис. Най-близките попадения във "
+"всички колекции са:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
-"Съжаляваме, %s не е валидна опция за сортиране. Използване на сортиране "
-"по заглавие."
+"Съжаляваме, %s не е валидна опция за сортиране. Използване на сортиране по "
+"заглавие."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 "Съжаляваме, сортирането е позволено само на множества от най-много %d "
 "записа. Използване на ред по подразбиране."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
-"Съжаляваме, %s не е валидна опция за сортиране. Използване на сортиране "
-"по заглавие."
+"Съжаляваме, %s не е валидна опция за сортиране. Използване на сортиране по "
+"заглавие."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Записът не съществува."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Използвайте други думи за търсене."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6444,13 +6414,13 @@ msgstr "Използвайте други думи за търсене."
 msgid "Browse"
 msgstr "Преглеждане"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 "Няма съвпадения, удовлетворяващи зададените от вас критерии за време, "
 "премахване на това условие..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
 "Няма съвпадения, удовлетворящи зададените от вас граници за търсене, "
@@ -6496,14 +6466,13 @@ msgstr "Известието %s е успешно обновено."
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Направили сте %(x_nb)s заявки. Наличен е %(x_url_open)sподробен "
-"списък%(x_url_close)s с възможност за (а) разглеждане на резултатите от "
-"търсене и (б) абониране за известяване по e-mail за тези заявки."
+"Направили сте %(x_nb)s заявки. Наличен е %(x_url_open)sподробен списък"
+"%(x_url_close)s с възможност за (а) разглеждане на резултатите от търсене и "
+"(б) абониране за известяване по e-mail за тези заявки."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6625,8 +6594,7 @@ msgstr "не"
 #, python-format
 msgid "if %(x_fmt_open)sno%(x_fmt_close)s you must specify a basket"
 msgstr ""
-"Ако отговорът е %(x_fmt_open)sне%(x_fmt_close)s, трябва да зададете "
-"кошница"
+"Ако отговорът е %(x_fmt_open)sне%(x_fmt_close)s, трябва да зададете кошница"
 
 #: invenio/legacy/webalert/templates.py:227
 msgid "Store results in basket?"
@@ -6646,9 +6614,9 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"Задаване на ново известяване от %(x_url1_open)sвашите "
-"търсения%(x_url1_close)s, %(x_url2_open)sпопулярните "
-"търсения%(x_url2_close)s или от входящата форма."
+"Задаване на ново известяване от %(x_url1_open)sвашите търсения"
+"%(x_url1_close)s, %(x_url2_open)sпопулярните търсения%(x_url2_close)s или от "
+"входящата форма."
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6699,8 +6667,8 @@ msgstr "Вие сте дефинирали %s известия."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 "Все още не сте извършили търсене. Моля, първо отидете на  "
 "%(x_url_open)sстраницата за търсене%(x_url_close)s."
@@ -6708,8 +6676,8 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
 "Вие сте извършили %(x_nb1)s търсения (%(x_nb2)s различни въпроса) през "
 "последните 30 дни."
@@ -6771,7 +6739,7 @@ msgstr "Вашите търсения"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6835,7 +6803,7 @@ msgstr ""
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6895,7 +6863,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6919,7 +6888,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "Нямате достатъчно права за достъп до съдържанието на кошницата."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6947,7 +6917,8 @@ msgid "You do not have permission to delete this note."
 msgstr "Нямате достатъчно права за достъп до съдържанието на кошницата."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6978,8 +6949,8 @@ msgstr "Записът не съществува."
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -7001,8 +6972,8 @@ msgstr "Копиране на записа в кошница"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -7035,8 +7006,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7109,8 +7080,7 @@ msgstr "Публична кошница"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 "Вие имате %(x_nb_perso)s лични кошници и сте абониран за %(x_nb_group)s "
 "групови кошници и %(x_nb_public)s кошници на други потребители."
@@ -7140,11 +7110,10 @@ msgstr "%i потребителски групи са абонирани за к
 #: invenio/legacy/webbasket/templates.py:108
 #, fuzzy, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
-"Може да погледнете в %(x_url_open)sстраниците за "
-"%(x_category)s%(x_url_close)s."
+"Може да погледнете в %(x_url_open)sстраниците за %(x_category)s"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
 #: invenio/legacy/webbasket/templates.py:198
@@ -7316,8 +7285,8 @@ msgstr "Външен запис"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7502,8 +7471,8 @@ msgstr "Споделяне на кошницата с нова група"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 "Вие сте влязъл като гост, затова вашите кошници ще изчезнат в края на "
 "текущата сесия."
@@ -7512,10 +7481,11 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
-"Ако желаете, може да  %(x_url_open)sвлезете или да се регистрирате "
-"тук%(x_url_close)s."
+"Ако желаете, може да  %(x_url_open)sвлезете или да се регистрирате тук"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7524,7 +7494,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Тази функционалност е забранена за гости."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Обратно към резултатите от търсенето"
 
@@ -7699,7 +7669,7 @@ msgstr "Добавяне към потребителите"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7846,219 +7816,218 @@ msgstr "Потребителят %s не съществува."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "Потребителят %s не съществува."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Написване на коментар"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_name)s написа на %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "коментари"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Показване на последните %i коментара:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Обсъждане на документа:"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Започни обсъждане относно кой да е аспект на този документ."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Съжаляваме, записът %s не съществува."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "Съжаляваме, %s не е валидна стойност за ID."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "Съжаляваме, не беше зададен ID на записа."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Може да започнете да преглеждате от  %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_name)s написа на %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Беше ли ви полезен този преглед?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Написване на преглед"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
-"Среден брой точки от прегледи: %(x_nb_score)s базирано на "
-"%(x_nb_reviews)s прегледа"
+"Среден брой точки от прегледи: %(x_nb_score)s базирано на %(x_nb_reviews)s "
+"прегледа"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "Читателите счетоха следните %s прегледи за най-полезни."
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Преглед на всички %s прегледа"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Оценка на документа"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Бъдете първия, който ще оцени този документ."
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "Точки"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Докладване на обида"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 #, fuzzy
 msgid "Undelete comment"
 msgstr "изтриване на коментарите"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Изтриване на коментар"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 #, fuzzy
 msgid "Unreport comment"
 msgstr "Изтриване на коментар"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Прегледано от %(x_nickname)s на %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
-"%(x_nb_people)i от общо %(x_nb_total)i човека оцениха този преглед за "
-"полезен"
+"%(x_nb_people)i от общо %(x_nb_total)i човека оцениха този преглед за полезен"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 #, fuzzy
 msgid "Undelete review"
 msgstr "Изтриване на избраните отзиви"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 #, fuzzy
 msgid "Delete review"
 msgstr "Изтриване на избраните отзиви"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 #, fuzzy
 msgid "Unreport review"
 msgstr "Напишете вашия преглед"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Коментари"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Прегледи"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Има общо %s прегледа"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Има общо %s коментара"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Бъдете първия, който ще оцени този документ."
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Абониране"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 #, fuzzy
 msgid "Unsubscribe"
 msgstr "Абониране"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -8067,43 +8036,43 @@ msgstr "Абониране"
 msgid "Record"
 msgstr "Запис"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "преглед"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "коментар"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Преглед"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Преглеждане"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Страница: "
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 #, fuzzy
 msgid "You are not authorized to comment or review."
 msgstr "Вие не сте упълномощен да разглеждате тази зона"
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
-msgstr "Забележка: Вашият прякор, %s, ще бъде показан като автор на този документ"
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
+msgstr ""
+"Забележка: Вашият прякор, %s, ще бъде показан като автор на този документ"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
@@ -8112,483 +8081,487 @@ msgstr ""
 "Забележка: не сте %(x_url_open)sзадали своя прякор%(x_url_close)s. "
 "%(x_nickname)s ще бъде показан като автор на този коментар."
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 #, fuzzy
 msgid "Max one file"
 msgstr "Добавяне на ново правило"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "Главн(и) файл(ове)"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Статия"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "Добавяне на коментар"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
-msgstr "Забележка: Вашият прякор, %s, ще бъде показан като автор на този преглед."
+msgstr ""
+"Забележка: Вашият прякор, %s, ще бъде показан като автор на този преглед."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Оцени статията"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Избери точки"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Озаглавете вашия преглед"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Напишете вашия преглед"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr "Добавяне на преглед"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Добавете преглед"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Вашият преглед беше успешно добавен."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Вашият коментар беше успешно добавен."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Обратно към записа"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr ""
-"Може да направите справка със списъка на %(x_url_open)sвашите "
-"групи%(x_url_close)s."
+"Може да направите справка със списъка на %(x_url_open)sвашите групи"
+"%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 #, fuzzy
 msgid "View most commented records"
 msgstr "преглед на коментарите"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 #, fuzzy
 msgid "View latest commented records"
 msgstr "преглед на коментарите"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all comments reported as abuse"
 msgstr "Преглед на всички потребители, за които е гласувано"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 #, fuzzy
 msgid "View most reviewed records"
 msgstr "премахване на записите"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 #, fuzzy
 msgid "View latest reviewed records"
 msgstr "Преглед на всички %s прегледа"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all reviews reported as abuse"
 msgstr "Преглед на всички потребители, за които е гласувано"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Преглед на всички потребители, които са дали коментар"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Ръководство"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Коментарите и прегледите не са активирани"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"Моля въведете ID на коментара/прегледа за да може да го прегледате преди "
-"да решите дали да го изтриете"
+"Моля въведете ID на коментара/прегледа за да може да го прегледате преди да "
+"решите дали да го изтриете"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "ID на коментара:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 #, fuzzy
 msgid "Record ID:"
 msgstr "ID на записа"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Преглед на коментар"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "До сега няма коментари."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Преглед на всички %s коментари"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Преглед на всички %s прегледи"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-"Това е списък, сортиран по общия брой отзиви, на всички потребители, "
-"които са имали поне един отзив на някой от техните коментари."
+"Това е списък, сортиран по общия брой отзиви, на всички потребители, които "
+"са имали поне един отзив на някой от техните коментари."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Псевдоним"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "ID на потребителя"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Брой на положителните гласове"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Брой на отрицателните гласове"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Пълен брой на гласовете"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Пълен брой отзиви"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Преглеждане на всички коментари на потребителя"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "За този преглед е гласувано %i пъти"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "За този коментар е гласувано %i пъти"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Написано от"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Обща информация"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Изтриване на избраните отзиви"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Забрана на избраното сведение за обида"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 #, fuzzy
 msgid "Undelete selected reviews"
 msgstr "Изтриване на избраните отзиви"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 #, fuzzy
 msgid "Undelete selected comments"
 msgstr "Изтриване на избраните коментари"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Изтриване на избраните коментари"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Това са прегледите на потребител %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Това са коментарите на потребител %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Това е коментар/преглед %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Това е коментар/преглед %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, fuzzy, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Това е коментар/преглед %(x_cmtID)s написан от %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, fuzzy, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Това е коментар/преглед %(x_cmtID)s написан от %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr ""
-"Това са всички прегледи, за които е гласувано, сортирани по тези, за "
-"които е гласувано най-много"
+"Това са всички прегледи, за които е гласувано, сортирани по тези, за които е "
+"гласувано най-много"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr ""
-"Това са всички коментари, за които е гласувано, сортирани по тези, за "
-"които е гласувано най-много"
+"Това са всички коментари, за които е гласувано, сортирани по тези, за които "
+"е гласувано най-много"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
-"Това са всички прегледи, за които е гласувано, сортирани по тези, за "
-"които е гласувано най-много"
+"Това са всички прегледи, за които е гласувано, сортирани по тези, за които е "
+"гласувано най-много"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 #, fuzzy
 msgid "Show comments"
 msgstr "преглед на коментарите"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
-"Това са всички коментари, за които е гласувано, сортирани по тези, за "
-"които е гласувано най-много"
+"Това са всички коментари, за които е гласувано, сортирани по тези, за които "
+"е гласувано най-много"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 #, fuzzy
 msgid "Show reviews"
 msgstr "преглед"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "ID на коментара"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "успешно изтрит"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 #, fuzzy
 msgid "successfully undeleted"
 msgstr "успешно изтрит"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "успешно забранена обида"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Все още не е прегледано"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "Вашият коментар е успешно публикуван"
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Изтриване на коментари"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "първо най-новите"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "преглед на коментарите"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "Детайли и коментари"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "Намерени са %s записа"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Коментари"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "Време"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Добавяне към потребителите"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "Показване"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Дата на създаване"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Следваща страница"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Показване на известията"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8597,106 +8570,106 @@ msgstr "Показване на известията"
 msgid "Refresh"
 msgstr "Референции"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Изтриване на коментар"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "Не бяха намерени стойности."
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Записът не е намерен"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "Нямате достатъчно права за достъп до съдържанието на кошницата."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Добавяне на коментар"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "Преглед на всички коментари"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 #, fuzzy
 msgid "Page Not Found"
 msgstr "Страницата %s не е намерена"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 #, fuzzy
 msgid "The requested comment could not be found"
 msgstr "Записът не съществува."
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 #, fuzzy
 msgid "The requested file could not be found"
 msgstr "Записът не съществува."
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Вие не сте упълномощен да разглеждате тази зона"
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Коментари"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "Преглед на всички коментари"
@@ -8815,11 +8788,11 @@ msgstr "Съжаляваме, страницата %s не съществува.
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
-"Може да погледнете в %(x_url_open)sстраниците за "
-"%(x_category)s%(x_url_close)s."
+"Може да погледнете в %(x_url_open)sстраниците за %(x_category)s"
+"%(x_url_close)s."
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
 #, fuzzy, python-format
@@ -8886,8 +8859,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8914,8 +8887,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -9013,11 +8986,6 @@ msgstr ""
 msgid "Apply"
 msgstr "Април"
 
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "Псевдоним"
-
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 #, fuzzy
 msgid "WebJournal Admin"
@@ -9101,9 +9069,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -9125,8 +9092,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9264,8 +9230,8 @@ msgid ""
 "Your message could not be sent to the following recipients as it would "
 "exceed their quotas:"
 msgstr ""
-"Вашето съобщение не може да бъде изпратено до следните получатели, поради"
-" тяхната квота:"
+"Вашето съобщение не може да бъде изпратено до следните получатели, поради "
+"тяхната квота:"
 
 #: invenio/legacy/webmessage/api.py:457
 msgid "Your message has been sent."
@@ -9610,16 +9576,16 @@ msgstr "Търси също:"
 #: invenio/legacy/websearch/templates.py:1589
 #, fuzzy
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 "Достъпът до тази колекция е ограничен. Ако мислите, че имате право на "
 "достъп, моля идентифицирайте се."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9634,7 +9600,8 @@ msgstr "Цитиран от: %s записа"
 #: invenio/legacy/websearch/templates.py:1856
 #, python-format
 msgid "Words nearest to %(x_word)s inside %(x_field)s in any collection are:"
-msgstr "Най-близки думи до %(x_word)s в полето %(x_field)s в коя да е колекция са:"
+msgstr ""
+"Най-близки думи до %(x_word)s в полето %(x_field)s в коя да е колекция са:"
 
 #: invenio/legacy/websearch/templates.py:1859
 #, python-format
@@ -9757,11 +9724,10 @@ msgstr "Вашите публикации"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
-"Логическата заявка не върна резултати. Моля, комбинирайте търсените думи "
-"по друг начин."
+"Логическата заявка не върна резултати. Моля, комбинирайте търсените думи по "
+"друг начин."
 
 #: invenio/legacy/websearch/templates.py:3357
 msgid "See also: similar author names"
@@ -9786,8 +9752,8 @@ msgstr "Може да започнете да преглеждате от %s."
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3832
@@ -9980,7 +9946,8 @@ msgid "in"
 msgstr "в"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "Не намерихте, каквото търсите? Опитайте търсене в други сървъри:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9996,8 +9963,8 @@ msgid ""
 "The external search engine has not responded in time. You can check its "
 "results here:"
 msgstr ""
-"Външната система за търсене не отговори на време. Може да проверите "
-"нейните резултати тук:"
+"Външната система за търсене не отговори на време. Може да проверите нейните "
+"резултати тук:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:146
 #: invenio/legacy/websearch_external_collections/templates.py:154
@@ -10076,8 +10043,8 @@ msgstr "задължителен"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -10087,8 +10054,8 @@ msgstr "Създаване на кошница"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 "Ако желаете да промените вашите електронен адрес или псевдоним, моля "
 "въведете отдолу новите стойности."
@@ -10107,16 +10074,16 @@ msgstr "Задаване на новите стойности"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
-"Тъй като това се счита като подпис за коментари и прегледи, веднъж "
-"зададено, не може да бъде променяно повече."
+"Тъй като това се счита като подпис за коментари и прегледи, веднъж зададено, "
+"не може да бъде променяно повече."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
 "Ако желаете да промените вашата парола, моля въведете отдолу старата и "
 "изберете нова."
@@ -10156,12 +10123,11 @@ msgstr "Избиране на нова парола"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 "Ако използвате олекотена сметка в CERN, можете да\n"
-"                %(x_url_open)sустановите наново паролата "
-"си%(x_url_close)s."
+"                %(x_url_open)sустановите наново паролата си%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:346
 #, python-format
@@ -10251,14 +10217,13 @@ msgstr "Избиране на метод"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"Ако сте забравили паролата си за вашата %(sitename)s "
-"%(x_fmt_open)sвътрешна сметка%(x_fmt_close)s, моля въведете отдолу вашия "
-"електронен адрес за да получите връзка за установяване на нова парола."
+"Ако сте забравили паролата си за вашата %(sitename)s %(x_fmt_open)sвътрешна "
+"сметка%(x_fmt_close)s, моля въведете отдолу вашия електронен адрес за да "
+"получите връзка за установяване на нова парола."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10274,18 +10239,18 @@ msgstr "Изпращане на връзка за установяване на 
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
-"Забележете, че ако сте използвали външна система за идентификация , то "
-"ние не можем да направим нищо и трябва да се обърнете към тях."
+"Забележете, че ако сте използвали външна система за идентификация , то ние "
+"не можем да направим нищо и трябва да се обърнете към тях."
 
 #: invenio/legacy/websession/templates.py:573
 #, fuzzy, python-format
@@ -10293,21 +10258,20 @@ msgid ""
 "Alternatively, you can ask %(x_name)s to change your login system from "
 "external to internal."
 msgstr ""
-"Като алтернатива може да помолите %s да промени вашата система за "
-"свързване от външна на вътрешна."
+"Като алтернатива може да помолите %s да промени вашата система за свързване "
+"от външна на вътрешна."
 
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 "%s ви дава възможност да персонализирате вашия изглед, да настроите ваша "
 "собствена библиотека от документи, или да зададете автоматично търсене, "
-"което ще се извършва периодично и ще ви уведомява за резултатите по "
-"e-mail."
+"което ще се извършва периодично и ще ви уведомява за резултатите по e-mail."
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10319,8 +10283,8 @@ msgid ""
 "Set or change your account email address or password. Specify your "
 "preferences about the look and feel of the interface."
 msgstr ""
-"Задайте или променете e-mail адреса или паролата на вашата сметка. "
-"Уточнете вашите предпочитания относно изгледа."
+"Задайте или променете e-mail адреса или паролата на вашата сметка. Уточнете "
+"вашите предпочитания относно изгледа."
 
 #: invenio/legacy/websession/templates.py:620
 msgid "View all the searches you performed during the last 30 days."
@@ -10328,12 +10292,11 @@ msgstr "Преглед на всички търсения, които сте и�
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 "С кошниците може да дефинирате специфични колекции или да съхранявате "
-"интересни записи, които да преглеждате по-късно или да споделяте с "
-"другите."
+"интересни записи, които да преглеждате по-късно или да споделяте с другите."
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10345,21 +10308,21 @@ msgid ""
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
 "Абонирайте се за търсене, което ще бъде периодично изпълнявано от нашата "
-"услуга. Резултатът може да ви бъде изпратен на e-mail или съхранен в една"
-" от вашите кошници."
+"услуга. Резултатът може да ви бъде изпратен на e-mail или съхранен в една от "
+"вашите кошници."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
 "Проверете за книги, наети от вас, изпратете заявка за вземане и т.н. "
 "Услугата изисква CERN ID."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
 "Вие сте влязъл като гост, вашите известия ще изчезнат в края на текущата "
 "сесия."
@@ -10367,13 +10330,13 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
-"Вие сте влязъл като %(x_user)s. Може да  а) "
-"%(x_url1_open)sизлезете%(x_url1_close)s; б) редактирате  "
-"%(x_url2_open)sнастройките%(x_url2_close)s на вашата сметка."
+"Вие сте влязъл като %(x_user)s. Може да  а) %(x_url1_open)sизлезете"
+"%(x_url1_close)s; б) редактирате  %(x_url2_open)sнастройките%(x_url2_close)s "
+"на вашата сметка."
 
 #: invenio/legacy/websession/templates.py:785
 #, fuzzy, python-format
@@ -10381,8 +10344,8 @@ msgid ""
 "You can consult the list of %(x_url_open)syour comments%(x_url_close)s "
 "submitted so far."
 msgstr ""
-"Може да направите справка със списъка на %(x_url_open)sвашите "
-"групи%(x_url_close)s."
+"Може да направите справка със списъка на %(x_url_open)sвашите групи"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:790
 msgid "Your Alert Searches"
@@ -10391,12 +10354,11 @@ msgstr "Вашите известия за търсене"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
-"Може да направите справка със списъка на "
-"%(x_url_open)sгрупите%(x_url_close)s, които администрирате, или на които "
-"сте член."
+"Може да направите справка със списъка на %(x_url_open)sгрупите"
+"%(x_url_close)s, които администрирате, или на които сте член."
 
 #: invenio/legacy/websession/templates.py:799
 #: invenio/legacy/websession/templates.py:2348
@@ -10407,11 +10369,11 @@ msgstr "Вашите групи"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"Може да направите справка със списъка на %(x_url_open)sвашите "
-"публикации%(x_url_close)s и да проверите техния статус."
+"Може да направите справка със списъка на %(x_url_open)sвашите публикации"
+"%(x_url_close)s и да проверите техния статус."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -10421,12 +10383,11 @@ msgstr "Вашите публикации"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"Може да направите справка със списъка на "
-"%(x_url_open)sдокументите%(x_url_close)s, които сте одобрили или "
-"рецензирали."
+"Може да направите справка със списъка на %(x_url_open)sдокументите"
+"%(x_url_close)s, които сте одобрили или рецензирали."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10437,8 +10398,8 @@ msgstr "Вашите одобрения"
 #, fuzzy, python-format
 msgid "You can consult the list of %(x_url_open)syour tickets%(x_url_close)s."
 msgstr ""
-"Може да направите справка със списъка на %(x_url_open)sвашите "
-"групи%(x_url_close)s."
+"Може да направите справка със списъка на %(x_url_open)sвашите групи"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:818
 #, fuzzy
@@ -10474,7 +10435,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -10524,8 +10486,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 "Ако все още не притежавате сметка в CERN, можете да регистрирате "
 "%(x_url_open)sолекотена такава%(x_url_close)s."
@@ -10533,18 +10495,18 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"Ако все още нямате сметка, моля "
-"%(x_url_open)sрегистрирайте%(x_url_close)s вътрешна такава."
+"Ако все още нямате сметка, моля %(x_url_open)sрегистрирайте%(x_url_close)s "
+"вътрешна такава."
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
 msgid "If you don't own an account yet, please contact %(x_name)s."
 msgstr ""
-"Ако все още нямате сметка, моля "
-"%(x_url_open)sрегистрирайте%(x_url_close)s вътрешна такава."
+"Ако все още нямате сметка, моля %(x_url_open)sрегистрирайте%(x_url_close)s "
+"вътрешна такава."
 
 #: invenio/legacy/websession/templates.py:1051
 msgid "Login method:"
@@ -10574,8 +10536,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -10600,9 +10562,10 @@ msgstr "Моля въведете вашия e-mail и желаните потр
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
-msgstr "Сметката не може да бъде използвана преди да бъде проверена и активирана."
+"It will not be possible to use the account before it has been verified and "
+"activated."
+msgstr ""
+"Сметката не може да бъде използвана преди да бъде проверена и активирана."
 
 #: invenio/legacy/websession/templates.py:1228
 msgid "Retype Password"
@@ -10618,35 +10581,35 @@ msgstr "регистриране"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
-"Моля не използвайте за тази услуга ценни пароли като например вашите "
-"Unix, AFS или NICE пароли. Вашият e-mail адрес ще остане строго "
-"поверителен и няма да бъде предоставян на трети лица. Той ще бъде "
-"използван, за да ви идентифицира за персонални услуги на %s. Например, "
-"може да зададете автоматична заявка за търсене на нови препринти и ще "
-"бъдете известявани за тях по e-mail."
+"Моля не използвайте за тази услуга ценни пароли като например вашите Unix, "
+"AFS или NICE пароли. Вашият e-mail адрес ще остане строго поверителен и няма "
+"да бъде предоставян на трети лица. Той ще бъде използван, за да ви "
+"идентифицира за персонални услуги на %s. Например, може да зададете "
+"автоматична заявка за търсене на нови препринти и ще бъдете известявани за "
+"тях по e-mail."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
-"Не е възможно сами да си създадете сметка. Ако искате такава, моля "
-"свържете се с %s."
+"Не е възможно сами да си създадете сметка. Ако искате такава, моля свържете "
+"се с %s."
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
-"Изглежда, че вие сте гост. Трябва първо да  %(x_url_open)sвлезете в "
-"системата%(x_url_close)s."
+"Изглежда, че вие сте гост. Трябва първо да  %(x_url_open)sвлезете в системата"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1267
 msgid "You are not authorized to access administrative functions."
@@ -10778,8 +10741,8 @@ msgstr "Ето няколко интересни връзки за админи�
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "За повече администраторски действия, вижте пълната %(x_url_open)sзона за "
 "администриране%(x_url_close)s."
@@ -11002,7 +10965,8 @@ msgstr "Потребител иска да се присъедини към гр
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 "Моля, %(x_url_open)sприемете или отхвърлете%(x_url_close)s тази "
 "потребителска молба."
@@ -11032,8 +10996,8 @@ msgstr "Молбата ви за присъединяване към група 
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour groups%(x_url_close)s."
 msgstr ""
-"Може да направите справка със списъка на %(x_url_open)sвашите "
-"групи%(x_url_close)s."
+"Може да направите справка със списъка на %(x_url_open)sвашите групи"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:2422
 #, fuzzy, python-format
@@ -11048,9 +11012,9 @@ msgstr "Групата %s е изтрита от нейния администр
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
 "Можете да направите справка със списъка на %(x_url_open)s%(x_nb_total)i "
 "групите%(x_url_close)s, за които сте абониран (%(x_nb_member)i) или "
@@ -11059,68 +11023,63 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
-"Вие сте влязъл като гост. Може да %(x_url_open)sвлезете%(x_url_close)s "
-"като редовен потребител."
+"Вие сте влязъл като гост. Може да %(x_url_open)sвлезете%(x_url_close)s като "
+"редовен потребител."
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
-"Потребителите %(x_fmt_open)sвлезли като гост%(x_fmt_close)s трябва първо "
-"да се %(x_url_open)sрегистрират%(x_url_close)s"
+"Потребителите %(x_fmt_open)sвлезли като гост%(x_fmt_close)s трябва първо да "
+"се %(x_url_open)sрегистрират%(x_url_close)s"
 
 #: invenio/legacy/websession/webaccount.py:127
 msgid "No queries found"
@@ -11128,8 +11087,8 @@ msgstr "Не са намерени заявки"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 "Достъпът до тази колекция е ограничен. Ако мислите, че имате право на "
 "достъп, моля идентифицирайте се."
@@ -11137,8 +11096,8 @@ msgstr ""
 #: invenio/legacy/websession/webaccount.py:399
 #, fuzzy
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 "Достъпът до тази колекция е ограничен. Ако мислите, че имате право на "
 "достъп, моля идентифицирайте се."
@@ -11149,8 +11108,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11162,8 +11121,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11243,8 +11202,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11297,8 +11255,8 @@ msgstr ""
 #, python-format
 msgid "You can now go to %(x_url_open)syour account page%(x_url_close)s."
 msgstr ""
-"Сега може да влезете в %(x_url_open)sстраницата на вашата "
-"сметка%(x_url_close)s."
+"Сега може да влезете в %(x_url_open)sстраницата на вашата сметка"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:136
 #: invenio/legacy/websession/webinterface.py:145
@@ -11311,8 +11269,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -11376,10 +11333,10 @@ msgstr "Методът за влизане е променен на вътреш
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -11407,8 +11364,8 @@ msgstr "Методът за влизане е успешно избран."
 #: invenio/legacy/websession/webinterface.py:452
 #, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -11537,8 +11494,8 @@ msgid ""
 "Cannot send password reset request since you are using external "
 "authentication system."
 msgstr ""
-"Връзката за установяване на нова парола не може да бъде изпратена, тъй "
-"като вие използвате външна система за удостоверяване."
+"Връзката за установяване на нова парола не може да бъде изпратена, тъй като "
+"вие използвате външна система за удостоверяване."
 
 #: invenio/legacy/websession/webinterface.py:665
 msgid "The entered email address does not exist in the database."
@@ -11549,8 +11506,8 @@ msgid ""
 "The entered email address is incorrect, please check that it is written "
 "correctly (e.g. johndoe@example.com)."
 msgstr ""
-"Въведеният e-mail е невалиден, моля проверете дали той е написан правилно"
-" (пр. johndoe@example.com)."
+"Въведеният e-mail е невалиден, моля проверете дали той е написан правилно "
+"(пр. johndoe@example.com)."
 
 #: invenio/legacy/websession/webinterface.py:684
 msgid "Incorrect email address"
@@ -11590,18 +11547,18 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
-"Втори e-mail ще бъде изпратен, когато сметката е активирана и може да "
-"бъде използвана."
+"Втори e-mail ще бъде изпратен, когато сметката е активирана и може да бъде "
+"използвана."
 
 #: invenio/legacy/websession/webinterface.py:989
 #, python-format
@@ -11642,8 +11599,8 @@ msgstr "Желаният псевдоним %s вече съществува в 
 #: invenio/modules/accounts/views/accounts.py:143
 msgid "Users cannot register themselves, only admin can register them."
 msgstr ""
-"Потребителите не могат да се регистрират сами, само администратор може да"
-" ги регистрира."
+"Потребителите не могат да се регистрират сами, само администратор може да ги "
+"регистрира."
 
 #: invenio/legacy/websession/webinterface.py:1023
 #: invenio/modules/accounts/views/accounts.py:148
@@ -11719,7 +11676,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 "Записът е създаден на %(x_date_creation)s, последна промяна на "
 "%(x_date_modification)s"
@@ -11744,37 +11702,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11782,15 +11740,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11858,8 +11816,8 @@ msgstr "Броят на страниците в публикацията не м
 #: invenio/legacy/websubmit/engine.py:931
 #, fuzzy
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr "Папката за тази публикация не може да бъде създадена."
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11895,8 +11853,8 @@ msgstr "Изпращане"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11944,11 +11902,11 @@ msgstr "Изберете категория и след това натисне�
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
-"За да продължите предишно прекъснато публикуване, моля въведете отдолу "
-"вашия номер за достъп:"
+"За да продължите предишно прекъснато публикуване, моля въведете отдолу вашия "
+"номер за достъп:"
 
 #: invenio/legacy/websubmit/templates.py:366
 msgid "GO"
@@ -11976,8 +11934,8 @@ msgstr "Обратно към главното меню"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 "Това е вашия номер на публикация. В случай на проблеми, той може да бъде "
 "използван, за да се продължи прекъснат процес на публикуване."
@@ -12028,8 +11986,8 @@ msgstr "Публикация номер"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 "Това е списъка с %(x_action)s функции за %(x_doctype)s документи на ниво "
 "%(x_step)s"
@@ -12114,9 +12072,9 @@ msgstr "Списък на рецензираните типове докумен
 #: invenio/legacy/websubmit/templates.py:1479
 #, fuzzy
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
-msgstr "Изберете един от следните типове документ за да проверите техния статус."
+"Select one of the following types of documents to check the documents status"
+msgstr ""
+"Изберете един от следните типове документ за да проверите техния статус."
 
 #: invenio/legacy/websubmit/templates.py:1447
 msgid "Go to specific approval workflow"
@@ -12253,7 +12211,8 @@ msgstr "Одобряване"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr "Този документ все още %(x_fmt_open)sчака одобрение%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -12287,8 +12246,7 @@ msgstr "Повторно изпращане"
 #: invenio/legacy/websubmit/templates.py:2150
 msgid "WARNING! Upon confirmation, an email will be sent to the referee."
 msgstr ""
-"ПРЕДУПРЕЖДЕНИЕ! Ако потвърдите, на вашия рецензент ще бъде изпратен "
-"e-mail."
+"ПРЕДУПРЕЖДЕНИЕ! Ако потвърдите, на вашия рецензент ще бъде изпратен e-mail."
 
 #: invenio/legacy/websubmit/templates.py:2153
 #, fuzzy
@@ -12296,8 +12254,8 @@ msgid ""
 "As a referee for this document, you may approve or reject it from the "
 "submission interface"
 msgstr ""
-"Като рецензент на този документ, вие може да натиснете този бутон за да "
-"го одобрите или отхвърлите."
+"Като рецензент на този документ, вие може да натиснете този бутон за да го "
+"одобрите или отхвърлите."
 
 #: invenio/legacy/websubmit/templates.py:2155
 msgid "Approve/Reject"
@@ -12352,8 +12310,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -12372,8 +12330,8 @@ msgstr "Изпрати препоръка"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -12414,7 +12372,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12435,14 +12394,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -12532,7 +12490,8 @@ msgstr "Публикация номер"
 #: invenio/legacy/websubmit/webinterface.py:726
 #, fuzzy
 msgid "Sorry, 'sub' parameter missing..."
-msgstr "Съобщението за грешка не може да бъде изпратено, параметърът %s липсва."
+msgstr ""
+"Съобщението за грешка не може да бъде изпратено, параметърът %s липсва."
 
 #: invenio/legacy/websubmit/webinterface.py:729
 msgid "Sorry. Cannot analyse parameter"
@@ -12559,10 +12518,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12847,8 +12805,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12891,11 +12849,6 @@ msgstr "изберете потребител"
 #, fuzzy
 msgid "Role details"
 msgstr "Статия"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Скриване"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -13011,8 +12964,8 @@ msgstr "Посоченият e-mail %s вече съществува в база
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -13077,9 +13030,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -13103,8 +13055,8 @@ msgstr "Избиране на нова парола"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr "Моля въведете вашия e-mail и желаните потребителско име и парола:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -13133,7 +13085,7 @@ msgid "Problem with login."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "Сега може да влезете във вашата %(x_url_open)sсметка%(x_url_close)s."
 
@@ -13177,8 +13129,7 @@ msgstr "Грешка при промяна на настройките"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13250,13 +13201,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13265,9 +13215,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13444,8 +13394,7 @@ msgstr "колекции"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13535,8 +13484,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13628,10 +13577,10 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
 "Вашето съобщение е твърде дълго, моля, редактирайте го. Максимално "
 "позволената дължина е %i символа.                          "
@@ -13677,12 +13626,12 @@ msgid "Review was sent"
 msgstr "Написване на коментар"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "За този коментар е гласувано %i пъти"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "За този коментар е гласувано %i пъти"
 
@@ -13735,9 +13684,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13756,8 +13704,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13767,7 +13715,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "Желаният псевдоним %s вече съществува в базата от данни."
 
@@ -13823,8 +13771,7 @@ msgstr "преглед"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13864,8 +13811,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13911,7 +13857,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "Функцията %s не съществува."
 
@@ -13994,11 +13940,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "моментно състояние:"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Вашите кошници"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -14033,8 +13974,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -14055,8 +13996,8 @@ msgstr "Индексът за думата не е наличен за"
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -14072,8 +14013,7 @@ msgstr "Валидиране на елемент %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14193,7 +14133,7 @@ msgstr "Показване на всичките %i автора"
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 #, fuzzy
 msgid "Edit This Record"
 msgstr "Редактиране на друг запис"
@@ -14295,10 +14235,6 @@ msgstr "преглед"
 msgid "Authors"
 msgstr "автор"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14391,8 +14327,8 @@ msgstr "Управление на груповите права"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "Нямате достатъчно права за достъп до съдържанието на кошницата."
 
 #: invenio/modules/groups/views.py:279
@@ -14405,12 +14341,12 @@ msgstr "Вие не сте администратор на никоя група
 msgid "Members"
 msgstr "Няма членове."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Бази от знания"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14420,11 +14356,11 @@ msgstr "Готово"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "всички"
@@ -14470,13 +14406,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "Има %i кошници"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "Има %i кошници"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14632,28 +14569,28 @@ msgstr "Непознат тип документ"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14717,8 +14654,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -15089,7 +15026,7 @@ msgid "Tag name"
 msgstr "Псевдоним"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "Желаният псевдоним %s вече съществува."
 
@@ -15193,11 +15130,6 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "Готово"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15239,8 +15171,7 @@ msgstr "Опции за търсене:"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15448,7 +15379,7 @@ msgid "just now"
 msgstr "Сега трябва да"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s секунди"
 
@@ -15507,6 +15438,36 @@ msgstr "всички години"
 msgid " years ago"
 msgstr "година"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "Администриране на BibFormat"
+
+#~ msgid "Not authorized"
+#~ msgstr "автор"
+
+#~ msgid "Really delete"
+#~ msgstr "успешно изтрит"
+
+#~ msgid "Verify problem"
+#~ msgstr "Проблем с базата данни"
+
+#~ msgid "File"
+#~ msgstr "заглавие"
+
+#~ msgid "niceName"
+#~ msgstr "Име"
+
+#~ msgid "Id"
+#~ msgstr "Id"
+
+#~ msgid "Tickets"
+#~ msgstr "Време"
+
+#~ msgid "by"
+#~ msgstr "от"
+
+#~ msgid "Done"
+#~ msgstr "Готово"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Моля, изберете категория"
 
@@ -15516,20 +15477,11 @@ msgstr "година"
 #~ msgid "Warning: Please, select a valid date"
 #~ msgstr "Моля, изберете категория"
 
-#~ msgid " or return to your %(x_url_open)ssearch%(x_url_close)s"
-#~ msgstr ""
-
 #~ msgid "*** basket name ***"
 #~ msgstr "Име на кошницата"
 
-#~ msgid ""
-#~ msgstr "На посочения адрес беше изпратен e-mail с информация за сметката."
-
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "допълнителни файлове"
-
-#~ msgid "Sorry, you must log in to perform this action."
-#~ msgstr ""
 
 #~ msgid "Please log in first."
 #~ msgstr "Моля, първо влезте."
@@ -15585,23 +15537,8 @@ msgstr "година"
 #~ msgid "now"
 #~ msgstr "не"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "Администриране на BibFormat"
-
-#~ msgid "Not authorized"
-#~ msgstr "автор"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "Потребителят %s не съществува."
-
-#~ msgid "Really delete"
-#~ msgstr "успешно изтрит"
-
-#~ msgid "Verify problem"
-#~ msgstr "Проблем с базата данни"
-
-#~ msgid "File"
-#~ msgstr "заглавие"
 
 #~ msgid "File %s already exists."
 #~ msgstr "Потребителят %s не съществува."
@@ -15654,9 +15591,6 @@ msgstr "година"
 #~ msgid "Not Mine!"
 #~ msgstr "Бележка"
 
-#~ msgid "Tickets"
-#~ msgstr "Време"
-
 #~ msgid "Request Tickets"
 #~ msgstr "Правила"
 
@@ -15692,9 +15626,6 @@ msgstr "година"
 
 #~ msgid "Create a new Person for your search"
 #~ msgstr "Не са намерени резултати."
-
-#~ msgid "Id"
-#~ msgstr "Id"
 
 #~ msgid "A %s has been added."
 #~ msgstr "Групата %s е изтрита"
@@ -15747,9 +15678,6 @@ msgstr "година"
 #~ msgid "creating a new basket"
 #~ msgstr "Създаване на кошница"
 
-#~ msgid "by"
-#~ msgstr "от"
-
 #~ msgid "on"
 #~ msgstr "на"
 
@@ -15768,9 +15696,6 @@ msgstr "година"
 #~ msgid "Editing topic"
 #~ msgstr "Редактиране на кошница"
 
-#~ msgid "niceName"
-#~ msgstr "Име"
-
 #~ msgid "Apply Changes"
 #~ msgstr "Запазване на промените"
 
@@ -15785,9 +15710,6 @@ msgstr "година"
 
 #~ msgid "Edit record %(x_recid)s, field %(x_field)s"
 #~ msgstr "Редактиране на запис %(x_recid)s, поле %(x_field)s"
-
-#~ msgid "Edit record %(x_recid)s, field %(x_field)s - Add a subfield"
-#~ msgstr ""
 
 #~ msgid "Submit and save record %s"
 #~ msgstr "Изпращане и запазване на запис %s"
@@ -15881,9 +15803,6 @@ msgstr "година"
 
 #~ msgid "Verbose"
 #~ msgstr "Многословно"
-
-#~ msgid "Done"
-#~ msgstr "Готово"
 
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "Вашите промени са ВРЕМЕННИ."
@@ -16068,9 +15987,6 @@ msgstr "година"
 #~ msgid "MEMBER_DELETED"
 #~ msgstr "ИЗТРИВАНЕ"
 
-#~ msgid "Export as"
-#~ msgstr ""
-
 #~ msgid "Search Services"
 #~ msgstr "Съвети за търсене"
 
@@ -16089,34 +16005,11 @@ msgstr "година"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "Ръководство за администриране на WebSubmit"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "Изпълняване на търсене"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Отменено"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "Вие сте член на следните групи:"
@@ -16130,12 +16023,6 @@ msgstr "година"
 #~ msgid "Invert Selection"
 #~ msgstr "Избери точки"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Автор:"
 
@@ -16147,12 +16034,6 @@ msgstr "година"
 
 #~ msgid "No status information found."
 #~ msgstr "Повече информация:"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "отдел"
@@ -16169,15 +16050,6 @@ msgstr "година"
 #~ msgid "The author has an internal ID!"
 #~ msgstr "Появи се вътрешна грешка"
 
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "коментари"
 
@@ -16187,87 +16059,20 @@ msgstr "година"
 #~ msgid " Delete this ticket"
 #~ msgstr "Изтриване на кошницата"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "Няма налични списания"
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Избери точки"
 
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
 #~ msgid "Paper title: "
 #~ msgstr "Страница: "
-
-#~ msgid "Ignore"
-#~ msgstr ""
 
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "Намерени са следните грешки"
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "Избери точки"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "Повече информация:"
@@ -16275,35 +16080,11 @@ msgstr "година"
 #~ msgid "Please provide your first name"
 #~ msgstr "Моля, първо влезте."
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "Заети от вас неща"
 
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
 #~ msgid "Your eMail:"
 #~ msgstr "Вашите известия"
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "Изтриване на избраните отзиви"
@@ -16311,186 +16092,35 @@ msgstr "година"
 #~ msgid "Mark as your documents"
 #~ msgstr "всички типове документи"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "Връщане към документа"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Връщане към документа"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "или създай нова"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "Добавяне към потребителите"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Страница: "
-
-#~ msgid "Showing the"
-#~ msgstr ""
 
 #~ msgid "most recent documents:"
 #~ msgstr "Списък на рецензираните документи"
 
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Управление на елементите"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Избери тема"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Дата на създаване"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "Общи настройки"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "публикации"
@@ -16498,190 +16128,17 @@ msgstr "година"
 #~ msgid "Choose system"
 #~ msgstr "Избери тема"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Намерени са следните грешки"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Нямате достъп до функциите за администриране."
 
 #~ msgid "Claim this paper"
 #~ msgstr "добавете този потребител"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Цитиран от: %s записа"
 
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
 #~ msgid "Revision"
 #~ msgstr "отдел"
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Промяна на атрибутите на шаблона"
@@ -16761,89 +16218,20 @@ msgstr "година"
 #~ msgid "No Record Found for %s."
 #~ msgstr "Записът не е намерен"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Потребителят %s не съществува."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "Атрибути на формат %s"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "Зависимости на шаблон %s"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "Валидиране на елемент %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "Зависимости на елемент %s"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Ограничен изходен формат"
@@ -16899,125 +16287,17 @@ msgstr "година"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Валидиране на елемент %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "Валидиране на формата"
 
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "База от знания %s"
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "Бележка"
 
 #~ msgid "never"
 #~ msgstr "Конвертиране"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display searches"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Set a new alert"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Modify alert settings"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display alerts"
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "Време"
@@ -17027,15 +16307,6 @@ msgstr "година"
 
 #~ msgid "No Keywords"
 #~ msgstr "ключова дума"
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
-
-#~ msgid "No Subject categories"
-#~ msgstr ""
-
-#~ msgid "Subject categories"
-#~ msgstr ""
 
 #~ msgid "No Collaborations"
 #~ msgstr "Колекции"
@@ -17049,17 +16320,8 @@ msgstr "година"
 #~ msgid "Affiliations"
 #~ msgstr "Цитирания"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
 #~ msgid "Citations%s"
 #~ msgstr "Цитирания"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Дата на създаване"
@@ -17070,42 +16332,6 @@ msgstr "година"
 #~ msgid "No publications available"
 #~ msgstr "Няма налични списания"
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr "Цитиран от: %s записа"
 
@@ -17115,20 +16341,8 @@ msgstr "година"
 #~ msgid "%i reviews"
 #~ msgstr "преглед"
 
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "Страница: "
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "Цитирания"
@@ -17136,35 +16350,8 @@ msgstr "година"
 #~ msgid "No Citation Information available"
 #~ msgstr "Няма налични списания"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Дискусия"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Вашите известия"
@@ -17184,130 +16371,15 @@ msgstr "година"
 #~ msgid "Statistics"
 #~ msgstr "Статистики за употреба"
 
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
 #~ msgid "Group: %s"
 #~ msgstr "Група: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Your Settings"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown to the external login "
-#~ "system."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The external login method %s does "
-#~ "not support email address based logins."
-#~ "  Please contact the site administrators."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "Страницата %s не е намерена"
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "Полето %s е задължително."
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "Броят на страниците в публикацията не може да бъде определен."
-

--- a/invenio/base/translations/ca/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/ca/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.1.1\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2013-02-25 11:41+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:56+0200\n"
 "Last-Translator: Ferran Jorba <Ferran.Jorba@uab.cat>\n"
 "Language-Team: CA <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -58,8 +58,8 @@ msgstr "Pàginia inicial"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -205,7 +205,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Hola:"
 
@@ -226,17 +226,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, fuzzy, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr "El sistema no intenta enviar un missatge de %s, a %s, amb el text %s."
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -262,48 +262,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr "Error a l'enviar un missatge de %s, a %s, amb el text %s."
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "La url que heu donat no és vàlida."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr "Petició de reiniciar la contrasenya de"
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "No esteu autoritzats a fer servir el préstec."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Ha fallat l'alta"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Seleccioneu-ne un o més:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Petició de rol d'autorització"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, fuzzy, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr "Podeu baixar-vos una versió més nova d'Invenio.  Visiteu "
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -503,7 +508,8 @@ msgstr "No teniu permís para pujar documents a la col·lecció «%s»"
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 "L'usuari «%(x_user)s» no està autoritzat a modificar la col·lecció "
 "«%(x_coll)s»"
@@ -713,7 +719,8 @@ msgid "The following errors have occurred:"
 msgstr "S'han trobat els següents errors:"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 "Alguns fitxers no s'han pogut passar al directori DONE.  Esborreu-los "
 "manualment."
@@ -728,17 +735,17 @@ msgid ""
 "Using %(x_fmt_open)sweb interface upload%(x_fmt_close)s, actions are "
 "executed a single time."
 msgstr ""
-"Usant la %(x_fmt_open)sinterfície web de pujada de "
-"fitxers%(x_fmt_close)s, les accions només s'executen un cop."
+"Usant la %(x_fmt_open)sinterfície web de pujada de fitxers%(x_fmt_close)s, "
+"les accions només s'executen un cop."
 
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
-"Consulteu la %(x_url_open)spàgina d'ajuda del Batch Uploader "
-"daemon%(x_url_close)s per executar aquestes accions periòdicament. "
+"Consulteu la %(x_url_open)spàgina d'ajuda del Batch Uploader daemon"
+"%(x_url_close)s per executar aquestes accions periòdicament. "
 
 #: invenio/legacy/batchuploader/templates.py:602
 msgid "Metadata folders"
@@ -819,7 +826,7 @@ msgstr "Id"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -861,8 +868,8 @@ msgstr "Teniu %i tasques."
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Anterior"
@@ -877,8 +884,8 @@ msgstr "tancar"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Següent"
 
@@ -894,18 +901,6 @@ msgstr "Següent"
 msgid "Admin Area"
 msgstr "Zona d'administració"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "autor"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
 msgid "ERROR: %(x_name)s does not exist"
@@ -920,15 +915,6 @@ msgstr ""
 #, python-format
 msgid "ERROR: %(x_name)s is not writable"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
-msgid "Limit to knowledge bases containing string:"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "suprimit correctament"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -958,10 +944,6 @@ msgstr "suprimit correctament"
 msgid "Delete"
 msgstr "Suprimeix"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:140
-msgid "Verify syntax"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:145
 #: invenio/modules/communities/views.py:258
 #, fuzzy
@@ -973,31 +955,9 @@ msgstr "Crear una clau nova"
 msgid "File %(x_name)s does not exist."
 msgstr "L'usuari %s no existeix"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:174
-msgid "Calling bibcheck -verify failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
-msgid "Verify BibCheck config file"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Problema a la base de dades"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "fitxer(s)"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
 msgstr "Desa els canvis"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:240
-msgid "Edit BibCheck config file"
-msgstr ""
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:268
 #, fuzzy, python-format
@@ -1014,10 +974,6 @@ msgstr ""
 msgid "File %(x_name)s: write failed."
 msgstr ""
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:279
-msgid "Save BibCheck config file"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:312
 #, python-format
 msgid "File %(x_name)s deleted."
@@ -1026,10 +982,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:314
 #, python-format
 msgid "File %(x_name)s: delete failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:316
-msgid "Delete BibCheck config file"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:195
@@ -1097,7 +1049,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1152,8 +1105,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1169,9 +1122,8 @@ msgstr "Codi de barres"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
 "S'ha retornat correctament l'ítem %(x_title)s, amb el codi de barres "
 "%(x_barcode)s."
@@ -1179,17 +1131,16 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
 "S'ha retornat correctament l'ítem %(x_title)s, amb el codi de barres "
 "%(x_barcode)s."
@@ -1216,15 +1167,16 @@ msgstr "Crear-ne un altre"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
 "S'ha retornat correctament l'ítem %(x_title)s, amb el codi de barres "
 "%(x_barcode)s."
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1256,9 +1208,8 @@ msgstr "Període de préstec"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
 "S'ha retornat correctament l'ítem %(x_title)s, amb el codi de barres "
 "%(x_barcode)s."
@@ -1327,8 +1278,8 @@ msgstr "Nova petició"
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1336,8 +1287,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1359,9 +1310,8 @@ msgstr "Nou préstec"
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
 "S'ha retornat correctament l'ítem %(x_title)s, amb el codi de barres "
 "%(x_barcode)s."
@@ -1405,8 +1355,8 @@ msgstr "No s'ha trobat cap usuari."
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1465,11 +1415,11 @@ msgstr "S'ha enregistrat correctament la nueva petició."
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1480,11 +1430,11 @@ msgstr "Sí"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1497,8 +1447,8 @@ msgstr "No"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1593,8 +1543,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1614,29 +1564,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1645,9 +1595,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr "El registre que sol·liciteu no existeix."
 
@@ -2007,16 +1957,14 @@ msgstr "Aquest ítem no té exemplars."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2037,8 +1985,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2200,8 +2148,8 @@ msgstr "Petició de préstec interbibliotecari"
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2308,7 +2256,7 @@ msgstr "Lloc"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Descripció"
 
@@ -2501,8 +2449,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2776,10 +2724,10 @@ msgstr "Confirmar"
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
-msgstr "Si ho desitgeu podeu %(x_url_open)sidentificar-vos aquí%(x_url_close)s."
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
+msgstr ""
+"Si ho desitgeu podeu %(x_url_open)sidentificar-vos aquí%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
 #, fuzzy
@@ -2832,7 +2780,7 @@ msgstr "Reiniciar"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "D'acord"
 
@@ -2840,8 +2788,8 @@ msgstr "D'acord"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
 "S'ha retornat correctament l'ítem %(x_title)s, amb el codi de barres "
 "%(x_barcode)s."
@@ -3303,8 +3251,8 @@ msgstr "Bústia"
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "Adreça electrònica"
 
@@ -4029,7 +3977,8 @@ msgstr "Comentaris addicionals"
 msgid ""
 "I accept the %(x_url_open)sconditions%(x_url_close)s of the service in "
 "particular the return of books in due time."
-msgstr "Acepto els %s del servicio, en particular retornar els llibres a temps."
+msgstr ""
+"Acepto els %s del servicio, en particular retornar els llibres a temps."
 
 #: invenio/legacy/bibcirculation/templates.py:9491
 msgid "I want this edition only."
@@ -4112,11 +4061,11 @@ msgstr "Període d'interès (fins a)"
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, fuzzy, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
-"El lector accepta el %s del servei, en particular tornar els llibres en "
-"el termini."
+"El lector accepta el %s del servei, en particular tornar els llibres en el "
+"termini."
 
 #: invenio/legacy/bibcirculation/templates.py:9721
 msgid "Borrower wants this edition only."
@@ -4133,11 +4082,11 @@ msgstr "Només aquesta edició"
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, fuzzy, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
-"Comproveu si el llibre existeix en Invenio abans de sol·licitar una "
-"petició de PI."
+"Comproveu si el llibre existeix en Invenio abans de sol·licitar una petició "
+"de PI."
 
 #: invenio/legacy/bibcirculation/templates.py:10332
 msgid "0 items found."
@@ -4195,17 +4144,17 @@ msgstr "ISSN"
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4581,30 +4530,30 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "El registre ha estat suprimit."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
-"Generat automàticament <span class=\"keyword "
-"single\">senzill</span>,<span class=\"keyword composite\">compost</span>,"
-" <span class=\"keyword author-kw\">autor</span>, i <span class=\"keyword "
-"other-kw\">altres paraules clau</span>."
+"Generat automàticament <span class=\"keyword single\">senzill</span>,<span "
+"class=\"keyword composite\">compost</span>, <span class=\"keyword author-kw"
+"\">autor</span>, i <span class=\"keyword other-kw\">altres paraules clau</"
+"span>."
 
 #: invenio/legacy/bibclassify/templates.py:230
 msgid "Automated keyword extraction wasn't run for this document yet."
@@ -4661,25 +4610,25 @@ msgstr "Tipus desconegut: %s"
 #: invenio/legacy/bibclassify/webinterface.py:225
 msgid "The site settings do not allow automatic keyword extraction"
 msgstr ""
-"La configuració d'aquest lloc no permet l'extracció automàtica de "
-"paraules clau"
+"La configuració d'aquest lloc no permet l'extracció automàtica de paraules "
+"clau"
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
-"La vostra petició s'ha registrat.  L'extracció automàtica de paraules "
-"clau s'executarà aviat.  Torneu en una estona."
+"La vostra petició s'ha registrat.  L'extracció automàtica de paraules clau "
+"s'executarà aviat.  Torneu en una estona."
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
-"Per desgràcia, no existeix una còpia local del text complet en PDF. No és"
-" posible generar automàticament les paraules clau."
+"Per desgràcia, no existeix una còpia local del text complet en PDF. No és "
+"posible generar automàticament les paraules clau."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:463
@@ -4689,10 +4638,10 @@ msgstr "Escolliu el fitxer"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4705,20 +4654,20 @@ msgstr "Accés"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
-"El fitxer que voleu editar està protegit contra modificacions.  La vostra"
-" acció no ha estat realitzada"
+"El fitxer que voleu editar està protegit contra modificacions.  La vostra "
+"acció no ha estat realitzada"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, fuzzy, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
-"El fitxer que heu penjat és massa petit (<%i o) i per tant no s'ha tingut"
-" en compte"
+"El fitxer que heu penjat és massa petit (<%i o) i per tant no s'ha tingut en "
+"compte"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
 #, fuzzy, python-format
@@ -4726,47 +4675,49 @@ msgid ""
 "The uploaded file is too big (>%(x_size)i o) and has therefore not been "
 "considered"
 msgstr ""
-"El fitxer que heu penjat és massa gran (>%i o) i per tant no s'ha tingut "
-"en compte"
+"El fitxer que heu penjat és massa gran (>%i o) i per tant no s'ha tingut en "
+"compte"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
-"El nom del fitxer que heu penjat és massa llarg i per tant no s'ha tingut"
-" en compte"
+"El nom del fitxer que heu penjat és massa llarg i per tant no s'ha tingut en "
+"compte"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
 msgid ""
 "You have already reached the maximum number of files for this type of "
 "document"
-msgstr "Ja heu arribat al màxim número de fitxers per a aquest tipus de document"
+msgstr ""
+"Ja heu arribat al màxim número de fitxers per a aquest tipus de document"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:627
 #: invenio/legacy/bibdocfile/managedocfiles.py:637
 #: invenio/legacy/bibdocfile/managedocfiles.py:749
 #, fuzzy, python-format
 msgid "A file named %(x_name)s already exists. Please choose another name."
-msgstr "Ja existeix un fitxer amb el nom %s.  Escolliu-ne un altre, si us plau."
+msgstr ""
+"Ja existeix un fitxer amb el nom %s.  Escolliu-ne un altre, si us plau."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
-msgstr "Ja existeix un fitxer amb el format '%s'.  Pujeu-lo en un altre format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
+msgstr ""
+"Ja existeix un fitxer amb el format '%s'.  Pujeu-lo en un altre format."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
-"No podeu usar el punt '.', barra '/', o barra inversa '\\\\\\\\' en els "
-"noms de fitxers.  Escolliu un nom diferent o pujeu un altre cop el vostre"
-" fitxer.  En particular, tingueu en compte que no heu d'incloure "
-"l'extensió en el nou nom."
+"No podeu usar el punt '.', barra '/', o barra inversa '\\\\\\\\' en els noms "
+"de fitxers.  Escolliu un nom diferent o pujeu un altre cop el vostre "
+"fitxer.  En particular, tingueu en compte que no heu d'incloure l'extensió "
+"en el nou nom."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
 msgid "Choose how you want to restrict access to this file."
@@ -4783,8 +4734,8 @@ msgstr "Podeu decidir amagar o no versions anteriors d'aquest fitxer."
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 "Quan reviseu un fitxer, els formats addicionals que hagéssiu penjat "
 "prèviament seran esborrats, ja que no estarien sincronitzats amb el nou "
@@ -4792,8 +4743,7 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 "Els formats alternatius per a la versió actual d'aquest fitxer seran "
 "esborrats"
@@ -4855,8 +4805,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 "Teniu problemes per afegir o revisar un fitxer? Envieu la versió nova o "
 "revisada a %(mailto_link)s."
@@ -4908,8 +4858,8 @@ msgstr "El registre que sol·liciteu no sembla estar integrat."
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 "El sistema ha trobat un error recuperant la llista dels fitxers d'aquest "
 "document."
@@ -5024,13 +4974,12 @@ msgstr "1. Escolliu els criteris de cerca"
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
-"Especifiqueu els criteris que vulgueu per filtrar els registres a "
-"canviar.  Useu «Cerca» per a veure quins registres es filtrarien amb "
-"aquests criteris."
+"Especifiqueu els criteris que vulgueu per filtrar els registres a canviar.  "
+"Useu «Cerca» per a veure quins registres es filtrarien amb aquests criteris."
 
 #: invenio/legacy/bibeditmulti/templates.py:361
 msgid "Preview results"
@@ -5042,11 +4991,11 @@ msgstr "2. Definiu els canvis"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
-"Especifiqueu els camps i subcamps a canviar per a cada registre que "
-"concordi amb els criteris de cerca."
+"Especifiqueu els camps i subcamps a canviar per a cada registre que concordi "
+"amb els criteris de cerca."
 
 #: invenio/legacy/bibeditmulti/templates.py:615
 msgid "Define new field action"
@@ -5172,16 +5121,14 @@ msgstr "Torna als resultats"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 "ATENCIÓ: els següents registres estan pendents d'actualitzar a la cua de "
-"tasques pendents.  Si seguiu amb els canvis, es perderan les "
-"modificacions fetes amb l'altre eina (és a dir, BibEdit) sobre aquest "
-"registre."
+"tasques pendents.  Si seguiu amb els canvis, es perderan les modificacions "
+"fetes amb l'altre eina (és a dir, BibEdit) sobre aquest registre."
 
 #: invenio/legacy/bibeditmulti/templates.py:736
 #: invenio/legacy/websearch/templates.py:2669
@@ -5304,7 +5251,7 @@ msgid "Total"
 msgstr "Total"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Seleccionar"
 
@@ -5460,8 +5407,8 @@ msgstr "Suprimeix la base de coneixement"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 "Limitar la visualizació a les bases de coneixement amb el text "
 "%(keyword_field)s en les seves regles i descripcions"
@@ -5518,75 +5465,75 @@ msgstr "Cal configurar-la"
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
-"Un base de coneixement dinàmic és una llista de valors d'un camp. La "
-"llista es genera dinàmicament a mesura que es cerquen registres a partir "
-"de un valor de cerca."
+"Un base de coneixement dinàmic és una llista de valors d'un camp. La llista "
+"es genera dinàmicament a mesura que es cerquen registres a partir de un "
+"valor de cerca."
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
-"Per example: els registres tenen el camp 270__a per al nom i l'adreça de "
-"la institució de l'autor.  Si poseu com a valor «270__a» i l'expressió "
-"«270__a:*Paris*», creareu una llista d'institucions a Paris."
+"Per example: els registres tenen el camp 270__a per al nom i l'adreça de la "
+"institució de l'autor.  Si poseu com a valor «270__a» i l'expressió «270__a:"
+"*Paris*», creareu una llista d'institucions a Paris."
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
-"Si deixeu l'expressió buida, creareu una llista amb tots els valors del "
-"camp 270__a."
+"Si deixeu l'expressió buida, creareu una llista amb tots els valors del camp "
+"270__a."
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, fuzzy, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
-"Si l'expressió conté «%», com ara «270__a:*%*», serà reemplaçat pel valor"
-" creat quan s'usi la base de coneixement."
+"Si l'expressió conté «%», com ara «270__a:*%*», serà reemplaçat pel valor "
+"creat quan s'usi la base de coneixement."
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 "Podeu entrar un nom de col·lecció si l'expressió s'ha d'avaluar en una "
 "col·lecció específica."
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
-"Exemple 1: els vostres registres tenen el camp 270__a per al nom i "
-"l'adreça de la institució de l'autor.  Si poseu com a valor «270__a» i "
-"l'expressió «270__a:*Paris*», creareu una llista d'institucions a Paris."
+"Exemple 1: els vostres registres tenen el camp 270__a per al nom i l'adreça "
+"de la institució de l'autor.  Si poseu com a valor «270__a» i l'expressió "
+"«270__a:*Paris*», creareu una llista d'institucions a Paris."
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, fuzzy, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
-"Exemple 2: mostrar el nom de l'institut (100__a) quan l'usuari informi "
-"del codi postal (270__a): escriviu 100__a en el camp, i l'expressió com a"
-" 270__a:*%*."
+"Exemple 2: mostrar el nom de l'institut (100__a) quan l'usuari informi del "
+"codi postal (270__a): escriviu 100__a en el camp, i l'expressió com a 270__a:"
+"*%*."
 
 #: invenio/legacy/bibknowledge/templates.py:262
 msgid "Any collection"
@@ -5623,7 +5570,7 @@ msgstr "Dependències de la base de coneixements"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5636,8 +5583,8 @@ msgid ""
 "Here you can add new mappings to this base                         and "
 "change the base attributes."
 msgstr ""
-"Aquí hi podeu afegir nous mapatges a aquesta base i canviar els atributs "
-"de la base."
+"Aquí hi podeu afegir nous mapatges a aquesta base i canviar els atributs de "
+"la base."
 
 #: invenio/legacy/bibknowledge/templates.py:364
 msgid "Map From"
@@ -5665,7 +5612,8 @@ msgstr "Actualitza els atributs de la base"
 
 #: invenio/legacy/bibknowledge/templates.py:672
 msgid "This knowledge base is not used in any format elements."
-msgstr "Aquesta base de coneixement no s'està utilitzant en cap element de format."
+msgstr ""
+"Aquesta base de coneixement no s'està utilitzant en cap element de format."
 
 #: invenio/legacy/bibknowledge/templates.py:703
 #, fuzzy, python-format
@@ -5675,8 +5623,8 @@ msgstr "La vostra regla: %s"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, fuzzy, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 "La banda esquerra de la regla (%s) ja apareix en aquestes bases de "
 "coneixement:"
@@ -5684,11 +5632,10 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:709
 #, fuzzy, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
-"La banda dreta de la regla (%s) ja apareix en aquestes bases de "
-"coneixement:"
+"La banda dreta de la regla (%s) ja apareix en aquestes bases de coneixement:"
 
 #: invenio/legacy/bibknowledge/templates.py:722
 msgid "Please select action"
@@ -5711,8 +5658,8 @@ msgid ""
 "It is not possible to have two rules with the same left side in the same "
 "knowledge base."
 msgstr ""
-"No és possible tenir dues reglas amb la mateixa banda esquerra a la "
-"mateixa base de coneixement."
+"No és possible tenir dues reglas amb la mateixa banda esquerra a la mateixa "
+"base de coneixement."
 
 #: invenio/legacy/bibrank/citation_grapher.py:207
 msgid "Citation history:"
@@ -5909,8 +5856,7 @@ msgstr "Error en recuperar el registre"
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 "Error al formatejar l'entrada en espera.  Probablemente el seu contingut "
 "estigui malament"
@@ -5986,8 +5932,8 @@ msgstr "Tornar a la selecció principal"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6002,8 +5948,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Resultats de la cerca"
 
@@ -6162,8 +6108,8 @@ msgstr "No s'han trobat valors."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6173,8 +6119,8 @@ msgid ""
 "mostly from %(x_range_from_year)s-%(x_range_to_year)s."
 msgstr ""
 "Atenció: la cerca als peus d'imatges només està disponible per a un "
-"subconjunt de documents, majoritàriament d'entre "
-"%(x_range_from_year)s-%(x_range_to_year)s."
+"subconjunt de documents, majoritàriament d'entre %(x_range_from_year)s-"
+"%(x_range_to_year)s."
 
 #: invenio/legacy/search_engine/__init__.py:2151
 #, fuzzy, python-format
@@ -6188,158 +6134,160 @@ msgstr "En comptes es cercarà %s."
 
 #: invenio/legacy/search_engine/__init__.py:2161
 msgid "Search term too generic, displaying only partial results..."
-msgstr "Terme de cerca massa genèric, només es mostraran uns resultats parcials..."
+msgstr ""
+"Terme de cerca massa genèric, només es mostraran uns resultats parcials..."
 
 #: invenio/legacy/search_engine/__init__.py:2165
 #, fuzzy
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
-msgstr "Terme de cerca massa genèric, només es mostraran uns resultats parcials..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
+msgstr ""
+"Terme de cerca massa genèric, només es mostraran uns resultats parcials..."
 
 #: invenio/legacy/search_engine/__init__.py:2169
 #, fuzzy
 msgid ""
 "Search term after citedby operator too generic, displaying only partial "
 "results..."
-msgstr "Terme de cerca massa genèric, només es mostraran uns resultats parcials..."
+msgstr ""
+"Terme de cerca massa genèric, només es mostraran uns resultats parcials..."
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
-"Encara no hi ha índex de frases per al text complet, cercant per "
-"combinació de paraules..."
+"Encara no hi ha índex de frases per al text complet, cercant per combinació "
+"de paraules..."
 
 #: invenio/legacy/search_engine/__init__.py:2213
 #, python-format
 msgid "No exact match found for %(x_query1)s, using %(x_query2)s instead..."
 msgstr ""
-"No s'ha trobat cap coincidència exacta per %(x_query1)s, però canviant-lo"
-" per %(x_query2)s..."
+"No s'ha trobat cap coincidència exacta per %(x_query1)s, però canviant-lo "
+"per %(x_query2)s..."
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
-"No s'entén la sintaxi de la vostra cerca.  S'ignoraran tots els "
-"parèntesis de la cerca.  Si així no funciona, repasseu la vostra cerca i "
-"torneu-ho a provar."
+"No s'entén la sintaxi de la vostra cerca.  S'ignoraran tots els parèntesis "
+"de la cerca.  Si així no funciona, repasseu la vostra cerca i torneu-ho a "
+"provar."
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
-"No s'ha trobat cap coincidència a la col·leció %(x_collection)s. Les "
-"altres col·leccions públicas donen %(x_url_open)s%(x_nb_hits)d "
-"resultats%(x_url_close)s."
+"No s'ha trobat cap coincidència a la col·leció %(x_collection)s. Les altres "
+"col·leccions públicas donen %(x_url_open)s%(x_nb_hits)d resultats"
+"%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
-"No s'ha trobat cap coincidència en col·leccions públiques. Si esteu "
-"cercant documents no públics, escolliu primer la col·lecció restringida."
+"No s'ha trobat cap coincidència en col·leccions públiques. Si esteu cercant "
+"documents no públics, escolliu primer la col·lecció restringida."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
-"No s'ha trobat cap coincidència en col·leccions públiques. Si esteu "
-"cercant documents no públics, escolliu primer la col·lecció restringida."
+"No s'ha trobat cap coincidència en col·leccions públiques. Si esteu cercant "
+"documents no públics, escolliu primer la col·lecció restringida."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 msgid "Your search did not match any records.  Please try again."
 msgstr "La vostra cerca no ha trobat cap registre. Torneu-ho a provar."
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 msgid "No match found, please enter different search terms."
 msgstr "No s'ha trobat res. Useu termes diferents de cerca."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "No hi ha registres que es refereixin a %s."
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "No hi ha registres citats per %s."
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "No hi ha registres citats per %s."
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "No hi ha cap índex de paraules disponible per a %s."
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "No hi ha cap índex de frases disponible per a %s."
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
-"El terme de cerca %(x_term)s dins l'índex %(x_index)s no s'ha trobat en "
-"cap registre. Els termes aproximats, a qualsevol col·lecció, són:"
+"El terme de cerca %(x_term)s dins l'índex %(x_index)s no s'ha trobat en cap "
+"registre. Els termes aproximats, a qualsevol col·lecció, són:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr ""
-"El terme de cerca %s no s'ha trobat en cap registre. Els termes "
-"aproximats, a qualsevol col·lecció, són:"
+"El terme de cerca %s no s'ha trobat en cap registre. Els termes aproximats, "
+"a qualsevol col·lecció, són:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr "No és possible ordenar per %s.  No s'rodenaran els registres."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 "Només es permet ordenar en conjunts de fins a %d registres.  Ordenat per "
 "defecte (\"primer els més recents\")."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr "No és possible ordenar per %s.  No s'rodenaran els registres."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "El registre %d el reemplaça."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Useu termes diferents de cerca."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6353,13 +6301,13 @@ msgstr "Useu termes diferents de cerca."
 msgid "Browse"
 msgstr "Índex"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 "No s'ha trobat cap coincidència en l'intèrval de temps especificat. "
 "Descartant aquesta condició..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
 "No s'ha trobat cap coincidència en les limitacions que heu especificat. "
@@ -6404,15 +6352,14 @@ msgstr "L'alerta %s ha estat actualitzada correctament"
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Heu fet %(x_nb)s cerques.  Hi ha una "
-"%(x_url_open)sdetailed_list%(x_url_close)s disponible amb possibilitat de"
-" (a) veure els resultats de la cerca i (b) subscriure-us per rebre "
-"notificacions per correu electrònic d'aquestes cerques."
+"Heu fet %(x_nb)s cerques.  Hi ha una %(x_url_open)sdetailed_list"
+"%(x_url_close)s disponible amb possibilitat de (a) veure els resultats de la "
+"cerca i (b) subscriure-us per rebre notificacions per correu electrònic "
+"d'aquestes cerques."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6553,9 +6500,9 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"Definir una nova alerta a partir de %(x_url1_open)sles vostres "
-"cerques%(x_url1_close)s, les %(x_url2_open)scerques més "
-"habituals%(x_url2_close)s, o el formulari de dades."
+"Definir una nova alerta a partir de %(x_url1_open)sles vostres cerques"
+"%(x_url1_close)s, les %(x_url2_open)scerques més habituals%(x_url2_close)s, "
+"o el formulari de dades."
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6606,20 +6553,20 @@ msgstr "Heu definit %s alertes."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
-"Encara no heu executat cap cerca. Aneu primer a la "
-"%(x_url_open)sinterfície de cerca%(x_url_close)s."
+"Encara no heu executat cap cerca. Aneu primer a la %(x_url_open)sinterfície "
+"de cerca%(x_url_close)s."
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
-"Heu executat %(x_nb1)s cerques (%(x_nb2)s qüestions diferents) durant els"
-" darrers 30 dies aproximadament."
+"Heu executat %(x_nb1)s cerques (%(x_nb2)s qüestions diferents) durant els "
+"darrers 30 dies aproximadament."
 
 #: invenio/legacy/webalert/templates.py:453
 #, fuzzy, python-format
@@ -6676,7 +6623,7 @@ msgstr "Les vostres cerques"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6740,7 +6687,7 @@ msgstr "%s personalitza, defineix una nova alerta"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6800,7 +6747,8 @@ msgstr "%s personalitza, mostra les alertes"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr "El cistell públic que heu seleccionat no existeix o no hi teniu accés."
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6822,7 +6770,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "No teniu permisos per a escriure notes en aquest ítem."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr "La nota que citeu no existeix o no hi teniu accés."
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6849,7 +6798,8 @@ msgid "You do not have permission to delete this note."
 msgstr "No teniu permisos per a rdnottst aquesta nota."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr "La nota que heu seleccionat no existeix o no hi teniu accés."
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6879,9 +6829,10 @@ msgstr "La url que heu donat no és vàlida."
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
-msgstr "Aquesta url no es vàlida: la sintaxi no és correcta o no es pot satisfer."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
+msgstr ""
+"Aquesta url no es vàlida: la sintaxi no és correcta o no es pot satisfer."
 
 #: invenio/legacy/webbasket/api.py:1849
 msgid ""
@@ -6902,15 +6853,15 @@ msgstr "Cap registre per afegir."
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
 msgid "Cannot add items to the selected basket. Invalid parameters."
 msgstr ""
-"No s'han pogut afegir ítems al cistell seleccionat.  Els paràmetres no "
-"eren vàlids."
+"No s'han pogut afegir ítems al cistell seleccionat.  Els paràmetres no eren "
+"vàlids."
 
 #: invenio/legacy/webbasket/api.py:1979
 msgid "Untitled basket"
@@ -6925,8 +6876,8 @@ msgid ""
 "A default topic and basket have been automatically created. Edit them to "
 "rename them as you see fit."
 msgstr ""
-"S'ha creat automàticament un nou cistell i tema.  Editeu-lo per posar-li "
-"el nom que més li escaigui."
+"S'ha creat automàticament un nou cistell i tema.  Editeu-lo per posar-li el "
+"nom que més li escaigui."
 
 #: invenio/legacy/webbasket/api.py:2262
 msgid "Please provide a name for the new basket."
@@ -6938,8 +6889,8 @@ msgstr "Seleccioneu un dels temes existents o creeu-ne un de nou."
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 "No us podeu subscrire a aquest cistell, perquè en sou el propietari o ja "
 "n'estàveu subscrit."
@@ -6949,8 +6900,8 @@ msgid ""
 "You cannot unsubscribe from this basket, you are the either owner or you "
 "have already unsubscribed."
 msgstr ""
-"No us podeu donar de baixa d'aquest cistell, perquè en sou el propietari "
-"o ja no n'estàveu subscrit."
+"No us podeu donar de baixa d'aquest cistell, perquè en sou el propietari o "
+"ja no n'estàveu subscrit."
 
 #: invenio/legacy/webbasket/api.py:2429 invenio/legacy/webbasket/api.py:2547
 #: invenio/legacy/webbasket/templates.py:120
@@ -7013,11 +6964,10 @@ msgstr "Cistells públics"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
-"Teniu %(x_nb_perso)s cistells personals, esteu subscrits a %(x_nb_group)s"
-" cistells de grup, i a %(x_nb_public)s cistells públics d'altres usuaris."
+"Teniu %(x_nb_perso)s cistells personals, esteu subscrits a %(x_nb_group)s "
+"cistells de grup, i a %(x_nb_public)s cistells públics d'altres usuaris."
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
 msgid ""
@@ -7046,8 +6996,7 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr "Podeu començar %(x_url_open)screant un cistell nou%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -7209,11 +7158,11 @@ msgstr "Registre extern"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
-"Escriviu una url per a l'item extern que hi voleu afegir i poseu-li un "
-"títol i descripció"
+"Escriviu una url per a l'item extern que hi voleu afegir i poseu-li un títol "
+"i descripció"
 
 #: invenio/legacy/webbasket/templates.py:1612
 #: invenio/modules/linkbacks/templates/linkbacks/index_base.html:44
@@ -7394,8 +7343,8 @@ msgstr "Comparteix cistell amb un nou grup"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 "Ara esteu identificat com a usuari visitant, de manera que els vostres "
 "cistells desapareixeran al final d'aquesta sessió."
@@ -7404,10 +7353,11 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
-"Si voleu podeu %(x_url_open)sidentificar o donar-vos d'alta "
-"aquí%(x_url_close)s."
+"Si voleu podeu %(x_url_open)sidentificar o donar-vos d'alta aquí"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7416,7 +7366,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Aquesta funcionalitat no està permesa als usuaris visitants."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Torna als resultats de la cerca"
 
@@ -7578,7 +7528,7 @@ msgstr "Afegir nota"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7710,209 +7660,210 @@ msgstr "El comentari %s no existeix."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "El registre %s no existeix."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Escriviu un comentari"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i comentaris per la volta «%(x_name)s»"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, python-format
 msgid "%(x_nb)i Comments"
 msgstr "%(x_nb)i comentaris"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Mostrar els darrers %i comentaris:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Comenteu aquest document"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Enceteu un debat sobre qualsevol aspecte d'aquest document."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Sembla que el registre %s no existeix."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "%s no és un identificador vàlid."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "No heu donat el número de registre."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Podeu començar a visualitzar des de %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i comentaris per la volta «%(x_name)s»"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Ha estat útil aquesta ressenya?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Escriviu-ne una ressenya"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
-msgstr "Puntuació mitjana: %(x_nb_score)s, basada en %(x_nb_reviews)s ressenyes"
+msgstr ""
+"Puntuació mitjana: %(x_nb_score)s, basada en %(x_nb_reviews)s ressenyes"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
-msgstr "Els lectors han trobat que les següents %s ressenyes són les més útils."
+msgstr ""
+"Els lectors han trobat que les següents %s ressenyes són les més útils."
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Visualitzar totes les %s ressenyes"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Valoreu aquest document"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 msgid "Be the first to review this document.</div>"
 msgstr "Sigueu el primer a escriure una ressenya d'aquest document.</div>"
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 msgid "Close"
 msgstr "Tanca"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Denuncieu-ne un abús"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr "Recupera el comentari suprimit"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Suprimeix el comentari"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr "Suprimeix la denúncia al comentari"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr "Fitxer adjunt"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr "Fitxers adjunts"
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr "Obre"
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Ressenyat per %(x_nickname)s el %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
-"%(x_nb_people)s de %(x_nb_total)s persones han trobat aquesta ressenya  "
-"útil"
+"%(x_nb_people)s de %(x_nb_total)s persones han trobat aquesta ressenya  útil"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr "Recupera la ressenya suprimida"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr "Suprimeix la ressenya"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr "Suprimeix la denúncia a la ressenya"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Comentaris"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Ressenyes"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Hi ha un total de %s ressenyes"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Hi ha un total de %s comentaris"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Sigueu el primer a escriure una ressenya d'aquest document."
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Subscriure's"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr "Donar-se de baixa"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7921,517 +7872,518 @@ msgstr "Donar-se de baixa"
 msgid "Record"
 msgstr "Registre"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "ressenya"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "comentari"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Ressenya"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Visualització"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Pàgina:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr "No esteu autoritzats a fer comentaris o ressenyes."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 "Vigileu: El vostre àlies, %s, serà el que es mostri com autor d'aquest "
 "comentari"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
-"Vigileu: encara no heu %(x_url_open)sdefinit el vostre "
-"àlies%(x_url_close)s. %(x_nickname)s s'usarà temporalment com a autor "
-"d'aquest comentari."
+"Vigileu: encara no heu %(x_url_open)sdefinit el vostre àlies%(x_url_close)s. "
+"%(x_nickname)s s'usarà temporalment com a autor d'aquest comentari."
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
-"Un cop identificats, els usuaris autoritzats també hi poden adjuntar "
-"fitxers."
+"Un cop identificats, els usuaris autoritzats també hi poden adjuntar fitxers."
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr "Opcionalment, afegiu-hi un fitxer a aquest comentari"
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr "Opcionalment, afegiu-hi fitxers a aquest comentari"
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr "Màxim un fitxer"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "Màxim %i fitxers"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr "Màxim %(x_nb_bytes)s per fitxer"
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr "Envieu-me un email quan es publiqui un nou comentari"
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Article"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "Afegeix un comentari"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr ""
-"Vigileu: El vostre àlies, %s, serà el que es mostri com a autor d'aquesta"
-" ressenya."
+"Vigileu: El vostre àlies, %s, serà el que es mostri com a autor d'aquesta "
+"ressenya."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Valoreu aquest article"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Seleccioneu una puntuació"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Doneu un títol a la vostra ressenya"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Escriviu la vostra ressenya"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr "Afegiu la vostra ressenya"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Afegiu la vostra ressenya"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "La vostra ressenya ha estat afegida correctament."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "El vostre comentari ha estat afegit correctament."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Torna al registre"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr ""
-"Podeu consultar la llista de les %(x_url_open)svostres "
-"tasques%(x_url_close)s."
+"Podeu consultar la llista de les %(x_url_open)svostres tasques"
+"%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr "Visualitza els registres més comentats"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr "Visualitza els registres amb els comentaris més recents"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr "Visualitzar tots els comentaris denunciats"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr "Visualitza els registres amb més ressenyes"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr "Visualitza els registres amb les ressenyes més recents"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr "Visualitzar totes les ressenyes denunciades"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Visualitzar tots els usuaris que han estat denunciats"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Guia"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Els comentaris i les ressenyes estan desactivades"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"Introduiu el número del comentari o ressenya, per poder visualitzar-ho "
-"abans de decidir de suprimir-lo o no"
+"Introduiu el número del comentari o ressenya, per poder visualitzar-ho abans "
+"de decidir de suprimir-lo o no"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "Número del comentari:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 "O entreu el número de registre per veure tots els comentaris i ressenyes "
 "associades:"
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr "Registre :"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Visualitzar el comentari"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Encara no hi ha denúncies."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Visualitzar tots els %s comentaris denunciats"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Visualitzar totes les %s ressenyes denunciades"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-"Aquesta és la llista, ordenada per número de denúncies, dels usuaris que "
-"han tingut al menys una denúncia a algun dels seus comentaris."
+"Aquesta és la llista, ordenada per número de denúncies, dels usuaris que han "
+"tingut al menys una denúncia a algun dels seus comentaris."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Àlies"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "Número d'usuari"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Nombre de vots positius"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Nombre de vots negatius"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Nombre total de vots"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Nombre total de denúncies"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Visualitza tots els comentaris/ressenyes denunciades d'aquest usuari"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Aquesta ressenya ha estat denunciada %i cops"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Aquest comentari ha estat denunciat %i vegades"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Escrit per"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Informacions generals"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Suprimeix les ressenyes seleccionades"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Suprimeix l'informe d'abús seleccionat"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr "Recupera les ressenyes eliminades"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr "Recupera els comentaris eliminats"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Suprimeix els comentaris seleccionats"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Aquestes són les ressenyes denunciades de l'usuari %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Aquests són els comentaris denunciats de l'usuari %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Aquesta és la ressenya %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Aquest és el comentari %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Aquesta és la ressenya %(x_cmtID)s escrita per l'usuari %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Aquest és el comentari %(x_cmtID)s escrit per l'usuari %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "Aquestes són totes les ressenyes denunciades, ordenades de més a menys"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "Aquests són tots els comentaris denunciats, ordenats de més a menys"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr "Ressenyes del registre %i, ordenades de més a menys denúncies"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr "Visualitza els comentaris"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr "Comentaris al registre %i, ordenats de més a menys denúncies"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr "Visualitza les ressenyes"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "número de comentari"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "suprimit correctament"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr "recuperat correctament"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "eliminat correctament l'informa d'abús"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Sense cap ressenya"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+"S'ha enviat aquesta ressenya a %(CFG_SITE_NAME)s per %(user_nickname)s:"
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr "S'ha enviat aquesta ressenya a %(CFG_SITE_NAME)s per %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+"S'ha enviat aquest comentari a %(CFG_SITE_NAME)s per %(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr "S'ha enviat aquest comentari a %(CFG_SITE_NAME)s per %(user_nickname)s:"
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr "Aquest és un missatge automàtic, no el responeu."
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr "Per publicar un altre comentari, aneu a <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr "Per contestar específicament a aquest comentari, aneu a <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr "Per donar-vos de baixa d'aquesta discussió, aneu a <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
-"Per resoldre dubtes, poseu-vos en contacte amb "
-"<%(CFG_SITE_SUPPORT_EMAIL)s>"
+"Per resoldre dubtes, poseu-vos en contacte amb <%(CFG_SITE_SUPPORT_EMAIL)s>"
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 msgid "Your comment will be lost."
 msgstr "El vostre comentari es perderà."
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Suprimeix els comentaris"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "el darrer primer"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "Visualitza els registres amb els comentaris més recents"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "afegir comentaris"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "registres trobats"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Comentaris"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "%i items"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Afegir items"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 #, fuzzy
 msgid "Display"
 msgstr "Mostra les alertes"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Data de comanda"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Pàgina següent"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Mostra les alertes"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8439,103 +8391,103 @@ msgstr "Mostra les alertes"
 msgid "Refresh"
 msgstr "Refresca"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Suprimeix la denúncia al comentari"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "%i items trobats"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "No s'ha trobat el registre"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr "El comentari especificat no pertany a aquest registre"
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 msgid "You do not have access to the specified comment"
 msgstr "No teniu accés al comentari especificat"
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, fuzzy, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
-"El tamany del fitxer \\\"%s\\\" (%s) és més gran que el màxim permès "
-"(%s). Torneu a seleccionar els fitxers."
+"El tamany del fitxer \\\"%s\\\" (%s) és més gran que el màxim permès (%s). "
+"Torneu a seleccionar els fitxers."
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Afegeix un comentari"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr "No podeu votar un comentari esborrat"
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 msgid "You cannot report a deleted comment"
 msgstr "No podeu denunciar un comentari esborrat"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr "No s'ha trobat la pàgina"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr "No s'ha trobat el comentari sol·licitat"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr "No podeu accedir als fitxers d'un comentari esborrat"
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr "No s'ha trobat el fitxer sol·licitat"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "No esteu autoritzats a fer servir el préstec."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Comentaris"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr ""
@@ -8650,11 +8602,11 @@ msgstr "Sembla que la pàgina %s no existeix."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
-"Us pot interessar consultar les %(x_url_open)spàgines "
-"%(x_category)s%(x_url_close)s."
+"Us pot interessar consultar les %(x_url_open)spàgines %(x_category)s"
+"%(x_url_close)s."
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
 #, fuzzy, python-format
@@ -8717,11 +8669,11 @@ msgstr "No ha estat possible oferir-vos cap revista"
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
-"Sembla ser que no hi ha cap revista definida en aquest servidor. "
-"Contacteu el suport si no és cert."
+"Sembla ser que no hi ha cap revista definida en aquest servidor. Contacteu "
+"el suport si no és cert."
 
 #: invenio/legacy/webjournal/config.py:239
 msgid "Select a journal on this server"
@@ -8749,11 +8701,11 @@ msgstr "No hi ha cap informació en el número actual"
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
-"Sembla que la configuració del número actual està buida.  Proveu "
-"d'escollir un número en concret o poseu-vos en contacte amb el suport."
+"Sembla que la configuració del número actual està buida.  Proveu d'escollir "
+"un número en concret o poseu-vos en contacte amb el suport."
 
 #: invenio/legacy/webjournal/config.py:298
 msgid "Issue number badly formed"
@@ -8807,8 +8759,8 @@ msgstr "Error del codi de revista"
 #: invenio/legacy/webjournal/config.py:495
 msgid "We could not find the id for this journal in the Database"
 msgstr ""
-"No ha estat possible trobar l'identificador intern d'aquesta revista a la"
-" base de dades"
+"No ha estat possible trobar l'identificador intern d'aquesta revista a la "
+"base de dades"
 
 #: invenio/legacy/webjournal/config.py:527
 #: invenio/legacy/webjournal/config.py:529
@@ -8935,9 +8887,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8959,8 +8910,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9072,8 +9022,8 @@ msgid ""
 "Your message is too long, please shorten it. Maximum size allowed is "
 "%(x_size)i characters."
 msgstr ""
-"El vostre missatge és massa llarg, si us plau editeu-lo. El tamany màxim "
-"és de %i caràcters"
+"El vostre missatge és massa llarg, si us plau editeu-lo. El tamany màxim és "
+"de %i caràcters"
 
 #: invenio/legacy/webmessage/api.py:402
 #, fuzzy, python-format
@@ -9098,8 +9048,8 @@ msgid ""
 "Your message could not be sent to the following recipients as it would "
 "exceed their quotas:"
 msgstr ""
-"No s'ha pogut enviar el vostre missatge als següents destinataris degut a"
-" la seva quota:"
+"No s'ha pogut enviar el vostre missatge als següents destinataris degut a la "
+"seva quota:"
 
 #: invenio/legacy/webmessage/api.py:457
 msgid "Your message has been sent."
@@ -9439,19 +9389,19 @@ msgstr "Cerqueu també:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
-"Aquesta col·lecció és restringida.  Si hi teniu accés, feu clic al botó "
-"de Cerca."
+"Aquesta col·lecció és restringida.  Si hi teniu accés, feu clic al botó de "
+"Cerca."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
-"Aquesta és una col·lecció externa allotjada.  Premeu el botó de cerca per"
-" a veure el seu contingut."
+"Aquesta és una col·lecció externa allotjada.  Premeu el botó de cerca per a "
+"veure el seu contingut."
 
 #: invenio/legacy/websearch/templates.py:1619
 msgid "This collection does not contain any document yet."
@@ -9547,8 +9497,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found %(x_nb_records)s "
 "records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sResultats globals:%(x_fmt_close)s %(x_nb_records)s "
-"registres trobats en %(x_nb_seconds)s segons."
+"%(x_fmt_open)sResultats globals:%(x_fmt_close)s %(x_nb_records)s registres "
+"trobats en %(x_nb_seconds)s segons."
 
 #: invenio/legacy/websearch/templates.py:3132
 #, python-format
@@ -9561,8 +9511,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found at least "
 "%(x_nb_records)s records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sResultats globals:%(x_fmt_close)s Al menys %(x_nb_records)s"
-" registres trobats en %(x_nb_seconds)s segons."
+"%(x_fmt_open)sResultats globals:%(x_fmt_close)s Al menys %(x_nb_records)s "
+"registres trobats en %(x_nb_seconds)s segons."
 
 #: invenio/legacy/websearch/templates.py:3184
 #, fuzzy
@@ -9589,11 +9539,10 @@ msgstr "Més detalls"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
-"La cerca booleana no ha donat cap resultat. Proveu de combinar els "
-"vostres termes de cerca d'una altra manera."
+"La cerca booleana no ha donat cap resultat. Proveu de combinar els vostres "
+"termes de cerca d'una altra manera."
 
 #: invenio/legacy/websearch/templates.py:3357
 msgid "See also: similar author names"
@@ -9618,8 +9567,8 @@ msgstr "Podeu començar a cercar des de %s."
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "Definiu una %(x_url1_open)salerta personal%(x_url1_close)s via correu "
 "electrònic o subscribiu-vos al %(x_url2_open)scanal RSS%(x_url2_close)s."
@@ -9808,7 +9757,8 @@ msgid "in"
 msgstr "dins"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "No heu trobat el que estaveu cercant? Proveu la vostra cerca a:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9824,8 +9774,7 @@ msgid ""
 "The external search engine has not responded in time. You can check its "
 "results here:"
 msgstr ""
-"El cercador extern no ha respòs a temps.  Podeu vere els seus resultats "
-"aquí:"
+"El cercador extern no ha respòs a temps.  Podeu vere els seus resultats aquí:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:146
 #: invenio/legacy/websearch_external_collections/templates.py:154
@@ -9901,8 +9850,8 @@ msgstr "obligatori"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 "La descripció hauria de ser prou significativa perquè podeu reconèixer\n"
 "la nova clau API"
@@ -9913,11 +9862,11 @@ msgstr "Crear una clau nova"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
-"Si voleu canviar la vostra adreça de correu electrònic o contrasenya, "
-"poseu-hi els nous valors en aquest formulari."
+"Si voleu canviar la vostra adreça de correu electrònic o contrasenya, poseu-"
+"hi els nous valors en aquest formulari."
 
 #: invenio/legacy/websession/templates.py:271
 msgid "Edit login credentials"
@@ -9933,19 +9882,19 @@ msgstr "Guardar els nous valors"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 "Ja que es considera com a signatura de comentaris i ressenyes, un cop "
 "definit ja no es pot canviar."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
-"Si voleu canviar la vostra o contrasenya, poseu-hi els valors antic i nou"
-" en aquest formulari."
+"Si voleu canviar la vostra o contrasenya, poseu-hi els valors antic i nou en "
+"aquest formulari."
 
 #: invenio/legacy/websession/templates.py:327
 msgid "Old password"
@@ -9982,8 +9931,8 @@ msgstr "Poseu la contrasenya nova"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 "Si feu ús d'un compte CERN lleuger podeu %(x_url_open)sreiniciar la "
 "contrassenya%(x_url_close)s."
@@ -9994,8 +9943,8 @@ msgid ""
 "You can change or reset your CERN account password by means of the "
 "%(x_url_open)sCERN account system%(x_url_close)s."
 msgstr ""
-"Podeu canviar o reiniciar la contrassenya del vostre compte del CERN via "
-"el %(x_url_open)ssistema de comptes del CERN%(x_url_close)s."
+"Podeu canviar o reiniciar la contrassenya del vostre compte del CERN via el "
+"%(x_url_open)ssistema de comptes del CERN%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:372
 msgid "Edit cataloging interface settings"
@@ -10075,15 +10024,13 @@ msgstr "Seleccioneu el mètode"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"Si heu perdut la contrassenya del %(x_fmt_open)scompte "
-"intern%(x_fmt_close)s de %(sitename)s, escriviu la vostra adreça "
-"electrònica en aquest formulari perquè us enviem un enllaç per reiniciar-"
-"la vostra contrassenya."
+"Si heu perdut la contrassenya del %(x_fmt_open)scompte intern%(x_fmt_close)s "
+"de %(sitename)s, escriviu la vostra adreça electrònica en aquest formulari "
+"perquè us enviem un enllaç per reiniciar-la vostra contrassenya."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10099,18 +10046,18 @@ msgstr "Envia l'enllaç per a reiniciar la contrasenya"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
-"Si el vostre compte utilitza el %(x_fmt_open)ssistema d'identificació del"
-" CERN%(x_fmt_close)s, podeu recuperar la vostra contrasenya a través del "
+"Si el vostre compte utilitza el %(x_fmt_open)ssistema d'identificació del "
+"CERN%(x_fmt_close)s, podeu recuperar la vostra contrasenya a través del "
 "%(x_url_open)ssistema d'autenticació del CERN%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 "Tingueu en compte que si heu estat utilitzant un sistema d'identificació "
 "extern, no podem fer-hi res, i els hi haurieu de demanar a ells."
@@ -10121,21 +10068,21 @@ msgid ""
 "Alternatively, you can ask %(x_name)s to change your login system from "
 "external to internal."
 msgstr ""
-"Alternativament, podeu demanar a %s que us canvïi el sistema "
-"d'identificació a l'intern."
+"Alternativament, podeu demanar a %s que us canvïi el sistema d'identificació "
+"a l'intern."
 
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 "%s us ofereix la possibilitat de personalitzar la interfície, crear la "
 "vostra pròpia biblioteca de documents, o crear alertes automàtiques que "
-"s'executin periòdicament i us notifiquin del resultat de la cerca per "
-"correu electrònic."
+"s'executin periòdicament i us notifiquin del resultat de la cerca per correu "
+"electrònic."
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10147,9 +10094,9 @@ msgid ""
 "Set or change your account email address or password. Specify your "
 "preferences about the look and feel of the interface."
 msgstr ""
-"Poseu o canvieu la vostra adreça de correu electrònic d'aquest compte o "
-"la contrasenya.  Especifiqueu les vostres preferències de com ha de ser "
-"la interfície."
+"Poseu o canvieu la vostra adreça de correu electrònic d'aquest compte o la "
+"contrasenya.  Especifiqueu les vostres preferències de com ha de ser la "
+"interfície."
 
 #: invenio/legacy/websession/templates.py:620
 msgid "View all the searches you performed during the last 30 days."
@@ -10157,12 +10104,12 @@ msgstr "Vegeu totes les cerques que heu fet durant els darrers 30 dies."
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
-"Els cistells us permeten definir col·lecions específiques d'items, "
-"guardar registres interessants que volgueu accedir-hi més endavant o "
-"compartir amb d'altres."
+"Els cistells us permeten definir col·lecions específiques d'items, guardar "
+"registres interessants que volgueu accedir-hi més endavant o compartir amb "
+"d'altres."
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10173,36 +10120,36 @@ msgid ""
 "Subscribe to a search which will be run periodically by our service. The "
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
-"Subscriuviu-vos a una cerca perquè s'executari periòdicament en el nostre"
-" servei. Podreu rebre el resultat correu electrònic o guardat en un dels "
+"Subscriuviu-vos a una cerca perquè s'executari periòdicament en el nostre "
+"servei. Podreu rebre el resultat correu electrònic o guardat en un dels "
 "vostres cistells."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
 "Comproveu els llibres que teniu en préstecs, sol·liciteu reserves, etc. "
 "Requereix l'ID del CERN."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
-"Ara esteu connectat com a usuari visitant, de manera que els vostres "
-"alertes desapareixeran al final d'aquesta sessió."
+"Ara esteu connectat com a usuari visitant, de manera que els vostres alertes "
+"desapareixeran al final d'aquesta sessió."
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
-"Esteu identificats com a %(x_user)s. Ara podeu a) %(x_url1_open"
-")sdesconectar-vos%(x_url1_close)s; b) modificar les "
-"%(x_url2_open)spreferències del vostre compte%(x_url2_close)s."
+"Esteu identificats com a %(x_user)s. Ara podeu a) %(x_url1_open)sdesconectar-"
+"vos%(x_url1_close)s; b) modificar les %(x_url2_open)spreferències del vostre "
+"compte%(x_url2_close)s."
 
 #: invenio/legacy/websession/templates.py:785
 #, fuzzy, python-format
@@ -10210,8 +10157,8 @@ msgid ""
 "You can consult the list of %(x_url_open)syour comments%(x_url_close)s "
 "submitted so far."
 msgstr ""
-"Podeu consultar la llista de les %(x_url_open)svostres "
-"tasques%(x_url_close)s."
+"Podeu consultar la llista de les %(x_url_open)svostres tasques"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:790
 msgid "Your Alert Searches"
@@ -10220,8 +10167,8 @@ msgstr "Les vostres alertes"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 "Podeu consultar la llista dels %(x_url_open)s grups%(x_url_close)s que "
 "administreu o en sou membre."
@@ -10235,11 +10182,11 @@ msgstr "Els vostres grups"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"Podeu consultar la llista de %(x_url_open)sels vostres "
-"lliuraments%(x_url_close)s i informar-vos del seu estat."
+"Podeu consultar la llista de %(x_url_open)sels vostres lliuraments"
+"%(x_url_close)s i informar-vos del seu estat."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -10249,11 +10196,11 @@ msgstr "Els vostres lliuraments"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"Podeu consultar la llista de %(x_url_open)sles vostres "
-"aprovacions%(x_url_close)s amb els documents que heu aprovat o revisat."
+"Podeu consultar la llista de %(x_url_open)sles vostres aprovacions"
+"%(x_url_close)s amb els documents que heu aprovat o revisat."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10264,8 +10211,8 @@ msgstr "Les vostres aprovacions"
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour tickets%(x_url_close)s."
 msgstr ""
-"Podeu consultar la llista de les %(x_url_open)svostres "
-"tasques%(x_url_close)s."
+"Podeu consultar la llista de les %(x_url_open)svostres tasques"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:818
 msgid "Your Tickets"
@@ -10287,9 +10234,8 @@ msgid ""
 "for a password reset at %(x_sitename)s\n"
 "for the account \"%(x_email)s\".x_sitename"
 msgstr ""
-"Algú (possiblement vosaltres mateixos), des de l'adreça %(x_ip_address)s,"
-" ha demanat un canvi de contrasenya a %(x_sitename)s per al compte "
-"%(x_email)s."
+"Algú (possiblement vosaltres mateixos), des de l'adreça %(x_ip_address)s, ha "
+"demanat un canvi de contrasenya a %(x_sitename)s per al compte %(x_email)s."
 
 #: invenio/legacy/websession/templates.py:877
 msgid "If you want to reset the password for this account, please go to:"
@@ -10303,10 +10249,10 @@ msgstr "per a confirmar la validesa d'aquesta petició."
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
-"Tingueu en compte que aquesta URL serà vàlida només durant uns %(days)s "
-"dies."
+"Tingueu en compte que aquesta URL serà vàlida només durant uns %(days)s dies."
 
 #: invenio/legacy/websession/templates.py:909
 #, fuzzy, python-format
@@ -10315,9 +10261,9 @@ msgid ""
 "to register a new account at %(x_sitename)s\n"
 "for the email address \"%(x_email)s\".x_sitename"
 msgstr ""
-"Algú (possiblement vosaltres mateixos), des de l'adreça %(x_ip_address)s,"
-" ha demanat donar d'alta un compte a %(x_sitename)s per l'adreça de "
-"correu electrònic %(x_email)s."
+"Algú (possiblement vosaltres mateixos), des de l'adreça %(x_ip_address)s, ha "
+"demanat donar d'alta un compte a %(x_sitename)s per l'adreça de correu "
+"electrònic %(x_email)s."
 
 #: invenio/legacy/websession/templates.py:914
 msgid "If you want to complete this account registration, please go to:"
@@ -10345,24 +10291,26 @@ msgid ""
 "                %(x_fmt_open)sSSO%(x_fmt_close)s system. You can\n"
 "                %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
-"Encara esteu reconeguts pel sistema central de "
-"%(x_fmt_open)sSSO%(x_fmt_close)s. També podeu %(x_url_open)sdesconnectar "
-"del SSO%(x_url_close)s."
+"Encara esteu reconeguts pel sistema central de %(x_fmt_open)sSSO"
+"%(x_fmt_close)s. També podeu %(x_url_open)sdesconnectar del SSO"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:978
 #, python-format
 msgid "If you wish you can %(x_url_open)slogin here%(x_url_close)s."
-msgstr "Si ho desitgeu podeu %(x_url_open)sidentificar-vos aquí%(x_url_close)s."
+msgstr ""
+"Si ho desitgeu podeu %(x_url_open)sidentificar-vos aquí%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1011
 msgid "If you already have an account, please login using the form below."
-msgstr "Si ja teniu un compte, si us plau identifiqueu-vos en aquest formulari."
+msgstr ""
+"Si ja teniu un compte, si us plau identifiqueu-vos en aquest formulari."
 
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 "Si encara no disposeu d'un compte al CERN, podeu crear un "
 "%(x_url_open)scompte CERN lleuger%(x_url_close)s."
@@ -10370,11 +10318,11 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"Si encara no teniu un compte, podeu %(x_url_open)sdonar-vos "
-"d'alta%(x_url_close)s en un compte intern."
+"Si encara no teniu un compte, podeu %(x_url_open)sdonar-vos d'alta"
+"%(x_url_close)s en un compte intern."
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
@@ -10411,11 +10359,11 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
-"La vostra petició ha estat validada.  Escriviu la nova contrasenya en "
-"aquest formulari."
+"La vostra petició ha estat validada.  Escriviu la nova contrasenya en aquest "
+"formulari."
 
 #: invenio/legacy/websession/templates.py:1150
 msgid "Set a new password for"
@@ -10435,13 +10383,15 @@ msgstr "Defineix la nova contrassenya"
 
 #: invenio/legacy/websession/templates.py:1175
 msgid "Please enter your email address and desired nickname and password:"
-msgstr "Introduiu la vostra adreça de correu electrònic i l'àlies i contrasenya:"
+msgstr ""
+"Introduiu la vostra adreça de correu electrònic i l'àlies i contrasenya:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
-msgstr "Aquesta compte no es podrà usar fins que no s'hagi verificat i activat."
+"It will not be possible to use the account before it has been verified and "
+"activated."
+msgstr ""
+"Aquesta compte no es podrà usar fins que no s'hagi verificat i activat."
 
 #: invenio/legacy/websession/templates.py:1228
 msgid "Retype Password"
@@ -10457,24 +10407,23 @@ msgstr "donar-se d'alta"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
-"No escolliu contrasenyes valuoses com les dels vostres comptes personals "
-"de correu electrònic o accés a dades professionals.  La vostra adreça de "
-"correu electrònic serà estrictament confidencial i no es passarà a "
-"tercers.  Serà usada per a identificar els vostres seveis personals a %s."
-"  Per exemple, podeu activar un servei d'alerta automàtic que cerqui nous"
-" registres i us notifiqui diàriament de les noves entrades per correu "
-"electrònic."
+"No escolliu contrasenyes valuoses com les dels vostres comptes personals de "
+"correu electrònic o accés a dades professionals.  La vostra adreça de correu "
+"electrònic serà estrictament confidencial i no es passarà a tercers.  Serà "
+"usada per a identificar els vostres seveis personals a %s.  Per exemple, "
+"podeu activar un servei d'alerta automàtic que cerqui nous registres i us "
+"notifiqui diàriament de les noves entrades per correu electrònic."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 "No és possible que vosaltres mateixos creeu un compte.  Poseu-vos en "
 "contacte amb %s si en voleu un."
@@ -10482,11 +10431,11 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
-"Sembla que sou un usuari visitant.  Primer us heu "
-"d'%(x_url_open)sidentificar%(x_url_close)s."
+"Sembla que sou un usuari visitant.  Primer us heu d'%(x_url_open)sidentificar"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1267
 msgid "You are not authorized to access administrative functions."
@@ -10615,8 +10564,8 @@ msgstr "Aquí teniu alguns enllaços d'administració interessants:"
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "Per a més activitats administratives, vegeu tota la %(x_url_open)sZona "
 "d'administració%(x_url_close)s."
@@ -10845,7 +10794,8 @@ msgstr "Un usuari vol unir-se al grup %s."
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 "Haurieu d'%(x_url_open)sacceptar o rebutjar%(x_url_close)s la petició "
 "d'aquest usuari."
@@ -10874,7 +10824,8 @@ msgstr "La vostra petició d'ingressar al grup %s ha estat rebutjada."
 #: invenio/legacy/websession/templates.py:2426
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour groups%(x_url_close)s."
-msgstr "Podeu consultar la llista dels %(x_url_open)svostres grups%(x_url_close)s."
+msgstr ""
+"Podeu consultar la llista dels %(x_url_open)svostres grups%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:2422
 #, fuzzy, python-format
@@ -10889,29 +10840,27 @@ msgstr "El grup %s ha estat suprimit pel seu administrador."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"Podeu consultar la llista dels %(x_url_open)s%(x_nb_total)i "
-"grups%(x_url_close)s dels que sou membre (%(x_nb_member)i) o "
+"Podeu consultar la llista dels %(x_url_open)s%(x_nb_total)i grups"
+"%(x_url_close)s dels que sou membre (%(x_nb_member)i) o "
 "administrador(%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 "Atenció: la contrasenya que heu posat per a l'usuari root de MySQL és la "
-"mateixa que la de porta Invenio per defecte.  Per motius de seguretat, us"
-" convindria canviar-la."
+"mateixa que la de porta Invenio per defecte.  Per motius de seguretat, us "
+"convindria canviar-la."
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 "Atenció: la contrasenya que heu posat a l'usuari MySQL d'Invenio és la "
 "mateixa que porta per defecte l'aplicació.  Per motius de seguretat, us "
@@ -10919,61 +10868,58 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
-"Atenció: la contrasenya per a l'usuari admin d'Invenio és buida. Per "
-"motius de seguretat, cal que en poseu una."
+"Atenció: la contrasenya per a l'usuari admin d'Invenio és buida. Per motius "
+"de seguretat, cal que en poseu una."
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
-"Atenció: l'adreça configurada per suport electrònic es info@invenio-"
-"software.org. Val la pena canviar-la a la vostra adreça particular."
+"Atenció: l'adreça configurada per suport electrònic es info@invenio-software."
+"org. Val la pena canviar-la a la vostra adreça particular."
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr "Podeu baixar-vos una versió més nova d'Invenio.  Visiteu "
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
-"No ha estat possible baixar o llegir les notes versió des de http"
-"://invenio-software.org/repo/invenio/tree/RELEASE-NOTES"
+"No ha estat possible baixar o llegir les notes versió des de http://invenio-"
+"software.org/repo/invenio/tree/RELEASE-NOTES"
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
-"Esteu connectat com a visitant.  Potser voleu %(x_url_open)sidentificar-"
-"vos%(x_url_close)s com a usuari conegut"
+"Esteu connectat com a visitant.  Potser voleu %(x_url_open)sidentificar-vos"
+"%(x_url_close)s com a usuari conegut"
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
-"Les %(x_fmt_open)svisitants%(x_fmt_close)s primer han de %(x_url_open"
-")sdonar-se d'alta%(x_url_close)s."
+"Les %(x_fmt_open)svisitants%(x_fmt_close)s primer han de %(x_url_open)sdonar-"
+"se d'alta%(x_url_close)s."
 
 #: invenio/legacy/websession/webaccount.py:127
 msgid "No queries found"
@@ -10981,19 +10927,19 @@ msgstr "No s'ha trobat cap cerca"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 "Aquesta col·lecció és restringida.  Si creieu que hi teniu accés, "
 "identifiqueu-vos."
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
-"Aquest document és restringit.  Si creieu que hi teniu accés, "
-"identifiqueu-vos."
+"Aquest document és restringit.  Si creieu que hi teniu accés, identifiqueu-"
+"vos."
 
 #: invenio/legacy/websession/webaccount.py:400
 msgid "The OpenID identifier is invalid"
@@ -11001,8 +10947,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11014,8 +10960,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11084,8 +11030,7 @@ msgstr "Escolliu el membre que vulgueu esborrar del grup."
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr "Escolliu una persona de la llista per afegir-la al grup."
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11097,8 +11042,7 @@ msgid ""
 "Please choose a user from the list if you want him to be removed from "
 "waiting list."
 msgstr ""
-"Escolliu el membre de la llista que vulgueu esborrar de la llista "
-"d'espera."
+"Escolliu el membre de la llista que vulgueu esborrar de la llista d'espera."
 
 #: invenio/legacy/websession/webgroup.py:731
 msgid "The user request for joining group has already been rejected."
@@ -11123,9 +11067,9 @@ msgid ""
 "authorization will last until %(x_expiration)s and until you close your "
 "browser if you are a guest user."
 msgstr ""
-"Ja teniu una autorització vàlida per a exercir el rol de %(x_role)s. "
-"Aquesta autorització durarà fins %(x_expiration)s i, si sou usuari "
-"convidat, fins que tanqueu el vostre navegador."
+"Ja teniu una autorització vàlida per a exercir el rol de %(x_role)s. Aquesta "
+"autorització durarà fins %(x_expiration)s i, si sou usuari convidat, fins "
+"que tanqueu el vostre navegador."
 
 #: invenio/legacy/websession/webinterface.py:128
 msgid "You have confirmed the validity of your email address!"
@@ -11140,7 +11084,8 @@ msgstr "Espereu si us plau a què l'administrador us activi el compte."
 #: invenio/legacy/websession/webinterface.py:144
 #, python-format
 msgid "You can now go to %(x_url_open)syour account page%(x_url_close)s."
-msgstr "Ja podeu anar a la %(x_url_open)spàgina del vostre compte%(x_url_close)s."
+msgstr ""
+"Ja podeu anar a la %(x_url_open)spàgina del vostre compte%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:136
 #: invenio/legacy/websession/webinterface.py:145
@@ -11153,8 +11098,7 @@ msgstr "Ja heu confirmat la validesa de la vostra adreça de correu electrònic!
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 "Aquesta petició de confirmació d'una adreça de correu electrònic no és "
 "vàlida o ha expirat."
@@ -11173,11 +11117,13 @@ msgstr "Aquesta petició per reiniciar la contrasenya ja s'ha usat."
 
 #: invenio/legacy/websession/webinterface.py:175
 msgid "This request for resetting a password is not valid or is expired."
-msgstr "Aquesta petició per reiniciar una contrasenya no és vàlida o ha expirat."
+msgstr ""
+"Aquesta petició per reiniciar una contrasenya no és vàlida o ha expirat."
 
 #: invenio/legacy/websession/webinterface.py:180
 msgid "This request for resetting the password is not valid or is expired."
-msgstr "Aquesta petició per reiniciar la contrasenya no és vàlida o ha expirat."
+msgstr ""
+"Aquesta petició per reiniciar la contrasenya no és vàlida o ha expirat."
 
 #: invenio/legacy/websession/webinterface.py:193
 msgid "The two provided passwords aren't equal."
@@ -11221,15 +11167,15 @@ msgstr "El mètode d'identificació canviat a l'intern."
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
-"Tingueu en compte que si és el primer cop qu esteu usant aquest compte "
-"amb el mètode d'identificació intern, el sistema us ha definit una "
-"contrasenya aleatòria.  Feu clic en el botó següent per a que s'us enviï,"
-" via correu electrònic, un enllaç per a reiniciar-la:"
+"Tingueu en compte que si és el primer cop qu esteu usant aquest compte amb "
+"el mètode d'identificació intern, el sistema us ha definit una contrasenya "
+"aleatòria.  Feu clic en el botó següent per a que s'us enviï, via correu "
+"electrònic, un enllaç per a reiniciar-la:"
 
 #: invenio/legacy/websession/webinterface.py:431
 msgid "Send Password"
@@ -11241,8 +11187,8 @@ msgid ""
 "Unable to switch to external login method %(x_name)s, because your email "
 "address is unknown."
 msgstr ""
-"No és possible canviar al mètode d'autenticació extern %s, perquè no "
-"consta la vostra adreça de correu electrònic."
+"No és possible canviar al mètode d'autenticació extern %s, perquè no consta "
+"la vostra adreça de correu electrònic."
 
 #: invenio/legacy/websession/webinterface.py:445
 #, fuzzy, python-format
@@ -11250,8 +11196,8 @@ msgid ""
 "Unable to switch to external login method %(x_meth)s, because your email "
 "address is unknown to the external login system."
 msgstr ""
-"No és possible canviar al mètode d'autenticació extern %s, perquè el "
-"sistem extern desconeix la vostra adreça de correu electrònic."
+"No és possible canviar al mètode d'autenticació extern %s, perquè el sistem "
+"extern desconeix la vostra adreça de correu electrònic."
 
 #: invenio/legacy/websession/webinterface.py:449
 msgid "Login method successfully selected."
@@ -11260,12 +11206,12 @@ msgstr "Mètode d'identificació seleccionat correctament."
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
-"El mètode d'identificació extern %s no accepta identificacions basades en"
-" adreça de correu electrònic.  Poseu-vos en cotacte amb els "
-"administradors de la instal·lació."
+"El mètode d'identificació extern %s no accepta identificacions basades en "
+"adreça de correu electrònic.  Poseu-vos en cotacte amb els administradors de "
+"la instal·lació."
 
 #: invenio/legacy/websession/webinterface.py:464
 msgid "Your nickname has not been updated"
@@ -11282,8 +11228,8 @@ msgid ""
 "%(x_url_open)sreset your password%(x_url_close)s anew."
 msgstr ""
 "Tingueu en compte si heu canviat la vostra adreça, haureu de "
-"%(x_url_open)stornar a posar la vostra contrasenya%(x_url_close)s un "
-"altre cop."
+"%(x_url_open)stornar a posar la vostra contrasenya%(x_url_close)s un altre "
+"cop."
 
 #: invenio/legacy/websession/webinterface.py:487
 #: invenio/legacy/websession/webinterface.py:1003
@@ -11401,17 +11347,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:665
 msgid "The entered email address does not exist in the database."
 msgstr ""
-"L'adreça de correu electrònic que heu entrat no existeix a la base de "
-"dades"
+"L'adreça de correu electrònic que heu entrat no existeix a la base de dades"
 
 #: invenio/legacy/websession/webinterface.py:683
 msgid ""
 "The entered email address is incorrect, please check that it is written "
 "correctly (e.g. johndoe@example.com)."
 msgstr ""
-"L'adreça de correu electrònic que heu entrat és incorrecte.  Comproveu si"
-" us plau que estigui escrita correctament (ex., "
-"Set.Ciencies@exemple.cat)."
+"L'adreça de correu electrònic que heu entrat és incorrecte.  Comproveu si us "
+"plau que estigui escrita correctament (ex., Set.Ciencies@exemple.cat)."
 
 #: invenio/legacy/websession/webinterface.py:684
 msgid "Incorrect email address"
@@ -11447,26 +11391,25 @@ msgid ""
 "In order to confirm its validity, an email message containing an account "
 "activation key has been sent to the given email address."
 msgstr ""
-"Per a confirmar la seva validesa, s'ha enviat un missatge a aquesta "
-"adreça que té una clau d'activació del compte."
+"Per a confirmar la seva validesa, s'ha enviat un missatge a aquesta adreça "
+"que té una clau d'activació del compte."
 
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
-"Seguiu les instruccions indicades per completar el procés d'alta del "
-"compte."
+"Seguiu les instruccions indicades per completar el procés d'alta del compte."
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
-"S'us enviarà un segon correu electrònic quan el compte s'hagi activat i "
-"el pugueu usar."
+"S'us enviarà un segon correu electrònic quan el compte s'hagi activat i el "
+"pugueu usar."
 
 #: invenio/legacy/websession/webinterface.py:989
 #, python-format
@@ -11517,7 +11460,8 @@ msgstr ""
 msgid ""
 "The site is having troubles in sending you an email for confirming your "
 "email address."
-msgstr "Tenim problemes per enviar-vos un correu per confirmar la vostra adreça."
+msgstr ""
+"Tenim problemes per enviar-vos un correu per confirmar la vostra adreça."
 
 #: invenio/legacy/websession/webinterface.py:1432
 msgid "Your tickets"
@@ -11583,7 +11527,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 "Registre creat el %(x_date_creation)s, darrera modificació el "
 "%(x_date_modification)s"
@@ -11604,82 +11549,81 @@ msgid ""
 "%(x_page)s of submission '%(x_sub)s%(x_subm)s' - Invalid Field Position "
 "Numbers"
 msgstr ""
-"No ha estat possible moure el camp de la posició %s a la %s de la pàgina "
-"%s del lliurament '%s%s' - Números de posició no vàlidos"
+"No ha estat possible moure el camp de la posició %s a la %s de la pàgina %s "
+"del lliurament '%s%s' - Números de posició no vàlidos"
 
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
-"No ha estat possible d'intercanviar el camp de la posició %s amb el camp "
-"de la posició %s a la pàgina %s del lliurament %s - no s'ha pogut moure "
-"el camp de la posició %s al camp temporal"
+"No ha estat possible d'intercanviar el camp de la posició %s amb el camp de "
+"la posició %s a la pàgina %s del lliurament %s - no s'ha pogut moure el camp "
+"de la posició %s al camp temporal"
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
-"No ha estat possible d'intercanviar el camp de la posició %s amb el camp "
-"de la posició %s a la pàgina %s del lliurament %s - no s'ha pogut moure "
-"el camp de la posició %s a la posició %s.  Si us plau demaneu a "
-"l'administrador que comprovi si un camp no ha estat encallat en una "
-"posició temporal."
+"No ha estat possible d'intercanviar el camp de la posició %s amb el camp de "
+"la posició %s a la pàgina %s del lliurament %s - no s'ha pogut moure el camp "
+"de la posició %s a la posició %s.  Si us plau demaneu a l'administrador que "
+"comprovi si un camp no ha estat encallat en una posició temporal."
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
-"No ha estat possible d'intercanviar el camp de la posició %s amb el camp "
-"de la posició %s a la pàgina %s del lliurament %s - no s'ha pogut moure "
-"el camp de la posició %s a la posició %s.  El camp està encallat en una "
-"posició temporal i ho ha de corregir manualment l'administrador."
+"No ha estat possible d'intercanviar el camp de la posició %s amb el camp de "
+"la posició %s a la pàgina %s del lliurament %s - no s'ha pogut moure el camp "
+"de la posició %s a la posició %s.  El camp està encallat en una posició "
+"temporal i ho ha de corregir manualment l'administrador."
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, fuzzy, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
-"No ha estat possible moure el camp de la posició %s a la %s de la pàgina "
-"%s del lliurament %s - no s'ha pogut colocar en una posició menor que la "
-"%s.  S'ha provat de recuperar.  Comproveu que l'ordre dels camps sigui el"
-" correcte."
+"No ha estat possible moure el camp de la posició %s a la %s de la pàgina %s "
+"del lliurament %s - no s'ha pogut colocar en una posició menor que la %s.  "
+"S'ha provat de recuperar.  Comproveu que l'ordre dels camps sigui el "
+"correcte."
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
 #, fuzzy, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
-"No ha estat possible moure el camp de la posició %s a la %s de la pàgina "
-"%s%s del lliurament %s - no s'ha pogut colocar en una posició dels camps "
-"sota la posició %s.  El camp que estava a la posició %s ara està en una "
-"posició temporal."
+"No ha estat possible moure el camp de la posició %s a la %s de la pàgina %s"
+"%s del lliurament %s - no s'ha pogut colocar en una posició dels camps sota "
+"la posició %s.  El camp que estava a la posició %s ara està en una posició "
+"temporal."
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, fuzzy, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
-"Camp mogut de la posició %s a la posició %s de la pàgina %s del "
-"lliurament '%s%s'."
+"Camp mogut de la posició %s a la posició %s de la pàgina %s del lliurament "
+"'%s%s'."
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
 #, fuzzy, python-format
@@ -11687,8 +11631,8 @@ msgid ""
 "Unable to delete field at position %(x_from)s from page %(x_to)s of "
 "submission '%(x_sub)s'"
 msgstr ""
-"No ha estat possible eliminar el camp a la posició %s de la pàgina %s del"
-" lliurament '%s%s'."
+"No ha estat possible eliminar el camp a la posició %s de la pàgina %s del "
+"lliurament '%s%s'."
 
 #: invenio/legacy/websubmit/admin_engine.py:4010
 #, fuzzy, python-format
@@ -11696,8 +11640,8 @@ msgid ""
 "Unable to delete field at position %(x_from)s from page %(x_to)s of "
 "submission '%(x_sub)s%(x_subm)s'"
 msgstr ""
-"No ha estat possible eliminar el camp a la posició %s de la pàgina %s del"
-" lliurament '%s%s'."
+"No ha estat possible eliminar el camp a la posició %s de la pàgina %s del "
+"lliurament '%s%s'."
 
 #: invenio/legacy/websubmit/engine.py:194
 #: invenio/legacy/websubmit/engine.py:871
@@ -11746,8 +11690,8 @@ msgstr "No ha estat possible determinar el número de pàgines del lliurament."
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
 "No es pot crear el directori per a aquest lliurament. L'administrador ha "
 "estat avisat."
@@ -11756,8 +11700,7 @@ msgstr ""
 #: invenio/legacy/websubmit/engine.py:1058
 msgid "Cannot create submission directory. The administrator has been alerted."
 msgstr ""
-"No es pot crear el directori de lliuraments. L'administrador ha estat "
-"avisat."
+"No es pot crear el directori de lliuraments. L'administrador ha estat avisat."
 
 #: invenio/legacy/websubmit/engine.py:462
 #: invenio/legacy/websubmit/engine.py:1080
@@ -11786,13 +11729,13 @@ msgstr "Lliura"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 "S'ha trobat un error de funcionament seriós.  S'ha avisat els "
-"administradors. <br /><em>Segurament això ha estat degut a caràcters "
-"erronis insertats al formulari</em> (p. ex., copiant i enganxant algun "
-"text d'un fitxer PDF)."
+"administradors. <br /><em>Segurament això ha estat degut a caràcters erronis "
+"insertats al formulari</em> (p. ex., copiant i enganxant algun text d'un "
+"fitxer PDF)."
 
 #: invenio/legacy/websubmit/engine.py:1501
 #, fuzzy, python-format
@@ -11806,13 +11749,14 @@ msgstr "No esteu autoritzats a accedir a aquest recurs."
 
 #: invenio/legacy/websubmit/engine.py:1812
 msgid "The chosen action is not supported by the document type."
-msgstr "L'acció que heu escollit no està suportada per a aquest tipus de document."
+msgstr ""
+"L'acció que heu escollit no està suportada per a aquest tipus de document."
 
 #: invenio/legacy/websubmit/templates.py:67
 msgid "Login to display all document types you can access"
 msgstr ""
-"Identifiqueu-vos per a visualitzar tots els tipus de document als que "
-"teniu accés"
+"Identifiqueu-vos per a visualitzar tots els tipus de document als que teniu "
+"accés"
 
 #: invenio/legacy/websubmit/templates.py:93
 msgid "Document types available for submission"
@@ -11840,8 +11784,8 @@ msgstr "Seleccioneu una categoria i després seleccioneu una acció."
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 "Per a continuar un lliurament interrumput, introduiu el número d'accés "
 "directament a aquesta cel·la:"
@@ -11872,8 +11816,8 @@ msgstr "Tornar al menú principal"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 "Aquest és el vostre número d'accés de lliurament.  El podeu usar per a "
 "continuar un lliurament interrumput en cas de problemes."
@@ -11924,8 +11868,8 @@ msgstr "Lliurament núm."
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 "Llista de funcions de %(x_action)s per als documents %(x_doctype)s en el "
 "nivell %(x_step)s"
@@ -12009,11 +11953,10 @@ msgstr "Llista de tipus de documents revisats"
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
-"Seleccioneu un dels tipus de documents següents per a comprovar l'estat "
-"dels documents"
+"Seleccioneu un dels tipus de documents següents per a comprovar l'estat dels "
+"documents"
 
 #: invenio/legacy/websubmit/templates.py:1447
 msgid "Go to specific approval workflow"
@@ -12149,10 +12092,11 @@ msgstr "Nota d'aprovació:"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
-"Aquest document encara està %(x_fmt_open)sesperant la seva "
-"aprovació%(x_fmt_close)s."
+"Aquest document encara està %(x_fmt_open)sesperant la seva aprovació"
+"%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
 #: invenio/legacy/websubmit/templates.py:2163
@@ -12185,16 +12129,15 @@ msgstr "Tornar-ho a enviar"
 #: invenio/legacy/websubmit/templates.py:2150
 msgid "WARNING! Upon confirmation, an email will be sent to the referee."
 msgstr ""
-"ATENCIÓ! Un correu electònic serà enviat al vostre revisor si ho "
-"confirmeu."
+"ATENCIÓ! Un correu electònic serà enviat al vostre revisor si ho confirmeu."
 
 #: invenio/legacy/websubmit/templates.py:2153
 msgid ""
 "As a referee for this document, you may approve or reject it from the "
 "submission interface"
 msgstr ""
-"Com a revisor d'aquest document, podeu aprovar-lo o rebutjar-lo des de la"
-" interfíci de lliuraments"
+"Com a revisor d'aquest document, podeu aprovar-lo o rebutjar-lo des de la "
+"interfíci de lliuraments"
 
 #: invenio/legacy/websubmit/templates.py:2155
 msgid "Approve/Reject"
@@ -12232,8 +12175,8 @@ msgstr "La petició de revisió va estar feta el primer cop el "
 #: invenio/legacy/websubmit/templates.py:2318
 msgid "Last request e-mail was sent to the publication committee chair on the "
 msgstr ""
-"El darrer missatge de petició va ser enviat al cap del comitè de "
-"publicació el "
+"El darrer missatge de petició va ser enviat al cap del comitè de publicació "
+"el "
 
 #: invenio/legacy/websubmit/templates.py:2268
 msgid "A referee has been selected by the publication committee on the "
@@ -12251,11 +12194,11 @@ msgstr "Seleccioneu un revisor"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
-"El revisor ha enviat les seves recomanacions finals al comitè de "
-"publicació el "
+"El revisor ha enviat les seves recomanacions finals al comitè de publicació "
+"el "
 
 #: invenio/legacy/websubmit/templates.py:2281
 #: invenio/legacy/websubmit/templates.py:2342
@@ -12273,11 +12216,11 @@ msgstr "Envieu una recomanació"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
-"El comitè de publicació ha enviat les seves recomanacions finals al cap "
-"de projecte el "
+"El comitè de publicació ha enviat les seves recomanacions finals al cap de "
+"projecte el "
 
 #: invenio/legacy/websubmit/templates.py:2291
 #: invenio/legacy/websubmit/templates.py:2358
@@ -12317,7 +12260,8 @@ msgid "Take a decision"
 msgstr "Preneu una decissió"
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr "Un consell editor ha estat seleccionat pel comitè de publicació el "
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12338,16 +12282,15 @@ msgstr "Un revisor ha estat seleccionat pel consell editor el "
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
-"El revisor ha enviat les seves recomanacions finals al comitè de "
-"publicació el "
+"El revisor ha enviat les seves recomanacions finals al comitè de publicació "
+"el "
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 "El consell editor ha enviat les seves recomanacions finals al comitè de "
 "publicació el "
@@ -12452,8 +12395,8 @@ msgid ""
 "Note that your submission has been inserted into the bibliographic task "
 "queue and is waiting for execution.\n"
 msgstr ""
-"La vostra contribució ha estat enviada a la cua de tasques "
-"bibliogràfiques i està esperant la seva execució.\n"
+"La vostra contribució ha estat enviada a la cua de tasques bibliogràfiques i "
+"està esperant la seva execució.\n"
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:206
 #, fuzzy, python-format
@@ -12464,20 +12407,18 @@ msgid ""
 "thereabouts.\n"
 msgstr ""
 "La cua de tasques s'està executant automàticament, i ara mateix hi ha %s "
-"tasques esperant la seva execució.  El vostre registre estarà a punt en "
-"poca estona, i cercable en una hora, aproximadament.\n"
+"tasques esperant la seva execució.  El vostre registre estarà a punt en poca "
+"estona, i cercable en una hora, aproximadament.\n"
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
-"Degut a una intervenció humana o a un problema temporal, la cua de "
-"tasques està en modus manual.  La vostra contribució ha quedat "
-"enregistrada però pot trigar més de l'habitual abans no estigui ben "
-"integrat i cercable.\n"
+"Degut a una intervenció humana o a un problema temporal, la cua de tasques "
+"està en modus manual.  La vostra contribució ha quedat enregistrada però pot "
+"trigar més de l'habitual abans no estigui ben integrat i cercable.\n"
 
 #: invenio/legacy/websubmit/web/approve.py:53
 msgid "approve.py: cannot determine document reference"
@@ -12759,8 +12700,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12803,11 +12744,6 @@ msgstr "connectat"
 #, fuzzy
 msgid "Role details"
 msgstr "Més detalls"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Amaga"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12925,12 +12861,12 @@ msgstr ""
 #: invenio/modules/accounts/forms.py:94
 #, fuzzy, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 "Tingueu en compte si heu canviat la vostra adreça, haureu de "
-"%(x_url_open)stornar a posar la vostra contrasenya%(x_url_close)s un "
-"altre cop."
+"%(x_url_open)stornar a posar la vostra contrasenya%(x_url_close)s un altre "
+"cop."
 
 #: invenio/modules/accounts/forms.py:117
 #, fuzzy, python-format
@@ -12996,25 +12932,26 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, fuzzy, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
-"Encara esteu reconeguts pel sistema central de "
-"%(x_fmt_open)sSSO%(x_fmt_close)s. També podeu %(x_url_open)sdesconnectar "
-"del SSO%(x_url_close)s."
+"Encara esteu reconeguts pel sistema central de %(x_fmt_open)sSSO"
+"%(x_fmt_close)s. També podeu %(x_url_open)sdesconnectar del SSO"
+"%(x_url_close)s."
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
 #, fuzzy, python-format
 msgid "If you wish you can %(x_url_open)ssign in again%(x_url_close)s."
-msgstr "Si ho desitgeu podeu %(x_url_open)sidentificar-vos aquí%(x_url_close)s."
+msgstr ""
+"Si ho desitgeu podeu %(x_url_open)sidentificar-vos aquí%(x_url_close)s."
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:27
 #, fuzzy
 msgid ""
 "Please enter your email address. You will receive a link to create a new "
 "password via email."
-msgstr "Introduiu la vostra adreça de correu electrònic i l'àlies i contrasenya:"
+msgstr ""
+"Introduiu la vostra adreça de correu electrònic i l'àlies i contrasenya:"
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:33
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:33
@@ -13025,9 +12962,10 @@ msgstr "Poseu la contrasenya nova"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
-msgstr "Introduiu la vostra adreça de correu electrònic i l'àlies i contrasenya:"
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
+msgstr ""
+"Introduiu la vostra adreça de correu electrònic i l'àlies i contrasenya:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
 #, fuzzy
@@ -13056,7 +12994,7 @@ msgid "Problem with login."
 msgstr "Comparar amb l'original"
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "Ja podeu accedir al vostre %(x_url_open)scompte%(x_url_close)s."
 
@@ -13101,8 +13039,7 @@ msgstr "Ha fallat l'edició de l'autorització de bibcatalog"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13174,13 +13111,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13189,9 +13125,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13364,8 +13300,7 @@ msgstr "col·leccions"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13419,8 +13354,7 @@ msgstr "Número de pàgina incorrecte --> es mostra la primera."
 #: invenio/modules/comments/api.py:176
 msgid "Bad number of results per page --> showing 10 results per page."
 msgstr ""
-"Nombre de resultats per pàgina incorrecte --> se'n mostraran 10 per "
-"pàgina."
+"Nombre de resultats per pàgina incorrecte --> se'n mostraran 10 per pàgina."
 
 #: invenio/modules/comments/api.py:185
 msgid "Bad display order --> showing most helpful first."
@@ -13434,8 +13368,7 @@ msgstr "Ordre incorrecte --> s'ordenarà per antiguitat."
 #: invenio/modules/comments/api.py:1650
 msgid "Comments on records have been disallowed by the administrator."
 msgstr ""
-"El administrador ha deshabilitado la opción de comentarios a los "
-"registros."
+"El administrador ha deshabilitado la opción de comentarios a los registros."
 
 #: invenio/modules/comments/api.py:246 invenio/modules/comments/api.py:269
 #: invenio/modules/comments/api.py:1437 invenio/modules/comments/api.py:1458
@@ -13456,8 +13389,8 @@ msgstr "Ja havíeu votat, de manera que aquest vot no s'ha comptabilitzat."
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 "Us heu subscrit a aquesta discussió.  A partir d'ara rebreu un correu "
 "electrònic cada cop que s'hi publiqui un nou comentari."
@@ -13489,8 +13422,8 @@ msgstr "%s no és un número vàlid de registre"
 #: invenio/modules/comments/api.py:1444 invenio/modules/comments/api.py:1465
 msgid "Your feedback could not be recorded, please try again."
 msgstr ""
-"No ha estat possible desar la vostra contribució.  Si us plau torneu-ho a"
-" provar."
+"No ha estat possible desar la vostra contribució.  Si us plau torneu-ho a "
+"provar."
 
 #: invenio/modules/comments/api.py:1573
 #, fuzzy, python-format
@@ -13520,8 +13453,8 @@ msgstr "Ja heu escrit una ressenya per a aquest registre."
 #: invenio/modules/comments/api.py:1712
 msgid "You already posted a comment short ago. Please retry later."
 msgstr ""
-"Fa poc que ja heu publicat un comentari.  Si us plau torneu-ho a provar "
-"més tard."
+"Fa poc que ja heu publicat un comentari.  Si us plau torneu-ho a provar més "
+"tard."
 
 #: invenio/modules/comments/api.py:1724
 msgid "Failed to insert your comment to the database. Please try again."
@@ -13553,13 +13486,13 @@ msgid "Record ID %(recid)s is not a number."
 msgstr "El registro %s no és numèric."
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
-"El vostre missatge és massa llarg, si us plau editeu-lo. El tamany màxim "
-"és de %i caràcters"
+"El vostre missatge és massa llarg, si us plau editeu-lo. El tamany màxim és "
+"de %i caràcters"
 
 #: invenio/modules/comments/forms.py:55
 #, fuzzy
@@ -13602,12 +13535,12 @@ msgid "Review was sent"
 msgstr "Escriviu un comentari"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Aquest comentari ha estat denunciat %i vegades"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Aquest comentari ha estat denunciat %i vegades"
 
@@ -13660,9 +13593,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13681,8 +13613,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13692,9 +13624,10 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
-msgstr "Ja existeix un fitxer amb el nom %s.  Escolliu-ne un altre, si us plau."
+msgstr ""
+"Ja existeix un fitxer amb el nom %s.  Escolliu-ne un altre, si us plau."
 
 #: invenio/modules/communities/views.py:135
 #: invenio/modules/communities/views.py:136
@@ -13748,8 +13681,7 @@ msgstr "ressenya"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13789,8 +13721,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13837,7 +13768,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "La funció %s no existeix."
 
@@ -13923,11 +13854,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "Estat de la recollida"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Les vostres tasques"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -13943,8 +13869,8 @@ msgid ""
 "We are sorry, a problem has occured during the processing of your video "
 "upload%(submission_title)s."
 msgstr ""
-"Per desgràcia hi ha hagut un problema durant el procés de càrrega del "
-"vostre video upload%(submission_title)s."
+"Per desgràcia hi ha hagut un problema durant el procés de càrrega del vostre "
+"video upload%(submission_title)s."
 
 #: invenio/modules/encoder/batch_engine.py:119
 #: invenio/modules/encoder/batch_engine.py:162
@@ -13964,8 +13890,8 @@ msgstr "Podeu comprovar l'estat del vostre vídeo aquí: %(record_url)s."
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 "Podeu donar un cop d'ull a %(guidelines_url)s i modificar o repetir el "
 "vostre lliurament."
@@ -13990,11 +13916,11 @@ msgstr "El vostre vídeo ara està accesible a: %(record_url)s."
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
-"Si la qualitat dels vídeos no és la que espereu, podeu donar un cop d'ull"
-" a %(guidelines_url)s i modificar o repetir el vostre lliurament."
+"Si la qualitat dels vídeos no és la que espereu, podeu donar un cop d'ull a "
+"%(guidelines_url)s i modificar o repetir el vostre lliurament."
 
 #: invenio/modules/formatter/engine.py:374
 #, fuzzy, python-format
@@ -14009,8 +13935,7 @@ msgstr "No s'ha pogut trobar l'element de format %s"
 #: invenio/modules/formatter/engine.py:878
 #, fuzzy, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr "Error a l'avaluar l'element de format %s amb el paràmetre %s."
 
 #: invenio/modules/formatter/engine.py:887
@@ -14134,7 +14059,7 @@ msgstr "Mostra tots els %i autors"
 msgid "Manage Files of This Record"
 msgstr "Gestioneu els fitxers d'aquest registre"
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr "Editeu aquest registre"
 
@@ -14328,8 +14253,8 @@ msgstr "Gestiona els permisos del grup"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "No teniu prou permisos en aquest grup."
 
 #: invenio/modules/groups/views.py:279
@@ -14342,12 +14267,12 @@ msgstr "No sou administrador de cap grup."
 msgid "Members"
 msgstr "Sense membres."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Falta el nom de la base de coneixement"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14357,11 +14282,11 @@ msgstr "Cap"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "qualsevol camp"
@@ -14407,13 +14332,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "No hi ha registres citats per %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "No hi ha registres citats per %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14569,28 +14495,28 @@ msgstr "Tipus de document desconegut"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14655,8 +14581,8 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr "Per a completar l'alta del compte, aneu a:"
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -15030,7 +14956,7 @@ msgid "Tag name"
 msgstr "Àlies"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "L'àlies %s ja està en ús."
 
@@ -15183,8 +15109,7 @@ msgstr "Opcions de préstec"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15246,7 +15171,7 @@ msgid "Identifiers"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/styles/harvesting_record.html:45
-#, fuzzy, python-format
+#, fuzzy
 msgid "Categories"
 msgstr "Pàgines de %(category)s"
 
@@ -15393,7 +15318,7 @@ msgid "just now"
 msgstr "Ara heu de"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s segons"
 
@@ -15452,6 +15377,48 @@ msgstr "qualsevol any"
 msgid " years ago"
 msgstr "any"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "Administració de BibCheck"
+
+#~ msgid "Not authorized"
+#~ msgstr "No autoritzat"
+
+#~ msgid "Limit to knowledge bases containing string:"
+#~ msgstr "Limitar-ho a les bases de coneixement amb el text:"
+
+#~ msgid "Really delete"
+#~ msgstr "Confirmació per a eliminar"
+
+#~ msgid "Verify syntax"
+#~ msgstr "Verifiqueu la sintaxi"
+
+#~ msgid "Calling bibcheck -verify failed."
+#~ msgstr "La invocació bibcheck -verify ha fallat."
+
+#~ msgid "Verify BibCheck config file"
+#~ msgstr "Verifiqueu el fitxer de configuració de BibCheck"
+
+#~ msgid "Verify problem"
+#~ msgstr "Problema de verificació"
+
+#~ msgid "File"
+#~ msgstr "Fitxer"
+
+#~ msgid "Edit BibCheck config file"
+#~ msgstr "Editar el fitxer de configuració de BibCheck"
+
+#~ msgid "Save BibCheck config file"
+#~ msgstr "Desar el fitxer de configuració de BibCheck"
+
+#~ msgid "Delete BibCheck config file"
+#~ msgstr "Suprimir el fitxer de configuració de BibCheck"
+
+#~ msgid "Id"
+#~ msgstr "Identificador"
+
+#~ msgid "Tickets"
+#~ msgstr "Tasques"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Atenció: seleccioneu un temps vàlid"
 
@@ -15463,9 +15430,6 @@ msgstr "any"
 
 #~ msgid "Warning: Please, select a valid date"
 #~ msgstr "Atenció: seleccioneu una data vàlida"
-
-#~ msgid ""
-#~ msgstr ""
 
 #~ msgid "Invalid MARCXML"
 #~ msgstr "MARCXML no vàlid"
@@ -15587,12 +15551,6 @@ msgstr "any"
 #~ msgid "now"
 #~ msgstr "ara"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "Administració de BibCheck"
-
-#~ msgid "Not authorized"
-#~ msgstr "No autoritzat"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "ERROR: %s no existeix"
 
@@ -15602,32 +15560,8 @@ msgstr "any"
 #~ msgid "ERROR: %s is not writable"
 #~ msgstr "ERROR: no teniu permís d'escriptura a %s"
 
-#~ msgid "Limit to knowledge bases containing string:"
-#~ msgstr "Limitar-ho a les bases de coneixement amb el text:"
-
-#~ msgid "Really delete"
-#~ msgstr "Confirmació per a eliminar"
-
-#~ msgid "Verify syntax"
-#~ msgstr "Verifiqueu la sintaxi"
-
 #~ msgid "File %s does not exist."
 #~ msgstr "El fitxer %s no existeix"
-
-#~ msgid "Calling bibcheck -verify failed."
-#~ msgstr "La invocació bibcheck -verify ha fallat."
-
-#~ msgid "Verify BibCheck config file"
-#~ msgstr "Verifiqueu el fitxer de configuració de BibCheck"
-
-#~ msgid "Verify problem"
-#~ msgstr "Problema de verificació"
-
-#~ msgid "File"
-#~ msgstr "Fitxer"
-
-#~ msgid "Edit BibCheck config file"
-#~ msgstr "Editar el fitxer de configuració de BibCheck"
 
 #~ msgid "File %s already exists."
 #~ msgstr "El fitxer %s ja existeix"
@@ -15638,20 +15572,11 @@ msgstr "any"
 #~ msgid "File %s: write failed."
 #~ msgstr "Fitxer %s: no s'ha pogut escriure."
 
-#~ msgid "Save BibCheck config file"
-#~ msgstr "Desar el fitxer de configuració de BibCheck"
-
 #~ msgid "File %s deleted."
 #~ msgstr "Fitxer %s eliminat."
 
 #~ msgid "File %s: delete failed."
 #~ msgstr "Fitxer %s: no s'ha pogut eliminar."
-
-#~ msgid "Delete BibCheck config file"
-#~ msgstr "Suprimir el fitxer de configuració de BibCheck"
-
-#~ msgid "Guests are not authorized to run batchuploader"
-#~ msgstr ""
 
 #~ msgid "The user '%s' is not authorized to run batchuploader"
 #~ msgstr "L'usuari «%s» no està autoritzat a fer càrregues massives"
@@ -15775,9 +15700,6 @@ msgstr "any"
 
 #~ msgid "Tickes you created about this person"
 #~ msgstr "Tasques que heu creat sobre aquesta persona"
-
-#~ msgid "Tickets"
-#~ msgstr "Tasques"
 
 #~ msgid "Request Tickets"
 #~ msgstr "Peticions"
@@ -15914,17 +15836,8 @@ msgstr "any"
 #~ msgid "Check if the book already exists on Invenio,"
 #~ msgstr "Comproveu si el llibre existeix en Invenio,"
 
-#~ msgid "Book does not exists on Invenio. Please fill the following form."
-#~ msgstr ""
-
 #~ msgid "This book is sent to you ..."
 #~ msgstr "S'us ha enviat aquest llibre..."
-
-#~ msgid "Id"
-#~ msgstr "Identificador"
-
-#~ msgid "More than one templates found in the document. No format found."
-#~ msgstr ""
 
 #~ msgid "Note for programmer: you have not implemented operator %s."
 #~ msgstr "Nota per al programador: no heu implementat l'operador %s."
@@ -15940,9 +15853,6 @@ msgstr "any"
 
 #~ msgid "No description entered for the template."
 #~ msgstr "No s'ha entrat cap descripció per a la plantilla."
-
-#~ msgid "No content type specified for the template. Using default: text/xml."
-#~ msgstr ""
 
 #~ msgid "Missing attribute \"name\" in TEMPLATE_REF."
 #~ msgstr "Falta l'atribut \"name\" a TEMPLATE_REF."
@@ -16091,28 +16001,8 @@ msgstr "any"
 #~ msgid "Quit searching."
 #~ msgstr "Abandona la cerca"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Cancel·lat"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr " Cercar una persona per a atribuir-li el document"
@@ -16128,9 +16018,6 @@ msgstr "any"
 
 #~ msgid "Hide successful claims"
 #~ msgstr "Amagar les reivindicacions satisfetes"
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
 
 #~ msgid "Author Name"
 #~ msgstr "Autor"
@@ -16192,23 +16079,13 @@ msgstr "any"
 #~ msgid "Make sure we match the right names!"
 #~ msgstr "Assegureu-vos que els noms es corresponguin!"
 
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr "Seleccioneu un autor per a cadascun dels registres que se li assignin."
+#~ msgid ""
+#~ "Please select an author on each of the records that will be assigned."
+#~ msgstr ""
+#~ "Seleccioneu un autor per a cadascun dels registres que se li assignin."
 
 #~ msgid "Papers without a name selected will be ignored in the process."
 #~ msgstr "En el procés, s'ignoraran els documents sense un nom seleccionat."
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Seleccioneu el nom per"
@@ -16240,29 +16117,8 @@ msgstr "any"
 #~ msgid "Confirmation needed to continue"
 #~ msgstr "Cal la confirmació per a continuar"
 
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-#~ "El resultat d'aquesta petició serà "
-#~ "visible immediatament, però ens cal la"
-#~ " vostra confirmació per fer-ho, "
-#~ "perquè aquest document ja havia estat"
-#~ " reivindicat manualment"
-
 #~ msgid "This will create a change request for the operators"
 #~ msgstr "Això crearà una petició de canvi als operadors"
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-#~ "El resultat d'aquesta petició serà "
-#~ "visible immediatament un cop sigui "
-#~ "confirmat per un operador"
 
 #~ msgid "Selected name on paper"
 #~ msgstr "Nom seleccionat en el document"
@@ -16290,16 +16146,6 @@ msgstr "any"
 
 #~ msgid "Please provide your eMail address"
 #~ msgstr "La vostra adreça de correu electrònic"
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-#~ "Aquesta adreça de correu electrònic està"
-#~ " reservada per un usuari.  Si us "
-#~ "plau, doneu-vos d'alta o doneu una"
-#~ " adreça alternativa"
 
 #~ msgid "Your eMail:"
 #~ msgstr "La vostra adreça de correu electrònic:"
@@ -16334,19 +16180,10 @@ msgstr "any"
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Marcar-ho com a documents _no_ seus"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr "  * Podeu tornar a aquesta pàgina més tard.  No es perderà res. <br />"
-
 #~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
+#~ "  * You can come back to this page later. Nothing will be lost. <br />"
 #~ msgstr ""
-#~ "  ** Ejecuta todas las peticiones "
-#~ "pendentes.  Los cambios que tengan "
-#~ "restricción de permisos se enviarán a"
-#~ " un operador para su revisión manual."
+#~ "  * Podeu tornar a aquesta pàgina més tard.  No es perderà res. <br />"
 
 #~ msgid "Create a new Person"
 #~ msgstr "Crear un nou grup"
@@ -16360,15 +16197,6 @@ msgstr "any"
 #~ msgid "Add to merge list"
 #~ msgstr "Afegir als usuaris"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Documents recents"
 
@@ -16378,201 +16206,20 @@ msgstr "any"
 #~ msgid "most recent documents:"
 #~ msgstr "els documents més recents"
 
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Gestionar els fitxers dels documents"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Escolliu el fitxer"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Llista de publicacions"
-
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
 
 #~ msgid "add external id"
 #~ msgstr "enllaç extern"
 
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
-
-#~ msgid "suggest missing ids"
-#~ msgstr ""
-
 #~ msgid "Choose system"
 #~ msgstr "Escolliu una plantilla"
-
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Fitxers que estan correctament a la cua:"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-#~ "Fatal: no estan habilitades les opcions"
-#~ " d'identificació d'autor (Author ID) en "
-#~ "aquest sistema."
 
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Fatal: no esteu autoritzat a accedir a aquesta funcionalitat."
@@ -16580,60 +16227,8 @@ msgstr "any"
 #~ msgid "Claim this paper"
 #~ msgstr "Reivindicar aquest document"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-#~ "<p>Malauradament, hi ha hagut un error"
-#~ " mentre es gestionava la vostra "
-#~ "petició.  Vegeu aquí més informació:</p>"
-
 #~ msgid "This page is not accessible directly."
 #~ msgstr "No podeu accedir a aquesta pàgina directament."
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The publication date of this book is %s."
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
 
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Paraules clau sospesades de tipus %s"
@@ -16728,18 +16323,6 @@ msgstr "any"
 #~ msgid "No Record Found for %s."
 #~ msgstr "No s'ha trobat cap registre per %s."
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-#~ "L'especificació per a l'etiqueta \"%s\" "
-#~ "ha d'acabar a la columna \":\", "
-#~ "línia %s."
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-#~ "L'especificació per a l'etiqueta \"%s\" "
-#~ "ha de començar amb \"tag\", línia "
-#~ "%s."
-
 #~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
 #~ msgstr "\"tag\" ha d'estar en minúscula a \"%s\", línia %s."
 
@@ -16750,7 +16333,8 @@ msgstr "any"
 #~ msgstr "Etiqueta \"%s\" no vàlida, línia %s."
 
 #~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr "La condició \"%s\" és fora d'una especificació d'etiqueta, línia %s."
+#~ msgstr ""
+#~ "La condició \"%s\" és fora d'una especificació d'etiqueta, línia %s."
 
 #~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
 #~ msgstr "La condició \"%s\" només pot tenir un sol caràcter, línia %s."
@@ -16761,15 +16345,6 @@ msgstr "any"
 #~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
 #~ msgstr "Falta la columna \":\" després de \"default\" a \"%s\", línia %s."
 
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-#~ "L'especificació de la plantilla per "
-#~ "defecte \"%s\" ha de començar per "
-#~ "\"default :\", línia %s."
-
 #~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
 #~ msgstr "La paraula \"default\" ha de ser en minúscules a \"%s\", línia %s."
 
@@ -16779,47 +16354,8 @@ msgstr "any"
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "No s'ha pogut llegir el format de sortida %s. %s"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-#~ "No s'ha pogut trobar el nom "
-#~ "especificat a l'etiqueta \"<name>\" a la"
-#~ " plantilla de format %s."
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-#~ "No s'ha pogut trobar la descripció "
-#~ "especificada a l'etiqueta \"<description>\" a"
-#~ " la plantilla de format %s."
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "La plantilla de format %s crida l'element no definit \"%s\"."
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-#~ "La plantilla de format %s crida a"
-#~ " l'element il·legible \"%s\". Comproveu els"
-#~ " permisos de fitxer de l'element."
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-#~ "No s'ha pogut carregar l'element \"%s\""
-#~ " a la plantilla %s. Comproveu el "
-#~ "codi de l'element."
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-#~ "L'element de format %s usa el "
-#~ "paràmetre desconegut \"%s\" a la "
-#~ "plantilla de format %s."
 
 #~ msgid "Could not read format template named %s. %s"
 #~ msgstr "No s'ha pogut llegir la plantilla de format %s. %s"
@@ -16829,16 +16365,6 @@ msgstr "any"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "No s'ha pogut llegir l'element de format %s. %s"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
-#~ "No s'ha pogut escriure al directori "
-#~ "etc/bibformat de la vostra instal·lació "
-#~ "d'Invenio. Comproveu els permisos del "
-#~ "directori."
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Format de sortida restringit"
@@ -16895,7 +16421,8 @@ msgstr "any"
 #~ msgstr "Valida de l'element de format %s"
 
 #~ msgid "No format specified for validation. Please specify one."
-#~ msgstr "No heu especificat cap format per a la validació.  Especifiqueu-ne un."
+#~ msgstr ""
+#~ "No heu especificat cap format per a la validació.  Especifiqueu-ne un."
 
 #~ msgid "Format Validation"
 #~ msgstr "Validació del format"
@@ -16903,48 +16430,11 @@ msgstr "any"
 #~ msgid "Knowledge Base %s"
 #~ msgstr "Base de coneixement %s"
 
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-#~ "Error en la conexió amb el "
-#~ "servidor SMPT esperant %s segons. "
-#~ "L'excepció és %s, a l'intentar enviar"
-#~ " el missatge de %s a %s con "
-#~ "el text %s."
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
 #~ msgid "Not Set"
 #~ msgstr "Sense definir"
 
 #~ msgid "never"
 #~ msgstr "mai"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
 
 #~ msgid "Name variants"
 #~ msgstr "Variants del nom"
@@ -16963,12 +16453,6 @@ msgstr "any"
 
 #~ msgid "Frequent keywords"
 #~ msgstr "Paraules claus freqüents"
-
-#~ msgid "No Subject categories"
-#~ msgstr ""
-
-#~ msgid "Subject categories"
-#~ msgstr ""
 
 #~ msgid "No Collaborations"
 #~ msgstr "Sense col·laboracions"
@@ -16991,9 +16475,6 @@ msgstr "any"
 #~ msgid "Citations%s"
 #~ msgstr "Citacions%s:"
 
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
-
 #~ msgid "No Publication Graph"
 #~ msgstr "Data de publicació"
 
@@ -17005,15 +16486,6 @@ msgstr "any"
 
 #~ msgid "Recompute Now!"
 #~ msgstr "Recalcula ara!"
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid "%s View your previously submitted comments"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
 
 #~ msgid "Cited by 1 record"
 #~ msgstr "Citat per 1 registre"
@@ -17042,23 +16514,8 @@ msgstr "any"
 #~ msgid "No Citation Information available"
 #~ msgstr "No hi ha informació de citacions disponible"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Discussió"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Les vostres alertes"
@@ -17081,22 +16538,8 @@ msgstr "any"
 #~ msgid "Group: %s"
 #~ msgstr "Grup: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "No s'ha trobat la pàgina %s"
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "El camp %s és obligatori."
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
-#~ msgstr ""
-#~ "No ha estat possible eliminar el "
-#~ "camp a la posició %s de la "
-#~ "pàgina %s del lliurament '%s'."
-

--- a/invenio/base/translations/cs/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/cs/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2012-02-16 18:24+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:56+0200\n"
 "Last-Translator: Jiří Kunčar <jiri.kuncar@cern.ch>\n"
 "Language-Team: CS <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -58,8 +58,8 @@ msgstr "Hlavní stránka"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -205,7 +205,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Vítejte:"
 
@@ -226,17 +226,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -262,50 +262,54 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Záznam byl vymazán."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr "Žádost o obnovu hesla pro"
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Nemáte oprávnění k použití půjčky."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Registrace selhání"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "košíky"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Role autorizačního požadavku"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, fuzzy, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
-"A nová verze Invenio je k dispozici ke stažení. Možná budete chtít "
-"navštívit "
+"A nová verze Invenio je k dispozici ke stažení. Možná budete chtít navštívit "
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -506,7 +510,8 @@ msgstr "Žádná práva k nahrání do kolekce '%s'"
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr "Uživatel '%(x_user)s' není oprávněn měnit collection '%(x_coll)s'"
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -719,10 +724,11 @@ msgstr "Záznam byl vymazán."
 
 #: invenio/legacy/batchuploader/templates.py:583
 #, fuzzy
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
-"Některé soubory nemohly být přesunuty do složky HOTOVO. Prosím, odstraňte"
-" ručně. "
+"Některé soubory nemohly být přesunuty do složky HOTOVO. Prosím, odstraňte "
+"ručně. "
 
 #: invenio/legacy/batchuploader/templates.py:585
 #, fuzzy
@@ -739,8 +745,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -823,7 +829,7 @@ msgstr "ID"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -869,8 +875,8 @@ msgstr "Máte %i lístků."
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Předchozí"
@@ -885,8 +891,8 @@ msgstr "zavřít"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Další"
 
@@ -902,18 +908,6 @@ msgstr "Další"
 msgid "Admin Area"
 msgstr "Areál administrátora"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "autor"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
 msgid "ERROR: %(x_name)s does not exist"
@@ -928,15 +922,6 @@ msgstr ""
 #, python-format
 msgid "ERROR: %(x_name)s is not writable"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
-msgid "Limit to knowledge bases containing string:"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "úspěšně smazáno"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -966,10 +951,6 @@ msgstr "úspěšně smazáno"
 msgid "Delete"
 msgstr "Smazat"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:140
-msgid "Verify syntax"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:145
 #: invenio/modules/communities/views.py:258
 #, fuzzy
@@ -981,31 +962,9 @@ msgstr "Vytvořit nový košík"
 msgid "File %(x_name)s does not exist."
 msgstr "Uživatel %s neexistuje."
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:174
-msgid "Calling bibcheck -verify failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
-msgid "Verify BibCheck config file"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Problém databáze"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "soubor(y)"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
 msgstr "Uložit změny"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:240
-msgid "Edit BibCheck config file"
-msgstr ""
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:268
 #, fuzzy, python-format
@@ -1022,10 +981,6 @@ msgstr ""
 msgid "File %(x_name)s: write failed."
 msgstr ""
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:279
-msgid "Save BibCheck config file"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:312
 #, python-format
 msgid "File %(x_name)s deleted."
@@ -1034,10 +989,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:314
 #, python-format
 msgid "File %(x_name)s: delete failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:316
-msgid "Delete BibCheck config file"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:195
@@ -1104,7 +1055,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1155,8 +1107,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1170,25 +1122,23 @@ msgstr "Prolistuj"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1213,13 +1163,14 @@ msgstr "Vytvořit nový"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1251,9 +1202,8 @@ msgstr "Výpůjční doba"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1320,8 +1270,8 @@ msgstr "Nová žádost"
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1329,8 +1279,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1353,9 +1303,8 @@ msgstr "Nový úvěr"
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1398,8 +1347,8 @@ msgstr "Hledej v %s záznamech:"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1460,11 +1409,11 @@ msgstr "Nová žádost byla úspěšně zaregistrována."
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1475,11 +1424,11 @@ msgstr "Ano"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1492,8 +1441,8 @@ msgstr "Ne"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1588,8 +1537,8 @@ msgstr "<strong>%s</strong> záznamů nalezeno"
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1609,29 +1558,29 @@ msgstr "<strong>%s</strong> záznamů nalezeno"
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1640,9 +1589,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr "Požadovaný záznam asi neexistuje."
 
@@ -2002,16 +1951,14 @@ msgstr "Záznam byl vymazán."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2032,8 +1979,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2195,8 +2142,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2303,7 +2250,7 @@ msgstr "Umístění"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Popis"
 
@@ -2497,8 +2444,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2779,9 +2726,8 @@ msgstr "Potvrdit"
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "Pokud chcete, můžete%(x_url_open) slogin zde%(x_url_close) s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2836,7 +2782,7 @@ msgstr "Resetovat"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "OK"
 
@@ -2844,8 +2790,8 @@ msgstr "OK"
 #, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3310,8 +3256,8 @@ msgstr "Schránka"
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "E-mail"
 
@@ -4146,8 +4092,8 @@ msgstr "Období zájmu (Do)"
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4166,8 +4112,8 @@ msgstr "Jen toto vydání"
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4226,17 +4172,17 @@ msgstr "ISSN"
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4614,25 +4560,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "Záznam byl vymazán."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4692,15 +4638,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4711,10 +4657,10 @@ msgstr "Vyberte soubor"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4727,8 +4673,8 @@ msgstr "Přístup"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 "Soubor, který chcete upravit je chráněn proti úpravám. Vaše akce nebyla "
 "aplikovaná"
@@ -4736,8 +4682,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, fuzzy, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr "Nahraný soubor je název příliš dlouhý, a proto není považována za"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4749,7 +4695,8 @@ msgstr "Nahraný soubor je název příliš dlouhý, a proto není považována 
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
 #, fuzzy
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr "Nahraný soubor je název příliš dlouhý, a proto není považována za"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4768,17 +4715,15 @@ msgstr "Soubor nazvaný %s již existuje.%s Prosím, vyberte jiné jméno. "
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "Soubor ve formátu '%s' již existuje. Nahrajte prosím jiný formát. "
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4792,21 +4737,20 @@ msgstr "Přidat nový soubor"
 #: invenio/legacy/bibdocfile/managedocfiles.py:900
 msgid "You can decide to hide or not previous version(s) of this file."
 msgstr ""
-"Můžete se rozhodnout, zda chcete skrýt nebo zobrazit předchozí verze "
-"tohoto souboru."
+"Můžete se rozhodnout, zda chcete skrýt nebo zobrazit předchozí verze tohoto "
+"souboru."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 #, fuzzy
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 "Alternativní formáty nahrané pro aktuální verzi tohoto souboru budou "
 "odstraněny"
@@ -4861,8 +4805,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4913,8 +4857,8 @@ msgstr "Záznam byl vymazán."
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -5035,9 +4979,9 @@ msgstr "1. Vyberte kritéria vyhledávání "
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -5051,8 +4995,8 @@ msgstr "2. Definování změn "
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -5183,11 +5127,10 @@ msgstr "Zpět na výsledky"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5319,7 +5262,7 @@ msgid "Total"
 msgstr "Celkem"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Vybrat"
 
@@ -5487,8 +5430,8 @@ msgstr "Smazat znalostní bázi"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5548,56 +5491,56 @@ msgstr "Prosím nastavte"
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5635,7 +5578,7 @@ msgstr "Závislosti znalostní báze"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5691,15 +5634,15 @@ msgstr "košíky"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, fuzzy, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr "Levá strana pravidla (%s) se již objevuje v těchto znalostních bází:"
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, fuzzy, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr "Pravá strana pravidla (%s) se již objevuje v těchto znalostních bází:"
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5932,8 +5875,7 @@ msgstr "Chyba při načítání záznam"
 #: invenio/legacy/oaiharvest/admin.py:1321
 #, fuzzy
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 "Chyba při formátování Holding Pen záznam. Pravděpodobně jeho obsah je "
 "rozdělen "
@@ -6011,8 +5953,8 @@ msgstr "Návrat do hlavního výběru"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6027,8 +5969,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Výsledky hledání"
 
@@ -6187,8 +6129,8 @@ msgstr "Nebyly nalezeny žádné hodnoty."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6217,8 +6159,8 @@ msgstr "Hledaný výraz příliš obecný, zobrazeny pouze dílčí výsledky ..
 #: invenio/legacy/search_engine/__init__.py:2165
 #, fuzzy
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr "Hledaný výraz příliš obecný, zobrazeny pouze dílčí výsledky ..."
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6230,11 +6172,9 @@ msgstr "Hledaný výraz příliš obecný, zobrazeny pouze dílčí výsledky ..
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
-"Index frází není k dispozici pro plné texty, zatím hledám slovní spojení "
-"..."
+"Index frází není k dispozici pro plné texty, zatím hledám slovní spojení ..."
 
 #: invenio/legacy/search_engine/__init__.py:2213
 #, python-format
@@ -6245,33 +6185,32 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
-"Syntaxe dotazu nepochopena. Ignorování všech závorek v dotazu. Pokud je "
-"toto nepomůže, zkontrolujte Váš dotaz a zkuste to znova."
+"Syntaxe dotazu nepochopena. Ignorování všech závorek v dotazu. Pokud je toto "
+"nepomůže, zkontrolujte Váš dotaz a zkuste to znova."
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
 "Žádný záznam nebyl nalezen v kolekci %(x_collection)s. Ostatní veřejně "
-"dostupné kolekce dali %(x_url_open)s%(x_nb_hits)d "
-"výsledků%(x_url_close)s."
+"dostupné kolekce dali %(x_url_open)s%(x_nb_hits)d výsledků%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 "Žádná veřejně přístupná kolekce nevyhovuje Vašemu dotazu. Jestliže jste "
 "hledali dokumenty veřejně nepřístupné, zvolte prosím nejdříve příslušnou "
 "neveřejnou kolekci."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
@@ -6280,50 +6219,50 @@ msgstr ""
 "hledali dokumenty veřejně nepřístupné, zvolte prosím nejdříve příslušnou "
 "neveřejnou kolekci."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr "Vaše zpětná vazba nemůže být zaznamenán, zkuste to prosím znovu."
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 msgid "No match found, please enter different search terms."
 msgstr "Nenalezena shoda, zadejte prosím jiné vyhledávací podmínky."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Nejsou tam žádné záznamy vztahující se k %s."
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Nejsou tam žádné záznamy citované %s."
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Nejsou tam žádné záznamy citované %s."
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Index slov není k dispozici pro %s."
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Index frází není k dispozici pro %s."
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 "Hledaný výraz %(x_term)s uvnitř indexu %(x_index)s neodpovídá žádnému "
 "záznamu. Nejbližší výrazy ve všech kolekcích jsou:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
@@ -6332,44 +6271,44 @@ msgstr ""
 "Hledaný výraz %s neodpovídá žádnému záznamu. Nejbližší termíny v každé "
 "kolekci jsou:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
-"Je mi líto, %s nevypadá jako platný druh volby řazení. Vybráno řazení "
-"podle názvu."
+"Je mi líto, %s nevypadá jako platný druh volby řazení. Vybráno řazení podle "
+"názvu."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 "Omlouváme se, třídění je povoleno na soubory o velikosti pouze do %d "
 "záznamů. Použito výchozí řazení."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
-"Je mi líto, %s nevypadá jako platný druh volby řazení. Vybráno řazení "
-"podle názvu."
+"Je mi líto, %s nevypadá jako platný druh volby řazení. Vybráno řazení podle "
+"názvu."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Záznam byl vymazán."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Použíjte jiný termín pro hledání."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6383,17 +6322,17 @@ msgstr "Použíjte jiný termín pro hledání."
 msgid "Browse"
 msgstr "Procházet..."
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 "Žádný výsledek nevyhovuje Vašim časovým kritériím, podmínka není vzata v "
 "úvahu..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
-"Žádný výsledek nevyhovuje Vašim omezujícím kritériím, podmínky nejsou "
-"vzaty v úvahu..."
+"Žádný výsledek nevyhovuje Vašim omezujícím kritériím, podmínky nejsou vzaty "
+"v úvahu..."
 
 #: invenio/legacy/webalert/api.py:54
 #, fuzzy, python-format
@@ -6437,10 +6376,9 @@ msgstr "Záznam byl vymazán."
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
 
 #: invenio/legacy/webalert/htmlparser.py:186
@@ -6635,15 +6573,15 @@ msgstr "Vy jste definován%s výstrahy."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:453
@@ -6701,7 +6639,7 @@ msgstr "Vaše vyhledávání"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6765,7 +6703,7 @@ msgstr "%S Přizpůsobit, Nastavení nového záznamu"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6827,7 +6765,8 @@ msgstr "Zobrazit výsledky:"
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
 #, fuzzy
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr "Vybraný veřejný košík neexistuje nebo nemáte přístup."
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6853,7 +6792,8 @@ msgstr "Tato kolekce ješte neobsahuje žádné záznamy."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
 #, fuzzy
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr "The poznámka se cituje neexistuje nebo nemáte přístup k němu."
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6886,7 +6826,8 @@ msgstr "Tato kolekce ješte neobsahuje žádné záznamy."
 
 #: invenio/legacy/webbasket/api.py:1689
 #, fuzzy
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr "Poznámka odstraňujete neexistuje nebo nemáte přístup."
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6921,8 +6862,8 @@ msgstr "Záznam byl vymazán."
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6943,8 +6884,8 @@ msgstr "Žádné záznamy pro přidání."
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6980,8 +6921,8 @@ msgstr "Prosím, vyberte existující téma, nebo vytvořit novou."
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7051,8 +6992,7 @@ msgstr "Veřejné košíky"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
@@ -7081,8 +7021,7 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:108
 #, fuzzy, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr "Můžete začít tím,%(x_url_open) screating nový koš%(x_url_close) s."
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -7242,8 +7181,8 @@ msgstr "Externí položka"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7426,8 +7365,8 @@ msgstr "Sdílet košík s novou skupinou"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 "Jste přihlášeni jako uživatel host, takže vaše košíky zmizí na konci "
 "současné relace."
@@ -7436,10 +7375,10 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, fuzzy, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
-"Pokud chcete, můžete%(x_url_open) slogin či se registrovat%(x_url_close) "
-"s."
+"Pokud chcete, můžete%(x_url_open) slogin či se registrovat%(x_url_close) s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7448,7 +7387,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Tato funkce je zakázáno pro anonymní uživatele."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Zpět na výsledky hledání"
 
@@ -7614,7 +7553,7 @@ msgstr "Přidat poznámku"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7750,213 +7689,213 @@ msgstr "ID %s komentáře neexistuje."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "ID %s záznamu neexistuje."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Napsat komentář"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "Citováno: %s záznamy"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "%i komentářů"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Zobrazuji %i nejnovějších komentářů:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Diskutovat o tomto dokumentu"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 #, fuzzy
 msgid "Start a discussion about any aspect of this document."
 msgstr "Start se diskutuje o každém aspektu tohoto dokumentu."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Promiň, záznam%s nevypadá, že neexistuje."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "Je mi líto,%s není platný občanský hodnotu."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 #, fuzzy
 msgid "Sorry, no record ID was provided."
 msgstr "Omlouvám se, nebyla ID záznamu poskytovány."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Můžete začít prohledávat%s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "Citováno: %s záznamy"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Pomohlo Vám toto hodnocení?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Napsat recenzi"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, fuzzy, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 "Průměrné skóre v recenzi:%(x_nb_score) je založena na%(x_nb_reviews) S "
 "hodnocení"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "Čtenáři nalezeny následující%s recenzí být velmi užitečné."
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Zobrazit všechny recenze %s"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Hodnotit tento dokument"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Buďte první hodnotitel tohoto dokumentu."
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "zavřít"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Nahlásit zneužití"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr "Obnovit komentář"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Smazat komentář"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr "Odhlásit komentář"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr "Přiložený soubor"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr "Přiložené soubory"
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, fuzzy, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Citováno: %s záznamy"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr "%(X_nb_people) je mimo%(x_nb_total) s lidem se toto hodnocení užitečné"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr "Obnovit recenzi"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr "Smazat recenzi"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr "Odhlásit recenzi"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Poznámky"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Recenze"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "K dispozici je celkem %s recenzí"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "K dispozici je celkem %s komentářů"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Buďte první hodnotitel tohoto dokumentu."
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Odebírat"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr "Neodebírat"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7965,512 +7904,517 @@ msgstr "Neodebírat"
 msgid "Record"
 msgstr "Záznam"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "recenze"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "poznámka"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Recenze"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Zobrazování"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Stránka:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr "Nemáte oprávnění komentovat nebo hodnotit."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr "Poznámka: Vaše přezdívka,%s, zobrazí se jako autor tohoto komentáře."
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 #, fuzzy
 msgid "Once logged in, authorized users can also attach files."
 msgstr "Jakmile se přihlásíte, můžete oprávnění uživatelé připojit soubory."
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 #, fuzzy
 msgid "Optionally, attach a file to this comment"
 msgstr "V případě potřeby připojit soubor na názor"
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 #, fuzzy
 msgid "Optionally, attach files to this comment"
 msgstr "V případě potřeby připojovat soubory k tomuto komentáři"
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr "Max jeden soubor"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "Max %i souborů"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr "Max %(x_nb_bytes)s na soubor"
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr "Pošlete mi e-mail, když je přidán nový komentář"
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Článek"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "Přidat komentář"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr "Poznámka: Vaše přezdívka,%s, zobrazí se jako autor tohoto přezkumu."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Hodnotit článek"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Vyberte skóre"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Přidej název do recenze"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Napište svoji recenzi"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr "Přidat recenzi"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Přidat recenzi"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Vaše recenze byla úspěšně přidána."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Váš komentář byl úspěšně přidán."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Zpět k záznamu"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
-msgstr "Můžete nahlédnout do seznamu%(x_url_open) syour vstupenky%(x_url_close) s."
+msgstr ""
+"Můžete nahlédnout do seznamu%(x_url_open) syour vstupenky%(x_url_close) s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr "Zobraz nejvíce komentované záznamy"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr "Zobrazit poslední komentované záznamy"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr "Zobrazit všechny komentáře nahlášeny jako zneužívání"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr "Zobrazit nejčastěji recenzované záznamy"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr "Zobrazit nejnovější recenzované záznamy"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr "Zobrazit všechny recenze nahlášené jako zneužití"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Zobrazit všechny uživatele, kteří byli hlášeni"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Příručka"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Komentáře a recenze jsou vypnuté"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 #, fuzzy
 msgid "Comment ID:"
 msgstr "Komentář ID:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 #, fuzzy
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
-"Nebo zadejte rekordní ID seznam veškerých souvisejících komentáře / "
-"recenze:"
+"Nebo zadejte rekordní ID seznam veškerých souvisejících komentáře / recenze:"
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr "ID záznamu:"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Zobrazit komentář"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 #, fuzzy
 msgid "There have been no reports so far."
 msgstr "Tam byly žádné zprávy tak daleko."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Zobrazit všechny nahlášené připomínky %s"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Zobrazit všechny nahlášené recenze %s"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Přezdívka"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "ID uživatele"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Počet pozitivních hlasů"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 #, fuzzy
 msgid "Number negative votes"
 msgstr "Počet negativních hlasů"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Celkový počet hlasů"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Celkový počet hlášení"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 #, fuzzy
 msgid "View all user's reported comments/reviews"
 msgstr "Zobrazit všechny uživatele vykazované názory na hodnocení"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Záznam byl vymazán."
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Záznam byl vymazán."
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Napsáno"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Obecné informace"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Smazat vybrané recenze"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Potlačit vybrané oznámení o zneužití"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr "Obnovit vybrané hodnocení"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr "Obnovit vybrané komentáře"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Smazat vybrané komentáře"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Zde jsou nahlášené recenze od uživatele %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Zde jsou nahlášené připomínky od uživatele %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Tady je recenze %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Tady je komentář %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, fuzzy, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Zde je přehled%(x_cmtID) je napsán uživatelem%(x_user) s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, fuzzy, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Tady je komentář%(x_cmtID) je napsán uživatelem%(x_user) s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 #, fuzzy
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "Tady jsou všechny hlášené Recenze tříděné podle nejčastěji uváděným"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 #, fuzzy
 msgid "Here are all reported comments sorted by the most reported"
-msgstr "Tady jsou všechny nahlášené připomínky tříděné podle nejčastěji hlášenou"
+msgstr ""
+"Tady jsou všechny nahlášené připomínky tříděné podle nejčastěji hlášenou"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
-"Tady jsou všechny názory na rekordních%i, tříděné podle nejčastěji "
-"uváděným"
+"Tady jsou všechny názory na rekordních%i, tříděné podle nejčastěji uváděným"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr "Zobrazit komentáře"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
-msgstr "Tady jsou všechny komentáře k záznamu%i, tříděné podle nejčastěji uváděným"
+msgstr ""
+"Tady jsou všechny komentáře k záznamu%i, tříděné podle nejčastěji uváděným"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr "Zobrazit hodnocení"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "ID komentáře"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "úspěšně smazáno"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr "úspěšně obnoveno"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 #, fuzzy
 msgid "successfully suppressed abuse report"
 msgstr "Úspěšně potlačil hlášení o zneužití"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Ještě nerecenzováno"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+"Následující recenze byla zaslána %(CFG_SITE_NAME)s od %(user_nickname)s:"
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr "Následující recenze byla zaslána %(CFG_SITE_NAME)s od %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+"Následující komentář byl poslán %(CFG_SITE_NAME)s od %(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr "Následující komentář byl poslán %(CFG_SITE_NAME)s od %(user_nickname)s:"
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr "Toto je automatická zpráva, prosím, neodpovídejte na ní."
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr "Pro zaslání dalšího komentáře přejděte na <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr "Pro přímou odpověď na tento komentář jděte na <%(x_url)s>"
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr "Pro odhlášení z odběru této diskuze jděte na <%(x_url)s>"
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr "Pro jakékoliv dotazy použíjte <%(CFG_SITE_SUPPORT_EMAIL)s>"
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 msgid "Your comment will be lost."
 msgstr "Váš komentář bude ztracen."
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Smazat komentáře"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "poslední záznam nejdříve"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "Zobrazit poslední komentované záznamy"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "přidat komentáře"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "nalezené záznamy"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Poznámky"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "%i položky"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Přidat položky"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "Zobrazit výsledky:"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Datum objednávky"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Následující stránka"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Zobrazit upozornění"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8478,104 +8422,104 @@ msgstr "Zobrazit upozornění"
 msgid "Refresh"
 msgstr "Obnovit"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Odhlásit komentář"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "Nalezeno %i položek"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Záznam nenalezen"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "Tato kolekce ješte neobsahuje žádné záznamy."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, fuzzy, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
-"Velikost souboru \\\"%s\\\" (%s) je vetší než maximální povolená velikost"
-" (%s). Vyberte soubor(y) znovu."
+"Velikost souboru \\\"%s\\\" (%s) je vetší než maximální povolená velikost "
+"(%s). Vyberte soubor(y) znovu."
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Přidat komentář"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 msgid "You cannot report a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr "Stránka nenalezena"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr "Požadovaný komentář nebyl nalezen"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr "Nelze nalést požadovaný soubor"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Nemáte oprávnění k použití půjčky."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Poznámky"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr ""
@@ -8690,8 +8634,8 @@ msgstr "Omlouváme se, stránka%s nevypadá, že neexistuje."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8762,8 +8706,8 @@ msgstr "Nemohli jsme zajistit vám nějaké časopisy"
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8794,8 +8738,8 @@ msgstr "Nenašli jsme žádnou informtion o aktuálním vydání"
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -8873,7 +8817,8 @@ msgstr ""
 #: invenio/legacy/webjournal/config.py:531
 #, fuzzy
 msgid "Sorry, this category does not exist for this journal and issue."
-msgstr "Omlouváme se, tato kategorie neexistuje pro tohoto časopisu a vydávání."
+msgstr ""
+"Omlouváme se, tato kategorie neexistuje pro tohoto časopisu a vydávání."
 
 #: invenio/legacy/webjournal/templates.py:53
 msgid "Available Journals"
@@ -8899,7 +8844,8 @@ msgstr ""
 #: invenio/legacy/webjournal/templates.py:308
 #, fuzzy, python-format
 msgid "If you cannot read this email please go to %(x_journal_link)s"
-msgstr "Pokud nemůžete přečíst tento e-mail najdete na adrese%(x_journal_link) s"
+msgstr ""
+"Pokud nemůžete přečíst tento e-mail najdete na adrese%(x_journal_link) s"
 
 #: invenio/legacy/webjournal/templates.py:699
 msgid "Apply"
@@ -8992,9 +8938,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -9016,8 +8961,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9129,8 +9073,8 @@ msgid ""
 "Your message is too long, please shorten it. Maximum size allowed is "
 "%(x_size)i characters."
 msgstr ""
-"Vaše zpráva je příliš dlouhá, upravte ji. Maximální povolená velikost je "
-"%i znaků."
+"Vaše zpráva je příliš dlouhá, upravte ji. Maximální povolená velikost je %i "
+"znaků."
 
 #: invenio/legacy/webmessage/api.py:402
 #, fuzzy, python-format
@@ -9155,8 +9099,8 @@ msgid ""
 "Your message could not be sent to the following recipients as it would "
 "exceed their quotas:"
 msgstr ""
-"Vaše zpráva nemohla být odeslána na následujícím příjemcům z důvodu "
-"jejich plné schánky:"
+"Vaše zpráva nemohla být odeslána na následujícím příjemcům z důvodu jejich "
+"plné schánky:"
 
 #: invenio/legacy/webmessage/api.py:457
 msgid "Your message has been sent."
@@ -9496,16 +9440,16 @@ msgstr "Hledat také:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 "Tato kolekce je omezena.  Pokud máte oprávnění k přístupu do systému, "
 "klepněte prosím na tlačítko Hledat."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 "To je hostovaná externí kolekce. Prosím, klikněte na tlačítko Hledat pro "
 "zobrazení obsahu."
@@ -9644,11 +9588,10 @@ msgstr "Další podrobnosti"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
-"Booleovský dotaz nevrátil žádný výsledek. Zkuste zkombinovat dané termíny"
-" jiným způsobem."
+"Booleovský dotaz nevrátil žádný výsledek. Zkuste zkombinovat dané termíny "
+"jiným způsobem."
 
 #: invenio/legacy/websearch/templates.py:3357
 msgid "See also: similar author names"
@@ -9673,8 +9616,8 @@ msgstr "Můžete začít prohledávat od %s."
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3832
@@ -9865,7 +9808,8 @@ msgid "in"
 msgstr "v"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "Nenalezli jste co jste hledali? Zkuste Váš dotaz na jiných servrech:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9881,8 +9825,7 @@ msgid ""
 "The external search engine has not responded in time. You can check its "
 "results here:"
 msgstr ""
-"Externí vyhledávač neodpověděl včas. Můžete zkontrolovat výsledky přímo "
-"zde:"
+"Externí vyhledávač neodpověděl včas. Můžete zkontrolovat výsledky přímo zde:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:146
 #: invenio/legacy/websearch_external_collections/templates.py:154
@@ -9959,8 +9902,8 @@ msgstr "povinný"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9970,8 +9913,8 @@ msgstr "Vytvořit nový košík"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:271
@@ -9988,19 +9931,19 @@ msgstr "Nastavení nových hodnot"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 "Protože je toto považováno za podpis pro komentáře a recenze, po prvním "
 "nastavení již nelze měnit."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
-"Pokud chcete změnit své heslo, zadejte staré a nastavte nové ve spodní "
-"části formuláře."
+"Pokud chcete změnit své heslo, zadejte staré a nastavte nové ve spodní části "
+"formuláře."
 
 #: invenio/legacy/websession/templates.py:327
 msgid "Old password"
@@ -10037,8 +9980,8 @@ msgstr "Nastavení nového hesla"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 "Pokud používáte lehký CERN účet mužete\n"
 "                %(x_url_open)sobnovit své heslo%(x_url_close)s."
@@ -10121,8 +10064,7 @@ msgid ""
 "Please select which login method you would like to use to authenticate "
 "yourself"
 msgstr ""
-"Vyberte, prosím, kterou přihlášovací metodu chcete používat k Vašemu "
-"ověření"
+"Vyberte, prosím, kterou přihlášovací metodu chcete používat k Vašemu ověření"
 
 #: invenio/legacy/websession/templates.py:503
 #: invenio/legacy/websession/templates.py:518
@@ -10132,14 +10074,13 @@ msgstr "Vyberte způsob"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"Pokud jste ztratili heslo pro %(sitename)s %(x_fmt_open)svnitří "
-"účet%(x_fmt_close)s, zadejte, prosím, Vaši emailovou adresu v "
-"následujícím formuláři pro zaslání odkazu na změnu hesla."
+"Pokud jste ztratili heslo pro %(sitename)s %(x_fmt_open)svnitří účet"
+"%(x_fmt_close)s, zadejte, prosím, Vaši emailovou adresu v následujícím "
+"formuláři pro zaslání odkazu na změnu hesla."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10155,18 +10096,18 @@ msgstr "Odešli odkaz na změnu hesla"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
-"Pokud jste používali %(x_fmt_open)spřihlašovací systém "
-"CERNu%(x_fmt_close)s, pak můžete obnovit Vaše heslo pomocí "
-"%(x_url_open)sauthentikačního systému CERNu%(x_url_close)s."
+"Pokud jste používali %(x_fmt_open)spřihlašovací systém CERNu%(x_fmt_close)s, "
+"pak můžete obnovit Vaše heslo pomocí %(x_url_open)sauthentikačního systému "
+"CERNu%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 "Všimněte si, že pokud jste používali externí přihlašovací systém, pak "
 "nemůžeme nic dělat a musíte se zeptat zde."
@@ -10177,20 +10118,20 @@ msgid ""
 "Alternatively, you can ask %(x_name)s to change your login system from "
 "external to internal."
 msgstr ""
-"Případně můžete požádat %s o změnu svého přihlašovacího účtu z externího "
-"na interní."
+"Případně můžete požádat %s o změnu svého přihlašovacího účtu z externího na "
+"interní."
 
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
-"%s Vám nabízí možnost přizpůsobit rozhraní, nastavit vlastní osobní "
-"knihovnu dokumentů, nebo nastavit automatické zaslání upozornění při "
-"změně výsledků dotazu na email."
+"%s Vám nabízí možnost přizpůsobit rozhraní, nastavit vlastní osobní knihovnu "
+"dokumentů, nebo nastavit automatické zaslání upozornění při změně výsledků "
+"dotazu na email."
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10209,8 +10150,8 @@ msgstr "Zobrazit všechny provedené vyhledávání během posledních 30 dnů."
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:636
@@ -10225,22 +10166,22 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:785
@@ -10248,7 +10189,8 @@ msgstr ""
 msgid ""
 "You can consult the list of %(x_url_open)syour comments%(x_url_close)s "
 "submitted so far."
-msgstr "Můžete nahlédnout do seznamu%(x_url_open) syour vstupenky%(x_url_close) s."
+msgstr ""
+"Můžete nahlédnout do seznamu%(x_url_open) syour vstupenky%(x_url_close) s."
 
 #: invenio/legacy/websession/templates.py:790
 msgid "Your Alert Searches"
@@ -10257,8 +10199,8 @@ msgstr "Vaše upozornění na vyhledávání"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:799
@@ -10270,8 +10212,8 @@ msgstr "Vaše skupiny"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:805
@@ -10282,8 +10224,8 @@ msgstr "Vaše podání"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:811
@@ -10294,7 +10236,8 @@ msgstr "Vaše schválení"
 #: invenio/legacy/websession/templates.py:815
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour tickets%(x_url_close)s."
-msgstr "Můžete nahlédnout do seznamu%(x_url_open) syour vstupenky%(x_url_close) s."
+msgstr ""
+"Můžete nahlédnout do seznamu%(x_url_open) syour vstupenky%(x_url_close) s."
 
 #: invenio/legacy/websession/templates.py:818
 msgid "Your Tickets"
@@ -10331,10 +10274,11 @@ msgstr "S cílem potvrdit platnost této žádosti."
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, fuzzy, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
-"Upozorňujeme, že tato adresa URL zůstane v platnosti po dobu asi%(ve "
-"dnech) s dny."
+"Upozorňujeme, že tato adresa URL zůstane v platnosti po dobu asi"
+"%(ve dnech) s dny."
 
 #: invenio/legacy/websession/templates.py:909
 #, python-format
@@ -10379,20 +10323,21 @@ msgstr "Pokud chcete, můžete%(x_url_open) slogin zde%(x_url_close) s."
 #: invenio/legacy/websession/templates.py:1011
 #, fuzzy
 msgid "If you already have an account, please login using the form below."
-msgstr "Pokud již máte účet, přihlaste se prosím pomocí níže uvedeného formuláře."
+msgstr ""
+"Pokud již máte účet, přihlaste se prosím pomocí níže uvedeného formuláře."
 
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1027
@@ -10428,11 +10373,11 @@ msgstr "Můžete použít svou přezdívku nebo e-mailovou adresu pro přihláš
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
-"Vaše žádost je platná. Prosím nastavte požadované nové heslo v "
-"následujícím formuláři."
+"Vaše žádost je platná. Prosím nastavte požadované nové heslo v následujícím "
+"formuláři."
 
 #: invenio/legacy/websession/templates.py:1150
 msgid "Set a new password for"
@@ -10456,8 +10401,8 @@ msgstr "Prosím, zadejte svou e-mailovou adresu, přezdívku a heslo:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1228
@@ -10474,24 +10419,24 @@ msgstr "registrovat"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1235
 #, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1267
@@ -10625,8 +10570,8 @@ msgstr "Zde jsou některé zajímavé odkazy Web Admin pro vás:"
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1378
@@ -10845,10 +10790,11 @@ msgstr "Uživatel chce vstoupit do skupiny %s."
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
-"Prosím, %(x_url_open)spříjměte nebo zamítne%(x_url_close)s tento "
-"požadavek od uživatele."
+"Prosím, %(x_url_open)spříjměte nebo zamítne%(x_url_close)s tento požadavek "
+"od uživatele."
 
 #: invenio/legacy/websession/templates.py:2400
 #, fuzzy, python-format
@@ -10874,7 +10820,8 @@ msgstr "Vaše žádost o vstup do skupiny %s byla zamítnuta."
 #: invenio/legacy/websession/templates.py:2426
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour groups%(x_url_close)s."
-msgstr "Můžete nahlédnout do seznamu %(x_url_open) svašich skupin%(x_url_close)s."
+msgstr ""
+"Můžete nahlédnout do seznamu %(x_url_open) svašich skupin%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:2422
 #, fuzzy, python-format
@@ -10889,16 +10836,15 @@ msgstr "Skupina %s byla odstraněna jejím správcem."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 "Varování: heslo MySQL uživatele root je stejné jako výchozí. Pro vyšší "
 "bezpečnost můžete chtít změnit výchozí heslo."
@@ -10906,61 +10852,56 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 #, fuzzy
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
-"A nová verze Invenio je k dispozici ke stažení. Možná budete chtít "
-"navštívit "
+"A nová verze Invenio je k dispozici ke stažení. Možná budete chtít navštívit "
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
-"Jste přihlášen jako host. Možná se budete chtít "
-"%(x_url_open)spřihlásit%(x_url_close)s jako bežný uživatel."
+"Jste přihlášen jako host. Možná se budete chtít %(x_url_open)spřihlásit"
+"%(x_url_close)s jako bežný uživatel."
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:127
@@ -10969,14 +10910,14 @@ msgstr "Žádné dotazy nalezeny"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -10985,8 +10926,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -10998,8 +10939,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11069,11 +11010,9 @@ msgstr "Prosím, vyberte člena, pokud jej chcete odstranit ze skupiny."
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
-"Prosím, vyberte uživatele ze seznamu, pokud chcete, aby se přidal ke "
-"skupině."
+"Prosím, vyberte uživatele ze seznamu, pokud chcete, aby se přidal ke skupině."
 
 #: invenio/legacy/websession/webgroup.py:664
 msgid "The user is already member of the group."
@@ -11108,8 +11047,8 @@ msgid ""
 "authorization will last until %(x_expiration)s and until you close your "
 "browser if you are a guest user."
 msgstr ""
-"Úspěšně jste získali oprávnění jako %(x_role)s! Toto oprávnění je platné "
-"do %(x_expiration)s nebo než zavřete prohlížeč pokud jste Host."
+"Úspěšně jste získali oprávnění jako %(x_role)s! Toto oprávnění je platné do "
+"%(x_expiration)s nebo než zavřete prohlížeč pokud jste Host."
 
 #: invenio/legacy/websession/webinterface.py:128
 msgid "You have confirmed the validity of your email address!"
@@ -11124,7 +11063,8 @@ msgstr "Prosím, počkejte na správce než aktivuje váš účet."
 #: invenio/legacy/websession/webinterface.py:144
 #, python-format
 msgid "You can now go to %(x_url_open)syour account page%(x_url_close)s."
-msgstr "Nyní můžete přejít na %(x_url_open)sstránku vášeho účtu%(x_url_close)s."
+msgstr ""
+"Nyní můžete přejít na %(x_url_open)sstránku vášeho účtu%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:136
 #: invenio/legacy/websession/webinterface.py:145
@@ -11137,8 +11077,7 @@ msgstr "Již jste potvrdil platnost vaší e-mailové adresy!"
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr "Tato žádost o potvrzení e-mailové adresy není platná nebo vypršela."
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -11201,10 +11140,10 @@ msgstr "Přepnuto na interní přihlašovací metodu."
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -11233,8 +11172,8 @@ msgstr "Přihlásit metodu úspěšně vybranou."
 #: invenio/legacy/websession/webinterface.py:452
 #, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -11361,8 +11300,8 @@ msgid ""
 "Cannot send password reset request since you are using external "
 "authentication system."
 msgstr ""
-"Nelze odeslat žádost o změnu hesla, protože používáte externí "
-"autentifikační systém."
+"Nelze odeslat žádost o změnu hesla, protože používáte externí autentifikační "
+"systém."
 
 #: invenio/legacy/websession/webinterface.py:665
 msgid "The entered email address does not exist in the database."
@@ -11373,8 +11312,8 @@ msgid ""
 "The entered email address is incorrect, please check that it is written "
 "correctly (e.g. johndoe@example.com)."
 msgstr ""
-"Zadaná e-mailová adresa není správná, zkontrolujte, že je napsána bez "
-"chyb (např. jan.novak@example.com)."
+"Zadaná e-mailová adresa není správná, zkontrolujte, že je napsána bez chyb "
+"(např. jan.novak@example.com)."
 
 #: invenio/legacy/websession/webinterface.py:684
 msgid "Incorrect email address"
@@ -11414,15 +11353,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:989
@@ -11539,7 +11478,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, fuzzy, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr "Záznam vytvořen %s, modifikován %s"
 
 #: invenio/legacy/webstyle/templates.py:707
@@ -11563,37 +11503,37 @@ msgstr "Přesunuto pole z pozice na pozici%s%s na stránku%podání '%s%s'."
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11601,15 +11541,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, fuzzy, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr "Přesunuto pole z pozice na pozici%s%s na stránku%podání '%s%s'."
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11675,8 +11615,8 @@ msgstr "Nelze určit počet předkládání stránek."
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11712,8 +11652,8 @@ msgstr "Přidej"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11764,8 +11704,8 @@ msgstr "Vyberte kategorii a poté klikněte na tlačítko akce."
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:366
@@ -11794,8 +11734,8 @@ msgstr "Zpět do hlavního menu"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:548
@@ -11845,8 +11785,8 @@ msgstr "Podací číslo"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1041
@@ -11933,9 +11873,9 @@ msgstr "Seznam rozhodčího typů dokumentů"
 #: invenio/legacy/websubmit/templates.py:1479
 #, fuzzy
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
-msgstr "Vyberte jednu z následujících typů dokumentů pro kontrolu dokumentů stav"
+"Select one of the following types of documents to check the documents status"
+msgstr ""
+"Vyberte jednu z následujících typů dokumentů pro kontrolu dokumentů stav"
 
 #: invenio/legacy/websubmit/templates.py:1447
 #, fuzzy
@@ -12079,10 +12019,11 @@ msgstr "Poznámka pro schválení:"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, fuzzy, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
-"Tento dokument je stále%(x_fmt_open) swaiting pro "
-"schvalování%(x_fmt_close) s."
+"Tento dokument je stále%(x_fmt_open) swaiting pro schvalování"
+"%(x_fmt_close) s."
 
 #: invenio/legacy/websubmit/templates.py:2142
 #: invenio/legacy/websubmit/templates.py:2163
@@ -12182,8 +12123,8 @@ msgstr "Vyber znalce"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -12202,8 +12143,8 @@ msgstr "Odeslat doporučení"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -12249,7 +12190,8 @@ msgstr "Přijmout rozhodnutí"
 
 #: invenio/legacy/websubmit/templates.py:2321
 #, fuzzy
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr "Redakční rada byla vybrána publikace výboru"
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12272,14 +12214,13 @@ msgstr "Znalec byl vybrán redakční radou dne"
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr "Znalec poslal své závěrečné doporučení redakční radě"
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -12398,10 +12339,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12699,8 +12639,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12743,11 +12683,6 @@ msgstr "připojeno"
 #, fuzzy
 msgid "Role details"
 msgstr "Další podrobnosti"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Příručka"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12863,8 +12798,8 @@ msgstr "Daná e-mailová adresa %s již existuje v databázi."
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -12929,9 +12864,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -12955,8 +12889,8 @@ msgstr "Nastavení nového hesla"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr "Prosím, zadejte svou e-mailovou adresu, přezdívku a heslo:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -12986,7 +12920,7 @@ msgid "Problem with login."
 msgstr "Srovnání s originálem"
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "Nyní můžete přistupovat k%(x_url_open) saccount%(x_url_close) s."
 
@@ -13029,8 +12963,7 @@ msgstr "Úprava bibcatalog povolení se nezdařila"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13102,13 +13035,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13117,9 +13049,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13294,8 +13226,7 @@ msgstr "kolekce"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13387,8 +13318,8 @@ msgstr "Promiňte, jste již hlasoval. Toto hlasování nebylo zaznamenáno. "
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13478,13 +13409,13 @@ msgid "Record ID %(recid)s is not a number."
 msgstr "Záznam ID%s není číslo."
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
-"Vaše zpráva je příliš dlouhá, upravte ji. Maximální povolená velikost je "
-"%i znaků."
+"Vaše zpráva je příliš dlouhá, upravte ji. Maximální povolená velikost je %i "
+"znaků."
 
 #: invenio/modules/comments/forms.py:55
 #, fuzzy
@@ -13527,12 +13458,12 @@ msgid "Review was sent"
 msgstr "Napsat komentář"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Záznam byl vymazán."
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Záznam byl vymazán."
 
@@ -13585,9 +13516,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13606,8 +13536,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13617,7 +13547,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "Soubor nazvaný %s již existuje.%s Prosím, vyberte jiné jméno. "
 
@@ -13673,8 +13603,7 @@ msgstr "recenze"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13714,8 +13643,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13762,7 +13690,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "Funkce %s neexistuje."
 
@@ -13847,11 +13775,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "Sklizeň stav"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Vaše oznámení"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -13886,8 +13809,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13908,8 +13831,8 @@ msgstr "Index slov není k dispozici pro %s."
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13925,8 +13848,7 @@ msgstr "Validace formátu elementu %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14048,7 +13970,7 @@ msgstr "Zobrazit %i autorů"
 msgid "Manage Files of This Record"
 msgstr "Správa souborů tohoto záznamu"
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr "Editovat tento záznam"
 
@@ -14242,8 +14164,8 @@ msgstr "Správa skupinových práv"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "Omlouváme se, tato kolekce ješte neobsahuje žádné záznamy."
 
 #: invenio/modules/groups/views.py:279
@@ -14256,12 +14178,12 @@ msgstr "Vy nejste správcem žádné skupiny."
 msgid "Members"
 msgstr "Žádní členové."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Znalost základní název chybí"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14271,11 +14193,11 @@ msgstr "Žádný"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "všechna pole"
@@ -14321,13 +14243,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "Nejsou tam žádné záznamy citované %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "Nejsou tam žádné záznamy citované %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14483,28 +14406,28 @@ msgstr "Typ souboru"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14569,8 +14492,8 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr "Chcete-li dokončit tento účet registraci naleznete na:"
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -14944,7 +14867,7 @@ msgid "Tag name"
 msgstr "avíza"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "Požadovaná přezdívka %s je již obsazena."
 
@@ -15050,11 +14973,6 @@ msgstr ""
 msgid "Saving..."
 msgstr "Nahrát"
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "Žádný"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15096,8 +15014,7 @@ msgstr "Možnosti vypůjčky"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15306,7 +15223,7 @@ msgid "just now"
 msgstr "Nyní je třeba"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s sekund"
 
@@ -15365,6 +15282,51 @@ msgstr "jakýkoli rok"
 msgid " years ago"
 msgstr "Rok"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "BibCheck Administrátor"
+
+#~ msgid "Not authorized"
+#~ msgstr "Není povoleno"
+
+#~ msgid "Limit to knowledge bases containing string:"
+#~ msgstr "Omezit na znalostní báze, které obsahují řetězec:"
+
+#~ msgid "Really delete"
+#~ msgstr "Opravdu smazat"
+
+#~ msgid "Verify syntax"
+#~ msgstr "Ověření syntaxe"
+
+#~ msgid "Calling bibcheck -verify failed."
+#~ msgstr "Volání bibcheck - ověření se nezdařilo."
+
+#~ msgid "Verify BibCheck config file"
+#~ msgstr "Ověřte BibCheck konfigurační soubor"
+
+#~ msgid "Verify problem"
+#~ msgstr "Ověřit problém"
+
+#~ msgid "File"
+#~ msgstr "Soubor"
+
+#~ msgid "Edit BibCheck config file"
+#~ msgstr "Úpravy BibCheck config file"
+
+#~ msgid "Save BibCheck config file"
+#~ msgstr "Uložit BibCheck konfigurační soubor"
+
+#~ msgid "Delete BibCheck config file"
+#~ msgstr "Smazat BibCheck konfigurační soubor"
+
+#~ msgid "Id"
+#~ msgstr "Id"
+
+#~ msgid "Tickets"
+#~ msgstr "název"
+
+#~ msgid "Done"
+#~ msgstr "květen"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Varování: Prosím, vyberte platný čas"
 
@@ -15376,9 +15338,6 @@ msgstr "Rok"
 
 #~ msgid "Warning: Please, select a valid date"
 #~ msgstr "Varování: Prosím, vyberte platné datum"
-
-#~ msgid ""
-#~ msgstr ""
 
 #~ msgid "Invalid MARCXML"
 #~ msgstr "Neplatný MARCXML"
@@ -15485,12 +15444,6 @@ msgstr "Rok"
 #~ msgid "now"
 #~ msgstr "nyní"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "BibCheck Administrátor"
-
-#~ msgid "Not authorized"
-#~ msgstr "Není povoleno"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "Chyba: %s neexistuje"
 
@@ -15499,30 +15452,6 @@ msgstr "Rok"
 
 #~ msgid "ERROR: %s is not writable"
 #~ msgstr "Chyba: %s není zapisovatelný"
-
-#~ msgid "Limit to knowledge bases containing string:"
-#~ msgstr "Omezit na znalostní báze, které obsahují řetězec:"
-
-#~ msgid "Really delete"
-#~ msgstr "Opravdu smazat"
-
-#~ msgid "Verify syntax"
-#~ msgstr "Ověření syntaxe"
-
-#~ msgid "Calling bibcheck -verify failed."
-#~ msgstr "Volání bibcheck - ověření se nezdařilo."
-
-#~ msgid "Verify BibCheck config file"
-#~ msgstr "Ověřte BibCheck konfigurační soubor"
-
-#~ msgid "Verify problem"
-#~ msgstr "Ověřit problém"
-
-#~ msgid "File"
-#~ msgstr "Soubor"
-
-#~ msgid "Edit BibCheck config file"
-#~ msgstr "Úpravy BibCheck config file"
 
 #~ msgid "File %s already exists."
 #~ msgstr "Soubor %s již existuje."
@@ -15533,17 +15462,11 @@ msgstr "Rok"
 #~ msgid "File %s: write failed."
 #~ msgstr "Soubor %s: chyba při zápisu."
 
-#~ msgid "Save BibCheck config file"
-#~ msgstr "Uložit BibCheck konfigurační soubor"
-
 #~ msgid "File %s deleted."
 #~ msgstr "Soubor %s odstraněn."
 
 #~ msgid "File %s: delete failed."
 #~ msgstr "Soubor %s: smazání nezdařilo."
-
-#~ msgid "Delete BibCheck config file"
-#~ msgstr "Smazat BibCheck konfigurační soubor"
 
 #~ msgid "Guests are not authorized to run batchuploader"
 #~ msgstr "Hosté nejsou oprávněni provozovat batchuploader"
@@ -15662,9 +15585,6 @@ msgstr "Rok"
 #~ msgid "Tickes you created about this person"
 #~ msgstr "Tickes jste vytvořili o této osobě"
 
-#~ msgid "Tickets"
-#~ msgstr "název"
-
 #~ msgid "Request Tickets"
 #~ msgstr "host"
 
@@ -15742,9 +15662,6 @@ msgstr "Rok"
 
 #~ msgid "This book is sent to you ..."
 #~ msgstr "Tato kniha je odeslán na vás ..."
-
-#~ msgid "Id"
-#~ msgstr "Id"
 
 #~ msgid "0 borrower(s) found."
 #~ msgstr "Hledej v %s záznamech:"
@@ -15923,9 +15840,6 @@ msgstr "Rok"
 #~ msgid "Verbose"
 #~ msgstr "Prolistuj"
 
-#~ msgid "Done"
-#~ msgstr "květen"
-
 #~ msgid "Edit current version"
 #~ msgstr "košíky"
 
@@ -16088,28 +16002,8 @@ msgstr "Rok"
 #~ msgid "Quit searching."
 #~ msgstr "Ukončete vyhledávání."
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Zrušeno"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr " Vyhledávání osob přispívající k práci"
@@ -16126,9 +16020,6 @@ msgstr "Rok"
 #~ msgid "Hide successful claims"
 #~ msgstr "Skrýt úspěšné nároky"
 
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Autor"
 
@@ -16143,12 +16034,6 @@ msgstr "Rok"
 
 #~ msgid "Operator review of user actions pending"
 #~ msgstr "Provozovatel přehled akcí uživatele čeká"
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
-#~ "Omlouváme se, v současné době žádné "
-#~ "záznamy, které se nacházejí v této "
-#~ "kategorii."
 
 #~ msgid "Review Transaction"
 #~ msgstr "Přehled transakce"
@@ -16189,26 +16074,12 @@ msgstr "Rok"
 #~ msgid "No title available"
 #~ msgstr "Není k dispozici"
 
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
+#~ msgid ""
+#~ "Please select an author on each of the records that will be assigned."
 #~ msgstr "Vyberte autora pro záznamy v pochybnost."
 
 #~ msgid "Papers without a name selected will be ignored in the process."
 #~ msgstr "Krabice, které nebyly vybrány, budou ignorovány v tomto procesu."
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Vyberte jméno pro"
@@ -16240,21 +16111,8 @@ msgstr "Rok"
 #~ msgid "Confirmation needed to continue"
 #~ msgstr "Je potřeba potvrzení pro pokračování"
 
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
 #~ msgid "This will create a change request for the operators"
 #~ msgstr "Tím se vytvoří požadavek na změnu pro hospodářské subjekty"
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
 
 #~ msgid "Selected name on paper"
 #~ msgstr "košíky"
@@ -16282,12 +16140,6 @@ msgstr "Rok"
 
 #~ msgid "Please provide your eMail address"
 #~ msgstr "Prosím, uveďte svou e-mailovou adresu"
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
 
 #~ msgid "Your eMail:"
 #~ msgstr "košíky"
@@ -16322,16 +16174,6 @@ msgstr "Rok"
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "košíky"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "košíky"
 
@@ -16344,15 +16186,6 @@ msgstr "Rok"
 #~ msgid "Add to merge list"
 #~ msgstr "Přidat k uživatelům"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Nedávné práce"
 
@@ -16362,128 +16195,17 @@ msgstr "Rok"
 #~ msgid "most recent documents:"
 #~ msgstr "poslední dokumenty:"
 
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Správa dokumentů soubory"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Vyberte soubor"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Seznam publikací"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "externí odkaz"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "přidání"
@@ -16491,138 +16213,17 @@ msgstr "Rok"
 #~ msgid "Choose system"
 #~ msgstr "Vyberte šablonu"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Záznam byl vymazán."
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-#~ "Kritická chyba: schopnosti rozeznání autor "
-#~ "ID jsou vypnuté na tomto systému."
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Kritická chyba: Nemáte oprávnění pro přístup k této funkci."
 
 #~ msgid "Claim this paper"
 #~ msgstr "Reklamace tento papír"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
 #~ msgid "This page is not accessible directly."
 #~ msgstr "Tato stránka v nepřístupné přímo."
 
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Citováno: %s záznamy"
-
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
 
 #~ msgid "Comparison of:"
 #~ msgstr "Srovnání:"
@@ -16632,27 +16233,6 @@ msgstr "Rok"
 
 #~ msgid "Failed to create a ticket"
 #~ msgstr "Nepodařilo se vytvořit si jízdenku"
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Změnit atributy šablony"
@@ -16732,89 +16312,20 @@ msgstr "Rok"
 #~ msgid "No Record Found for %s."
 #~ msgstr "Záznam nenalezen"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Soubor %s neexistuje"
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "Výstupní formát %s atributů"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "Formátovací šablona %s závislostí"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "Validace formátu elementu %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "Formátovací prvek %s závislostí"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Limitovaný výstupní formát"
@@ -16870,80 +16381,17 @@ msgstr "Rok"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Validace formátu elementu %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "Formát validace"
 
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "Znalostní báze %s"
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "Ne Set"
 
 #~ msgid "never"
 #~ msgstr "nikdy"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
 
 #~ msgid "Name variants"
 #~ msgstr "Název variant"
@@ -16978,17 +16426,11 @@ msgstr "Rok"
 #~ msgid "Affiliations"
 #~ msgstr "Citační historie:"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
 #~ msgid "No Frequent Co-authors"
 #~ msgstr "Občasní spoluautoři"
 
 #~ msgid "Citations%s"
 #~ msgstr "Citace"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Datum vydání"
@@ -16998,18 +16440,6 @@ msgstr "Rok"
 
 #~ msgid "No publications available"
 #~ msgstr "Žádné informace nejsou k dispozici"
-
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid "%s View your previously submitted comments"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
 
 #~ msgid "Cited by 1 record"
 #~ msgstr "Citováno 1 záznamem"
@@ -17038,56 +16468,8 @@ msgstr "Rok"
 #~ msgid "No Citation Information available"
 #~ msgstr "Žádné informace o citacích nejsou k dispozici"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Diskuse"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please do not use valuable passwords "
-#~ "such as your Unix, AFS or NICE "
-#~ "passwords with this service. Your email"
-#~ " address will stay strictly confidential"
-#~ " and will not be disclosed to "
-#~ "any third party. It will be used"
-#~ " to identify you for personal "
-#~ "services of %s. For example, you "
-#~ "may set up an automatic alert "
-#~ "search that will look for new "
-#~ "preprints and will notify you daily "
-#~ "of new arrivals by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "It is not possible to create an"
-#~ " account yourself. Contact %s if you"
-#~ " want an account."
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Vaše upozornění"
@@ -17110,106 +16492,12 @@ msgstr "Rok"
 #~ msgid "Group: %s"
 #~ msgstr "Skupina: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown to the external login "
-#~ "system."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The external login method %s does "
-#~ "not support email address based logins."
-#~ "  Please contact the site administrators."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "Stránka %s nebyla nalezena"
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "Pole %s je povinné."
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "Nelze smazat pole v pozici%s%z stránku podání '%s'"
-

--- a/invenio/base/translations/de/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/de/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012 CERN.
+# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2012-08-30 11:59+0200\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:56+0200\n"
 "Last-Translator: Alexander Wagner <a.wagner@fz-juelich.de>\n"
 "Language-Team: DE <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -58,8 +58,8 @@ msgstr "Hauptseite"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -206,7 +206,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Hallo:"
 
@@ -227,17 +227,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -263,50 +263,55 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Die angegebene URL ist nicht gültig."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr "Anfrage zum Neusetzen des Passworts für"
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Sie sind nicht berechtigt die Ausleihe zu nutzen."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Registration fehlgeschlagen"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Bitte wähle einen oder mehrere aus:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Anfrage nach Berechtigungen"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, fuzzy, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
-"Eine neuere Version von Invenio steht zum Herunterladen bereit. Sie "
-"können Sie besuchen  "
+"Eine neuere Version von Invenio steht zum Herunterladen bereit. Sie können "
+"Sie besuchen  "
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -478,8 +483,7 @@ msgstr "   Benutzername/E-Mail"
 #, fuzzy
 msgid "You can approve or reject this account request at"
 msgstr ""
-"Sie können die Anfrage nach dem Benutzerkonto bestätigen oder ablehnen "
-"über"
+"Sie können die Anfrage nach dem Benutzerkonto bestätigen oder ablehnen über"
 
 #: invenio/legacy/authorlist/webinterface.py:86
 #: invenio/legacy/authorlist/webinterface.py:111
@@ -511,10 +515,11 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
-"Der Benutzer '%(x_user)s' ist nicht berechtigt die Sammlung '%(x_coll)s' "
-"zu verändern."
+"Der Benutzer '%(x_user)s' ist nicht berechtigt die Sammlung '%(x_coll)s' zu "
+"verändern."
 
 #: invenio/legacy/batchuploader/templates.py:235
 msgid "Select file to upload"
@@ -587,8 +592,8 @@ msgid ""
 "another file%(x_url2_close)s"
 msgstr ""
 "Ihre Datei wurde erfolgreich zur Bearbeitung übermittelt. Sie können das "
-"Hochladen %(x_url1_open)s überprüfen%(x_url1_close)s oder eine andere "
-"Datei %(x_url2_open)s übermitteln%(x_url2_close)s"
+"Hochladen %(x_url1_open)s überprüfen%(x_url1_close)s oder eine andere Datei "
+"%(x_url2_open)s übermitteln%(x_url2_close)s"
 
 #: invenio/legacy/batchuploader/templates.py:282
 msgid "No metadata files have been uploaded yet."
@@ -722,7 +727,8 @@ msgid "The following errors have occurred:"
 msgstr "Folgende Fehler wurden gefunden:"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -739,8 +745,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -822,7 +828,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -864,8 +870,8 @@ msgstr "Sie haben %i Aufgaben."
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Vorherige"
@@ -880,8 +886,8 @@ msgstr "schließen"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Nächste"
 
@@ -896,18 +902,6 @@ msgstr "Nächste"
 #: invenio/legacy/weblinkback/adminlib.py:55
 msgid "Admin Area"
 msgstr "Administration"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "Autor"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
@@ -927,11 +921,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
 msgid "Limit to knowledge bases containing string:"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "erfolgreich gelöscht"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -961,10 +950,6 @@ msgstr "erfolgreich gelöscht"
 msgid "Delete"
 msgstr "Löschen"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:140
-msgid "Verify syntax"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:145
 #: invenio/modules/communities/views.py:258
 #, fuzzy
@@ -984,23 +969,9 @@ msgstr ""
 msgid "Verify BibCheck config file"
 msgstr ""
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Datenbankproblem"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "Datei(en)"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
 msgstr "Änderungen speichern"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:240
-msgid "Edit BibCheck config file"
-msgstr ""
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:268
 #, python-format
@@ -1017,10 +988,6 @@ msgstr ""
 msgid "File %(x_name)s: write failed."
 msgstr ""
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:279
-msgid "Save BibCheck config file"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:312
 #, python-format
 msgid "File %(x_name)s deleted."
@@ -1029,10 +996,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:314
 #, python-format
 msgid "File %(x_name)s: delete failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:316
-msgid "Delete BibCheck config file"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:195
@@ -1099,7 +1062,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1150,8 +1114,8 @@ msgstr "Ihr Konto wurde erfolgreich erstellt."
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1165,25 +1129,23 @@ msgstr "Durchblättern"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "Ihr Konto wurde erfolgreich erstellt."
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "Ihr Konto wurde erfolgreich erstellt."
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1208,13 +1170,14 @@ msgstr "Neues erzeugen"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "Ihr Konto wurde erfolgreich erstellt."
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1246,9 +1209,8 @@ msgstr "Ausleihfrist"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "Ihr Konto wurde erfolgreich erstellt."
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1315,8 +1277,8 @@ msgstr "Neue Anfrage"
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1324,8 +1286,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1347,9 +1309,8 @@ msgstr "Neue Ausleihe"
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "Ihr Konto wurde erfolgreich erstellt."
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1391,8 +1352,8 @@ msgstr "%s Datensätze gefunden"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1451,11 +1412,11 @@ msgstr "Eine neue Anfrage wurde erfolgreich registriert."
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1466,11 +1427,11 @@ msgstr "Ja"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1483,8 +1444,8 @@ msgstr "Nein"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1579,8 +1540,8 @@ msgstr "<strong>%s</strong> Datensätze gefunden"
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1600,29 +1561,29 @@ msgstr "<strong>%s</strong> Datensätze gefunden"
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1631,9 +1592,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr "Angefragter Datensatz scheint nicht zu existieren."
 
@@ -1994,16 +1955,14 @@ msgstr "Der Datensatz wurde gelöscht."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2024,8 +1983,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2186,8 +2145,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2294,7 +2253,7 @@ msgstr "Ort"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -2488,8 +2447,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2766,12 +2725,10 @@ msgstr "Bestätigen"
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr ""
-"Wenn sie möchten können Sie sich %(x_url_open)shier "
-"einloggen%(x_url_close)s."
+"Wenn sie möchten können Sie sich %(x_url_open)shier einloggen%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
 #, fuzzy
@@ -2824,7 +2781,7 @@ msgstr "Zurücksetzen"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "OK"
 
@@ -2832,8 +2789,8 @@ msgstr "OK"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "Ihr Konto wurde erfolgreich erstellt."
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3293,8 +3250,8 @@ msgstr "Mailbox"
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "E-Mail"
 
@@ -3782,8 +3739,8 @@ msgstr "Neue Exemplardetails"
 #, fuzzy, python-format
 msgid "A %(x_url_open)snew copy%(x_url_close)s has been added."
 msgstr ""
-"Die Anfrage des Benutzers bitte %(x_url_open)sakzeptieren or "
-"abweisen%(x_url_close)s."
+"Die Anfrage des Benutzers bitte %(x_url_open)sakzeptieren or abweisen"
+"%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:7443
 #, fuzzy
@@ -4124,8 +4081,8 @@ msgstr "Interessenszeitraum (Bis)"
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4143,8 +4100,8 @@ msgstr "Nur diese Ausgabe"
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4204,17 +4161,17 @@ msgstr "ISSN"
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4592,25 +4549,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "Der Datensatz wurde gelöscht."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4670,15 +4627,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4689,10 +4646,10 @@ msgstr "Datei auswählen"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4705,17 +4662,17 @@ msgstr "Zugriff"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
-"Die Datei, die Sie editieren wollten, ist gegen Änderungen geschützt. "
-"Ihre Änderungen wurden nicht umgesetzt"
+"Die Datei, die Sie editieren wollten, ist gegen Änderungen geschützt. Ihre "
+"Änderungen wurden nicht umgesetzt"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, fuzzy, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 "Die hochgeladene Datei ist zu klein (<%i o) und wurde deshalb nicht "
 "berücksichtigt"
@@ -4730,10 +4687,11 @@ msgstr ""
 "berücksichtigt"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
-"Der Dateiname der hochgeladenen Datei ist zu lang und wurde deshalb nicht"
-" berücksichtigt"
+"Der Dateiname der hochgeladenen Datei ist zu lang und wurde deshalb nicht "
+"berücksichtigt"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
 msgid ""
@@ -4753,8 +4711,7 @@ msgstr "Der Dateiname %s existiert bereits. Bitte wählen Sie einen anderen."
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr ""
 "Eine Datei im Format '%s' existiert bereits. Bitte übermitteln Sie ein "
 "anderes Format."
@@ -4762,15 +4719,14 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
-"Es ist nicht erlaubt, einen Punkt '.', Schrägstrich '/' oder einen "
-"Backslash '\\\\' im Dateinamen zu verwenden. Bitte wählen Sie einen neuen"
-" Dateinamen und übermitteln Sie Ihre Datei erneut. In Einzelfällen sollte"
-" die Dateiendung nicht in das Benennungsfeld eingefügt werden."
+"Es ist nicht erlaubt, einen Punkt '.', Schrägstrich '/' oder einen Backslash "
+"'\\\\' im Dateinamen zu verwenden. Bitte wählen Sie einen neuen Dateinamen "
+"und übermitteln Sie Ihre Datei erneut. In Einzelfällen sollte die "
+"Dateiendung nicht in das Benennungsfeld eingefügt werden."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
 msgid "Choose how you want to restrict access to this file."
@@ -4790,18 +4746,17 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 "Wenn Sie eine Datei überarbeiten, werden die eventuell vorhanden "
-"zusätzlichen Formate gelöscht, da diese nicht mehr auf dem Stand der "
-"neuen Datei sind."
+"zusätzlichen Formate gelöscht, da diese nicht mehr auf dem Stand der neuen "
+"Datei sind."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 #, fuzzy
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 "Sich gegenseitig ausschließende Formate für die aktuelle übermittelte "
 "Version der Datei werden gelöscht"
@@ -4835,8 +4790,8 @@ msgstr "Änderungen speichern"
 #, python-format
 msgid "Need help revising or adding files to record %(recid)s"
 msgstr ""
-"Benötige Hilfe bei der Überarbeitung oder beim Hinzufügen von Dateien zum"
-" Datensatz %(recid)s"
+"Benötige Hilfe bei der Überarbeitung oder beim Hinzufügen von Dateien zum "
+"Datensatz %(recid)s"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:927
 #, python-format
@@ -4847,8 +4802,8 @@ msgid ""
 "Best regards"
 msgstr ""
 "Lieber Support,\n"
-"Ich benötige Hilfe bei der Überarbeitung oder beim Hinzufügen von Dateien"
-" zum\n"
+"Ich benötige Hilfe bei der Überarbeitung oder beim Hinzufügen von Dateien "
+"zum\n"
 "Datensatz %(recid)s. Die neue Version habe ich an die Mail angehangen.\n"
 "Viele Grüße"
 
@@ -4858,17 +4813,17 @@ msgid ""
 "Having a problem revising a file? Send the revised version to "
 "%(mailto_link)s."
 msgstr ""
-"Probleme beim Überarbeiten einer Datei? Die überarbeitet Version kann "
-"auch zu %(mailto_link)s geschickt werden."
+"Probleme beim Überarbeiten einer Datei? Die überarbeitet Version kann auch "
+"zu %(mailto_link)s geschickt werden."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
-"Probleme beim Hinzufügen oder Überarbeiten einer Datei? Die "
-"neue/überarbeitet Version kann auch zu %(mailto_link)s geschickt werden."
+"Probleme beim Hinzufügen oder Überarbeiten einer Datei? Die neue/"
+"überarbeitet Version kann auch zu %(mailto_link)s geschickt werden."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
 msgid "revise"
@@ -4919,8 +4874,8 @@ msgstr "Angefragter Datensatz scheint nicht übernommen worden zu sein."
 #: invenio/legacy/bibdocfile/webinterface.py:139
 #, fuzzy
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 "Ein Fehler ist beim Wiederherstellen der Dateiliste für dieses Dokument "
 "aufgetreten."
@@ -4966,7 +4921,8 @@ msgstr "Zugang zum Volltext"
 #: invenio/legacy/bibdocfile/webinterface.py:324
 #, fuzzy
 msgid "An error has happened in trying to retrieve the requested file."
-msgstr "Ein Fehler ist beim Wiederherstellen der gewünschten Datei aufgetreten."
+msgstr ""
+"Ein Fehler ist beim Wiederherstellen der gewünschten Datei aufgetreten."
 
 #: invenio/legacy/bibdocfile/webinterface.py:326
 msgid "Not enough information to retrieve the document"
@@ -4975,7 +4931,8 @@ msgstr "Nicht genügend Informationen, um das Dokument zu wiederzufinden"
 #: invenio/legacy/bibdocfile/webinterface.py:334
 #, fuzzy
 msgid "An error has happened in trying to retrieving the requested file."
-msgstr "Ein Fehler ist beim Wiederherstellen der gewünschten Datei aufgetreten."
+msgstr ""
+"Ein Fehler ist beim Wiederherstellen der gewünschten Datei aufgetreten."
 
 #: invenio/legacy/bibdocfile/webinterface.py:382
 msgid "Manage Document Files"
@@ -5042,13 +4999,13 @@ msgstr "1. Suchkriterium auswählen"
 #: invenio/legacy/bibeditmulti/templates.py:359
 #, fuzzy
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 "Geben Sie die Kriterien an, die Sie zum Einschränken der Datensätze "
-"verwenden möchten. Verwenden Sie \"Suchen\", um zu sehen, welche "
-"Datensätze bei diesen Kritierien heraus gefiltert werden."
+"verwenden möchten. Verwenden Sie \"Suchen\", um zu sehen, welche Datensätze "
+"bei diesen Kritierien heraus gefiltert werden."
 
 #: invenio/legacy/bibeditmulti/templates.py:361
 msgid "Preview results"
@@ -5060,8 +5017,8 @@ msgstr "2. Änderung definieren"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 "Geben Sie Felder und die dazugehörigen Unterfelder an, die dann in jedem "
 "Datensatz, auf den das Suchkriterium passt, geändert werden."
@@ -5191,11 +5148,10 @@ msgstr "Zurück zu Suchergebnissen"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5320,7 +5276,7 @@ msgid "Total"
 msgstr "Gesamt"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Auswählen"
 
@@ -5484,8 +5440,8 @@ msgstr "Wissensdatenbank löschen"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5543,56 +5499,56 @@ msgstr "Bitte konfigurieren"
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5633,7 +5589,7 @@ msgstr "Wissensdatenbank Abhängigkeiten"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5687,15 +5643,15 @@ msgstr "Ihre Regel: %s"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5793,8 +5749,7 @@ msgstr "Vielen Dank für Verbesserungsvorschläge!"
 #: invenio/legacy/errorlib/webinterface.py:155
 msgid "Use the back button of your browser to return to the previous page."
 msgstr ""
-"Benutzen Sie den Zurück Button des Browsers um eine Seite zurück zu "
-"gelangen."
+"Benutzen Sie den Zurück Button des Browsers um eine Seite zurück zu gelangen."
 
 #: invenio/legacy/errorlib/webinterface.py:158
 msgid "Thank you!"
@@ -5920,8 +5875,7 @@ msgstr "Fehler beim Erhalten des Datensatzes"
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -5996,8 +5950,8 @@ msgstr "Zurückt zur Hauptauswahl"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6012,8 +5966,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Suchergebnisse"
 
@@ -6172,8 +6126,8 @@ msgstr "Keine Werte gefunden."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6182,8 +6136,8 @@ msgid ""
 "Warning: figure caption search is only available for a subset of papers "
 "mostly from %(x_range_from_year)s-%(x_range_to_year)s."
 msgstr ""
-"Achtung: Bildunterschriften-Suche ist nur verfügbar für eine Teilmenge "
-"von Dokumenten, für die meisten ab from 2008-2011."
+"Achtung: Bildunterschriften-Suche ist nur verfügbar für eine Teilmenge von "
+"Dokumenten, für die meisten ab from 2008-2011."
 
 #: invenio/legacy/search_engine/__init__.py:2151
 #, fuzzy, python-format
@@ -6203,8 +6157,8 @@ msgstr "Suchbegriff zu allgemein, es werden nur einige Treffer angezeigt..."
 #: invenio/legacy/search_engine/__init__.py:2165
 #, fuzzy
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr "Suchbegriff zu allgemein, es werden nur einige Treffer angezeigt..."
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6217,8 +6171,7 @@ msgstr "Suchbegriff zu allgemein, es werden nur einige Treffer angezeigt..."
 #: invenio/legacy/search_engine/__init__.py:2173
 #, fuzzy
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 "Derzeit kein Phrasen-Index  für Volltext verfügbar, es wird nach "
 "Wordkombinationen geschaut..."
@@ -6233,87 +6186,87 @@ msgstr ""
 #: invenio/legacy/search_engine/__init__.py:2352
 #, fuzzy
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
-"Such-Syntax missverstanden. Ignoriere alle Klammern in der Anfrage. Wenn "
-"das nicht hilft, bitte die Suchanfrage überprüfen und erneut versuchen"
+"Such-Syntax missverstanden. Ignoriere alle Klammern in der Anfrage. Wenn das "
+"nicht hilft, bitte die Suchanfrage überprüfen und erneut versuchen"
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
-"Kein Resultat in der Sammlung %(x_collection)s gefunden. Andere "
-"öffentliche Sammlungen ergaben %(x_url_open)s%(x_nb_hits)d "
-"Ergebnisse%(x_url_close)s."
+"Kein Resultat in der Sammlung %(x_collection)s gefunden. Andere öffentliche "
+"Sammlungen ergaben %(x_url_open)s%(x_nb_hits)d Ergebnisse%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
-"In keiner allgemein zugänglichen Sammlung wurde Ihre Suche gefunden. Wenn"
-" Sie private Dokumente durchsuchen möchten, wählen Sie bitte zuerst eine "
+"In keiner allgemein zugänglichen Sammlung wurde Ihre Suche gefunden. Wenn "
+"Sie private Dokumente durchsuchen möchten, wählen Sie bitte zuerst eine "
 "private Sammlung aus."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
-"In keiner allgemein zugänglichen Sammlung wurde Ihre Suche gefunden. Wenn"
-" Sie private Dokumente durchsuchen möchten, wählen Sie bitte zuerst eine "
+"In keiner allgemein zugänglichen Sammlung wurde Ihre Suche gefunden. Wenn "
+"Sie private Dokumente durchsuchen möchten, wählen Sie bitte zuerst eine "
 "private Sammlung aus."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
-"Ihre Rückmeldung konnte nicht entgegengenommen werden, bitte versuchen "
-"sie es erneut."
-
-#: invenio/legacy/search_engine/__init__.py:3369
-msgid "No match found, please enter different search terms."
-msgstr "Keine Übereinstimmung gefunden, bitte verwenden Sie andere Suchbegriffe."
+"Ihre Rückmeldung konnte nicht entgegengenommen werden, bitte versuchen sie "
+"es erneut."
 
 #: invenio/legacy/search_engine/__init__.py:3375
+msgid "No match found, please enter different search terms."
+msgstr ""
+"Keine Übereinstimmung gefunden, bitte verwenden Sie andere Suchbegriffe."
+
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Es gibt keine Datensätze, die %s referenzieren."
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Es gibt keine Datensätze, die zitiert werden durch %s."
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Es gibt keine Datensätze, die zitiert werden durch %s."
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Es steht kein Wortindex zur Verfügung für %s."
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Es steht kein Phrasen-Index zur Verfügung für %s."
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 "Zu Suchbegriff %(x_term)s im Index %(x_index)s wurden keine passenden "
 "Datensätze gefunden. Die ähnlichsten Begriffe in allen Sammlungen sind:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
@@ -6322,44 +6275,41 @@ msgstr ""
 "Suchbegriff %s hat keine passenden Datensätze gefunden. Die ähnlichsten "
 "Begriffe in allen Sammlungen sind:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
-"%s schein keine gültige Sortieroption zu sein. Sortierung nach Titel "
-"gewählt."
+"%s schein keine gültige Sortieroption zu sein. Sortierung nach Titel gewählt."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
-"Sortierung ist nur für %d Datensäzte erlaubt. Standard Sortierung "
-"verwendet."
+"Sortierung ist nur für %d Datensäzte erlaubt. Standard Sortierung verwendet."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
-"%s schein keine gültige Sortieroption zu sein. Sortierung nach Titel "
-"gewählt."
+"%s schein keine gültige Sortieroption zu sein. Sortierung nach Titel gewählt."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Der Datensatz existiert nicht."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Unterschiedliche Suchabfragen verwenden"
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6373,13 +6323,13 @@ msgstr "Unterschiedliche Suchabfragen verwenden"
 msgid "Browse"
 msgstr "Blättern"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 "Kein Resultat in der eingegebene Zeitbeschränkung, Bedingung wird "
 "ignoriert..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
 "Kein Resultat in der eingegebene Suchbeschränkung, Bedingung wird "
@@ -6402,8 +6352,8 @@ msgstr "Sie haben keine Rechte für diese Aktion."
 #: invenio/legacy/webalert/api.py:198
 msgid "You already have an alert defined for the specified query and basket."
 msgstr ""
-"Sie haben für diese Suchanfrage/diesen Korb bereits eine Benachrichtigung"
-" eingerichtet"
+"Sie haben für diese Suchanfrage/diesen Korb bereits eine Benachrichtigung "
+"eingerichtet"
 
 #: invenio/legacy/webalert/api.py:221 invenio/legacy/webalert/api.py:345
 msgid "The alert name cannot be empty."
@@ -6426,15 +6376,14 @@ msgstr "Diese Benachrichtigung %s wurde erfolgreich aktualisiert."
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Sie haben %(x_nb)s Suchanfragen abgesetzt. Eine %(x_url_open)sdetailierte"
-" Liste%(x_url_close)s ist vorhanden und es besteht die Möglichkeit: (a) "
-"Suchergebnisse anzuschauen und (b) für diese Suchanfragen eine "
-"automatische E-Mail-Benachrichtigung zu abonnieren."
+"Sie haben %(x_nb)s Suchanfragen abgesetzt. Eine %(x_url_open)sdetailierte "
+"Liste%(x_url_close)s ist vorhanden und es besteht die Möglichkeit: (a) "
+"Suchergebnisse anzuschauen und (b) für diese Suchanfragen eine automatische "
+"E-Mail-Benachrichtigung zu abonnieren."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6575,9 +6524,9 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"Eine neue Benachrichtigung von %(x_url1_open)sIhren "
-"Suchabfragen%(x_url1_close)s, %(x_url2_open)sbeliebten "
-"Suchabfragen%(x_url2_close)s oder über das Eingabeformular einrichten."
+"Eine neue Benachrichtigung von %(x_url1_open)sIhren Suchabfragen"
+"%(x_url1_close)s, %(x_url2_open)sbeliebten Suchabfragen%(x_url2_close)s oder "
+"über das Eingabeformular einrichten."
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6628,8 +6577,8 @@ msgstr "Sie haben %s Benachrichtigungen eingerichtet."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 "Sie haben bisher keine Suche ausgeführt. Bitte gehen Sie zuerst zum "
 "%(x_url_open)sSuchinterface%(x_url_close)s."
@@ -6637,8 +6586,8 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
 "Sie haben %(x_nb1)s Suchen (%(x_nb2)s unterschiedliche Abfragen) in den "
 "letzen 30 tagen ausgeführt."
@@ -6698,7 +6647,7 @@ msgstr "Ihre Suchabfragen"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6762,7 +6711,7 @@ msgstr "%s Personalisieren, Neue Benachrichtigung einrichten"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6822,7 +6771,8 @@ msgstr "%s Personalisieren, Benachrichtigungen darstellen"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6844,7 +6794,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "Sie haben keine Rechte um Bemerkungen zu diesem Element zu schreiben."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 "Die Bemerkung auf die Sie sich beziehen existiert nicht oder Sie haben "
 "keinen Zugriff auf diese."
@@ -6877,10 +6828,11 @@ msgid "You do not have permission to delete this note."
 msgstr "Sie haben keine Berechtigung die Bemerkung zu löschen."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
-"Der Bemerkung, die Sie löschen wollen, existiert nicht oder Sie haben "
-"keine Berechtigung diese zu löschen."
+"Der Bemerkung, die Sie löschen wollen, existiert nicht oder Sie haben keine "
+"Berechtigung diese zu löschen."
 
 #: invenio/legacy/webbasket/api.py:1791
 #, fuzzy, python-format
@@ -6890,8 +6842,7 @@ msgstr "Sie haben nicht genügend Rechte um den Datensatz #%i hinzuzufügen."
 #: invenio/legacy/webbasket/api.py:1797
 msgid "Some of the items were not added due to lack of sufficient rights."
 msgstr ""
-"Einige der Elemente wurden nicht hinzugefügt, da die nötigen Rechte "
-"fehlen."
+"Einige der Elemente wurden nicht hinzugefügt, da die nötigen Rechte fehlen."
 
 #: invenio/legacy/webbasket/api.py:1814
 msgid "Please provide a title for the external source."
@@ -6911,11 +6862,11 @@ msgstr "Die angegebene URL ist nicht gültig."
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
-"Die angegebene URL ist nicht gültig: Die Syntax der Anfrage ist "
-"fehlerhaft bzw. die Anfragenicht ausgeführt werden."
+"Die angegebene URL ist nicht gültig: Die Syntax der Anfrage ist fehlerhaft "
+"bzw. die Anfragenicht ausgeführt werden."
 
 #: invenio/legacy/webbasket/api.py:1849
 msgid ""
@@ -6936,15 +6887,15 @@ msgstr "Keine Datensätze zum Hinzufügen"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
 msgid "Cannot add items to the selected basket. Invalid parameters."
 msgstr ""
-"Elemente können nicht zu dem ausgewählten Korb hinzugefügt werden. "
-"Ungültige Parameter."
+"Elemente können nicht zu dem ausgewählten Korb hinzugefügt werden. Ungültige "
+"Parameter."
 
 #: invenio/legacy/webbasket/api.py:1979
 #, fuzzy
@@ -6970,15 +6921,16 @@ msgstr "Bitte geben Sie einen Namen für den neuen Korb an."
 
 #: invenio/legacy/webbasket/api.py:2268
 msgid "Please select an existing topic or create a new one."
-msgstr "Bitte wählen Sie ein existierendes Thema aus oder erstellen Sie ein Neues."
+msgstr ""
+"Bitte wählen Sie ein existierendes Thema aus oder erstellen Sie ein Neues."
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
-"Sie können den Korb nicht abonnieren, da Sie entweder der Besitzer sind "
-"oder ihn bereits abonniert haben."
+"Sie können den Korb nicht abonnieren, da Sie entweder der Besitzer sind oder "
+"ihn bereits abonniert haben."
 
 #: invenio/legacy/webbasket/api.py:2337
 msgid ""
@@ -7049,8 +7001,7 @@ msgstr "Öffentliche Körbe"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 "Sie haben %(x_nb_perso)s persönliche Körbe und sind eingetragen bei "
 "%(x_nb_group)s Gruppenkörben und %(x_nb_public)s Körben anderer Nutzer."
@@ -7078,15 +7029,15 @@ msgid ""
 "You have no personal or group baskets or are subscribed to any public "
 "baskets."
 msgstr ""
-"Sie haben keinen persönlichen Korb, keinen Gruppen-Korb und Sie sind "
-"nicht für einen öffentlichen Korbeingetragen."
+"Sie haben keinen persönlichen Korb, keinen Gruppen-Korb und Sie sind nicht "
+"für einen öffentlichen Korbeingetragen."
 
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
-msgstr "Sie können jetzt %(x_url_open)s einen neuen Korb erstellen%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
+msgstr ""
+"Sie können jetzt %(x_url_open)s einen neuen Korb erstellen%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
 #: invenio/legacy/webbasket/templates.py:198
@@ -7189,8 +7140,8 @@ msgid ""
 "Displaying public baskets %(x_from)i - %(x_to)i out of "
 "%(x_total_public_basket)i public baskets in total."
 msgstr ""
-"Es werden %(x_from)i bis %(x_to)i öffentliche Körbe angezeigt von "
-"insgesamt %(x_total_public_basket)i öffentlichen Körben."
+"Es werden %(x_from)i bis %(x_to)i öffentliche Körbe angezeigt von insgesamt "
+"%(x_total_public_basket)i öffentlichen Körben."
 
 #: invenio/legacy/webbasket/templates.py:1376
 #: invenio/legacy/webbasket/templates.py:1400
@@ -7247,11 +7198,11 @@ msgstr "Externe Werte"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
-"Tragen sie eine URL für einen externes Element ein und füllen sie Titel "
-"und Beschreibung"
+"Tragen sie eine URL für einen externes Element ein und füllen sie Titel und "
+"Beschreibung"
 
 #: invenio/legacy/webbasket/templates.py:1612
 #: invenio/modules/linkbacks/templates/linkbacks/index_base.html:44
@@ -7271,7 +7222,8 @@ msgstr "Ausführen %(x_url_open)sder Körbe %(x_url_close)s."
 #: invenio/legacy/webbasket/templates.py:1649
 #, python-format
 msgid " or return to your %(x_url_open)sprevious basket%(x_url_close)s"
-msgstr "oder zurückkehren zu Ihrem %(x_url_open)svorherigen Korb%(x_url_close)s"
+msgstr ""
+"oder zurückkehren zu Ihrem %(x_url_open)svorherigen Korb%(x_url_close)s"
 
 #: invenio/legacy/webbasket/templates.py:1653
 #, fuzzy, python-format
@@ -7290,8 +7242,7 @@ msgid ""
 "%(x_url_open)screate a new one%(x_url_close)s first)%(x_fmt_close)s"
 msgstr ""
 "Wählen Sie einen Korb: %(x_basket_selection_box)s %(x_fmt_open)s(or "
-"%(x_url_open)sErstellen sie einen Neuen%(x_url_close)s "
-"first)%(x_fmt_close)s"
+"%(x_url_open)sErstellen sie einen Neuen%(x_url_close)s first)%(x_fmt_close)s"
 
 #: invenio/legacy/webbasket/templates.py:1764
 msgid "Optionally, add a note to each one of these items"
@@ -7433,15 +7384,16 @@ msgstr "Korb mit einer neuen Gruppe austauschen"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr "Sie sind als Gast eingeloggt. Körbe verfallen am Ende der Sitzung."
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
 "Wenn Sie möchten können Sie sich %(x_url_open)shier einloggen oder "
 "registrieren%(x_url_close)s."
@@ -7453,7 +7405,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Diese Funktion ist für Gäste gesperrt."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Suchergebnisse"
 
@@ -7618,7 +7570,7 @@ msgstr "Bemerkung hinzufügen"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7754,213 +7706,214 @@ msgstr "Kommentar-ID %s existiert nicht."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "Datensatz-ID %s existiert nicht."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Kommentar schreiben"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i Kommentare für Runde \"%(x_name)s\""
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "%i Kommentare"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Die letzen %i Kommentare anzeigen:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Dokument diskutieren"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Diskussion über Dokument starten."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Entschuldigung, Datensatz %s scheint nicht zu existieren."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "%s ist keine gültige ID."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "Es wurde keine Datensatz-ID angegeben."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Sie könnten Ihre Durchsuchen beginnen von %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i Kommentare für Runde \"%(x_name)s\""
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "War dieses Review hilfreich?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Ein Review schreiben"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 "Durchschnittliche Review-Bewertung: %(x_nb_score)s, basiert auf "
 "%(x_nb_reviews)s Reviews"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "Leser haben folgende %s Reviews als hilfreich eingestuft:"
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Alle %s Reviews anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Dieses Dokument bewerten"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Als Erster ein Review für dieses Dokument verfassen"
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "schließen"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Missbrauch melden"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr "Wiederhergestellter Kommentar"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Kommentar löschen"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 #, fuzzy
 msgid "Unreport comment"
 msgstr "Wiederherrgestellter Kommentar"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr "Angehangene Datei"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr "Angehangene Dateien"
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Rezensiert von %(x_nickname)s am %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
-msgstr "%(x_nb_people)s von %(x_nb_total)s haben dieses Review nützlich gefunden"
+msgstr ""
+"%(x_nb_people)s von %(x_nb_total)s haben dieses Review nützlich gefunden"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr "Wiederhergestellte Review"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr "Review löschen"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 #, fuzzy
 msgid "Unreport review"
 msgstr "Wiederhergestellte Review"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Kommentare"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Reviews"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Es sind total %s Reviews vorhanden"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Es sind total %s Kommentare vorhanden"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Als Erster ein Review für dieses Dokument verfassen"
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Eintragen"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr "Austragen"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7969,42 +7922,41 @@ msgstr "Austragen"
 msgid "Record"
 msgstr "Datensatz"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "Review"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "Kommentar"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Review"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Anzeige"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Seite:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr "Sie sind nicht berechtigt zu Kommentieren oder zu Rezensieren."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr "Notiz: Ihr Nickname, %s, wird als Author des Kommentars angezeigt"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
@@ -8013,480 +7965,482 @@ msgstr ""
 "Notiz: Sie haben %(x_url_open)sIhren Nicknamen%(x_url_close)s nicht "
 "definiert. %(x_nickname)s wird als Author des Kommentars angezeigt."
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
-"Einmal eingeloggte, autorisierte Benutzer können ebenfalls Dateien "
-"anhängen."
+"Einmal eingeloggte, autorisierte Benutzer können ebenfalls Dateien anhängen."
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr "Bei Bedarf kann eine Datei zu diesem Kommentar angehängt werden."
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr "Bei Bedarf können Dateien zu diesem Kommentar angehängt werden."
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr "Maximal eine Datei"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "Maximal %i Datei(en)"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr "Maximal %(x_nb_bytes)s pro Datei"
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
-msgstr "Schicken Sie mir eine E-Mail, sobald ein neuer Kommentar erstellt wurde"
+msgstr ""
+"Schicken Sie mir eine E-Mail, sobald ein neuer Kommentar erstellt wurde"
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Artikel"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "Kommentar hinzufügen"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr "Notiz: Ihr Nickname, %s, wird als Author des Reviews angezeigt"
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Diesen Artikel bewerten"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Punktezahl auswählen"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Einen Titel für das Review definieren"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Ein Review schreiben"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr "Review hinzufügen"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Review hinzufügen"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Ihr Review wurde erfolgreich hinzugefügt."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Ihr Kommentar wurde erfolgreich hinzugefügt."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Zum Datensatz zurück"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
-msgstr "Sie können die Liste %(x_url_open)sIhrer Aufgaben%(x_url_close)s einsehen."
+msgstr ""
+"Sie können die Liste %(x_url_open)sIhrer Aufgaben%(x_url_close)s einsehen."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr "Meistkommentierte Datensätze anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 #, fuzzy
 msgid "View latest commented records"
 msgstr "Kürzlich kommentierte Datensätze anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr "Alle als Missbrauch gemeldeten Kommentare anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr "Meistrezensierte Datensätze anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 #, fuzzy
 msgid "View latest reviewed records"
 msgstr "Kürzlich rezensierte Datensätze anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr "Alle als Missbrauch gemeldeten Reviews anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Alle gemeldeten Benutzer anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Handbuch"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Kommentare und Reviews sind ausgeschaltet"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"Bitte geben Sie die ID des Kommentars/Reviews ein um es anzuschauen bevor"
-" Sie es löschen"
+"Bitte geben Sie die ID des Kommentars/Reviews ein um es anzuschauen bevor "
+"Sie es löschen"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "Kommentar-ID:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
-"Oder geben sie die Datensatz-Id ein, um alle dazugehörigen "
-"Kommentars/Reviews aufzulisten:"
+"Oder geben sie die Datensatz-Id ein, um alle dazugehörigen Kommentars/"
+"Reviews aufzulisten:"
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr "Datensatz-ID"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Kommentar anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Bisher sind keine Reports eingegangen"
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Alle %s gemoldene Kommentare anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Alle %s gemoldene Reviews anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-"Das ist eine Liste aller Benutzer, die mindestens einen Kommentar "
-"abgegeben haben, sortiert nach der grössen Anzahl Kommentare."
+"Das ist eine Liste aller Benutzer, die mindestens einen Kommentar abgegeben "
+"haben, sortiert nach der grössen Anzahl Kommentare."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Nickname"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "Benutzer ID"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Totale Anzahl positiver Stimmen"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Totale Anzahl negativer Stimmen"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Totale Anzahl von Stimmabgaben"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Totale Anzahl von Reports"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Kommentare/Reviews von allen Benutzern anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Dieses Review wurde %i mal gemeldet"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Dieser Kommentar wurde %i mal gemeldet"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Verfasst von"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Generelle Informationen"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Ausgewählte Reviews löschen"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 #, fuzzy
 msgid "Suppress selected abuse report"
 msgstr "Abschalten von 'Missbrauch melden' auswählen"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr "Wiederherstellen ausgewählter Reviews"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr "Wiederherstellen ausgewählter Kommentare"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Ausgewählte Kommentare löschen"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Das sind die gemoldenen Reviews von Benutzer %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Das sind die gemoldenen Kommentare von Benutzer %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Das ist Review %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Das ist der Kommentar %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Das ist der Review %(x_cmtID)s, geschrieben vom Benutzer %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Das ist der Kommentar %(x_cmtID)s, geschrieben vom Benutzer %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 #, fuzzy
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "Das sind alle begutachteten Reviews, sortiert meist begutachteten"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 #, fuzzy
 msgid "Here are all reported comments sorted by the most reported"
 msgstr ""
-"Das sind alle begutachteten Kommentare, sortiert nach dem meist "
-"begutachteten"
+"Das sind alle begutachteten Kommentare, sortiert nach dem meist begutachteten"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
-"Das sind alle Reviews für Datensatz %i, sortiert nach dem meist "
-"begutachteten"
+"Das sind alle Reviews für Datensatz %i, sortiert nach dem meist begutachteten"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr "Kommentare anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
 "Das sind alle gemeldeten Kommentare für Datensatz % i, sortiert nach dem "
 "meist begutachteten"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr "Reviews anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "Kommentar-ID"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "erfolgreich gelöscht"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr "erfolgreich wiederhergestellt"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "Missbrauchsmeldungen erfolgreich ausgeschaltet"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Bisher nicht rezensiert"
 
-#: invenio/legacy/webcomment/templates.py:2257
+#: invenio/legacy/webcomment/templates.py:2256
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 "Die folgende Rezension wurde gesendet zu %(CFG_SITE_NAME)s durch "
 "%(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2258
+#: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 "Der folgende Kommentar wurde gesendet zu %(CFG_SITE_NAME)s durch "
 "%(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
-"Das ist eine automatisch erstellte Nachricht, bitte antworten sie nicht "
-"auf diese."
+"Das ist eine automatisch erstellte Nachricht, bitte antworten sie nicht auf "
+"diese."
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr "Einen anderen Kommentar schreiben, gehe zu  <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr "Gezielt auf diesen Kommentar antworten, gehe zu <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr "Abmelden von dieser Diskussion, gehe zu <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr "Für beliebige Fragen, bitten <%(CFG_SITE_SUPPORT_EMAIL)s> nutzen"
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 msgid "Your comment will be lost."
 msgstr "Ihr Kommentar wird verlorengehen."
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Kommentare löschen"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "das Letzte zuerst"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "Kürzlich kommentierte Datensätze anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "Details und Kommentare"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "Datensätze gefunden"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Kommentare"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "%i Elemente"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Elemente hinzufügen"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "Anzeigen"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Bestelldatum"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Nächste Seite"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Benachrichtigungen darstellen"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8495,52 +8449,52 @@ msgstr "Benachrichtigungen darstellen"
 msgid "Refresh"
 msgstr "Aktualisiere Ansicht"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Wiederherrgestellter Kommentar"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "%i Werte gefunden."
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Datensatz nicht gefunden"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "Sie haben keine Berechtigung die Bemerkung zu löschen."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, fuzzy, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
@@ -8549,51 +8503,51 @@ msgstr ""
 "Die Dateigröße \\\"%s\\\" (%s) ist größer als das erlaubte Maximum (%s). "
 "Bitte Dateien neu auswählen."
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Kommentar hinzufügen"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "Alle gemeldeten Kommentare anzeigen"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr "Seite nicht gefunden"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr "Der angefragte Kommentar konnte nicht gefunden werden."
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr "Die angefragte Datei konnte nicht gefunden werden."
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Sie sind nicht berechtigt die Ausleihe zu nutzen."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Kommentare"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "Alle gemeldeten Kommentare anzeigen"
@@ -8709,11 +8663,10 @@ msgstr "Seite %s scheint nicht zu existieren."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
-"Sie können auf %(x_url_open)s%(x_category)s Seiten%(x_url_close)s "
-"zugreifen."
+"Sie können auf %(x_url_open)s%(x_category)s Seiten%(x_url_close)s zugreifen."
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
 #, fuzzy, python-format
@@ -8778,8 +8731,8 @@ msgstr "Wir können nicht alle Zeitschriften vorhalten"
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8807,8 +8760,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -8910,11 +8863,6 @@ msgstr ""
 msgid "Apply"
 msgstr "Anwenden"
 
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "Nickname"
-
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 msgid "WebJournal Admin"
 msgstr "WebJournal Verwaltung"
@@ -8996,9 +8944,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -9020,8 +8967,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9133,8 +9079,8 @@ msgid ""
 "Your message is too long, please shorten it. Maximum size allowed is "
 "%(x_size)i characters."
 msgstr ""
-"Ihre Nachricht ist zu lang, bitte ändern Sie diese. Die maximale erlaubte"
-" Grösse ist %i Zeichen."
+"Ihre Nachricht ist zu lang, bitte ändern Sie diese. Die maximale erlaubte "
+"Grösse ist %i Zeichen."
 
 #: invenio/legacy/webmessage/api.py:402
 #, fuzzy, python-format
@@ -9503,19 +9449,19 @@ msgstr "Suchen Sie auch nach:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
-"Dies ist eine private Sammlung. Suche und Nutzung sind nur mit den "
-"nötigen Berechtigungen möglich."
+"Dies ist eine private Sammlung. Suche und Nutzung sind nur mit den nötigen "
+"Berechtigungen möglich."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
-"Das ist eine externe Sammlung. Bitte klicken Sie auf den Suchknopf, um "
-"den Inhalt zu sehen."
+"Das ist eine externe Sammlung. Bitte klicken Sie auf den Suchknopf, um den "
+"Inhalt zu sehen."
 
 #: invenio/legacy/websearch/templates.py:1619
 msgid "This collection does not contain any document yet."
@@ -9529,7 +9475,8 @@ msgstr "Zitiert von %i Datensätzen"
 #: invenio/legacy/websearch/templates.py:1856
 #, python-format
 msgid "Words nearest to %(x_word)s inside %(x_field)s in any collection are:"
-msgstr "Ähnliche Worte zu %(x_word)s in %(x_field)s in beliebiger Sammlung sind:"
+msgstr ""
+"Ähnliche Worte zu %(x_word)s in %(x_field)s in beliebiger Sammlung sind:"
 
 #: invenio/legacy/websearch/templates.py:1859
 #, python-format
@@ -9609,8 +9556,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found %(x_nb_records)s "
 "records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sErgebnisübersicht:%(x_fmt_close)s "
-"Datensätze%(x_nb_records)s wurden in %(x_nb_seconds)s Sekunden gefunden."
+"%(x_fmt_open)sErgebnisübersicht:%(x_fmt_close)s Datensätze%(x_nb_records)s "
+"wurden in %(x_nb_seconds)s Sekunden gefunden."
 
 #: invenio/legacy/websearch/templates.py:3132
 #, python-format
@@ -9623,8 +9570,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found at least "
 "%(x_nb_records)s records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sErgebnisübersicht:%(x_fmt_close)s "
-"Datensätze%(x_nb_records)s wurden in %(x_nb_seconds)s Sekunden gefunden."
+"%(x_fmt_open)sErgebnisübersicht:%(x_fmt_close)s Datensätze%(x_nb_records)s "
+"wurden in %(x_nb_seconds)s Sekunden gefunden."
 
 #: invenio/legacy/websearch/templates.py:3184
 #, fuzzy
@@ -9651,11 +9598,10 @@ msgstr "Weitere Details"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
-"Die boolsche Suchfrage hat keine Datensätze gefunden. Bitte kombinieren "
-"Sie Ihre Suchfrage anders."
+"Die boolsche Suchfrage hat keine Datensätze gefunden. Bitte kombinieren Sie "
+"Ihre Suchfrage anders."
 
 #: invenio/legacy/websearch/templates.py:3357
 msgid "See also: similar author names"
@@ -9680,13 +9626,13 @@ msgstr "Sie können von %s starten zu browsen."
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
-"Definieren Sie eine persönliche %(x_url1_open)sE-Mail-"
-"Benachrichtigung%(x_url1_close)s\n"
-"                                  oder abonnieren Sie den "
-"%(x_url2_open)sRSS Feed%(x_url2_close)s."
+"Definieren Sie eine persönliche %(x_url1_open)sE-Mail-Benachrichtigung"
+"%(x_url1_close)s\n"
+"                                  oder abonnieren Sie den %(x_url2_open)sRSS "
+"Feed%(x_url2_close)s."
 
 #: invenio/legacy/websearch/templates.py:3832
 #, fuzzy, python-format
@@ -9696,8 +9642,8 @@ msgstr "%(x_url_open)sRRS feed%(x_url_close)s. abonnieren."
 #: invenio/legacy/websearch/templates.py:3841
 msgid "Interested in being notified about new results for this query?"
 msgstr ""
-"Sind Sie interessiert über neue Ergebnisse zu dieser Suchabfrage "
-"informiert zu werden?"
+"Sind Sie interessiert über neue Ergebnisse zu dieser Suchabfrage informiert "
+"zu werden?"
 
 #: invenio/legacy/websearch/templates.py:3907
 #: invenio/legacy/websearch/templates.py:3932
@@ -9880,7 +9826,8 @@ msgid "in"
 msgstr "in"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr ""
 "Haben Sie nicht gefunden was Sie suchten? Versuchen Sie Ihre Suche auf "
 "anderen Servern:"
@@ -9898,8 +9845,8 @@ msgid ""
 "The external search engine has not responded in time. You can check its "
 "results here:"
 msgstr ""
-"Ihre externe Suchmaschine hat nicht geantwortet. Sie können die Resultate"
-" hier überprüfen:"
+"Ihre externe Suchmaschine hat nicht geantwortet. Sie können die Resultate "
+"hier überprüfen:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:146
 #: invenio/legacy/websearch_external_collections/templates.py:154
@@ -9978,8 +9925,8 @@ msgstr "obligatorisch"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9989,11 +9936,11 @@ msgstr "Neuen Korb erstellen"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
-"Wenn Sie Ihre E-Mail-Adresse ändern oder zum ersten mal eingeben möchten,"
-" definieren Sie diese im Formular unten."
+"Wenn Sie Ihre E-Mail-Adresse ändern oder zum ersten mal eingeben möchten, "
+"definieren Sie diese im Formular unten."
 
 #: invenio/legacy/websession/templates.py:271
 msgid "Edit login credentials"
@@ -10009,19 +9956,19 @@ msgstr "Neue Werte definieren"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 "Einmal gesetzt, kann die Unterschrift für Kommentare und Reviews nicht "
 "verändert werden."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
-"Wenn Sie Ihr Passwort ändern möchten, geben Sie bitte das alte Passwort "
-"ein und definieren Sie das neue weiter unten."
+"Wenn Sie Ihr Passwort ändern möchten, geben Sie bitte das alte Passwort ein "
+"und definieren Sie das neue weiter unten."
 
 #: invenio/legacy/websession/templates.py:327
 msgid "Old password"
@@ -10042,8 +9989,7 @@ msgstr "optional"
 #: invenio/modules/accounts/forms.py:130 invenio/modules/accounts/forms.py:169
 msgid "The password phrase may contain punctuation, spaces, etc."
 msgstr ""
-"Die Passwortphrase darf Interpunktionszeichen, Leerschläge usw. "
-"beinhalten."
+"Die Passwortphrase darf Interpunktionszeichen, Leerschläge usw. beinhalten."
 
 #: invenio/legacy/websession/templates.py:333
 msgid "You must fill the old password in order to set a new one."
@@ -10060,8 +10006,8 @@ msgstr "Neues Passwort definieren"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 "Wenn Sie ein einfaches CERN Benutzerkonto nutzen, können Sie Ihr \n"
 "                %(x_url_open)sPasswort neu setzen%(x_url_close)s."
@@ -10072,9 +10018,8 @@ msgid ""
 "You can change or reset your CERN account password by means of the "
 "%(x_url_open)sCERN account system%(x_url_close)s."
 msgstr ""
-"Sie können Ihr Passwort für Ihr CERN Benutzerkonto ändern oder neu "
-"setzen, mittels des %(x_url_open)sCERN Benutzerkonto-"
-"Systems%(x_url_close)s."
+"Sie können Ihr Passwort für Ihr CERN Benutzerkonto ändern oder neu setzen, "
+"mittels des %(x_url_open)sCERN Benutzerkonto-Systems%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:372
 msgid "Edit cataloging interface settings"
@@ -10156,15 +10101,13 @@ msgstr "Methode auswählen"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"Wenn Sie Ihr Passwort für das %(sitename)s "
-"%(x_fmt_open)sBenutzerkonto%(x_fmt_close)s vergessen haben, geben Sie "
-"bitte Ihre E-Mail-Adresse ein und ein Link zum Neusetzen des Passworts "
-"wird Ihnen zugeschickt."
+"Wenn Sie Ihr Passwort für das %(sitename)s %(x_fmt_open)sBenutzerkonto"
+"%(x_fmt_close)s vergessen haben, geben Sie bitte Ihre E-Mail-Adresse ein und "
+"ein Link zum Neusetzen des Passworts wird Ihnen zugeschickt."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10180,19 +10123,19 @@ msgstr "Link zum Neusetzen des Passworts zuschicken"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
-"Bitte beachten Sie, dass, wenn Sie ein externes Loginsystem verwenden, "
-"wir nichts unternehmen können und Sie beim externen Loginsystem "
-"nachfragen müssen."
+"Bitte beachten Sie, dass, wenn Sie ein externes Loginsystem verwenden, wir "
+"nichts unternehmen können und Sie beim externen Loginsystem nachfragen "
+"müssen."
 
 #: invenio/legacy/websession/templates.py:573
 #, fuzzy, python-format
@@ -10200,21 +10143,20 @@ msgid ""
 "Alternatively, you can ask %(x_name)s to change your login system from "
 "external to internal."
 msgstr ""
-"Alternativ können Sie %s fragen, um Ihr Loginsystem von extern nach "
-"intern zu ändern."
+"Alternativ können Sie %s fragen, um Ihr Loginsystem von extern nach intern "
+"zu ändern."
 
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 "%s gibt Ihnen die Möglichkeit, Ihre Oberfläche zu personalisieren, Ihre "
-"persönliche Bibliothek zu erstellen oder automatische Benachrichtigungen "
-"zu erstellen, die Sie periodisch über neue Suchresultate per E-Mail "
-"informieren."
+"persönliche Bibliothek zu erstellen oder automatische Benachrichtigungen zu "
+"erstellen, die Sie periodisch über neue Suchresultate per E-Mail informieren."
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10226,23 +10168,22 @@ msgid ""
 "Set or change your account email address or password. Specify your "
 "preferences about the look and feel of the interface."
 msgstr ""
-"Definieren oder ändern Sie Ihre E-Mail-Adresse oder Ihr Passwort. "
-"Definieren Sie Ihre Vorzüge über das Aussehen der Oberfläche."
+"Definieren oder ändern Sie Ihre E-Mail-Adresse oder Ihr Passwort. Definieren "
+"Sie Ihre Vorzüge über das Aussehen der Oberfläche."
 
 #: invenio/legacy/websession/templates.py:620
 msgid "View all the searches you performed during the last 30 days."
 msgstr ""
-"Zeige alle Suchabfragen an, die Sie in den letzten 30 Tagen ausgeführt "
-"haben."
+"Zeige alle Suchabfragen an, die Sie in den letzten 30 Tagen ausgeführt haben."
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
-"In Ihren Körben können Sie spezifische Sammlungen definieren, "
-"interessante Datensätze speichern auf die sie später zugreifen wollen "
-"oder Dokumente mit anderen Benutzern austauschen."
+"In Ihren Körben können Sie spezifische Sammlungen definieren, interessante "
+"Datensätze speichern auf die sie später zugreifen wollen oder Dokumente mit "
+"anderen Benutzern austauschen."
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10254,19 +10195,19 @@ msgid ""
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
 "Definieren Sie eine Suchabfrage die periodisch von unserem Service "
-"durchlaufen wird. Das Resulatat kann Ihnen per E-Mail zugesandt werden "
-"oder in einem Ihrer Körbe gespeichert werden."
+"durchlaufen wird. Das Resulatat kann Ihnen per E-Mail zugesandt werden oder "
+"in einem Ihrer Körbe gespeichert werden."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr "Ein Buch ausleihen, Ausleihe-Anfragen absenden, usw erfordert CERN ID."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
 "Sie sind als Gast eingeloggt. Ihre Benachrichtigungen werden am Ende der "
 "Session gelöscht."
@@ -10274,9 +10215,9 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 "Sie sind eingeloggt als %(x_user)s. Sie könnnen a) sich "
 "%(x_url1_open)sausloggen%(x_url1_close)s; b) Ihre "
@@ -10287,7 +10228,8 @@ msgstr ""
 msgid ""
 "You can consult the list of %(x_url_open)syour comments%(x_url_close)s "
 "submitted so far."
-msgstr "Sie können die Liste %(x_url_open)sIhrer Aufgaben%(x_url_close)s einsehen."
+msgstr ""
+"Sie können die Liste %(x_url_open)sIhrer Aufgaben%(x_url_close)s einsehen."
 
 #: invenio/legacy/websession/templates.py:790
 msgid "Your Alert Searches"
@@ -10296,8 +10238,8 @@ msgstr "Ihre Suchbenachrichtigungen"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 "Sie können jetzt die Liste %(x_url_open)sIhrer Gruppen%(x_url_close)s "
 "anzeigen die Sie administrieren oder in welchen Sie Mitglied sind."
@@ -10311,8 +10253,8 @@ msgstr "Ihre Gruppen"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
 "Sie können jetzt die Liste %(x_url_open)sIhrer Eingaben%(x_url_close)s "
 "anzeigen und deren Status abfragen."
@@ -10325,12 +10267,12 @@ msgstr "Ihre Eintragungen"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"Sie können jetzt die Liste %(x_url_open)sIhrer "
-"Zustimmungen%(x_url_close)s anzeigen mit den Dokumenten denen Sie "
-"zugestimmt oder die sie referenziert haben."
+"Sie können jetzt die Liste %(x_url_open)sIhrer Zustimmungen%(x_url_close)s "
+"anzeigen mit den Dokumenten denen Sie zugestimmt oder die sie referenziert "
+"haben."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10340,7 +10282,8 @@ msgstr "Ihre Bestätigungen"
 #: invenio/legacy/websession/templates.py:815
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour tickets%(x_url_close)s."
-msgstr "Sie können die Liste %(x_url_open)sIhrer Aufgaben%(x_url_close)s einsehen."
+msgstr ""
+"Sie können die Liste %(x_url_open)sIhrer Aufgaben%(x_url_close)s einsehen."
 
 #: invenio/legacy/websession/templates.py:818
 msgid "Your Tickets"
@@ -10370,8 +10313,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:877
 msgid "If you want to reset the password for this account, please go to:"
 msgstr ""
-"Wenn Sie Ihr Passwort für dieses Benutzerkonto neu setzen wollen, klicken"
-" Sie hier: "
+"Wenn Sie Ihr Passwort für dieses Benutzerkonto neu setzen wollen, klicken "
+"Sie hier: "
 
 #: invenio/legacy/websession/templates.py:883
 #: invenio/legacy/websession/templates.py:920
@@ -10381,7 +10324,8 @@ msgstr "zum Bestätigen der Echtheit dieser Anfrage."
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -10392,15 +10336,15 @@ msgid ""
 "for the email address \"%(x_email)s\".x_sitename"
 msgstr ""
 "Jemand (wahrscheinlich Sie) haben von %(x_ip_address)s aus nach \n"
-"dem Registrieren für eine neues Benutzerkonto für die "
-"E-Mail\"%(x_email)s\" auf %(x_sitename)s\n"
+"dem Registrieren für eine neues Benutzerkonto für die E-Mail\"%(x_email)s\" "
+"auf %(x_sitename)s\n"
 "gefragt."
 
 #: invenio/legacy/websession/templates.py:914
 msgid "If you want to complete this account registration, please go to:"
 msgstr ""
-"Wenn Sie die Registrierung für dieses Benutzerkonto fertigstellen wollen,"
-" klicken Sie hier:"
+"Wenn Sie die Registrierung für dieses Benutzerkonto fertigstellen wollen, "
+"klicken Sie hier:"
 
 #: invenio/legacy/websession/templates.py:940
 #, fuzzy, python-format
@@ -10431,8 +10375,7 @@ msgstr ""
 #, python-format
 msgid "If you wish you can %(x_url_open)slogin here%(x_url_close)s."
 msgstr ""
-"Wenn sie möchten können Sie sich %(x_url_open)shier "
-"einloggen%(x_url_close)s."
+"Wenn sie möchten können Sie sich %(x_url_open)shier einloggen%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1011
 msgid "If you already have an account, please login using the form below."
@@ -10441,29 +10384,27 @@ msgstr "Wenn Sie bereits ein Konto haben, loggen Sie sich bitte ein."
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
-"Falls Sie noch kein eingenes CERN Benutzerkonto besitzen, können Sie sich"
-" %(x_url_open)sfür ein einfaches CERN Benutzerkonto "
-"registrieren%(x_url_close)s."
+"Falls Sie noch kein eingenes CERN Benutzerkonto besitzen, können Sie sich "
+"%(x_url_open)sfür ein einfaches CERN Benutzerkonto registrieren"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"Falls Sie noch kein Konto besitzen, "
-"%(x_url_open)sregistrieren%(x_url_close)s Sie sich bitte für ein internes"
-" Konto."
+"Falls Sie noch kein Konto besitzen, %(x_url_open)sregistrieren"
+"%(x_url_close)s Sie sich bitte für ein internes Konto."
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
 msgid "If you don't own an account yet, please contact %(x_name)s."
 msgstr ""
-"Falls Sie noch kein Benutzerkonto besitzen, können Sie gerne %s "
-"kontaktieren."
+"Falls Sie noch kein Benutzerkonto besitzen, können Sie gerne %s kontaktieren."
 
 #: invenio/legacy/websession/templates.py:1051
 msgid "Login method:"
@@ -10490,13 +10431,12 @@ msgstr "Haben Sie Ihr Passwort vergessen?"
 #: invenio/legacy/websession/templates.py:1094
 msgid "You can use your nickname or your email address to login."
 msgstr ""
-"Sie können Ihren Benutzernamen oder Ihr E-Mail benutzen um sich "
-"einzuloggen."
+"Sie können Ihren Benutzernamen oder Ihr E-Mail benutzen um sich einzuloggen."
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -10518,16 +10458,16 @@ msgstr "Neues Passwort setzen"
 #: invenio/legacy/websession/templates.py:1175
 msgid "Please enter your email address and desired nickname and password:"
 msgstr ""
-"Bitte geben Sie die gewünschte E-Mail-Adresse, den gewünschten "
-"Benutzernamen und das Passwort ein:"
+"Bitte geben Sie die gewünschte E-Mail-Adresse, den gewünschten Benutzernamen "
+"und das Passwort ein:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
-"Dieses Konto kann nicht verwendet werden bis es verifiziert und aktiviert"
-" wurde."
+"Dieses Konto kann nicht verwendet werden bis es verifiziert und aktiviert "
+"wurde."
 
 #: invenio/legacy/websession/templates.py:1228
 msgid "Retype Password"
@@ -10543,36 +10483,35 @@ msgstr "registrieren"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
 "Bitte verwenden Sie kein wertvolles Passwort für diesen Service wie zum "
-"Beispiel ihr Unix, AFS oder NICE-Passwort. Ihre E-Mail-Adresse wird "
-"streng vertraulich behandelt und nicht an dritte weitergegeben. Sie "
-"werden sie benutzen um sich für den persönlichen Service von %s zu "
-"identifizieren. Zum Beispiel können Sie eine automatische "
-"Benachrichtigung für eine Suchabfrage erstellen die Sie täglich über "
-"Neuigkeiten per E-Mail informiert."
+"Beispiel ihr Unix, AFS oder NICE-Passwort. Ihre E-Mail-Adresse wird streng "
+"vertraulich behandelt und nicht an dritte weitergegeben. Sie werden sie "
+"benutzen um sich für den persönlichen Service von %s zu identifizieren. Zum "
+"Beispiel können Sie eine automatische Benachrichtigung für eine Suchabfrage "
+"erstellen die Sie täglich über Neuigkeiten per E-Mail informiert."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
-"Es ist für Sie nicht möglich, ein Konto zu erstellen. Kontaktieren Sie %s"
-" wenn Sie ein Konto möchten."
+"Es ist für Sie nicht möglich, ein Konto zu erstellen. Kontaktieren Sie %s "
+"wenn Sie ein Konto möchten."
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
-"Sie scheinen ein Gast zu sein. Sie müssen sich zuerst "
-"%(x_url_open)seinloggen%(x_url_close)s."
+"Sie scheinen ein Gast zu sein. Sie müssen sich zuerst %(x_url_open)seinloggen"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1267
 msgid "You are not authorized to access administrative functions."
@@ -10702,8 +10641,8 @@ msgstr "Das sind einige interessante Administrations-Links für Sie:"
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "Für mehr administrative Aufgaben, benutzen Sie den kompletten "
 "%(x_url_open)sVerwaltungsbereich%(x_url_close)s."
@@ -10877,8 +10816,7 @@ msgid ""
 msgstr ""
 "Hallo:\n"
 "\n"
-"Es könnte für Sie interessant sein, an Gruppe \"%(x_name)s\" "
-"teilzunehmen.\n"
+"Es könnte für Sie interessant sein, an Gruppe \"%(x_name)s\" teilzunehmen.\n"
 "Wenn Sie hier klicken, können Sie teilnehmen: %(x_url)s.\n"
 "\n"
 "Viele Grüße.\n"
@@ -10889,8 +10827,8 @@ msgid ""
 "If you want to invite new members to join your group, please use the "
 "%(x_url_open)sweb message%(x_url_close)s system."
 msgstr ""
-"Wenn Sie neue Mitglieder in die Gruppe einladen wollen, verwenden Sie "
-"bitte das %(x_url_open)sNachrichtensystem%(x_url_close)s."
+"Wenn Sie neue Mitglieder in die Gruppe einladen wollen, verwenden Sie bitte "
+"das %(x_url_open)sNachrichtensystem%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:2100
 #, fuzzy, python-format
@@ -10933,10 +10871,11 @@ msgstr "Ein Benutzer will der Gruppe %s beitreten."
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
-"Die Anfrage des Benutzers bitte %(x_url_open)sakzeptieren or "
-"abweisen%(x_url_close)s."
+"Die Anfrage des Benutzers bitte %(x_url_open)sakzeptieren or abweisen"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:2400
 #, fuzzy, python-format
@@ -10962,7 +10901,8 @@ msgstr "Ihre Anfrage zur Aufnahme in die Gruppe %s wurde abgewiesen."
 #: invenio/legacy/websession/templates.py:2426
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour groups%(x_url_close)s."
-msgstr "Sie können die Liste Ihrer %(x_url_open)s groups%(x_url_close)s anzeigen."
+msgstr ""
+"Sie können die Liste Ihrer %(x_url_open)s groups%(x_url_close)s anzeigen."
 
 #: invenio/legacy/websession/templates.py:2422
 #, fuzzy, python-format
@@ -10977,19 +10917,18 @@ msgstr "Die Gruppe %s wurde vom Administrator gelöscht."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"Sie können die Liste der %(x_url_open)s%(x_nb_total)i "
-"Gruppen%(x_url_close)s einsehen. Sie sind eingeschrieben in "
-"(%(x_nb_member)i) oder administrieren (%(x_nb_admin)i)."
+"Sie können die Liste der %(x_url_open)s%(x_nb_total)i Gruppen%(x_url_close)s "
+"einsehen. Sie sind eingeschrieben in (%(x_nb_member)i) oder administrieren "
+"(%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 "Achtung: Das Passwort für den MySQL Administrator ist dasselbe wie das "
 "Standard Invenio Passwort. Aus Sicherheitsgründen wird empfohlen, das "
@@ -10998,62 +10937,58 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 "Achtung: Das Passwort für den MySQL Administrator ist dasselbe wie das "
-"standardmäßig mitgelieferte Passwort. Aus Sicherheitsgründen wird "
-"empfohlen, das Passwort zu ändern."
+"standardmäßig mitgelieferte Passwort. Aus Sicherheitsgründen wird empfohlen, "
+"das Passwort zu ändern."
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
-"Achtung: Das Passwort für den Invenio Administrator ist momentan leer.Aus"
-" Sicherheitsgründen wird nachhaltig empfohlen, das Passwort zu ändern."
+"Achtung: Das Passwort für den Invenio Administrator ist momentan leer.Aus "
+"Sicherheitsgründen wird nachhaltig empfohlen, das Passwort zu ändern."
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
-"Achtung: Die E-Mail-Adresse für den Support ist momentan auf info"
-"@invenio-software.org gesetzt. Es wird empfohlen, diese auf Ihre eigene "
-"Adresse umzustellen."
+"Achtung: Die E-Mail-Adresse für den Support ist momentan auf info@invenio-"
+"software.org gesetzt. Es wird empfohlen, diese auf Ihre eigene Adresse "
+"umzustellen."
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
-"Eine neuere Version von Invenio steht zum Herunterladen bereit. Sie "
-"können Sie besuchen  "
+"Eine neuere Version von Invenio steht zum Herunterladen bereit. Sie können "
+"Sie besuchen  "
 
 #: invenio/legacy/websession/templates.py:2491
 #, fuzzy
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
-"Die Release Notes von http://invenio-software.org/repo/invenio/tree"
-"/RELEASE-NOTES können nicht heruntergeladen oder nicht ausgewertet werden"
+"Die Release Notes von http://invenio-software.org/repo/invenio/tree/RELEASE-"
+"NOTES können nicht heruntergeladen oder nicht ausgewertet werden"
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
 "Sie sind als Gast eingeloggt. Sie können sich als normaler Benutzer "
 "%(x_url_open)seinloggen%(x_url_close)s."
@@ -11061,8 +10996,8 @@ msgstr ""
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 "Die %(x_fmt_open)sGastbenutzer%(x_fmt_close)s müssen sich zuerst "
 "%(x_url_open)sregistrieren%(x_url_close)s"
@@ -11073,16 +11008,16 @@ msgstr "Keine Abfragen gefunden"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
-"Dies ist eine private Sammlung. Bitte loggen Sie sich ein, wenn Sie "
-"denken, dass Sie eine Zugriffs-Berechtigung haben."
+"Dies ist eine private Sammlung. Bitte loggen Sie sich ein, wenn Sie denken, "
+"dass Sie eine Zugriffs-Berechtigung haben."
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 "Dies ist eine private Datei. Bitte loggen Sie sich ein, wenn Sie denken, "
 "dass Sie eine Zugriffs-Berechtigung haben."
@@ -11093,8 +11028,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11106,8 +11041,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11176,12 +11111,12 @@ msgstr "Die Gruppe wurde bereits gelöscht."
 
 #: invenio/legacy/websession/webgroup.py:611
 msgid "Please choose a member if you want to remove him from the group."
-msgstr "Wählen Sie ein Mitglied aus, wenn Sie es aus der Gruppe entfernen möchten."
+msgstr ""
+"Wählen Sie ein Mitglied aus, wenn Sie es aus der Gruppe entfernen möchten."
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 "Wählen Sie ein Nutzer von der Liste aus, wenn Sie Ihn zu der Gruppe "
 "hinzufügen möchten."
@@ -11195,8 +11130,8 @@ msgid ""
 "Please choose a user from the list if you want him to be removed from "
 "waiting list."
 msgstr ""
-"Wählen Sie einen Nutzer von der Liste aus, wenn Sie Ihn aus der "
-"Warteliste entfernen wollen."
+"Wählen Sie einen Nutzer von der Liste aus, wenn Sie Ihn aus der Warteliste "
+"entfernen wollen."
 
 #: invenio/legacy/websession/webgroup.py:731
 msgid "The user request for joining group has already been rejected."
@@ -11222,9 +11157,9 @@ msgid ""
 "authorization will last until %(x_expiration)s and until you close your "
 "browser if you are a guest user."
 msgstr ""
-"Sie haben die Berechtigung für %(x_role)s erhalten! Diese Berechtigung "
-"ist gültig bis %(x_expiration)s beziehungsweise bis der Browser "
-"geschlossen wird, wenn Sie ein Gast-Benutzer sind."
+"Sie haben die Berechtigung für %(x_role)s erhalten! Diese Berechtigung ist "
+"gültig bis %(x_expiration)s beziehungsweise bis der Browser geschlossen "
+"wird, wenn Sie ein Gast-Benutzer sind."
 
 #: invenio/legacy/websession/webinterface.py:128
 msgid "You have confirmed the validity of your email address!"
@@ -11234,8 +11169,7 @@ msgstr "Sie haben die Gültigkeit Ihrer E-Mail-Adresse bestätigt!"
 #: invenio/legacy/websession/webinterface.py:141
 msgid "Please, wait for the administrator to enable your account."
 msgstr ""
-"Bitte warten Sie auf den Adminstrator, um Ihr Benutzerkonto "
-"freizuschalten."
+"Bitte warten Sie auf den Adminstrator, um Ihr Benutzerkonto freizuschalten."
 
 #: invenio/legacy/websession/webinterface.py:135
 #: invenio/legacy/websession/webinterface.py:144
@@ -11254,11 +11188,10 @@ msgstr "Sie haben bereits die Gültigkeit Ihrer E-Mail-Adresse bestätigt!"
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
-"Die Anfrage für die Bestätigung der E-Mail-Adresse hat ergeben, dass "
-"diese nicht gültig oder ausgelaufen ist."
+"Die Anfrage für die Bestätigung der E-Mail-Adresse hat ergeben, dass diese "
+"nicht gültig oder ausgelaufen ist."
 
 #: invenio/legacy/websession/webinterface.py:153
 msgid "This request for an authorization is not valid or is expired."
@@ -11291,8 +11224,8 @@ msgstr "Die beiden eingetragenen Passwörter sind nicht gleich."
 #: invenio/legacy/websession/webinterface.py:208
 msgid "The password was successfully set! You can now proceed with the login."
 msgstr ""
-"Das Passwort wurde erfolgreich gesetzt! Sie können nun fortfahren mit dem"
-" Login."
+"Das Passwort wurde erfolgreich gesetzt! Sie können nun fortfahren mit dem "
+"Login."
 
 #: invenio/legacy/websession/webinterface.py:339
 #, fuzzy, python-format
@@ -11327,16 +11260,15 @@ msgstr "Umgeschaltet auf die interne Login-Methode."
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
-"Bitte beachten Sie, wenn dies das erste Mal ist, dass Sie das Konto mit "
-"der internen Login-Methode benutzen, wurde für Sie ein zufälliges "
-"Passwort gesetzt. Bitte klicken Sie auf folgenden Button, damit wird ein "
-"Link zum Neusetzen des Passworts an Ihre E-Mail-Adresse verschickt werden"
-" kann:"
+"Bitte beachten Sie, wenn dies das erste Mal ist, dass Sie das Konto mit der "
+"internen Login-Methode benutzen, wurde für Sie ein zufälliges Passwort "
+"gesetzt. Bitte klicken Sie auf folgenden Button, damit wird ein Link zum "
+"Neusetzen des Passworts an Ihre E-Mail-Adresse verschickt werden kann:"
 
 #: invenio/legacy/websession/webinterface.py:431
 msgid "Send Password"
@@ -11348,8 +11280,8 @@ msgid ""
 "Unable to switch to external login method %(x_name)s, because your email "
 "address is unknown."
 msgstr ""
-"Es kann nicht zur externen Loginmethode %s gewechselt werden, weil ihre E"
-"-Mail-Adresse nicht bekannt ist."
+"Es kann nicht zur externen Loginmethode %s gewechselt werden, weil ihre E-"
+"Mail-Adresse nicht bekannt ist."
 
 #: invenio/legacy/websession/webinterface.py:445
 #, fuzzy, python-format
@@ -11357,8 +11289,8 @@ msgid ""
 "Unable to switch to external login method %(x_meth)s, because your email "
 "address is unknown to the external login system."
 msgstr ""
-"Es kann nicht zur externen Loginmethode %s gewechselt werden, weil ihre E"
-"-Mail-Adresse im externen Loginsystem nicht bekannt ist."
+"Es kann nicht zur externen Loginmethode %s gewechselt werden, weil ihre E-"
+"Mail-Adresse im externen Loginsystem nicht bekannt ist."
 
 #: invenio/legacy/websession/webinterface.py:449
 msgid "Login method successfully selected."
@@ -11367,11 +11299,11 @@ msgstr "Loginmethode erfolgreich gewählt."
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
-"Die externe Loginmethode %s unterstützt keine E-Mail-basierte Logins. "
-"Bitte kontaktieren Sie den Seitenadministrator."
+"Die externe Loginmethode %s unterstützt keine E-Mail-basierte Logins. Bitte "
+"kontaktieren Sie den Seitenadministrator."
 
 #: invenio/legacy/websession/webinterface.py:464
 #, fuzzy
@@ -11388,8 +11320,8 @@ msgid ""
 "Note that if you have changed your email address, you will have to "
 "%(x_url_open)sreset your password%(x_url_close)s anew."
 msgstr ""
-"Beachten Sie, dass Sie bei Änderung Ihrer E-Mail-Adresse auch "
-"Ihr%(x_url_open)sPasswort neu setzen%(x_url_close)s müssen."
+"Beachten Sie, dass Sie bei Änderung Ihrer E-Mail-Adresse auch Ihr"
+"%(x_url_open)sPasswort neu setzen%(x_url_close)s müssen."
 
 #: invenio/legacy/websession/webinterface.py:487
 #: invenio/legacy/websession/webinterface.py:1003
@@ -11500,8 +11432,8 @@ msgid ""
 "Cannot send password reset request since you are using external "
 "authentication system."
 msgstr ""
-"Die Anfrage zum Neusetzen des Passworts kann nicht gesendet werden, da "
-"Sie ein externes Authenifizierungssystem verwenden."
+"Die Anfrage zum Neusetzen des Passworts kann nicht gesendet werden, da Sie "
+"ein externes Authenifizierungssystem verwenden."
 
 #: invenio/legacy/websession/webinterface.py:665
 msgid "The entered email address does not exist in the database."
@@ -11512,8 +11444,8 @@ msgid ""
 "The entered email address is incorrect, please check that it is written "
 "correctly (e.g. johndoe@example.com)."
 msgstr ""
-"Die eingegebene E-Mail-Adresse ist inkorrekt. Bitte überprüfen Sie dass "
-"sie richtig geschrieben ist (z.B. johndoe@example.invalid)."
+"Die eingegebene E-Mail-Adresse ist inkorrekt. Bitte überprüfen Sie dass sie "
+"richtig geschrieben ist (z.B. johndoe@example.invalid)."
 
 #: invenio/legacy/websession/webinterface.py:684
 msgid "Incorrect email address"
@@ -11555,8 +11487,8 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 "Bitte folgen Sie die dort angegebenen Anweisungen, um die Konto-"
 "Registrierung zu vervollständigen."
@@ -11564,11 +11496,11 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
-"Ein zweites E-Mail wird gesendet wenn das Konto aktiviert wurde und "
-"benutzt werden kann."
+"Ein zweites E-Mail wird gesendet wenn das Konto aktiviert wurde und benutzt "
+"werden kann."
 
 #: invenio/legacy/websession/webinterface.py:989
 #, python-format
@@ -11609,8 +11541,8 @@ msgstr "Gewünschter Benutzername %s ist bereits in der Datenbank vorhanden."
 #: invenio/modules/accounts/views/accounts.py:143
 msgid "Users cannot register themselves, only admin can register them."
 msgstr ""
-"Benutzer können sich nicht selbst eintragen, nur Administratoren können "
-"sie eintragen."
+"Benutzer können sich nicht selbst eintragen, nur Administratoren können sie "
+"eintragen."
 
 #: invenio/legacy/websession/webinterface.py:1023
 #: invenio/modules/accounts/views/accounts.py:148
@@ -11686,7 +11618,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 "Datensatz erzeugt am %(x_date_creation)s, letzte Änderung am "
 "%(x_date_modification)s"
@@ -11694,8 +11627,8 @@ msgstr ""
 #: invenio/legacy/webstyle/templates.py:707
 msgid "The server encountered an error while dealing with your request."
 msgstr ""
-"Der Server ist auf einen Fehler gestoßen, während Ihre Anfrage bearbeitet"
-" wurde."
+"Der Server ist auf einen Fehler gestoßen, während Ihre Anfrage bearbeitet "
+"wurde."
 
 #: invenio/legacy/webstyle/templates.py:709
 #, python-format
@@ -11709,46 +11642,46 @@ msgid ""
 "%(x_page)s of submission '%(x_sub)s%(x_subm)s' - Invalid Field Position "
 "Numbers"
 msgstr ""
-"Ein Verschieben des Feldes von Position %s zu Position %s auf der Seite "
-"%s der Eintragung '%s%s' ist nicht möglich - Ungültige Nummer für die "
-"Feld Position"
+"Ein Verschieben des Feldes von Position %s zu Position %s auf der Seite %s "
+"der Eintragung '%s%s' ist nicht möglich - Ungültige Nummer für die Feld "
+"Position"
 
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
-"Ein Austauschen des Feldes von Position %s zu Position %s auf der Seite "
-"%s der Eintragung %s ist nicht möglich - Feld an Position %s kann nicht "
-"an eine temporäre Feldposition verschoben werden"
+"Ein Austauschen des Feldes von Position %s zu Position %s auf der Seite %s "
+"der Eintragung %s ist nicht möglich - Feld an Position %s kann nicht an eine "
+"temporäre Feldposition verschoben werden"
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
-"Ein Austauschen des Feldes von Position %s zu Position %s auf der Seite "
-"%s der Eintragung %s ist nicht möglich - Feld an Position %s kann nicht "
-"an Position %s verschoben werden. Bitten Sie den Administrator zu "
-"überprüfen, ob das Feld nicht an einer temporären Position festsitzt. "
+"Ein Austauschen des Feldes von Position %s zu Position %s auf der Seite %s "
+"der Eintragung %s ist nicht möglich - Feld an Position %s kann nicht an "
+"Position %s verschoben werden. Bitten Sie den Administrator zu überprüfen, "
+"ob das Feld nicht an einer temporären Position festsitzt. "
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
-"Ein Austauschen des Feldes von Position %s zu Position %s auf der Seite "
-"%s der Eintragung %s ist nicht möglich - Feld an Position %s kann nicht "
-"an Position %s aus seiner temporären Position heraus verschoben werden. "
+"Ein Austauschen des Feldes von Position %s zu Position %s auf der Seite %s "
+"der Eintragung %s ist nicht möglich - Feld an Position %s kann nicht an "
+"Position %s aus seiner temporären Position heraus verschoben werden. "
 "Momentan sitzt das Feld in der temporären Position fest und muss vom "
 "Administrator manuell korrigiert werden."
 
@@ -11756,37 +11689,36 @@ msgstr ""
 #, fuzzy, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
-"Ein Verschieben des Feldes von Position %s zu Position %s auf der Seite "
-"%s der Eintragung %s ist nicht möglich - die Position des Feldes kann "
-"nicht unter die Position %s heruntergesetzt werden. Wiederherstellung "
-"wird versucht - Bitte überprüfen Sie, ob die Feldreihenfolge noch korrekt"
-" ist."
+"Ein Verschieben des Feldes von Position %s zu Position %s auf der Seite %s "
+"der Eintragung %s ist nicht möglich - die Position des Feldes kann nicht "
+"unter die Position %s heruntergesetzt werden. Wiederherstellung wird "
+"versucht - Bitte überprüfen Sie, ob die Feldreihenfolge noch korrekt ist."
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
 #, fuzzy, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
-"Ein Verschieben des Feldes von Position %s zu Position %s auf der Seite "
-"%s der Eintragung %s%s ist nicht möglich - die Position des Feldes kann "
-"nicht auf Position %s erhöht werden. Das Feld von Position %s wurde in "
-"eine temporäre Position gesetzt."
+"Ein Verschieben des Feldes von Position %s zu Position %s auf der Seite %s "
+"der Eintragung %s%s ist nicht möglich - die Position des Feldes kann nicht "
+"auf Position %s erhöht werden. Das Feld von Position %s wurde in eine "
+"temporäre Position gesetzt."
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, fuzzy, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
-"Feld von Position %s zu Position %s auf der Seite %s der Eintragung "
-"'%s%s' verschoben."
+"Feld von Position %s zu Position %s auf der Seite %s der Eintragung '%s%s' "
+"verschoben."
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
 #, fuzzy, python-format
@@ -11794,8 +11726,8 @@ msgid ""
 "Unable to delete field at position %(x_from)s from page %(x_to)s of "
 "submission '%(x_sub)s'"
 msgstr ""
-"Feld an Position %s von Seite %s der Eintragung '%s%s' kann nicht "
-"gelöscht werden"
+"Feld an Position %s von Seite %s der Eintragung '%s%s' kann nicht gelöscht "
+"werden"
 
 #: invenio/legacy/websubmit/admin_engine.py:4010
 #, fuzzy, python-format
@@ -11803,8 +11735,8 @@ msgid ""
 "Unable to delete field at position %(x_from)s from page %(x_to)s of "
 "submission '%(x_sub)s%(x_subm)s'"
 msgstr ""
-"Feld an Position %s von Seite %s der Eintragung '%s%s' kann nicht "
-"gelöscht werden"
+"Feld an Position %s von Seite %s der Eintragung '%s%s' kann nicht gelöscht "
+"werden"
 
 #: invenio/legacy/websubmit/engine.py:194
 #: invenio/legacy/websubmit/engine.py:871
@@ -11854,8 +11786,8 @@ msgstr "Die Anzahl der Seiten der Eingabe können nicht bestimmt werden."
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
 "Es kann kein Verzeichnis für diese Eingabe erstellt werden. Der "
 "Administrator wurde benachrichtigt."
@@ -11894,8 +11826,8 @@ msgstr "Absenden"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 "Ein ernster Funkionsfehler ist aufgetreten. Administratoren wurden "
 "benachrichtigt. <br /><em>Bitte berücksichtigen Sie, dass dies durch die "
@@ -11946,8 +11878,8 @@ msgstr "Wählen Sie eine Kategorie und klicken Sie dann auf den Button."
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 "Um mit einer unterbrochenen Eingabe weiterzufahren geben Sie die "
 "Zugangsnummer in die Box ein:"
@@ -11979,8 +11911,8 @@ msgstr "Zurück zum Hauptmenu"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 "Das ist Ihre Eingabenummer. Im Falle eines Problems, kann Sie genutzt "
 "werden, um die unterbrochene Eingabe fortzusetzen."
@@ -12031,8 +11963,8 @@ msgstr "Eintragungsnr."
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 "Das ist die %(x_action)s Funktionsliste für %(x_doctype)s Dokumente auf "
 "Level %(x_step)s"
@@ -12117,11 +12049,10 @@ msgstr "Liste der referenzierten Dokumenttypen"
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
-"Wählen Sie einen der folgenden Dokumenttypen aus, um den Dokumentstatus "
-"zu überprüfen."
+"Wählen Sie einen der folgenden Dokumenttypen aus, um den Dokumentstatus zu "
+"überprüfen."
 
 #: invenio/legacy/websubmit/templates.py:1447
 #, fuzzy
@@ -12258,10 +12189,11 @@ msgstr "Bemerkung zur Akzeptierung:"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
-"Dieses Dokument %(x_fmt_open)swartet immer noch auf die "
-"Zulassung%(x_fmt_close)s."
+"Dieses Dokument %(x_fmt_open)swartet immer noch auf die Zulassung"
+"%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
 #: invenio/legacy/websubmit/templates.py:2163
@@ -12283,8 +12215,8 @@ msgid ""
 "You can send an approval request email again by clicking the following "
 "button:"
 msgstr ""
-"Sie können einen Zulassungs-Antrag erneut senden wenn Sie auf diesen "
-"Button klicken:"
+"Sie können einen Zulassungs-Antrag erneut senden wenn Sie auf diesen Button "
+"klicken:"
 
 #: invenio/legacy/websubmit/templates.py:2149
 #: invenio/legacy/websubmit/web/publiline.py:367
@@ -12294,8 +12226,7 @@ msgstr "Nochmals senden"
 #: invenio/legacy/websubmit/templates.py:2150
 msgid "WARNING! Upon confirmation, an email will be sent to the referee."
 msgstr ""
-"WARNUNG! Auf Grund der Bestätigung wird eine E-Mail zum Referenten "
-"gesendet."
+"WARNUNG! Auf Grund der Bestätigung wird eine E-Mail zum Referenten gesendet."
 
 #: invenio/legacy/websubmit/templates.py:2153
 #, fuzzy
@@ -12361,11 +12292,11 @@ msgstr "Referenten auswählen"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
-"Der Referent hat seine entgültigen Empfehlungen an das Publikationgremium"
-" übermittelt am "
+"Der Referent hat seine entgültigen Empfehlungen an das Publikationgremium "
+"übermittelt am "
 
 #: invenio/legacy/websubmit/templates.py:2281
 #: invenio/legacy/websubmit/templates.py:2342
@@ -12385,11 +12316,11 @@ msgstr "Empfehlung schreiben"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
-"Das Publikationgremium hat seine endgültigen Empfehlungen übermittelt an "
-"den Projektleiter am  "
+"Das Publikationgremium hat seine endgültigen Empfehlungen übermittelt an den "
+"Projektleiter am  "
 
 #: invenio/legacy/websubmit/templates.py:2291
 #: invenio/legacy/websubmit/templates.py:2358
@@ -12431,7 +12362,8 @@ msgstr "Treffe eine Entscheidung"
 
 #: invenio/legacy/websubmit/templates.py:2321
 #, fuzzy
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr "Eine Redaktion wurde ausgewählt durch das Publikationgremium am "
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12452,19 +12384,18 @@ msgstr "Ein Referent wurde durch die Redaktion ausgewählt am "
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
-"Ein Referent hat seine endgültigen Empfehlungen an die Redaktion "
-"übermittelt am "
+"Ein Referent hat seine endgültigen Empfehlungen an die Redaktion übermittelt "
+"am "
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
-"Die Redaktion hat ihre endgültigen Empfehlungen an das Publikationgremium"
-" übermittelt am "
+"Die Redaktion hat ihre endgültigen Empfehlungen an das Publikationgremium "
+"übermittelt am "
 
 #: invenio/legacy/websubmit/templates.py:2350
 msgid "No recommendation from the editorial board yet."
@@ -12568,8 +12499,8 @@ msgid ""
 "Note that your submission has been inserted into the bibliographic task "
 "queue and is waiting for execution.\n"
 msgstr ""
-"Ihre Eintragungen wurden für die automatische bibliografische Bearbeitung"
-" übermittelt und wartet auf die Ausführung.\n"
+"Ihre Eintragungen wurden für die automatische bibliografische Bearbeitung "
+"übermittelt und wartet auf die Ausführung.\n"
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:206
 #, fuzzy, python-format
@@ -12579,22 +12510,20 @@ msgid ""
 "available within a few minutes and searchable within an hour or "
 "thereabouts.\n"
 msgstr ""
-"Die Abarbeitung der Aufträge läuft momentan automatisch. Im Moment warten"
-" %s Aufträge auf die Ausführung. Ihr Datensatz sollte innerhalb einiger "
-"Minuten verfügbar und innerhalb einiger Stunden suchbar sein oder so "
-"ähnlich.\n"
+"Die Abarbeitung der Aufträge läuft momentan automatisch. Im Moment warten %s "
+"Aufträge auf die Ausführung. Ihr Datensatz sollte innerhalb einiger Minuten "
+"verfügbar und innerhalb einiger Stunden suchbar sein oder so ähnlich.\n"
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
-"Aufgrund von menschlicher Interatkion oder einem temporären Problem, "
-"läuft die Abarbeitung von Aufträgen nicht automatisch. Ihre Übermittlung "
-"wurde registriert, allerdings könnte es länger als normal daueren, bis "
-"diese vollständig integriert und suchbar ist.\n"
+"Aufgrund von menschlicher Interatkion oder einem temporären Problem, läuft "
+"die Abarbeitung von Aufträgen nicht automatisch. Ihre Übermittlung wurde "
+"registriert, allerdings könnte es länger als normal daueren, bis diese "
+"vollständig integriert und suchbar ist.\n"
 
 #: invenio/legacy/websubmit/web/approve.py:53
 #, fuzzy
@@ -12883,8 +12812,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12927,11 +12856,6 @@ msgstr "verbunden"
 #, fuzzy
 msgid "Role details"
 msgstr "Weitere Details"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Verstecken"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -13047,11 +12971,11 @@ msgstr "Angegebene E-Mail-Adresse %s existiert bereits in der Datenbank."
 #: invenio/modules/accounts/forms.py:94
 #, fuzzy, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
-"Beachten Sie, dass Sie bei Änderung Ihrer E-Mail-Adresse auch "
-"Ihr%(x_url_open)sPasswort neu setzen%(x_url_close)s müssen."
+"Beachten Sie, dass Sie bei Änderung Ihrer E-Mail-Adresse auch Ihr"
+"%(x_url_open)sPasswort neu setzen%(x_url_close)s müssen."
 
 #: invenio/modules/accounts/forms.py:117
 #, fuzzy, python-format
@@ -13115,9 +13039,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, fuzzy, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 "Sie werden immer noch erkannt von dem zentralen\n"
 "                %(x_fmt_open)sSSO%(x_fmt_close)s System. Sie können sich "
@@ -13128,8 +13051,7 @@ msgstr ""
 #, fuzzy, python-format
 msgid "If you wish you can %(x_url_open)ssign in again%(x_url_close)s."
 msgstr ""
-"Wenn sie möchten können Sie sich %(x_url_open)shier "
-"einloggen%(x_url_close)s."
+"Wenn sie möchten können Sie sich %(x_url_open)shier einloggen%(x_url_close)s."
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:27
 #, fuzzy
@@ -13137,8 +13059,8 @@ msgid ""
 "Please enter your email address. You will receive a link to create a new "
 "password via email."
 msgstr ""
-"Bitte geben Sie die gewünschte E-Mail-Adresse, den gewünschten "
-"Benutzernamen und das Passwort ein:"
+"Bitte geben Sie die gewünschte E-Mail-Adresse, den gewünschten Benutzernamen "
+"und das Passwort ein:"
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:33
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:33
@@ -13149,11 +13071,11 @@ msgstr "Neues Passwort definieren"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
-"Bitte geben Sie die gewünschte E-Mail-Adresse, den gewünschten "
-"Benutzernamen und das Passwort ein:"
+"Bitte geben Sie die gewünschte E-Mail-Adresse, den gewünschten Benutzernamen "
+"und das Passwort ein:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
 #, fuzzy
@@ -13182,7 +13104,7 @@ msgid "Problem with login."
 msgstr "Vergleiche mit dem Original"
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "Sie können jetzt auf Ihr %(x_url_open)sKonto%(x_url_close)s zugreifen."
 
@@ -13225,8 +13147,7 @@ msgstr "Keine Berechtigung für das Bearbeiten von bibcatalog"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13298,13 +13219,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13313,9 +13233,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13496,8 +13416,7 @@ msgstr "Sammlungen"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13581,16 +13500,15 @@ msgstr "Der gemeldete Kommentar existiert nicht mehr."
 #: invenio/modules/comments/api.py:276
 msgid "Sorry, you have already voted. This vote has not been recorded."
 msgstr ""
-"Sie haben bereits abgestimmt. Diese erneute Abstimmung wurde nicht "
-"erfasst."
+"Sie haben bereits abgestimmt. Diese erneute Abstimmung wurde nicht erfasst."
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
-"Sie sind eingetragen für diese Diskussion. Sie werden jetzt immer eine "
-"E-Mail erhalten, wenn ein neuer Kommentar erstellt wird."
+"Sie sind eingetragen für diese Diskussion. Sie werden jetzt immer eine E-"
+"Mail erhalten, wenn ein neuer Kommentar erstellt wird."
 
 #: invenio/modules/comments/api.py:290
 msgid "You have been unsubscribed from this discussion."
@@ -13619,8 +13537,8 @@ msgstr "%s ist eine ungültige Datensatz-ID"
 #: invenio/modules/comments/api.py:1444 invenio/modules/comments/api.py:1465
 msgid "Your feedback could not be recorded, please try again."
 msgstr ""
-"Ihre Rückmeldung konnte nicht entgegengenommen werden, bitte versuchen "
-"sie es erneut."
+"Ihre Rückmeldung konnte nicht entgegengenommen werden, bitte versuchen sie "
+"es erneut."
 
 #: invenio/modules/comments/api.py:1573
 #, fuzzy, python-format
@@ -13651,8 +13569,8 @@ msgstr "Sie haben diesen Datensatz bereits rezensiert."
 #: invenio/modules/comments/api.py:1712
 msgid "You already posted a comment short ago. Please retry later."
 msgstr ""
-"Sie haben bereits vor Kurzem ein Kommentar verschickt. Bitte versuchen "
-"Sie es später nochmal."
+"Sie haben bereits vor Kurzem ein Kommentar verschickt. Bitte versuchen Sie "
+"es später nochmal."
 
 #: invenio/modules/comments/api.py:1724
 msgid "Failed to insert your comment to the database. Please try again."
@@ -13664,8 +13582,7 @@ msgstr ""
 #, fuzzy
 msgid "Unknown action --> showing you the default add comment form."
 msgstr ""
-"Unbekannte Aktion --> Ihnen wird das Standard-Hinzufüge-Formular "
-"angezeigt."
+"Unbekannte Aktion --> Ihnen wird das Standard-Hinzufüge-Formular angezeigt."
 
 #: invenio/modules/comments/api.py:1865
 #, fuzzy, python-format
@@ -13687,13 +13604,13 @@ msgid "Record ID %(recid)s is not a number."
 msgstr "Datensatz-ID %s ist keine Zahl."
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
-"Ihre Nachricht ist zu lang, bitte ändern Sie diese. Die maximale erlaubte"
-" Grösse ist %i Zeichen."
+"Ihre Nachricht ist zu lang, bitte ändern Sie diese. Die maximale erlaubte "
+"Grösse ist %i Zeichen."
 
 #: invenio/modules/comments/forms.py:55
 #, fuzzy
@@ -13736,12 +13653,12 @@ msgid "Review was sent"
 msgstr "Kommentar schreiben"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Dieser Kommentar wurde %i mal gemeldet"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Dieser Kommentar wurde %i mal gemeldet"
 
@@ -13794,9 +13711,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13815,8 +13731,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13826,7 +13742,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "Der Dateiname %s existiert bereits. Bitte wählen Sie einen anderen."
 
@@ -13882,8 +13798,7 @@ msgstr "Review"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13923,8 +13838,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13970,7 +13884,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "Funktion %s existiert nicht"
 
@@ -14055,11 +13969,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "Harvesting Status"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Ihre Aufgaben"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -14094,8 +14003,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -14116,8 +14025,8 @@ msgstr "Es steht kein Wortindex zur Verfügung für %s."
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -14133,8 +14042,7 @@ msgstr "Format Element %s überprüfen"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14256,7 +14164,7 @@ msgstr "Zeige alle %i Autoren"
 msgid "Manage Files of This Record"
 msgstr "Dateien für diesen Datensatz verwalten"
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr "Datensatz editieren"
 
@@ -14355,10 +14263,6 @@ msgstr "1 Review"
 msgid "Authors"
 msgstr "Autor"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14451,8 +14355,8 @@ msgstr "Gruppenrechte einstellen"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "Sie haben nicht genügend Rechte auf dieser Gruppe."
 
 #: invenio/modules/groups/views.py:279
@@ -14465,12 +14369,12 @@ msgstr "Sie sind kein Administrator einer Gruppe."
 msgid "Members"
 msgstr "Keine Mitglieder."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Name derWissensdatenbank fehlt"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14480,11 +14384,11 @@ msgstr "nichts"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "alle Felder"
@@ -14530,13 +14434,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "Es gibt keine Datensätze, die zitiert werden durch %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "Es gibt keine Datensätze, die zitiert werden durch %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14692,28 +14597,28 @@ msgstr "Unbekannter Dokumenttyp"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14778,11 +14683,11 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
-"Wenn Sie die Registrierung für dieses Benutzerkonto fertigstellen wollen,"
-" klicken Sie hier:"
+"Wenn Sie die Registrierung für dieses Benutzerkonto fertigstellen wollen, "
+"klicken Sie hier:"
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
 msgid "Sign-up"
@@ -15154,7 +15059,7 @@ msgid "Tag name"
 msgstr "Nickname"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "Gewünschter Benutzername %s ist bereits registriert."
 
@@ -15259,11 +15164,6 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "nichts"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15305,8 +15205,7 @@ msgstr "Ausleih-Optionen"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15514,7 +15413,7 @@ msgid "just now"
 msgstr "Sie müssen jetzt"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s Sekunden"
 
@@ -15573,6 +15472,48 @@ msgstr "beliebiges Jahr"
 msgid " years ago"
 msgstr "Jahr"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "BibCheck Verwaltung"
+
+#~ msgid "Not authorized"
+#~ msgstr "Keine Berechtigung"
+
+#~ msgid "Really delete"
+#~ msgstr "Wirklich gelöschen"
+
+#~ msgid "Verify syntax"
+#~ msgstr "Syntax überprüfen"
+
+#~ msgid "Verify problem"
+#~ msgstr "Problem überprüfen"
+
+#~ msgid "File"
+#~ msgstr "Datei"
+
+#~ msgid "Edit BibCheck config file"
+#~ msgstr "Bearbeiten von BibCheck-Konfigurationsdatei"
+
+#~ msgid "Save BibCheck config file"
+#~ msgstr "Speichern von BibCheck-Konfigurationsdatei"
+
+#~ msgid "Delete BibCheck config file"
+#~ msgstr "Löschen von BibCheck-Konfigurationsdatei"
+
+#~ msgid "niceName"
+#~ msgstr "Name"
+
+#~ msgid "Id"
+#~ msgstr "ID"
+
+#~ msgid "Tickets"
+#~ msgstr "Aufgaben"
+
+#~ msgid "by"
+#~ msgstr "von"
+
+#~ msgid "Done"
+#~ msgstr "Erledigt"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Bitte wählen Sie einen gültigen Zeitpunkt"
 
@@ -15585,9 +15526,6 @@ msgstr "Jahr"
 #~ msgid "Warning: Please, select a valid date"
 #~ msgstr "Bitte wählen Sie eine gültiges Datum"
 
-#~ msgid ""
-#~ msgstr ""
-
 #~ msgid " or return to your %(x_url_open)ssearch%(x_url_close)s"
 #~ msgstr "oder zurückkehren zu Ihrer %(x_url_open)sSuche%(x_url_close)s"
 
@@ -15599,9 +15537,6 @@ msgstr "Jahr"
 
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "Zusätliche Zitationsgrößen"
-
-#~ msgid "Sorry, you must log in to perform this action."
-#~ msgstr ""
 
 #~ msgid "Please log in first."
 #~ msgstr "Bitte loggen Sie sich zuerst ein."
@@ -15690,12 +15625,6 @@ msgstr "Jahr"
 #~ msgid "now"
 #~ msgstr "jetzt"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "BibCheck Verwaltung"
-
-#~ msgid "Not authorized"
-#~ msgstr "Keine Berechtigung"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "Fehler: %s existiert nicht."
 
@@ -15704,21 +15633,6 @@ msgstr "Jahr"
 
 #~ msgid "ERROR: %s is not writable"
 #~ msgstr "Fehler: % kann nicht geschrieben werden"
-
-#~ msgid "Really delete"
-#~ msgstr "Wirklich gelöschen"
-
-#~ msgid "Verify syntax"
-#~ msgstr "Syntax überprüfen"
-
-#~ msgid "Verify problem"
-#~ msgstr "Problem überprüfen"
-
-#~ msgid "File"
-#~ msgstr "Datei"
-
-#~ msgid "Edit BibCheck config file"
-#~ msgstr "Bearbeiten von BibCheck-Konfigurationsdatei"
 
 #~ msgid "File %s already exists."
 #~ msgstr "Datei %s existiert bereits."
@@ -15729,17 +15643,11 @@ msgstr "Jahr"
 #~ msgid "File %s: write failed."
 #~ msgstr "Fehler beim Schreiben der Datei %s."
 
-#~ msgid "Save BibCheck config file"
-#~ msgstr "Speichern von BibCheck-Konfigurationsdatei"
-
 #~ msgid "File %s deleted."
 #~ msgstr "Datei %s wurde gelöscht."
 
 #~ msgid "File %s: delete failed."
 #~ msgstr "Fehler beim Löschen der Datei %s."
-
-#~ msgid "Delete BibCheck config file"
-#~ msgstr "Löschen von BibCheck-Konfigurationsdatei"
 
 #~ msgid "Guests are not authorized to run batchuploader"
 #~ msgstr "Gäste sind nicht berechtigt den Batchuploader auszuführen."
@@ -15867,9 +15775,6 @@ msgstr "Jahr"
 #~ msgid "Tickes you created about this person"
 #~ msgstr "Aufgaben, die Sie zu dieser Person erstellt haben"
 
-#~ msgid "Tickets"
-#~ msgstr "Aufgaben"
-
 #~ msgid "Request Tickets"
 #~ msgstr "Angefragte Aufgaben"
 
@@ -15948,9 +15853,6 @@ msgstr "Jahr"
 #~ msgid "This book is sent to you ..."
 #~ msgstr "Dieses Buch wurde an Sie verschickt ..."
 
-#~ msgid "Id"
-#~ msgstr "ID"
-
 #~ msgid "0 borrower(s) found."
 #~ msgstr "0 Bibliotheksbenutzer gefunden"
 
@@ -15962,9 +15864,6 @@ msgstr "Jahr"
 
 #~ msgid "There %s request(s) on the book who has been returned."
 #~ msgstr "Es gibt eine Anfrage/Anfragen %s für das zurückgegebenen Buch."
-
-#~ msgid "There are no requests waiting on the item <strong>%s</strong>."
-#~ msgstr ""
 
 #~ msgid "Hold requests and loans overview on"
 #~ msgstr "Überblick Vormerkungen und Ausleihen auf"
@@ -16014,12 +15913,6 @@ msgstr "Jahr"
 #~ msgid "Check if the book already exists on Invenio,"
 #~ msgstr "Prüfen, ob das Buch bereits in Invenio existiert,"
 
-#~ msgid "Book does not exists on Invenio. Please fill the following form."
-#~ msgstr ""
-
-#~ msgid "Please note that this URL will remain  for about %(days)s days only."
-#~ msgstr ""
-
 #~ msgid "No fulltext"
 #~ msgstr "Kein Volltext"
 
@@ -16065,9 +15958,6 @@ msgstr "Jahr"
 #~ msgid "creating a new basket"
 #~ msgstr "Neuen Korb erzeugen"
 
-#~ msgid "by"
-#~ msgstr "von"
-
 #~ msgid "on"
 #~ msgstr "an"
 
@@ -16089,9 +15979,6 @@ msgstr "Jahr"
 #~ msgid "Editing topic"
 #~ msgstr "Thema editieren"
 
-#~ msgid "niceName"
-#~ msgstr "Name"
-
 #~ msgid "Apply Changes"
 #~ msgstr "Änderungen speichern"
 
@@ -16106,9 +15993,6 @@ msgstr "Jahr"
 
 #~ msgid "Edit record %(x_recid)s, field %(x_field)s"
 #~ msgstr "Editiere Datensatz %(x_recid)s, Feld %(x_field)s"
-
-#~ msgid "Edit record %(x_recid)s, field %(x_field)s - Add a subfield"
-#~ msgstr ""
 
 #~ msgid "Submit and save record %s"
 #~ msgstr "Bestätigen und Datensatz %s speichern"
@@ -16176,9 +16060,6 @@ msgstr "Jahr"
 #~ msgid "The collection to which this file belong is restricted: "
 #~ msgstr "Die Sammmlung zu der diese Datei gehört ist privat:"
 
-#~ msgid "This record does not exist. Please try another record ID."
-#~ msgstr ""
-
 #~ msgid "Cannot edit deleted record.\""
 #~ msgstr "Gelöschter Datensatz kann nicht editiert werden."
 
@@ -16202,9 +16083,6 @@ msgstr "Jahr"
 
 #~ msgid "Verbose"
 #~ msgstr "ausführliche Anzeige"
-
-#~ msgid "Done"
-#~ msgstr "Erledigt"
 
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "Ihre Änderungen sind TEMPORÄR."
@@ -16238,9 +16116,6 @@ msgstr "Jahr"
 
 #~ msgid "from"
 #~ msgstr "von"
-
-#~ msgid "There are record revisions not yet synchronized with the database."
-#~ msgstr ""
 
 #~ msgid "Please try again in a few minutes."
 #~ msgstr "Bitte versuchen Sie es später nochmal."
@@ -16446,17 +16321,11 @@ msgstr "Jahr"
 #~ msgid "Citation Metrics"
 #~ msgstr "Zitationsmetriken"
 
-#~ msgid "WebSearch Admin Guide"
-#~ msgstr ""
-
 #~ msgid "Submit Guide"
 #~ msgstr "Hinweise zum Eintragen"
 
 #~ msgid "Add to personal basket"
 #~ msgstr "Zum persönlichen Korb hinzufügen"
-
-#~ msgid "WebSubmit Admin Guide"
-#~ msgstr ""
 
 #~ msgid "Click here to review the transactions."
 #~ msgstr "Hier klicken, um die Transaktion zu überprüfen."
@@ -16464,28 +16333,8 @@ msgstr "Jahr"
 #~ msgid "Quit searching."
 #~ msgstr "Suche beenden"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Abgebrochen"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "Suche nach einer Person, um den Artikel zuzuordnen zu"
@@ -16502,9 +16351,6 @@ msgstr "Jahr"
 #~ msgid "Hide successful claims"
 #~ msgstr "Verstecke die erfolgreichen Beanspruchungen"
 
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Autor"
 
@@ -16519,11 +16365,6 @@ msgstr "Jahr"
 
 #~ msgid "Operator review of user actions pending"
 #~ msgstr "Betreiber-Überpfüfung von ausstehenden Nutzer-Aktionen"
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
-#~ "Sorry, momentan konnten keine Datensätze "
-#~ "in dieser Kategorie gefunden werden."
 
 #~ msgid "Review Transaction"
 #~ msgstr "Transaktion überprüfen"
@@ -16540,18 +16381,8 @@ msgstr "Jahr"
 #~ msgid "The author has an internal ID!"
 #~ msgstr "Es gab einen internen Fehler"
 
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-#~ "Diese Datensätze wurden gekennzeichtnet, als"
-#~ " nicht zu dieser Person zugehöring"
-
 #~ msgid "They will be regarded in the next run of the author "
 #~ msgstr "Sie werden beim nächsten Ausführen vom Autor betrachtet "
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-#~ "Algorithmus zur Vereindeutigung und sollte "
-#~ "von dieser Aufzählung verschwinden."
 
 #~ msgid "No comments"
 #~ msgstr "Keine Kommentare"
@@ -16568,26 +16399,12 @@ msgstr "Jahr"
 #~ msgid "No title available"
 #~ msgstr "Nicht verfügbar"
 
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
+#~ msgid ""
+#~ "Please select an author on each of the records that will be assigned."
 #~ msgstr "Bitte wählen Sie einen Autor für die fraglichen Datensätze aus."
 
 #~ msgid "Papers without a name selected will be ignored in the process."
 #~ msgstr "Nicht ausgefüllte Kästchen werden bei der Bearbeitung ignoriert. "
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Name auswählen für"
@@ -16619,28 +16436,8 @@ msgstr "Jahr"
 #~ msgid "Confirmation needed to continue"
 #~ msgstr "Bestätigung wird benötigt, um fortzufahren"
 
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-#~ "Das Ergebnis von dieser Anfrage wird "
-#~ "in Kürze zu sehen sein, aber wir"
-#~ " benötigen Ihre Bestätigung, da dieser "
-#~ "Artikel zurvor manuell beansprucht wurde."
-
 #~ msgid "This will create a change request for the operators"
 #~ msgstr "Ein Änderungswunsch wird für den Betreiber erstellt"
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-#~ "Das Ergebnis dieser Anfrage wird erst"
-#~ " nach einer Bestätigung des Betreibers "
-#~ "sichtbar sein"
 
 #~ msgid "Selected name on paper"
 #~ msgstr "Name des Artikels auswählen"
@@ -16668,16 +16465,6 @@ msgstr "Jahr"
 
 #~ msgid "Please provide your eMail address"
 #~ msgstr "Bitte Ihre E-Mail-Adresse angegeben"
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-#~ "Diese E-Mail-Adresse ist reserviert "
-#~ "durch einen (anderen) Nutzer. Bitte "
-#~ "loggen Sie sich ein oder geben Sie"
-#~ " eine andere E-Mail-Adresse ein"
 
 #~ msgid "Your eMail:"
 #~ msgstr "Ihre E-Mail:"
@@ -16712,24 +16499,6 @@ msgstr "Jahr"
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Dokument als _nicht_ Ihre kenzeichnen"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-#~ "  * Sie können später zu dieser"
-#~ " Seite zurückkehren. Nichts wird verloren"
-#~ " gehen. <br />"
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-#~ "  ** Alle gewünschten Änderungen "
-#~ "ausführen. Änderungen die eine "
-#~ "Berechtigungerfordern, werden für eine "
-#~ "manuelle Überprüfung an den Betreiber "
-#~ "übermittelt."
-
 #~ msgid "Create a new Person"
 #~ msgstr "Ein Neues erzeugen"
 
@@ -16742,143 +16511,23 @@ msgstr "Jahr"
 #~ msgid "Add to merge list"
 #~ msgstr "Zu einem Benutzer hinzufügen"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Neueste Artikel"
 
 #~ msgid "most recent documents:"
 #~ msgstr "Neueste Dokumente:"
 
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Dokument Dateien verwalten"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Datei auswählen"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Publikationsliste"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "externer Link"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "Eintragungen"
@@ -16886,160 +16535,23 @@ msgstr "Jahr"
 #~ msgid "Choose system"
 #~ msgstr "Vorlage auswählen"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Der folgenden Dateien wurden erfolgreich zur Bearbeitung übermittelt:"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-#~ "Schwerwiegender Fehler: Abfragemöglichkeiten für "
-#~ "die Autor-ID sind auf diesem "
-#~ "System ausgestellt."
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Sie sind nicht berechtigt, diese Funktion zu verwenden!"
 
 #~ msgid "Claim this paper"
 #~ msgstr "Den Arkikel beanspuchen"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-#~ "<p>Sorry. Ein Fehler ist bei der "
-#~ "Erledigung Ihrer Anfrage aufgetreten. Weitere"
-#~ " Infomationen finden Sie unten:</p>"
-
 #~ msgid "This page is not accessible directly."
 #~ msgstr "Diese Seite ist nicht direkt zugänglich."
 
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Zitiert von: %s Datensätzen"
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
 
 #~ msgid "Revision"
 #~ msgstr "Überarbeitung"
 
 #~ msgid "Failed to create a ticket"
 #~ msgstr "Aufgabe konnte nicht erstellt werden"
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Attribute der Vorlage ändern"
@@ -17119,89 +16631,20 @@ msgstr "Jahr"
 #~ msgid "No Record Found for %s."
 #~ msgstr "Datensatz nicht gefunden"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Benutzer %s existiert nicht."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "Ausgabeformat %s Attribute"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "Formatvorlage %s Abhängigkeiten"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "Format Element %s überprüfen"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "Formatelement %s Abhängigkeiten"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Eingeschränktes Ausgabeformat"
@@ -17257,101 +16700,14 @@ msgstr "Jahr"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Format Element %s überprüfen"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "Formatüberprüfung"
-
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
 
 #~ msgid "Knowledge Base %s"
 #~ msgstr "Wissensdatenbank %s"
 
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Not Set"
-#~ msgstr ""
-
 #~ msgid "never"
 #~ msgstr "nie"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
 
 #~ msgid "Name variants"
 #~ msgstr "Namensvarianten"
@@ -17386,17 +16742,11 @@ msgstr "Jahr"
 #~ msgid "Affiliations"
 #~ msgstr "Verbindungen"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
 #~ msgid "No Frequent Co-authors"
 #~ msgstr "Keine häufigen Mitautoren"
 
 #~ msgid "Citations%s"
 #~ msgstr "Zitationen"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Veröffentlichungsdatum"
@@ -17406,18 +16756,6 @@ msgstr "Jahr"
 
 #~ msgid "No publications available"
 #~ msgstr "Keine Informationen verfügbar"
-
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
 
 #~ msgid "Cited by 1 record"
 #~ msgstr "Zitiert von 1 Datensatz"
@@ -17446,23 +16784,8 @@ msgstr "Jahr"
 #~ msgid "No Citation Information available"
 #~ msgstr "Keine Zitations-Informationen verfügbar."
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Diskussion"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Ihre Benachrichtigungen"
@@ -17485,22 +16808,8 @@ msgstr "Jahr"
 #~ msgid "Group: %s"
 #~ msgstr "Gruppe: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "Seite %s nicht gefunden"
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "Das Feld %s ist obligatorisch."
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
-#~ msgstr ""
-#~ "Feld an Position %s von Seite %s"
-#~ " der Eintragung '%s' kann nicht "
-#~ "gelöscht werden"
-

--- a/invenio/base/translations/el/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/el/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -15,15 +15,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.0.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2012-03-01 16:53+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:57+0200\n"
 "Last-Translator: Nikolaos Kasioumis <nikolaos.kasioumis@cern.ch>\n"
 "Language-Team: EL <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -43,7 +43,8 @@ msgstr "Δεν έχετε δικαίωμα να χρησιμοποιήσετε �
 #: invenio/base/templates/401.html:29
 #, fuzzy
 msgid "You do not have access to this page."
-msgstr "Δεν έχετε τα απαιτούμενα δικαιώματα για να διαγράψετε αυτή τη σημείωση."
+msgstr ""
+"Δεν έχετε τα απαιτούμενα δικαιώματα για να διαγράψετε αυτή τη σημείωση."
 
 #: invenio/base/templates/401.html:30 invenio/base/templates/404.html:30
 msgid "Click the following link to go to the main page:"
@@ -57,8 +58,8 @@ msgstr "κεντρική σελίδα"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -204,7 +205,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Χαίρετε:"
 
@@ -225,17 +226,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -261,50 +262,55 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Η διεύθυνση URL που δώσατε δεν είναι έγκυρη."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr "Αίτημα επαναφοράς κωδικού για"
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Δεν έχετε δικαίωμα να χρησιμοποιήσετε τον δανεισμό."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Πρόβλημα στην εγγραφή"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Παρακαλώ επιλέξτε ένα ή περισσότερα"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Αίτηση εξουσιοδότησης ρόλων"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, fuzzy, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 "Μια νεότερη έκδοση του Invenio είναι διαθέσιμη για κατέβασμα. Παρακαλώ "
 "επισκευθείτε το "
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -473,8 +479,7 @@ msgstr "    Όνομα χρήστη/Email"
 #: invenio/legacy/webuser.py:857
 msgid "You can approve or reject this account request at"
 msgstr ""
-"Μπορείτε να δεχτείτε ή να απορρίψετε την αίτηση δημιουργίας λογαριασμού "
-"στο"
+"Μπορείτε να δεχτείτε ή να απορρίψετε την αίτηση δημιουργίας λογαριασμού στο"
 
 #: invenio/legacy/authorlist/webinterface.py:86
 #: invenio/legacy/authorlist/webinterface.py:111
@@ -506,7 +511,8 @@ msgstr "Δεν έχετε δικαίωμα να μεταφορτώσετε στ�
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 "Ο χρήστης '%(x_user)s' δεν έχει δικαίωμα να τροποποιήσει την συλλογή "
 "'%(x_coll)s'"
@@ -717,7 +723,8 @@ msgid "The following errors have occurred:"
 msgstr "Έχουν εντοπιστεί τα παρακάτω σφάλματα:"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 "Κάποια αρχεία δεν μπόρεσαν να μεταφερθούν στον φάκελο DONE. Παρακαλώ, "
 "μεταφέρετέ τα χειροκίνητα."
@@ -738,12 +745,11 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
-"Δείτε τη %(x_url_open)sσελίδα βοήθειας για το Μαζικό "
-"Ανέβασμα%(x_url_close)s για το πως μπορείτε να εκτελείτε αυτές τις "
-"ενέργειες περιοδικά."
+"Δείτε τη %(x_url_open)sσελίδα βοήθειας για το Μαζικό Ανέβασμα%(x_url_close)s "
+"για το πως μπορείτε να εκτελείτε αυτές τις ενέργειες περιοδικά."
 
 #: invenio/legacy/batchuploader/templates.py:602
 msgid "Metadata folders"
@@ -824,7 +830,7 @@ msgstr "ID"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -866,8 +872,8 @@ msgstr "Έχετε %i tickets."
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Προηγούμενο"
@@ -882,8 +888,8 @@ msgstr "κλείσιμο"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Επόμενο"
 
@@ -899,18 +905,6 @@ msgstr "Επόμενο"
 msgid "Admin Area"
 msgstr "Περιοχή Διαχειριστή"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "συγγραφέας"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
 msgid "ERROR: %(x_name)s does not exist"
@@ -925,15 +919,6 @@ msgstr ""
 #, python-format
 msgid "ERROR: %(x_name)s is not writable"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
-msgid "Limit to knowledge bases containing string:"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "διαγράφηκε επιτυχώς"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -963,10 +948,6 @@ msgstr "διαγράφηκε επιτυχώς"
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:140
-msgid "Verify syntax"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:145
 #: invenio/modules/communities/views.py:258
 #, fuzzy
@@ -978,31 +959,9 @@ msgstr "Δημιουργία νέου καλαθιού"
 msgid "File %(x_name)s does not exist."
 msgstr "Ο χρήστης %s δεν υπάρχει."
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:174
-msgid "Calling bibcheck -verify failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
-msgid "Verify BibCheck config file"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Πρόβλημα βάσης δεδομένων"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "αρχείο(α)"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
 msgstr "Αποθήκευση Αλλαγών"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:240
-msgid "Edit BibCheck config file"
-msgstr ""
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:268
 #, fuzzy, python-format
@@ -1019,10 +978,6 @@ msgstr ""
 msgid "File %(x_name)s: write failed."
 msgstr ""
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:279
-msgid "Save BibCheck config file"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:312
 #, python-format
 msgid "File %(x_name)s deleted."
@@ -1031,10 +986,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:314
 #, python-format
 msgid "File %(x_name)s: delete failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:316
-msgid "Delete BibCheck config file"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:195
@@ -1102,7 +1053,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1153,8 +1105,8 @@ msgstr "Καταχωρήθηκε επιτυχώς το νέο αίτημα."
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1168,25 +1120,23 @@ msgstr "Barcode"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "Καταχωρήθηκε επιτυχώς το νέο αίτημα."
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "Καταχωρήθηκε επιτυχώς το νέο αίτημα."
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1211,13 +1161,14 @@ msgstr "Δημιουργία νέου"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "Καταχωρήθηκε επιτυχώς το νέο αίτημα."
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1249,9 +1200,8 @@ msgstr "Περίοδος δανεισμού"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "Καταχωρήθηκε επιτυχώς το νέο αίτημα."
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1318,8 +1268,8 @@ msgstr "Νέο αίτημα"
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1327,8 +1277,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1350,9 +1300,8 @@ msgstr "Νέο αίτημα δανεισμού"
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "Καταχωρήθηκε επιτυχώς το νέο αίτημα."
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1394,8 +1343,8 @@ msgstr "0 δανειζόμενοι βρέθηκαν."
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1454,11 +1403,11 @@ msgstr "Καταχωρήθηκε επιτυχώς το νέο αίτημα."
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1469,11 +1418,11 @@ msgstr "Ναι"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1486,8 +1435,8 @@ msgstr "Όχι"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1582,8 +1531,8 @@ msgstr "<strong>%s</strong> εγγραφές βρέθηκαν"
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1603,29 +1552,29 @@ msgstr "<strong>%s</strong> εγγραφές βρέθηκαν"
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1634,9 +1583,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr "Η εγγραφή που ζητήσατε δεν υπάρχει."
 
@@ -1996,16 +1945,14 @@ msgstr "Αυτό το τεκμήριο δεν έχει αντίτυπα."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2026,8 +1973,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2189,8 +2136,8 @@ msgstr "Αίτημα διαδανεισμού"
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2297,7 +2244,7 @@ msgstr "Τοποθεσία"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Περιγραφή"
 
@@ -2490,8 +2437,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2766,10 +2713,10 @@ msgstr "Επιβεβαίωση"
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
-msgstr "Αν επιθυμείτε μπορείτε να κάνετε %(x_url_open)slogin εδώ%(x_url_close)s."
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
+msgstr ""
+"Αν επιθυμείτε μπορείτε να κάνετε %(x_url_open)slogin εδώ%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
 #, fuzzy
@@ -2822,7 +2769,7 @@ msgstr "Επαναφορά"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "ΟΚ"
 
@@ -2830,8 +2777,8 @@ msgstr "ΟΚ"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "Καταχωρήθηκε επιτυχώς το νέο αίτημα."
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3290,8 +3237,8 @@ msgstr "Θυρίδα ταχυδρομείου"
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "Email"
 
@@ -4099,8 +4046,8 @@ msgstr "Περίοδος ενδιαφέροντος (Έως)"
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4118,8 +4065,8 @@ msgstr "Μόνο αυτή η έκδοση"
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, fuzzy, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr "Έλεγχος αν το βιβλίο υπάρχει στο σύστημα,"
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4178,17 +4125,17 @@ msgstr "ISSN"
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4564,25 +4511,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "Η εγγραφή έχει διαγραφεί."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4642,15 +4589,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4661,10 +4608,10 @@ msgstr "Επιλέξτε ένα αρχείο"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4677,20 +4624,20 @@ msgstr "πρόσβαση"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
-"Το αρχείο που προσπαθείτε να τροποποιήσετε, προστατεύεται από τις "
-"αλλαγές. Η ενέργειά σας δεν εφαρμόστηκε."
+"Το αρχείο που προσπαθείτε να τροποποιήσετε, προστατεύεται από τις αλλαγές. Η "
+"ενέργειά σας δεν εφαρμόστηκε."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, fuzzy, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
-"Το αρχείο που ανεβάσατε είναι πολύ μικρό (<%i o) και γι'αυτό δεν θα "
-"ληφθεί υπόψη"
+"Το αρχείο που ανεβάσατε είναι πολύ μικρό (<%i o) και γι'αυτό δεν θα ληφθεί "
+"υπόψη"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
 #, fuzzy, python-format
@@ -4698,11 +4645,12 @@ msgid ""
 "The uploaded file is too big (>%(x_size)i o) and has therefore not been "
 "considered"
 msgstr ""
-"Το αρχείο που ανεβάσατε είναι πολύ μεγάλο (>%i o) και γι'αυτό δεν θα "
-"ληφθεί υπόψη"
+"Το αρχείο που ανεβάσατε είναι πολύ μεγάλο (>%i o) και γι'αυτό δεν θα ληφθεί "
+"υπόψη"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 "Το όνομα του αρχείου που ανεβάσατε είναι πολύ μεγάλο και γι'αυτό δεν θα "
 "ληφθεί υπόψη"
@@ -4725,21 +4673,20 @@ msgstr "Ένα αρχείο με όνομα %s υπάρχει ήδη. Παρακ
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
-msgstr "Ένα αρχείο του τύπου '%s' υπάρχει ήδη. Παρακαλώ επιλέξτε ένα άλλο τύπο."
+"A file with format '%(x_name)s' already exists. Please upload another format."
+msgstr ""
+"Ένα αρχείο του τύπου '%s' υπάρχει ήδη. Παρακαλώ επιλέξτε ένα άλλο τύπο."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
-"Δεν επιτρέπεται η χρήση της τελείας '.', του slash '/', ή του backslash "
-"'\\\\' σε ονόματα αρχείων. Επιλέξτε ένα διαφορετικό όνομα και ανεβάστε το"
-" αρχείο ξανά. Σημειώστε οτι δεν πρέπει να συμπεριλάβετε την κατάληξη στο "
+"Δεν επιτρέπεται η χρήση της τελείας '.', του slash '/', ή του backslash '\\"
+"\\' σε ονόματα αρχείων. Επιλέξτε ένα διαφορετικό όνομα και ανεβάστε το "
+"αρχείο ξανά. Σημειώστε οτι δεν πρέπει να συμπεριλάβετε την κατάληξη στο "
 "πεδίο μετονομασίας."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4759,19 +4706,18 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 "Όταν αναθεωρείτε ένα αρχείο, οι πρόσθετες μορφές που μπορεί να είχατε "
 "ανεβάσει, αφαιρούνται, καθότι δεν θα συμφωνούν με το νέο αρχείο."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
-"Οι πρόσθετε μορφές που ανέβηκαν για την τρέχουσα έκδοση του αρχείου "
-"αυτού, θα διαγραφούν"
+"Οι πρόσθετε μορφές που ανέβηκαν για την τρέχουσα έκδοση του αρχείου αυτού, "
+"θα διαγραφούν"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
 msgid "Keep previous versions"
@@ -4803,8 +4749,8 @@ msgstr "Αποθήκευση αλλαγών"
 #, python-format
 msgid "Need help revising or adding files to record %(recid)s"
 msgstr ""
-"Χρειάζεται η συνδρομή σας για ενημέρωση και προσθήκη αρχείων στην εγγραφή"
-" %(recid)s"
+"Χρειάζεται η συνδρομή σας για ενημέρωση και προσθήκη αρχείων στην εγγραφή "
+"%(recid)s"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:927
 #, python-format
@@ -4831,11 +4777,11 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
-"Έχετε δυσκολία στην ενημέρωση/προσθήκη κάποιου αρχείου; Στείλτε την "
-"νέα/ενημερωμένη έκδοση στο %(mailto_link)s."
+"Έχετε δυσκολία στην ενημέρωση/προσθήκη κάποιου αρχείου; Στείλτε την νέα/"
+"ενημερωμένη έκδοση στο %(mailto_link)s."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
 msgid "revise"
@@ -4884,11 +4830,11 @@ msgstr "Η εγγραφή που ζητήσατε δεν έχει ενσωματ
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
-"Εμφανίστηκε πρόβλημα κατά την ανάκτηση της λίστας των αρχείων για το "
-"έγγραφο αυτό."
+"Εμφανίστηκε πρόβλημα κατά την ανάκτηση της λίστας των αρχείων για το έγγραφο "
+"αυτό."
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
 #: invenio/legacy/websession/webinterface.py:1023
@@ -4909,7 +4855,8 @@ msgstr "Η πρόσβαση στο αρχείο αυτό είναι περιορ
 
 #: invenio/legacy/bibdocfile/webinterface.py:228
 msgid "An error has happened in trying to stream the request file."
-msgstr "Παρουσιάστηκε σφάλμα στην προσπάθεια να γίνει stream το ζητούμενο αρχείο."
+msgstr ""
+"Παρουσιάστηκε σφάλμα στην προσπάθεια να γίνει stream το ζητούμενο αρχείο."
 
 #: invenio/legacy/bibdocfile/webinterface.py:231
 msgid "The requested file is hidden and can not be accessed."
@@ -4998,13 +4945,13 @@ msgstr "1. Επιλογή κριτηρίων αναζήτησης"
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
-"Καθορίστε τα κριτήρια που θα θέλατε να χρησιμοποιήσετε για φιλτράρισμα "
-"των εγγραφών που θα αλλάξουν. Χρησιμοποιήστε την Αναζήτηση για να δείτε "
-"ποιές εγγραφές θα φιλτραριστούν χρησιμοποιώντας τα συγκεκριμένα κριτήρια."
+"Καθορίστε τα κριτήρια που θα θέλατε να χρησιμοποιήσετε για φιλτράρισμα των "
+"εγγραφών που θα αλλάξουν. Χρησιμοποιήστε την Αναζήτηση για να δείτε ποιές "
+"εγγραφές θα φιλτραριστούν χρησιμοποιώντας τα συγκεκριμένα κριτήρια."
 
 #: invenio/legacy/bibeditmulti/templates.py:361
 msgid "Preview results"
@@ -5016,8 +4963,8 @@ msgstr "2. Ορισμός αλλαγών"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 "Καθορίστε τα πεδία και τα υποπεδία που θα πρέπει να αλλαχτούν σε κάθε "
 "εγγραφή που ταιριάζει με τα κριτήρια της αναζήτησης."
@@ -5146,11 +5093,10 @@ msgstr "Επιστροφή στα Αποτελέσματα"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5274,7 +5220,7 @@ msgid "Total"
 msgstr "Σύνολο"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Επιλογή"
 
@@ -5430,8 +5376,8 @@ msgstr "Διαγραφή Γνωσιακής Βάσης"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 "Περιορισμός εμφάνισης σε γνωσιακές βάσεις που έχουν το %(keyword_field)s "
 "στους κανόνες και τις περιγραφές τους"
@@ -5475,7 +5421,8 @@ msgstr "Αν ανεβάσετε κάποιο άλλο αρχείο, η παρο�
 #: invenio/legacy/bibknowledge/templates.py:197
 #, fuzzy, python-format
 msgid "The current taxonomy can be accessed with this URL: %(x_url)s"
-msgstr "Η τρέχουσα ταξινόμηση μπορεί να προσπελαστεί από αυτή την διεύθυνση: %s"
+msgstr ""
+"Η τρέχουσα ταξινόμηση μπορεί να προσπελαστεί από αυτή την διεύθυνση: %s"
 
 #: invenio/legacy/bibknowledge/templates.py:199
 #, fuzzy, python-format
@@ -5488,32 +5435,31 @@ msgstr "Παρακαλώ ρυθμίστε"
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
-"Μια δυναμική γνωσιακή βάση είναι μια λίστα από τιμές ενός δεδομένου "
-"πεδίου. Η λίστα δημιουργείται δυναμικά αναζητώντας τις εγγραφές "
-"χρησιμοποιώντας μια συμβολοσειρά αναζήτησης."
+"Μια δυναμική γνωσιακή βάση είναι μια λίστα από τιμές ενός δεδομένου πεδίου. "
+"Η λίστα δημιουργείται δυναμικά αναζητώντας τις εγγραφές χρησιμοποιώντας μια "
+"συμβολοσειρά αναζήτησης."
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
-"Παράδειγμα: Οι εγγραφές σας περιέχουν το πεδίο 270__a για το όνομα και τη"
-" διεύθυνση του ιδρύματος του συγγραφέα. Αν ορίσετε το πεδίο σε '270__a' "
-"και την έκφραση σε '270__a:*Paris*', μια λίστα με τα ιδρύματα στο Παρίσι "
-"θα δημιουργηθεί."
+"Παράδειγμα: Οι εγγραφές σας περιέχουν το πεδίο 270__a για το όνομα και τη "
+"διεύθυνση του ιδρύματος του συγγραφέα. Αν ορίσετε το πεδίο σε '270__a' και "
+"την έκφραση σε '270__a:*Paris*', μια λίστα με τα ιδρύματα στο Παρίσι θα "
+"δημιουργηθεί."
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 "Αν η έκφραση είναι κενή, μια λίστα με όλες τις τιμές του 270__a θα "
 "δημιουργηθεί."
@@ -5521,44 +5467,45 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:248
 #, fuzzy, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 "Αν η έκφραση περιέχει '%', όπως '270__a:*%*', θα αντικατασταθεί από μια "
 "συμβολοσειρά αναζήτησης όταν η γνωσιακή βάση χρησιμοποιηθεί."
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 "Μπορείτε να εισάγετε ένα όνομα συλλογής, αν η έκφραση θα πρέπει να "
 "αξιολογηθεί σε μια συγκεκριμένη συλλογή."
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
-"Παράδειγμα 1: Οι εγγραφές σας περιέχουν το πεδίο 270__a για το όνομα και "
-"τη διεύθυνση του ιδρύματος του συγγραφέα. Αν ορίσετε το πεδίο σε '270__a'"
-" και την έκφραση σε '270__a:*Paris*', μια λίστα από ιδρύματα στο Παρίσι "
-"θα δημιουργηθεί."
+"Παράδειγμα 1: Οι εγγραφές σας περιέχουν το πεδίο 270__a για το όνομα και τη "
+"διεύθυνση του ιδρύματος του συγγραφέα. Αν ορίσετε το πεδίο σε '270__a' και "
+"την έκφραση σε '270__a:*Paris*', μια λίστα από ιδρύματα στο Παρίσι θα "
+"δημιουργηθεί."
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, fuzzy, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
-"Παράδειγμα 2: Επέστρεψε το όνομα του ιδρύματος (100__a) όταν ο χρήστης "
-"δώσει τον ταχυδρομικό του κώδικα (270__a): Όρισε το πεδίο σε 100__a, την "
-"έκφραση σε 270__a:*%*."
+"Παράδειγμα 2: Επέστρεψε το όνομα του ιδρύματος (100__a) όταν ο χρήστης δώσει "
+"τον ταχυδρομικό του κώδικα (270__a): Όρισε το πεδίο σε 100__a, την έκφραση "
+"σε 270__a:*%*."
 
 #: invenio/legacy/bibknowledge/templates.py:262
 msgid "Any collection"
@@ -5595,7 +5542,7 @@ msgstr "Συσχετισμοί Γνωσιακών Βάσεων"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5647,18 +5594,18 @@ msgstr "Ο κανόνας σας: %s"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, fuzzy, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
-"Η αριστερή μεριά του κανόνα (%s) ήδη εμφανίζεται στις εξής γνωσιακές "
-"βάσεις:"
+"Η αριστερή μεριά του κανόνα (%s) ήδη εμφανίζεται στις εξής γνωσιακές βάσεις:"
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, fuzzy, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
-msgstr "Η δεξιά μεριά του κανόνα (%s) ήδη εμφανίζεται στις εξής γνωσιακές βάσεις:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
+msgstr ""
+"Η δεξιά μεριά του κανόνα (%s) ήδη εμφανίζεται στις εξής γνωσιακές βάσεις:"
 
 #: invenio/legacy/bibknowledge/templates.py:722
 msgid "Please select action"
@@ -5755,8 +5702,8 @@ msgstr "Ευχαριστούμε που βοηθάτε να γίνει καλύ�
 #: invenio/legacy/errorlib/webinterface.py:155
 msgid "Use the back button of your browser to return to the previous page."
 msgstr ""
-"Χρησιμοποιήστε το αντίστοιχο κουμπί του φυλλομετρητή σας για να "
-"επιστρέψετε στην προηγούμενη σελίδα."
+"Χρησιμοποιήστε το αντίστοιχο κουμπί του φυλλομετρητή σας για να επιστρέψετε "
+"στην προηγούμενη σελίδα."
 
 #: invenio/legacy/errorlib/webinterface.py:158
 msgid "Thank you!"
@@ -5880,11 +5827,10 @@ msgstr "Λάθος κατά την ανάκτηση της εγγραφής"
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
-"Λάθος κατά τη διαμόρφωση της εγγραφής από τη λίστα αναθεώρησης. Πιθανώς "
-"το περιεχόμενό της να μην είναι έγκυρο"
+"Λάθος κατά τη διαμόρφωση της εγγραφής από τη λίστα αναθεώρησης. Πιθανώς το "
+"περιεχόμενό της να μην είναι έγκυρο"
 
 #: invenio/legacy/oaiharvest/admin.py:1326
 msgid "Accept Holding Pen version"
@@ -5958,8 +5904,8 @@ msgstr "Επιστροφή στην αρχική επιλογή"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -5974,8 +5920,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Αποτελέσματα αναζήτησης"
 
@@ -6134,8 +6080,8 @@ msgstr "Δεν βρέθηκαν τιμές."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6144,8 +6090,8 @@ msgid ""
 "Warning: figure caption search is only available for a subset of papers "
 "mostly from %(x_range_from_year)s-%(x_range_to_year)s."
 msgstr ""
-"Προειδοποίηση: η αναζήτηση λεζάντας διαγραμμάτων είναι διαθέσιμη μόνο για"
-" ένα τμήμα δημοσιεύσεων, κυρίως από το 2008 μέχρι το 2011."
+"Προειδοποίηση: η αναζήτηση λεζάντας διαγραμμάτων είναι διαθέσιμη μόνο για "
+"ένα τμήμα δημοσιεύσεων, κυρίως από το 2008 μέχρι το 2011."
 
 #: invenio/legacy/search_engine/__init__.py:2151
 #, fuzzy, python-format
@@ -6166,8 +6112,8 @@ msgstr ""
 #: invenio/legacy/search_engine/__init__.py:2165
 #, fuzzy
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 "Ο όρος αναζήτησης είναι πολύ γενικός. Εμφανίζεται ένα τμήμα των "
 "αποτελεσμάτων..."
@@ -6183,8 +6129,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 "Δεν είναι διαθέσιμο κάποιο ευρετήριο για το πλήρες κείμενο, γίνεται "
 "αναζήτηση για συδυασμό λέξεων..."
@@ -6198,14 +6143,14 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 "Υπάρχει πρόβλημα στην σύνταξη των όρων αναζήτησης. Θα αγνοηθούν όλες οι "
-"παρενθέσεις στο ερώτημα.Αν δεν σας καλύπτει, ελέγξτε τους όρους "
-"αναζήτησης και δοκιμάστε ξανά."
+"παρενθέσεις στο ερώτημα.Αν δεν σας καλύπτει, ελέγξτε τους όρους αναζήτησης "
+"και δοκιμάστε ξανά."
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
@@ -6214,16 +6159,16 @@ msgstr ""
 "Κανένα αποτέλεσμα στην συλλογή %(x_collection)s. Άλλες συλλογές έδωσαν "
 "%(x_url_open)s%(x_nb_hits)d αποτελέσματα%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 "Καμιά ανοιχτή συλλογή δεν ικανοποίησε το ερώτημά σας. Άν ψάχνετε και σε "
 "κλειστές συλλογές, παρακαλώ επιλέξτε τις στην αρχή."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
@@ -6231,50 +6176,51 @@ msgstr ""
 "Καμιά ανοιχτή συλλογή δεν ικανοποίησε το ερώτημά σας. Άν ψάχνετε και σε "
 "κλειστές συλλογές, παρακαλώ επιλέξτε τις στην αρχή."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr "Το σχόλιο σας δεν μπόρεσε να καταγραφεί, παρακαλώ ξαναδοκιμάστε."
 
-#: invenio/legacy/search_engine/__init__.py:3369
-msgid "No match found, please enter different search terms."
-msgstr "Δεν βρέθηκε αποτέλεσμα, παρακαλώ εισάγετε διαφορετικά κριτήρια αναζήτησης."
-
 #: invenio/legacy/search_engine/__init__.py:3375
+msgid "No match found, please enter different search terms."
+msgstr ""
+"Δεν βρέθηκε αποτέλεσμα, παρακαλώ εισάγετε διαφορετικά κριτήρια αναζήτησης."
+
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Δεν υπάρχουν εγγραφές που να αναφέρονται στο %s."
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Δεν υπάρχουν εγγραφές που να παραπέμπονται από το %s."
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Δεν υπάρχουν εγγραφές που να παραπέμπονται από το %s."
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Δεν υπάρχει ευρετήριο λέξεων για το %s."
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Δεν υπάρχει ευρετήριο φράσεων για το %s."
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
-"Ο όρος %(x_term)s στο ευρετήριο %(x_index)s δεν ταίριαξε σε κάποια "
-"εγγραφή. Παραπλήσιοι όροι σε όλες τις συλλογές:"
+"Ο όρος %(x_term)s στο ευρετήριο %(x_index)s δεν ταίριαξε σε κάποια εγγραφή. "
+"Παραπλήσιοι όροι σε όλες τις συλλογές:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
@@ -6283,44 +6229,44 @@ msgstr ""
 "Ο όρος %s δεν ταίριαξε σε κάποια εγγραφή. Παραπλήσιοι όροι σε όλες τις "
 "συλλογές:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
-"Λυπούμαστε, η '%s' δεν είναι έγκυρη επιλογή ταξινόμησης. Έγινε επιλογή "
-"της ταξινόμησης κατά τίτλο."
+"Λυπούμαστε, η '%s' δεν είναι έγκυρη επιλογή ταξινόμησης. Έγινε επιλογή της "
+"ταξινόμησης κατά τίτλο."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 "Λυπούμαστε, η ταξινόμηση επιτρέπεται σε σετ των %d εγγραφών το πολύ. Θα "
 "γίνει χρήση της της εξ΄ορισμού ταξινόμησης."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
-"Λυπούμαστε, η '%s' δεν είναι έγκυρη επιλογή ταξινόμησης. Έγινε επιλογή "
-"της ταξινόμησης κατά τίτλο."
+"Λυπούμαστε, η '%s' δεν είναι έγκυρη επιλογή ταξινόμησης. Έγινε επιλογή της "
+"ταξινόμησης κατά τίτλο."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Αυτή η εγγραφή δεν υπάρχει."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Χρησιμοποιήστε διαφορετικά κριτήρια έρευνας."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6334,17 +6280,16 @@ msgstr "Χρησιμοποιήστε διαφορετικά κριτήρια έ�
 msgid "Browse"
 msgstr "Φυλλομέτρηση"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
-"Κανένα αποτέλεσμα στα χρονικά περιθώρια, θα γίνει παράβλεψη του κριτηρίου"
-" αυτού..."
+"Κανένα αποτέλεσμα στα χρονικά περιθώρια, θα γίνει παράβλεψη του κριτηρίου "
+"αυτού..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
-"Κανένα αποτέλεσμα στα όρια έρευνας, θα γίνει παράβλεψη του κριτηρίου "
-"αυτού..."
+"Κανένα αποτέλεσμα στα όρια έρευνας, θα γίνει παράβλεψη του κριτηρίου αυτού..."
 
 #: invenio/legacy/webalert/api.py:54
 #, fuzzy, python-format
@@ -6362,7 +6307,8 @@ msgstr "Δεν έχετε τα απαιτούμενα δικαιώματα γι�
 
 #: invenio/legacy/webalert/api.py:198
 msgid "You already have an alert defined for the specified query and basket."
-msgstr "Έχετε ορίσει ήδη μια ειδοποίηση για την συγκεκριμένη έρευνα και καλάθι."
+msgstr ""
+"Έχετε ορίσει ήδη μια ειδοποίηση για την συγκεκριμένη έρευνα και καλάθι."
 
 #: invenio/legacy/webalert/api.py:221 invenio/legacy/webalert/api.py:345
 msgid "The alert name cannot be empty."
@@ -6385,15 +6331,14 @@ msgstr "Η ειδοποίηση %s έχει ενημερωθεί επιτυχώ�
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Έχετε εκτελέσει %(x_nb)s έρευνες. Μια %(x_url_open)sαναλυτική "
-"λίστα%(x_url_close)s είναι διαθέσιμη με δυνατότητα (α) να δείτε τα "
-"αποτελέσματα τους και (β) να εγγραφείτε σε μια υπηρεσία που θα σας "
-"ενημερώνει με email για τις έρευνες αυτές."
+"Έχετε εκτελέσει %(x_nb)s έρευνες. Μια %(x_url_open)sαναλυτική λίστα"
+"%(x_url_close)s είναι διαθέσιμη με δυνατότητα (α) να δείτε τα αποτελέσματα "
+"τους και (β) να εγγραφείτε σε μια υπηρεσία που θα σας ενημερώνει με email "
+"για τις έρευνες αυτές."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6467,8 +6412,8 @@ msgid ""
 "This alert will notify you each time/only if a new item satisfies the "
 "following query:"
 msgstr ""
-"Η ειδοποίηση αυτή θα σας ενημερώνει κάθε φορά/μόνο εάν ένα νέο "
-"αντικείμενο ικανοποιεί τηνπαρακάτω έρευνα:"
+"Η ειδοποίηση αυτή θα σας ενημερώνει κάθε φορά/μόνο εάν ένα νέο αντικείμενο "
+"ικανοποιεί τηνπαρακάτω έρευνα:"
 
 #: invenio/legacy/webalert/templates.py:173
 msgid "QUERY"
@@ -6534,9 +6479,9 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"Καθορίστε μια νέα ειδοποίηση από τις %(x_url1_open)sέρευνές "
-"σας%(x_url1_close)s, τις %(x_url2_open)sδημοφιλείς "
-"έρευνες%(x_url2_close)s ή την φόρμα εισαγωγής."
+"Καθορίστε μια νέα ειδοποίηση από τις %(x_url1_open)sέρευνές σας"
+"%(x_url1_close)s, τις %(x_url2_open)sδημοφιλείς έρευνες%(x_url2_close)s ή "
+"την φόρμα εισαγωγής."
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6587,20 +6532,20 @@ msgstr "Έχετε ορίσει %s ειδοποιήσεις."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
-"Δεν έχετε εκτελέσει καμιά έρευνα ακόμη. Παρακαλώ επισκευτείτε την σελίδα "
-"της %(x_url_open)sαναζήτησης %(x_url_close)s πρώτα."
+"Δεν έχετε εκτελέσει καμιά έρευνα ακόμη. Παρακαλώ επισκευτείτε την σελίδα της "
+"%(x_url_open)sαναζήτησης %(x_url_close)s πρώτα."
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
-"Έχετε  πραγματοποιήσει %(x_nb1)s έρευνες (%(x_nb2)s διαφορετικές "
-"ερωτήσεις) τις τελευταίες 30 ημέρες."
+"Έχετε  πραγματοποιήσει %(x_nb1)s έρευνες (%(x_nb2)s διαφορετικές ερωτήσεις) "
+"τις τελευταίες 30 ημέρες."
 
 #: invenio/legacy/webalert/templates.py:453
 #, fuzzy, python-format
@@ -6657,7 +6602,7 @@ msgstr "Οι Αναζητήσεις μου"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6721,7 +6666,7 @@ msgstr "%s ρυθμίσεις, καθορισμός νέας ειδοποίησ�
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6781,14 +6726,14 @@ msgstr "%s ρυθμίσεις, παρουσίαση ειδοποιήσεων"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr "Το επιλεγμένο δημόσιο καλάθι δεν υπάρχει ή δεν έχετε πρόσβαση σε αυτό."
 
 #: invenio/legacy/webbasket/api.py:112
 msgid "Please select a valid public basket from the list of public baskets."
 msgstr ""
-"Παρακαλώ επιλέγξτε ένα έγκυρο δημόσιο καλάθι από τη λίστα δημοσίων "
-"καλαθιών."
+"Παρακαλώ επιλέγξτε ένα έγκυρο δημόσιο καλάθι από τη λίστα δημοσίων καλαθιών."
 
 #: invenio/legacy/webbasket/api.py:135 invenio/legacy/webbasket/api.py:298
 #: invenio/legacy/webbasket/api.py:1001
@@ -6803,14 +6748,14 @@ msgstr "Επιστροφή στην προβολή του δημόσιου κα�
 #: invenio/legacy/webbasket/api.py:1548 invenio/legacy/webbasket/api.py:1613
 msgid "You do not have permission to write notes to this item."
 msgstr ""
-"Δεν έχετε τα απαιτούμενα δικαιώματα για την προσθήκη σημειώσεων σε αυτό "
-"το αντικείμενο."
+"Δεν έχετε τα απαιτούμενα δικαιώματα για την προσθήκη σημειώσεων σε αυτό το "
+"αντικείμενο."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
-"Η σημείωση στην οποία αναφέρεστε δεν υπάρχει ή δεν έχετε πρόσβαση σε "
-"αυτήν."
+"Η σημείωση στην οποία αναφέρεστε δεν υπάρχει ή δεν έχετε πρόσβαση σε αυτήν."
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
 msgid "You must fill in both the subject and the body of the note."
@@ -6833,13 +6778,15 @@ msgstr "Το συγκεκριμένο καλάθι δεν είναι πλέον 
 
 #: invenio/legacy/webbasket/api.py:1678
 msgid "You do not have permission to delete this note."
-msgstr "Δεν έχετε τα απαιτούμενα δικαιώματα για να διαγράψετε αυτή τη σημείωση."
+msgstr ""
+"Δεν έχετε τα απαιτούμενα δικαιώματα για να διαγράψετε αυτή τη σημείωση."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
-"Η σημείωση που προσπαθείτε να διαγράψετε δεν υπάρχει ή δεν έχετε πρόσβαση"
-" σε αυτήν."
+"Η σημείωση που προσπαθείτε να διαγράψετε δεν υπάρχει ή δεν έχετε πρόσβαση σε "
+"αυτήν."
 
 #: invenio/legacy/webbasket/api.py:1791
 #, fuzzy, python-format
@@ -6872,19 +6819,19 @@ msgstr "Η διεύθυνση URL που δώσατε δεν είναι έγκυ
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
-"Η διεύθυνση URL που δώσατε δεν είναι έγκυρη: Η σύνταξη της αίτησης δεν "
-"είναι σωστή ή η αίτηση δεν μπορεί να εκπληρωθεί."
+"Η διεύθυνση URL που δώσατε δεν είναι έγκυρη: Η σύνταξη της αίτησης δεν είναι "
+"σωστή ή η αίτηση δεν μπορεί να εκπληρωθεί."
 
 #: invenio/legacy/webbasket/api.py:1849
 msgid ""
 "The url you have provided is not valid: The server failed to fulfil an "
 "apparently valid request."
 msgstr ""
-"Η διεύθυνση URL που δώσατε δεν είναι έγκυρη: Ο διακομιστής δεν κατάφερε "
-"να εκπληρώσει μια φαινομενικά έγκυρη αίτηση."
+"Η διεύθυνση URL που δώσατε δεν είναι έγκυρη: Ο διακομιστής δεν κατάφερε να "
+"εκπληρώσει μια φαινομενικά έγκυρη αίτηση."
 
 #: invenio/legacy/webbasket/api.py:1898 invenio/legacy/webbasket/api.py:1910
 #: invenio/legacy/webbasket/api.py:2042 invenio/legacy/webbasket/api.py:2111
@@ -6897,15 +6844,15 @@ msgstr "Καμία εγγραφή για προσθήκη."
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
 msgid "Cannot add items to the selected basket. Invalid parameters."
 msgstr ""
-"Η προσθήκη αντικειμένων στο συγκεκριμένο καλάθι δεν είναι δυνατή. Μη "
-"έγκυρες παράμετροι."
+"Η προσθήκη αντικειμένων στο συγκεκριμένο καλάθι δεν είναι δυνατή. Μη έγκυρες "
+"παράμετροι."
 
 #: invenio/legacy/webbasket/api.py:1979
 #, fuzzy
@@ -6922,8 +6869,8 @@ msgid ""
 "A default topic and basket have been automatically created. Edit them to "
 "rename them as you see fit."
 msgstr ""
-"Ένα προεπιλεγμένο θέμα και καλάθι δημιουργήθηκαν αυτόματα. Επεξεργαστείτε"
-" τα για να τα μετονομάσετε όπως εσείς επιθυμείτε."
+"Ένα προεπιλεγμένο θέμα και καλάθι δημιουργήθηκαν αυτόματα. Επεξεργαστείτε τα "
+"για να τα μετονομάσετε όπως εσείς επιθυμείτε."
 
 #: invenio/legacy/webbasket/api.py:2262
 msgid "Please provide a name for the new basket."
@@ -6935,8 +6882,8 @@ msgstr "Παρακαλώ επιλέγξτε ένα υπάρχον θέμα ή δ
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 "Δεν μπορείτε να εγγραφείτε σε αυτό το καλάθι, είτε είστε ο ιδιοκτήτης ή "
 "έχετε ήδη εγγραφεί."
@@ -6946,8 +6893,8 @@ msgid ""
 "You cannot unsubscribe from this basket, you are the either owner or you "
 "have already unsubscribed."
 msgstr ""
-"Δεν μπορείτε να διαγραφείτε από αυτό το καλάθι, είτε είστε ο ιδιοκτήτης "
-"είτε έχετε ήδη διαγραφεί."
+"Δεν μπορείτε να διαγραφείτε από αυτό το καλάθι, είτε είστε ο ιδιοκτήτης είτε "
+"έχετε ήδη διαγραφεί."
 
 #: invenio/legacy/webbasket/api.py:2429 invenio/legacy/webbasket/api.py:2547
 #: invenio/legacy/webbasket/templates.py:120
@@ -7010,12 +6957,11 @@ msgstr "Δημόσια καλάθια"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 "Έχετε %(x_nb_perso)s προσωπικά καλάθια και είσαστε εγγεγραμμένος σε "
-"%(x_nb_group)s ομαδικά καλάθια και σε %(x_nb_public)s δημόσια καλάθια "
-"άλλων χρηστών."
+"%(x_nb_group)s ομαδικά καλάθια και σε %(x_nb_public)s δημόσια καλάθια άλλων "
+"χρηστών."
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
 msgid ""
@@ -7038,17 +6984,16 @@ msgid ""
 "You have no personal or group baskets or are subscribed to any public "
 "baskets."
 msgstr ""
-"Δεν έχετε κάποιο προσωπικό ή ομαδικό καλάθι, ή δεν έχετε εγγραφεί σε "
-"κάποιο δημόσιο καλάθι."
+"Δεν έχετε κάποιο προσωπικό ή ομαδικό καλάθι, ή δεν έχετε εγγραφεί σε κάποιο "
+"δημόσιο καλάθι."
 
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
-"Μπορείτε να ξεκινήσετε %(x_url_open)sδημιουργώντας ένα νέο "
-"καλάθι%(x_url_close)s."
+"Μπορείτε να ξεκινήσετε %(x_url_open)sδημιουργώντας ένα νέο καλάθι"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
 #: invenio/legacy/webbasket/templates.py:198
@@ -7209,8 +7154,8 @@ msgstr "Εξωτερικό αντικείμενο"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 "Δώστε μια διεύθυνση URL για το εξωτερικό αντικείμενο που θέλετε να "
 "προσθέσετε και συμπληρώστε έναν τίτλο και μια περιγραφή"
@@ -7251,8 +7196,8 @@ msgid ""
 "Please choose a basket: %(x_basket_selection_box)s %(x_fmt_open)s(or "
 "%(x_url_open)screate a new one%(x_url_close)s first)%(x_fmt_close)s"
 msgstr ""
-"Παρακαλώ επιλέξτε ένα καλάθι: %(x_basket_selection_box)s %(x_fmt_open)s(ή"
-" %(x_url_open)sδημιουργήστε ένα νέο%(x_url_close)s πρώτα)%(x_fmt_close)s"
+"Παρακαλώ επιλέξτε ένα καλάθι: %(x_basket_selection_box)s %(x_fmt_open)s(ή "
+"%(x_url_open)sδημιουργήστε ένα νέο%(x_url_close)s πρώτα)%(x_fmt_close)s"
 
 #: invenio/legacy/webbasket/templates.py:1764
 msgid "Optionally, add a note to each one of these items"
@@ -7394,8 +7339,8 @@ msgstr "Διαμοιρασμός του καλαθιού σε νέα ομάδα"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 "Έχετε συνδεθεί σαν επισκέπτης, οπότε τα καλάθια σας θα εξαφανιστούν στο "
 "τέλος της τρέχουσας συνεδρίας. "
@@ -7404,10 +7349,11 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
-"Αν επιθυμείτε, μπορείτε να κάνετε %(x_url_open)slogin η να εγγραφείτε "
-"εδώ%(x_url_close)s."
+"Αν επιθυμείτε, μπορείτε να κάνετε %(x_url_open)slogin η να εγγραφείτε εδώ"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7416,7 +7362,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Η λειτουργία αυτή δεν επιτρέπεται στους επισκέπτες."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Επιστροφή στα αποτελέσματα αναζήτησης"
 
@@ -7476,8 +7422,8 @@ msgstr "Η συλλογή αυτή δεν περιέχει κάποιο έγγρ
 #: invenio/legacy/webbasket/templates.py:2519
 msgid "You do not have sufficient rights to view this basket's content."
 msgstr ""
-"Δεν έχετε τα απαιτούμενα δικαιώματα για να δείτε τα περιεχόμενα αυτού του"
-" καλαθιού."
+"Δεν έχετε τα απαιτούμενα δικαιώματα για να δείτε τα περιεχόμενα αυτού του "
+"καλαθιού."
 
 #: invenio/legacy/webbasket/templates.py:2562
 msgid "Move item up"
@@ -7560,8 +7506,8 @@ msgstr "Το αντικείμενο που επιλέξατε δεν υπάρχ�
 #: invenio/legacy/webbasket/templates.py:3847
 msgid "You do not have sufficient rights to view this item's notes."
 msgstr ""
-"Δεν έχετε τα απαιτούμενα δικαιώματα για να δείτε τις σημειώσεις αυτού του"
-" αντικειμένου."
+"Δεν έχετε τα απαιτούμενα δικαιώματα για να δείτε τις σημειώσεις αυτού του "
+"αντικειμένου."
 
 #: invenio/legacy/webbasket/templates.py:3066
 msgid "You do not have sufficient rights to view this item."
@@ -7583,7 +7529,7 @@ msgstr "Προσθήκη σημείωσης"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7719,213 +7665,212 @@ msgstr "Η ταυτότητα σχολίου %s δεν υπάρχει."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "Η ταυτότητα εγγραφής %s δεν υπάρχει."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Γράψτε ένα σχόλιο"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i σχόλια για στάδιο \"%(x_name)s\""
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "%i σχόλια"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Εμφάνιση των τελευταίων %i σχολίων:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Συζήτηση για στο έγγραφο"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Ξεκινήστε μια συζήτηση σχετικά με το έγγραφο αυτό."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Λυπούμαστε, η εγγραφή %s δεν υπάρχει."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "Λυπούμαστε, το %s δεν είναι έγκυρη τιμή ταυτότητας."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "Λυπούμαστε, δεν δόθηκε καμία ταυτότητα εγγραφής."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Πιθανόν να θέλετε να φυλλομετρήσετε από %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i σχόλια για στάδιο \"%(x_name)s\""
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Σας φάνηκε χρήσιμη η κριτική;"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Γράψτε μια κριτική"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 "Μέση βαθμολογία κριτικών: %(x_nb_score)s βασισμένη σε %(x_nb_reviews)s "
 "κριτικές"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "Οι αναγνώστε βρήκαν τις παρακάτω %s κριτικές αρκετά χρήσιμες."
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Δείτε και τις %s κριτικές"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Βαθμολογήστε το έγγραφο αυτό"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Γίνετε ο πρώτος που θα γράψει κριτική για το έγγραφο αυτό."
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "κλείσιμο"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Αναφορά προσβλητικού περιεχομένου"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr "Επαναφορά σχολίου"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Διαγραφή σχολίου"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr "Χαρακτηρισμός σχολίου ως μη ενοχλητικό"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr "Συνημμένο αρχείο"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr "Συνημμένα αρχεία"
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Κρίθηκε από τον %(x_nickname)s στις %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
-"%(x_nb_people)s από %(x_nb_total)s ανθρώπους βρήκαν την κριτική αυτή "
-"χρήσιμη"
+"%(x_nb_people)s από %(x_nb_total)s ανθρώπους βρήκαν την κριτική αυτή χρήσιμη"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr "Επαναφορά κριτικής"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr "Διαγραφή κριτικής"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr "Σήμανση κριτικής ως μη κακόβουλη"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Σχόλια"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Κριτικές"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Υπάρχουν συνολικά %s κριτικές"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Υπάρχουν συνολικά %s σχόλια"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Γίνετε ο πρώτος που θα γράψει κριτική για το έγγραφο αυτό."
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Εγγραφή"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr "Διαγραφή συνδρομής"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7934,521 +7879,522 @@ msgstr "Διαγραφή συνδρομής"
 msgid "Record"
 msgstr "Εγγραφή"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "κριτική"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "σχόλιο"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Κριτική"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Βλέπετε την "
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Σελίδα: "
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr "Δεν έχετε δικαίωμα να σχολιάσετε ή να κάνετε κριτική."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 "Σημείωση: Το ψευδώνυμό σας, %s, θα εμφανίζεται ως συγγραφέας του σχολίου "
 "αυτού."
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
-"Σημείωση: δεν έχετε %(x_url_open)sορίσει το ψευδώνυμό σας%(x_url_close)s."
-" Ο %(x_nickname)s θα εμφανίζεται σαν συντάκτης του σχολίου αυτού."
+"Σημείωση: δεν έχετε %(x_url_open)sορίσει το ψευδώνυμό σας%(x_url_close)s. Ο "
+"%(x_nickname)s θα εμφανίζεται σαν συντάκτης του σχολίου αυτού."
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
-"Αφού συνδεθούν, οι εξουσιοδοτημένοι χρήστες μπορούν επίσης να επισυνάψουν"
-" αρχεία."
+"Αφού συνδεθούν, οι εξουσιοδοτημένοι χρήστες μπορούν επίσης να επισυνάψουν "
+"αρχεία."
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr "Προαιρετικά, μπορείτε να επισυνάψετε ένα αρχείο σε αυτό το σχόλιο"
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr "Προαιρετικά, μπορείτε να επισυνάψετε αρχεία σε αυτό το σχόλιο"
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr "Όριο ένα αρχείο"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "Όριο %i αρχεία"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr "Όριο %(x_nb_bytes)s ανά αρχείο"
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr "Να μου αποσταλεί email όταν το σχόλιό μου δημοσιευτεί"
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Άρθρο"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "Προσθήκη σχολίου"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr "Σημείωση: Ο %s, θα εμφανίζεται σαν συγγραφέας της κριτικής αυτής."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Βαθμολογήστε αυτό το άρθρο"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Επιλέξτε μια βαθμολογία"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Δώστε έναν τίτλο στην κριτική σας"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Γράψτε μια κριτική"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr "Προσθήκη Κριτικής"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Προσθήκη Κριτικής"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Η κριτική σας προστέθηκε επιτυχώς."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Το σχόλιό σας προστέθηκε επιτυχώς."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Επιστροφή στην εγγραφή"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr ""
-"Μπορείτε να συμβουλευτείτε την λίστα των "
-"%(x_url_open)stickets%(x_url_close)s σας."
+"Μπορείτε να συμβουλευτείτε την λίστα των %(x_url_open)stickets"
+"%(x_url_close)s σας."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr "Προβολή των εγγραφών με τα περισσότερα σχόλια"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr "Προβολή των εγγραφών με τα πιο πρόσφατα σχόλια"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr "Προβολή των σχολίων που έχουν αναφερθεί ως κακόβουλα"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr "Προβολή των εγγραφών με τις περισσότερες κριτικές"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr "Προβολή των εγγραφών με τις πιο πρόσφατες κριτικές"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr "Προβολή των κριτικών που έχουν αναφερθεί ως κακόβουλες"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Προβολή όλων των χρηστών που έχουν αναφερθεί"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Οδηγός"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Τα σχόλια και οι κριτικές έχουν απενεργοποιηθεί"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"Παρακαλώ εισάγετε το ID του σχολίου/κριτικής ώστε να μπορέσετε να το "
-"δείτε πριν αποφασίσετε εάν θα το σβήσετε"
+"Παρακαλώ εισάγετε το ID του σχολίου/κριτικής ώστε να μπορέσετε να το δείτε "
+"πριν αποφασίσετε εάν θα το σβήσετε"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "ID σχολίου:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
-"Εναλλακτικά, εισάγετε την ταυτότητα εγγραφής για να εμφανίσετε τα σχετικά"
-" σχόλια/κριτικές:"
+"Εναλλακτικά, εισάγετε την ταυτότητα εγγραφής για να εμφανίσετε τα σχετικά "
+"σχόλια/κριτικές:"
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr "ID εγγραφής:"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Επισκόπηση Σχολίου"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Δεν υπάρχουν ύποπτες αναφορές μέχρι στιγμής."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Προβολή των %s ύποπτων σχολίων που υπάρχουν"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Προβολή των %s ύποπτων κριτικών που υπάρχουν"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
 "Ακολουθεί μια λίστα από όλους τους χρήστες, των οποίων τα σχόλια τους "
 "αναφέρθηκαν ως ύποπτα, ταξινομημένη με τον συνολικό αριθμό αναφορών."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Ψευδώνυμο"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "ID Χρήστη"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Αριθμός θετικών ψήφων"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Αριθμός αρνητικών ψήφων"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Συνολικός αριθμός ψήφων"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Συνολικός αριθμός αναφορών"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Επισκόπηση των ύποπτων σχολίων/κριτικών όλων των χρηστών"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Αυτη η κριτική έχει αναφερθεί ως ύποπτη %i φορές"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Αυτό το σχόλιο έχει αναφερθεί ως ύποπτο %i φορές"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Συντάχθηκε από"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Γενικές πληροφορίες"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Διαγραφή επιλεγμένων κριτικών"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Αποσιώπηση επιλεγμένων αναφορών για πιθανή προσβλητική χρήση"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr "Επαναφέρετε τις επιλεγμένες κριτικές"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr "Επαναφέρετε τα επιλεγμένα σχόλια"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Διαγραφή επιλεγμένων σχολίων"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Ορίστε οι ύποπτες κριτικές του χρήστη %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Ορίστε τα ύποπτα σχόλια του χρήστη %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Η κριτική %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Το σχόλιο %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Η κριτική %(x_cmtID)s γραμμένο από τον χρήστη %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Το σχόλιο %(x_cmtID)s γραμμένο από τον χρήστη %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "Ορίστε όλες οι ύποπτες κριτικές, ταξινομημένες κατά αριθμό αναφορών"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "Ορίστε όλα τα ύποπτα σχόλια, ταξινομημένα κατά αριθμό αναφορών"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
-"Εδώ φαίνονται όλες οι κριτικές για την εγγραφή %i, ταξινομημένες κατά "
-"αριθμό αναφορών"
+"Εδώ φαίνονται όλες οι κριτικές για την εγγραφή %i, ταξινομημένες κατά αριθμό "
+"αναφορών"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr "Εμφάνιση σχολίων"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr "Όλα τα σχόλια για την εγγραφή %i, ταξινομημένα κατά αριθμό αναφορών"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr "Εμφάνιση κριτικών"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "ID σχολίου"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "διαγράφηκε επιτυχώς"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr "επανήλθε επιτυχώς"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "η αναφορά για πιθανά προσβλητικό περιεχόμενο αποσιωπήθηκε επιτυχώς"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Χωρίς κριτική ακόμα"
 
-#: invenio/legacy/webcomment/templates.py:2257
+#: invenio/legacy/webcomment/templates.py:2256
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 "Η παρακάτω κριτική απεστάλη στην %(CFG_SITE_NAME)s από τον/την "
 "%(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2258
+#: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 "Το παρακάτω σχόλιο απεστάλη στην %(CFG_SITE_NAME)s από τον/την "
 "%(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr "Αυτό είναι ένα αυτοματοποιημένο μήνυμα, παρακαλώ μην απαντήσετε."
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr "Για αποστολή νέου σχολίου, επισκευτείτε το <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr "Για απάντηση στο συγκεκριμένο σχόλιο, επισκευτείτε το <%(x_url)s"
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
-"Για να διαγραφείτε από την συγκεκριμένη συζήτηση, επισκευτείτε το "
-"<%(x_url)s"
+"Για να διαγραφείτε από την συγκεκριμένη συζήτηση, επισκευτείτε το <%(x_url)s"
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
-"Για οποιαδήποτε ερώτηση, παρακαλώ επικοινωνήστε με "
-"<%(CFG_SITE_SUPPORT_EMAIL)s>"
+"Για οποιαδήποτε ερώτηση, παρακαλώ επικοινωνήστε με <"
+"%(CFG_SITE_SUPPORT_EMAIL)s>"
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 msgid "Your comment will be lost."
 msgstr "Το σχόλιό σας θα χαθεί."
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Διαγραφή σχολίων"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "Το τελευταίο, πρώτο"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "Προβολή των εγγραφών με τα πιο πρόσφατα σχόλια"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "Λεπτομέρειες και σχόλια"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "βρέθηκαν εγγραφές"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Σχόλια"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "%i αντικείμενα"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Προσθήκη αντικειμένων"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "Προβολή"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Ημ/νία παραγγελίας"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Επόμενη σελίδα"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Παρουσίαση ειδοποιήσεων"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8456,52 +8402,53 @@ msgstr "Παρουσίαση ειδοποιήσεων"
 msgid "Refresh"
 msgstr "Ανανέωση"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Χαρακτηρισμός σχολίου ως μη ενοχλητικό"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "%i αντικείμενα βρέθηκαν"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Η εγγραφή δεν βρέθηκε"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
-msgstr "Δεν έχετε τα απαιτούμενα δικαιώματα για να διαγράψετε αυτή τη σημείωση."
+msgstr ""
+"Δεν έχετε τα απαιτούμενα δικαιώματα για να διαγράψετε αυτή τη σημείωση."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, fuzzy, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
@@ -8510,51 +8457,51 @@ msgstr ""
 "Το μέγεθος του αρχείου \\\"%s\\\" (%s) είναι μεγαλύτερο από το μέγιστο "
 "επιτρεπόμενο όριο (%s). Επιλέξτε αρχεία ξανά."
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Προσθήκη σχολίου"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "Προβολή όλων των πιθανά προσβλητικών σχολίων"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr "Η σελίδα δε βρέθηκε"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr "Το συγκεκριμένο σχόλιο δεν υπάρχει"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr "Το αρχείο που ζητήσατε δεν υπάρχει"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Δεν έχετε δικαίωμα να χρησιμοποιήσετε τον δανεισμό."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Σχόλια"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "Προβολή όλων των πιθανά προσβλητικών σχολίων"
@@ -8669,11 +8616,11 @@ msgstr "Λυπούμαστε, η σελίδα %s δεν υπάρχει."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
-"Μπορείτε να κοιτάξετε στις %(x_url_open)s%(x_category)s "
-"σελίδες%(x_url_close)s"
+"Μπορείτε να κοιτάξετε στις %(x_url_open)s%(x_category)s σελίδες"
+"%(x_url_close)s"
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
 #, fuzzy, python-format
@@ -8736,11 +8683,11 @@ msgstr "Δεν μπορέσαμε να σας παρέχουμε κάποιο π
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
-"Φαίνεται οτι δεν έχουν οριστεί διαθέσιμα περιοδικά στον server. Αν "
-"νομίζετε οτι υπάρχει πρόβλημα, επικοινωνήστε με τον διαχειριστή."
+"Φαίνεται οτι δεν έχουν οριστεί διαθέσιμα περιοδικά στον server. Αν νομίζετε "
+"οτι υπάρχει πρόβλημα, επικοινωνήστε με τον διαχειριστή."
 
 #: invenio/legacy/webjournal/config.py:239
 msgid "Select a journal on this server"
@@ -8768,12 +8715,11 @@ msgstr "Δεν μπορέσαμ ενα βρούμε πληροφορίες γι�
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
-"Η παραμετροποίηση για το τρέχον τεύχος  φαίνεται να είναι κενή. "
-"Προσπαθήστε να δώσετε έναν αριθμό τεύχους ή επικοινωνήστε με την "
-"υποστήριξη."
+"Η παραμετροποίηση για το τρέχον τεύχος  φαίνεται να είναι κενή. Προσπαθήστε "
+"να δώσετε έναν αριθμό τεύχους ή επικοινωνήστε με την υποστήριξη."
 
 #: invenio/legacy/webjournal/config.py:298
 msgid "Issue number badly formed"
@@ -8837,8 +8783,8 @@ msgstr "Η κατηγορία %(category_name)s δεν υπάρχει"
 #: invenio/legacy/webjournal/config.py:531
 msgid "Sorry, this category does not exist for this journal and issue."
 msgstr ""
-"Λυπούμαστε, η κατηγορία αυτή δεν υπάρχει για το συγκεκριμένο περιοδικό "
-"και τεύχος"
+"Λυπούμαστε, η κατηγορία αυτή δεν υπάρχει για το συγκεκριμένο περιοδικό και "
+"τεύχος"
 
 #: invenio/legacy/webjournal/templates.py:53
 msgid "Available Journals"
@@ -8859,8 +8805,8 @@ msgid ""
 "The issue could not be correctly regenerated. Please contact your "
 "administrator."
 msgstr ""
-"Το συμβάν δεν μπόρεσε να επαναδημιουργηθεί. Παρακαλώ επικοινωνήστε με τον"
-" διαχειριστή."
+"Το συμβάν δεν μπόρεσε να επαναδημιουργηθεί. Παρακαλώ επικοινωνήστε με τον "
+"διαχειριστή."
 
 #: invenio/legacy/webjournal/templates.py:308
 #, python-format
@@ -8872,11 +8818,6 @@ msgstr ""
 #: invenio/legacy/webjournal/templates.py:699
 msgid "Apply"
 msgstr "Εφαρμογή"
-
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "Ψευδώνυμο"
 
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 msgid "WebJournal Admin"
@@ -8957,9 +8898,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8981,8 +8921,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9082,7 +9021,8 @@ msgstr "Το γραμματοκιβώτιο σας έχει αδειάσει."
 #: invenio/legacy/webmessage/api.py:373
 #, python-format
 msgid "The chosen date (%(x_year)i/%(x_month)i/%(x_day)i) is invalid."
-msgstr "Η επιλεγμένη ημ/νία (%(x_year)i/%(x_month)i/%(x_day)i) είναι λανθασμένη."
+msgstr ""
+"Η επιλεγμένη ημ/νία (%(x_year)i/%(x_month)i/%(x_day)i) είναι λανθασμένη."
 
 #: invenio/legacy/webmessage/api.py:382
 msgid "Please enter a user name or a group name."
@@ -9120,8 +9060,8 @@ msgid ""
 "Your message could not be sent to the following recipients as it would "
 "exceed their quotas:"
 msgstr ""
-"Το μήνυμά σας δεν μπόρεσε να αποσταλεί στους παρακάτω παραλήπτες  "
-"εξαιτίας του ορίου τους:"
+"Το μήνυμά σας δεν μπόρεσε να αποσταλεί στους παρακάτω παραλήπτες  εξαιτίας "
+"του ορίου τους:"
 
 #: invenio/legacy/webmessage/api.py:457
 msgid "Your message has been sent."
@@ -9236,8 +9176,7 @@ msgstr "Είστε σίγουρος οτι θέλετε να αδειάσετε 
 #, python-format
 msgid "Quota used: %(x_nb_used)i messages out of max. %(x_nb_total)i"
 msgstr ""
-"Χώρος που χρησιμοποιήθηκε: %(x_nb_used)i μηνύματα από μέγιστο "
-"%(x_nb_total)i"
+"Χώρος που χρησιμοποιήθηκε: %(x_nb_used)i μηνύματα από μέγιστο %(x_nb_total)i"
 
 #: invenio/legacy/webmessage/templates.py:599
 msgid "Please select one or more:"
@@ -9463,19 +9402,19 @@ msgstr "Αναζήτηση Επίσης σε:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
-"Η συλλογή αυτή είναι περιορισμένη. Αν πιστεύετε οτι έχετε δικαίωμα "
-"πρόσβασης σ'αυτή, παρακαλώ χρησιμοποιήστε το κουμπί Αναζήτηση."
+"Η συλλογή αυτή είναι περιορισμένη. Αν πιστεύετε οτι έχετε δικαίωμα πρόσβασης "
+"σ'αυτή, παρακαλώ χρησιμοποιήστε το κουμπί Αναζήτηση."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
-"Αυτή είναι μια εξωτερική συλλογή. Παρακαλώ επιλέξτε Αναζήτηση για να "
-"δείτε το περιεχόμενό της."
+"Αυτή είναι μια εξωτερική συλλογή. Παρακαλώ επιλέξτε Αναζήτηση για να δείτε "
+"το περιεχόμενό της."
 
 #: invenio/legacy/websearch/templates.py:1619
 msgid "This collection does not contain any document yet."
@@ -9490,8 +9429,8 @@ msgstr "Παραπέμπεται από: %i εγγραφές"
 #, python-format
 msgid "Words nearest to %(x_word)s inside %(x_field)s in any collection are:"
 msgstr ""
-"Οι πλησιέστερες λέξεις στο %(x_word)s στο πεδίο %(x_field)s, σε "
-"οποιαδήποτε συλλογή είναι:"
+"Οι πλησιέστερες λέξεις στο %(x_word)s στο πεδίο %(x_field)s, σε οποιαδήποτε "
+"συλλογή είναι:"
 
 #: invenio/legacy/websearch/templates.py:1859
 #, python-format
@@ -9571,8 +9510,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found %(x_nb_records)s "
 "records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sΑποτελέσμα έρευνας:%(x_fmt_close)s Βρέθηκαν "
-"%(x_nb_records)s εγγραφές σε %(x_nb_seconds)s δευτερόλεπτα."
+"%(x_fmt_open)sΑποτελέσμα έρευνας:%(x_fmt_close)s Βρέθηκαν %(x_nb_records)s "
+"εγγραφές σε %(x_nb_seconds)s δευτερόλεπτα."
 
 #: invenio/legacy/websearch/templates.py:3132
 #, python-format
@@ -9585,8 +9524,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found at least "
 "%(x_nb_records)s records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sΠερίληψη αποτελεσμάτων:%(x_fmt_close)s Βρέθηκαν τουλάχιστον"
-" %(x_nb_records)s εγγραφές σε %(x_nb_seconds)s δευτερόλεπτα."
+"%(x_fmt_open)sΠερίληψη αποτελεσμάτων:%(x_fmt_close)s Βρέθηκαν τουλάχιστον "
+"%(x_nb_records)s εγγραφές σε %(x_nb_seconds)s δευτερόλεπτα."
 
 #: invenio/legacy/websearch/templates.py:3184
 #, fuzzy
@@ -9613,8 +9552,7 @@ msgstr "Περισσότερες λεπτομέρειες"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 "Το ερώτημα δεν επέστρεψε αποτελέσματα. Παρακαλούμε δοκιμάστε διαφορετικό "
 "συνδιασμό των όρων."
@@ -9642,12 +9580,12 @@ msgstr "Πιθανόν να θέλετε να ξεκινήσετε την φυλ
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "Δημιουργήστε ένα προσωπικό %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  ή εγγραφείτε στο %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  ή εγγραφείτε στο %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 
 #: invenio/legacy/websearch/templates.py:3832
 #, python-format
@@ -9657,8 +9595,7 @@ msgstr "Εγγραφείτε στην %(x_url2_open)sροή RSS%(x_url2_close)s.
 #: invenio/legacy/websearch/templates.py:3841
 msgid "Interested in being notified about new results for this query?"
 msgstr ""
-"Ενδιαφέρεστε να ενημερώνεστε για νέα αποτελέσματα σχετικά με το ερώτημα "
-"αυτό;"
+"Ενδιαφέρεστε να ενημερώνεστε για νέα αποτελέσματα σχετικά με το ερώτημα αυτό;"
 
 #: invenio/legacy/websearch/templates.py:3907
 #: invenio/legacy/websearch/templates.py:3932
@@ -9837,7 +9774,8 @@ msgid "in"
 msgstr "σε"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr ""
 "Δεν βρήκατε αυτό που αναζητούσατε; Δοκιμάστε την έρευνά σας σε άλλους "
 "servers:"
@@ -9855,8 +9793,8 @@ msgid ""
 "The external search engine has not responded in time. You can check its "
 "results here:"
 msgstr ""
-"Η εξωτερική μηχανή αναζήτησης δεν απάντησε εγκαίρως. Μπορείτε να ελέγξετε"
-" τα αποτελέσματα εδώ:"
+"Η εξωτερική μηχανή αναζήτησης δεν απάντησε εγκαίρως. Μπορείτε να ελέγξετε τα "
+"αποτελέσματα εδώ:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:146
 #: invenio/legacy/websearch_external_collections/templates.py:154
@@ -9935,8 +9873,8 @@ msgstr "υποχρεωτικό"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9946,8 +9884,8 @@ msgstr "Δημιουργία νέου καλαθιού"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 "Εαν θέλετε να αλλάξετε την διεύθυνση του email σας ή το ψευδώνυμό σας, "
 "παρακαλώ συμπληρώστε τα νέα στοιχεία στην παρακάτω φόρμα."
@@ -9966,19 +9904,19 @@ msgstr "Καθοριμός νέων τιμών"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
-"Αφ΄οτου οριστεί, δεν μπορεί να αλλαχτεί, μια και θεωρείται σαν υπογραφή "
-"για τα σχόλια και τις κριτικές."
+"Αφ΄οτου οριστεί, δεν μπορεί να αλλαχτεί, μια και θεωρείται σαν υπογραφή για "
+"τα σχόλια και τις κριτικές."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
-"Εαν θέλετε να αλλάξετε τον κωδικό σας, παρακαλώ εισάγετε τον παλιό και "
-"τον καινούριο, στην παρακάτω φόρμα."
+"Εαν θέλετε να αλλάξετε τον κωδικό σας, παρακαλώ εισάγετε τον παλιό και τον "
+"καινούριο, στην παρακάτω φόρμα."
 
 #: invenio/legacy/websession/templates.py:327
 msgid "Old password"
@@ -10017,8 +9955,8 @@ msgstr "Εισαγωγή νέου κωδικού"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 "Αν χρησιμοποιείτε ένα απλό λογαριασμό μπορείτε να κάνετε\n"
 "               %(x_url_open)sεπαναφορά του κωδικού%(x_url_close)s."
@@ -10101,8 +10039,7 @@ msgid ""
 "Please select which login method you would like to use to authenticate "
 "yourself"
 msgstr ""
-"Παρακαλώ επιλέξτε ποιόν τρόπο αυθεντικοποίησης επιθυμείτε να "
-"χρησιμοποιήσετε"
+"Παρακαλώ επιλέξτε ποιόν τρόπο αυθεντικοποίησης επιθυμείτε να χρησιμοποιήσετε"
 
 #: invenio/legacy/websession/templates.py:503
 #: invenio/legacy/websession/templates.py:518
@@ -10112,15 +10049,14 @@ msgstr "Επιλογή μεθόδου"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"Εάν έχετε χάσει τον κωδικό σας για τον "
-"%(x_fmt_open)sλογαριασμό%(x_fmt_close)s του %(sitename)s %(x_fmt_open)s, "
-"τοτε παρακαλώ εισάγετε στην παρακάτω φόρμα την διεύθυνση του email σας "
-"και θα σας αποσταλεί ένας σύνδεσμος για να τον επαναφέρετε."
+"Εάν έχετε χάσει τον κωδικό σας για τον %(x_fmt_open)sλογαριασμό"
+"%(x_fmt_close)s του %(sitename)s %(x_fmt_open)s, τοτε παρακαλώ εισάγετε στην "
+"παρακάτω φόρμα την διεύθυνση του email σας και θα σας αποσταλεί ένας "
+"σύνδεσμος για να τον επαναφέρετε."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10136,21 +10072,21 @@ msgstr "Αποστολή συνδέσμου επαναφοράς κωδικού"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
-"Εάν χρησιμοποιούσατε το %(x_fmt_open)sσύστημα login του "
-"CERN%(x_fmt_close)s, τότε μπορείτε να επαναφέρετε τον κωδικό σας μέσω του"
-" %(x_url_open)sσυστήματος αυθεντικοποίησης του CERN%(x_url_close)s."
+"Εάν χρησιμοποιούσατε το %(x_fmt_open)sσύστημα login του CERN%(x_fmt_close)s, "
+"τότε μπορείτε να επαναφέρετε τον κωδικό σας μέσω του "
+"%(x_url_open)sσυστήματος αυθεντικοποίησης του CERN%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
-"Σημειώστε οτι αν χρησιμοποιείτε κάποιο εξωτερικό σύστημα για login τότε "
-"θα πρέπει να επικοινωνήσετε με τον διαχειριστή εκείνης της υπηρεσίας."
+"Σημειώστε οτι αν χρησιμοποιείτε κάποιο εξωτερικό σύστημα για login τότε θα "
+"πρέπει να επικοινωνήσετε με τον διαχειριστή εκείνης της υπηρεσίας."
 
 #: invenio/legacy/websession/templates.py:573
 #, fuzzy, python-format
@@ -10158,21 +10094,21 @@ msgid ""
 "Alternatively, you can ask %(x_name)s to change your login system from "
 "external to internal."
 msgstr ""
-"Εναλλακτικά, θα μπορούσατε να αιτηθείτε στο %s αλλαγή του τρόπου login "
-"από το εξωτερικό σύστημα, σε εσωτερικό."
+"Εναλλακτικά, θα μπορούσατε να αιτηθείτε στο %s αλλαγή του τρόπου login από "
+"το εξωτερικό σύστημα, σε εσωτερικό."
 
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 "Το %s σας προσφέρει την δυνατότητα να εξατομικεύσετε το interface, να "
-"ορίσετε την δική σας προσωπική βιβλιοθήκη εγγράφων, ή να θέσετε μια "
-"αυτόματη έρευνα που θα εκτελείται περιοδικά και θα σας ενημερώνει με "
-"email για οποιεσδήποτε αλλαγές στα αποτελέσματα αναζήτησης."
+"ορίσετε την δική σας προσωπική βιβλιοθήκη εγγράφων, ή να θέσετε μια αυτόματη "
+"έρευνα που θα εκτελείται περιοδικά και θα σας ενημερώνει με email για "
+"οποιεσδήποτε αλλαγές στα αποτελέσματα αναζήτησης."
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10184,8 +10120,8 @@ msgid ""
 "Set or change your account email address or password. Specify your "
 "preferences about the look and feel of the interface."
 msgstr ""
-"Ορίστε η αλλάξτε τον το email σας ή τον κωδικό σας. Ορίστε τις "
-"προτιμήσεις σας σχετικά με την μορφή εμφάνισης του interface."
+"Ορίστε η αλλάξτε τον το email σας ή τον κωδικό σας. Ορίστε τις προτιμήσεις "
+"σας σχετικά με την μορφή εμφάνισης του interface."
 
 #: invenio/legacy/websession/templates.py:620
 msgid "View all the searches you performed during the last 30 days."
@@ -10193,12 +10129,12 @@ msgstr "Δείτε όλες τις έρευνες που εκτελέσατε τ
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
-"Με τα καλάθια μπορείτε να ορίζεσε συγκεκριμένες συλλογές αντικειμένων και"
-" να αποθηκεύετε χρήσιμες εγγραφές για να τις προσπελάσετε αργότερα ή να "
-"τις μοιραστείτε με άλλους."
+"Με τα καλάθια μπορείτε να ορίζεσε συγκεκριμένες συλλογές αντικειμένων και να "
+"αποθηκεύετε χρήσιμες εγγραφές για να τις προσπελάσετε αργότερα ή να τις "
+"μοιραστείτε με άλλους."
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10209,36 +10145,36 @@ msgid ""
 "Subscribe to a search which will be run periodically by our service. The "
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
-"Εγγραφείτε σε μια έρευνα, η οποία θα εκτελείται περιοδικά από την "
-"υπηρεσία μας. Τα αποτελέσματα μπορούν να σας αποστέλλονται μέσω email ή "
-"να αποθηκεύοναι σε ένα από τα καλάθια σας."
+"Εγγραφείτε σε μια έρευνα, η οποία θα εκτελείται περιοδικά από την υπηρεσία "
+"μας. Τα αποτελέσματα μπορούν να σας αποστέλλονται μέσω email ή να "
+"αποθηκεύοναι σε ένα από τα καλάθια σας."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
 "Για να ελέγξετε το βιβλίο που έχετε δανεισμένο, να υποβάλετε αιτήματα "
 "δανεισμού, κτλ. πρέπει να έχετε CERN ID."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
-"Έχετε συνδεθεί σαν χρήστης guest, οπότε τα καλάθια σας θα εξαφανιστούν "
-"στο τέλος της τρέχουσας συνεδρίας."
+"Έχετε συνδεθεί σαν χρήστης guest, οπότε τα καλάθια σας θα εξαφανιστούν στο "
+"τέλος της τρέχουσας συνεδρίας."
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 "Έχετε συνθεθεί ως %(x_user)s. Ίσως να θέλετε α) %(x_url1_open)sνα κάνετε "
-"logout%(x_url1_close)s; β) να τροποποιήσετε τις %(x_url2_open)sρυθμίσεις "
-"του λογαριασμού%(x_url2_close)s σας."
+"logout%(x_url1_close)s; β) να τροποποιήσετε τις %(x_url2_open)sρυθμίσεις του "
+"λογαριασμού%(x_url2_close)s σας."
 
 #: invenio/legacy/websession/templates.py:785
 #, fuzzy, python-format
@@ -10246,8 +10182,8 @@ msgid ""
 "You can consult the list of %(x_url_open)syour comments%(x_url_close)s "
 "submitted so far."
 msgstr ""
-"Μπορείτε να συμβουλευτείτε την λίστα των "
-"%(x_url_open)stickets%(x_url_close)s σας."
+"Μπορείτε να συμβουλευτείτε την λίστα των %(x_url_open)stickets"
+"%(x_url_close)s σας."
 
 #: invenio/legacy/websession/templates.py:790
 msgid "Your Alert Searches"
@@ -10256,12 +10192,11 @@ msgstr "Οι αναζητήσεις ειδοποιήσεων μου."
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
-"Μπορείτε να συμβουλευτείτε την λίστα των "
-"%(x_url_open)sομάδων%(x_url_close)s που διαχειρίζεστε ή των οποίων είστε "
-"μέλος."
+"Μπορείτε να συμβουλευτείτε την λίστα των %(x_url_open)sομάδων%(x_url_close)s "
+"που διαχειρίζεστε ή των οποίων είστε μέλος."
 
 #: invenio/legacy/websession/templates.py:799
 #: invenio/legacy/websession/templates.py:2348
@@ -10272,12 +10207,11 @@ msgstr "Οι ομάδες μου"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"Μπορείτε να συμβουλευτείτε την λίστα των "
-"%(x_url_open)sυποβολών%(x_url_close)s σας και να δείτε την κατάστασή "
-"τους."
+"Μπορείτε να συμβουλευτείτε την λίστα των %(x_url_open)sυποβολών"
+"%(x_url_close)s σας και να δείτε την κατάστασή τους."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -10287,12 +10221,11 @@ msgstr "Οι υποβολές μου"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"Μπορείτε να συμβουλευτείτε την λίστα των "
-"%(x_url_open)sεγκρίσεών%(x_url_close)s σας, με τα έγγραφα που εσείς έχετε"
-" εγκρίνει ή αξιολογήσει."
+"Μπορείτε να συμβουλευτείτε την λίστα των %(x_url_open)sεγκρίσεών"
+"%(x_url_close)s σας, με τα έγγραφα που εσείς έχετε εγκρίνει ή αξιολογήσει."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10303,8 +10236,8 @@ msgstr "Οι εγκρίσεις μου"
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour tickets%(x_url_close)s."
 msgstr ""
-"Μπορείτε να συμβουλευτείτε την λίστα των "
-"%(x_url_open)stickets%(x_url_close)s σας."
+"Μπορείτε να συμβουλευτείτε την λίστα των %(x_url_open)stickets"
+"%(x_url_close)s σας."
 
 #: invenio/legacy/websession/templates.py:818
 msgid "Your Tickets"
@@ -10333,8 +10266,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:877
 msgid "If you want to reset the password for this account, please go to:"
 msgstr ""
-"Εάν επιθυμείτε να επαναφέρετε τον κωδικό για τον λογαριασμό αυτό, "
-"παρακαλώ επισκευτείτε το:"
+"Εάν επιθυμείτε να επαναφέρετε τον κωδικό για τον λογαριασμό αυτό, παρακαλώ "
+"επισκευτείτε το:"
 
 #: invenio/legacy/websession/templates.py:883
 #: invenio/legacy/websession/templates.py:920
@@ -10344,10 +10277,10 @@ msgstr "ώστε να επιβεβαιώσετε την εγκυρότητα τ�
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
-"Έχετε υπόψην σας οτι αυτό το URL θα παραμείνει σε ισχύ για %(days)s "
-"ημέρες."
+"Έχετε υπόψην σας οτι αυτό το URL θα παραμείνει σε ισχύ για %(days)s ημέρες."
 
 #: invenio/legacy/websession/templates.py:909
 #, fuzzy, python-format
@@ -10389,37 +10322,37 @@ msgstr ""
 "Είστε ακόμα αναγνωρισμένος από το κεντρικό\n"
 "                σύστημα %(x_fmt_open)sSingle Sign-On%(x_fmt_close)s. "
 "Μπορείτε\n"
-"                αν επιθυμείτε να "
-"%(x_url_open)sαποσυνδεθείτε%(x_url_close)s."
+"                αν επιθυμείτε να %(x_url_open)sαποσυνδεθείτε%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:978
 #, python-format
 msgid "If you wish you can %(x_url_open)slogin here%(x_url_close)s."
-msgstr "Αν επιθυμείτε μπορείτε να κάνετε %(x_url_open)slogin εδώ%(x_url_close)s."
+msgstr ""
+"Αν επιθυμείτε μπορείτε να κάνετε %(x_url_open)slogin εδώ%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1011
 msgid "If you already have an account, please login using the form below."
 msgstr ""
-"Εάν έχετε ήδη λογαριασμό, παρακαλώ μπείτε στο σύστημα χρησιμοποιώντας την"
-" παρακάτω φόρμα."
+"Εάν έχετε ήδη λογαριασμό, παρακαλώ μπείτε στο σύστημα χρησιμοποιώντας την "
+"παρακάτω φόρμα."
 
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
-"Εάν δεν έχετε ήδη λογαριασμό του CERN, μπορείτε να κάνετε έγγραφή για ένα"
-" %(x_url_open)sνέο απλό λογαριασμό%(x_url_close)s."
+"Εάν δεν έχετε ήδη λογαριασμό του CERN, μπορείτε να κάνετε έγγραφή για ένα "
+"%(x_url_open)sνέο απλό λογαριασμό%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"Εάν δεν έχετε ήδη λογαριασμό, παρακαλώ κάντε "
-"%(x_url_open)sεγγραφή%(x_url_close)s για έναν εσωτερικό λογαριασμό."
+"Εάν δεν έχετε ήδη λογαριασμό, παρακαλώ κάντε %(x_url_open)sεγγραφή"
+"%(x_url_close)s για έναν εσωτερικό λογαριασμό."
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
@@ -10451,13 +10384,13 @@ msgstr "Ξεχάσατε τον κωδικό σας;"
 #: invenio/legacy/websession/templates.py:1094
 msgid "You can use your nickname or your email address to login."
 msgstr ""
-"Μπορείτε να χρησιμοποιήσετε το ψευδώνυμό σας ή την διεύθυνση του email "
-"για να μπείτε στο σύστημα."
+"Μπορείτε να χρησιμοποιήσετε το ψευδώνυμό σας ή την διεύθυνση του email για "
+"να μπείτε στο σύστημα."
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 "Η αίτησή σας είναι έγκυρη. Παρακαλώ ορίστε τον επιθυμητό κωδικό στην "
 "παρακάτω φόρμα."
@@ -10481,13 +10414,13 @@ msgstr "Ορισμός του νέου κωδικού"
 #: invenio/legacy/websession/templates.py:1175
 msgid "Please enter your email address and desired nickname and password:"
 msgstr ""
-"Παρακαλώ εισάγετε την διεύθυνση του email, το επιθυμητό ψευδώνυμο και τον"
-" κωδικό:"
+"Παρακαλώ εισάγετε την διεύθυνση του email, το επιθυμητό ψευδώνυμο και τον "
+"κωδικό:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
 "Ο λογαριασμός δεν θα μπορεί να χρησιμοποιηθεί προτού επιβεβαιωθεί και "
 "ενεργοποιηθεί."
@@ -10506,30 +10439,30 @@ msgstr "εγγραφή"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
 "Παρακαλώ μην χρησιμοποιείτε κωδικούς που έχετε και σε άλλα συστήματα. Το "
-"στοιχεία του email σας θα μείνουν εμπιστευτικά και δεν θα παραχωρηθούν σε"
-" κάποιο τρίτο φορέα. Το email σας θα χρησιμοποιείται μόνο για υπηρεσίες "
-"στο %s."
+"στοιχεία του email σας θα μείνουν εμπιστευτικά και δεν θα παραχωρηθούν σε "
+"κάποιο τρίτο φορέα. Το email σας θα χρησιμοποιείται μόνο για υπηρεσίες στο "
+"%s."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
-"Δεν είναι δυνατό να δημιουργήσετε λογαριασμό από μόνος σας. Επικοινωνήστε"
-" με τον %s για να δημιουργήσει έναν για εσάς."
+"Δεν είναι δυνατό να δημιουργήσετε λογαριασμό από μόνος σας. Επικοινωνήστε με "
+"τον %s για να δημιουργήσει έναν για εσάς."
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
 "Φαίνεται οτι είστε χρήστης guest. Θα πρέπει πρώτα να κάνετε "
 "%(x_url_open)slogin%(x_url_close)s."
@@ -10662,8 +10595,8 @@ msgstr "Ορίστε ορισμένοι χρήσιμοι σύνδεσμοι γι
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "Για περισσότερες λειτουργίες διαχείρισης, επισκεφθείτε την "
 "%(x_url_open)sΠεριοχή Διαχειριστή%(x_url_close)s."
@@ -10848,8 +10781,8 @@ msgid ""
 "If you want to invite new members to join your group, please use the "
 "%(x_url_open)sweb message%(x_url_close)s system."
 msgstr ""
-"Εάν θέλετε να προσκαλέσετε νέα μέλη στην ομάδα σας, παρακαλώ "
-"χρησιμοποιήστε το σύστημα του %(x_url_open)sweb message%(x_url_close)s."
+"Εάν θέλετε να προσκαλέσετε νέα μέλη στην ομάδα σας, παρακαλώ χρησιμοποιήστε "
+"το σύστημα του %(x_url_open)sweb message%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:2100
 #, fuzzy, python-format
@@ -10892,7 +10825,8 @@ msgstr "Ένας χρήστης θέλει να προσχωρήσει στην 
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 "Παρακαλώ %(x_url_open)sεπιλέξτε ή απορρίψτε%(x_url_close)s το αίτημα του "
 "χρήστη αυτού."
@@ -10922,8 +10856,8 @@ msgstr "Το αίτημα σας για προσχώρηση στην ομάδα
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour groups%(x_url_close)s."
 msgstr ""
-"Μπορείτε να συμβουλευτείτε την λίστα των "
-"%(x_url_open)sομάδων%(x_url_close)s σας."
+"Μπορείτε να συμβουλευτείτε την λίστα των %(x_url_open)sομάδων%(x_url_close)s "
+"σας."
 
 #: invenio/legacy/websession/templates.py:2422
 #, fuzzy, python-format
@@ -10938,82 +10872,76 @@ msgstr "Η ομάδα %s διεγράφη από τον διαχειριστή."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"Μπορείτε να συμβουλευτείτε την λίστα των %(x_url_open)s%(x_nb_total)i "
-"ομάδων%(x_url_close)s οποίων είστε μέλος ή %(x_nb_member)i) διαχειρίζεστε"
-" (%(x_nb_admin)i)."
+"Μπορείτε να συμβουλευτείτε την λίστα των %(x_url_open)s%(x_nb_total)i ομάδων"
+"%(x_url_close)s οποίων είστε μέλος ή %(x_nb_member)i) διαχειρίζεστε "
+"(%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
-"Προειδοποίηση: Ο κωδικός της MySQL για τον χρήστη root είναι ίδιος με τον"
-" προκαθορισμένο κωδικό του Invenio. Για λόγους ασφαλείας, προτείνουμε να "
+"Προειδοποίηση: Ο κωδικός της MySQL για τον χρήστη root είναι ίδιος με τον "
+"προκαθορισμένο κωδικό του Invenio. Για λόγους ασφαλείας, προτείνουμε να "
 "αλλάξετε τον κωδικό."
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
-"Προειδοποίηση: Ο κωδικός της MySQL για τον χρήστη του invenio είναι ίδιος"
-" με τον προκαθορισμένο.Για λόγους ασφαλείας, προτείνουμε να αλλάξετε τον "
-"κωδικό."
+"Προειδοποίηση: Ο κωδικός της MySQL για τον χρήστη του invenio είναι ίδιος με "
+"τον προκαθορισμένο.Για λόγους ασφαλείας, προτείνουμε να αλλάξετε τον κωδικό."
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
-"Προειδοποίηση: Ο κωδικός για τον διαχειριστή του Invenio είναι κενός. Για"
-" λόγους ασφαλείας, προτείνουμε να εισάγετε κάποιο κωδικό."
+"Προειδοποίηση: Ο κωδικός για τον διαχειριστή του Invenio είναι κενός. Για "
+"λόγους ασφαλείας, προτείνουμε να εισάγετε κάποιο κωδικό."
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
-"Προειδοποίηση: Η διεύθυνση του email για το υποστήριξη του συστήματος "
-"είναι επί του παρόντος το info@invenio-software.org. Προτείνεται να την "
-"αλλάξετε και να εισάγετε την δική σας διεύθυνση."
+"Προειδοποίηση: Η διεύθυνση του email για το υποστήριξη του συστήματος είναι "
+"επί του παρόντος το info@invenio-software.org. Προτείνεται να την αλλάξετε "
+"και να εισάγετε την δική σας διεύθυνση."
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 "Μια νεότερη έκδοση του Invenio είναι διαθέσιμη για κατέβασμα. Παρακαλώ "
 "επισκευθείτε το "
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
-"Δεν είναι δυνατό να κατέβουν και να αναλυθούν οι σημειώσεις έκδοσης από "
-"το http://invenio-software.org/repo/invenio/tree/RELEASE-NOTES"
+"Δεν είναι δυνατό να κατέβουν και να αναλυθούν οι σημειώσεις έκδοσης από το "
+"http://invenio-software.org/repo/invenio/tree/RELEASE-NOTES"
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
 "Βρίσκεστε στο σύστημα σαν επισκέπτης. Ίσως θα θέλατε να κάνετε "
 "%(x_url_open)slogin%(x_url_close)s σαν κανονικός χρήστης."
@@ -11021,12 +10949,11 @@ msgstr ""
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
-"Οι χρήστες που βρίσκονται στο σύστημα σαν "
-"%(x_fmt_open)sεπισκέπτες%(x_fmt_close)s χρειάζεται πρώτα να "
-"%(x_url_open)sεγγραφούν%(x_url_close)s"
+"Οι χρήστες που βρίσκονται στο σύστημα σαν %(x_fmt_open)sεπισκέπτες"
+"%(x_fmt_close)s χρειάζεται πρώτα να %(x_url_open)sεγγραφούν%(x_url_close)s"
 
 #: invenio/legacy/websession/webaccount.py:127
 msgid "No queries found"
@@ -11034,16 +10961,16 @@ msgstr "Δεν βρέθηκαν ερωτήματα"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
-"Η συλλογή αυτή είναι περιορισμένη. Αν πιστεύετε οτι έχετε δικαίωμα "
-"πρόσβασης σ'αυτή, παρακαλώ ακολουθήστε την διαδικασία πιστοποίησης."
+"Η συλλογή αυτή είναι περιορισμένη. Αν πιστεύετε οτι έχετε δικαίωμα πρόσβασης "
+"σ'αυτή, παρακαλώ ακολουθήστε την διαδικασία πιστοποίησης."
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 "Το αρχείο αυτό έχει περιορισμούς πρόσβασης. Αν πιστεύετε οτι έχετε τα "
 "απαραίτητα δικαιώματα, κάντε login."
@@ -11054,8 +10981,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11067,8 +10994,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11139,8 +11066,7 @@ msgstr "Παρακαλώ επιλέξτε ένα μέλος για να το δ�
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 "Παρακαλώ επιλέξτε έναν χρήστη από την λίστα αν θέλετε να προστεθεί στην "
 "ομάδα."
@@ -11178,9 +11104,9 @@ msgid ""
 "authorization will last until %(x_expiration)s and until you close your "
 "browser if you are a guest user."
 msgstr ""
-"Έχετε αποκτήσει εξουσιοδότηση ως %(x_role)s! Η εξουσιοδότηση αυτή θα "
-"είναι σε ισχύ μέχρι τις %(x_expiration)s ή, αν είστε χρήστης guest, μέχρι"
-" να κλείσετε τον φυλλομετρητή σας."
+"Έχετε αποκτήσει εξουσιοδότηση ως %(x_role)s! Η εξουσιοδότηση αυτή θα είναι "
+"σε ισχύ μέχρι τις %(x_expiration)s ή, αν είστε χρήστης guest, μέχρι να "
+"κλείσετε τον φυλλομετρητή σας."
 
 #: invenio/legacy/websession/webinterface.py:128
 msgid "You have confirmed the validity of your email address!"
@@ -11190,16 +11116,15 @@ msgstr "Έχετε επιβεβαιώσει την εγκυρότητα του e
 #: invenio/legacy/websession/webinterface.py:141
 msgid "Please, wait for the administrator to enable your account."
 msgstr ""
-"Παρακαλώ περιμένετε μέχρι ο διαχειριστής να ενεργοποιήσει τον λογαριασμό "
-"σας."
+"Παρακαλώ περιμένετε μέχρι ο διαχειριστής να ενεργοποιήσει τον λογαριασμό σας."
 
 #: invenio/legacy/websession/webinterface.py:135
 #: invenio/legacy/websession/webinterface.py:144
 #, python-format
 msgid "You can now go to %(x_url_open)syour account page%(x_url_close)s."
 msgstr ""
-"Έχετε τώρα πρόσβαση στην %(x_url_open)sσελίδα του "
-"λογαριασμού%(x_url_close)s σας."
+"Έχετε τώρα πρόσβαση στην %(x_url_open)sσελίδα του λογαριασμού%(x_url_close)s "
+"σας."
 
 #: invenio/legacy/websession/webinterface.py:136
 #: invenio/legacy/websession/webinterface.py:145
@@ -11212,9 +11137,9 @@ msgstr "Έχετε ήδη επιβεβαιώσει την εγκυρότητα �
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
-msgstr "Αυτή η αίτηση για επιβεβαίωση του email σας δεν είναι έγκυρη ή έχει λήξει."
+"This request for confirmation of an email address is not valid or is expired."
+msgstr ""
+"Αυτή η αίτηση για επιβεβαίωση του email σας δεν είναι έγκυρη ή έχει λήξει."
 
 #: invenio/legacy/websession/webinterface.py:153
 msgid "This request for an authorization is not valid or is expired."
@@ -11226,15 +11151,18 @@ msgstr "Επαναφορά κωδικού"
 
 #: invenio/legacy/websession/webinterface.py:172
 msgid "This request for resetting a password has already been used."
-msgstr "Αυτή η αίτηση για επαναφορά του κωδικού σας δεν είναι έγκυρη ή έχει λήξει."
+msgstr ""
+"Αυτή η αίτηση για επαναφορά του κωδικού σας δεν είναι έγκυρη ή έχει λήξει."
 
 #: invenio/legacy/websession/webinterface.py:175
 msgid "This request for resetting a password is not valid or is expired."
-msgstr "Αυτή η αίτηση για επαναφορά του κωδικού σας δεν είναι έγκυρη ή έχει λήξει."
+msgstr ""
+"Αυτή η αίτηση για επαναφορά του κωδικού σας δεν είναι έγκυρη ή έχει λήξει."
 
 #: invenio/legacy/websession/webinterface.py:180
 msgid "This request for resetting the password is not valid or is expired."
-msgstr "Αυτή η αίτηση για επαναφορά του κωδικού σας δεν είναι έγκυρη ή έχει λήξει."
+msgstr ""
+"Αυτή η αίτηση για επαναφορά του κωδικού σας δεν είναι έγκυρη ή έχει λήξει."
 
 #: invenio/legacy/websession/webinterface.py:193
 msgid "The two provided passwords aren't equal."
@@ -11243,8 +11171,8 @@ msgstr "Οι δύο κωδικοί που έχετε εισάγει δεν τα�
 #: invenio/legacy/websession/webinterface.py:208
 msgid "The password was successfully set! You can now proceed with the login."
 msgstr ""
-"Ο κωδικός σας άλλαξε με επιτυχία! Μπορείτε να προχωρήσετε με την είσοδο "
-"στο σύστημα."
+"Ο κωδικός σας άλλαξε με επιτυχία! Μπορείτε να προχωρήσετε με την είσοδο στο "
+"σύστημα."
 
 #: invenio/legacy/websession/webinterface.py:339
 #, fuzzy, python-format
@@ -11278,16 +11206,15 @@ msgstr "Αλλαγή σε εσωτερική μέθοδο αυθεντικοπο
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 "Σας ενημερώνουμε οτι εάν αυτή είναι η πρώτη φορά πουχρησιμοποιείτε τον "
-"λογαριασμό αυτό με την μέθοδο της εσωτερικής πιστοποίησης, τότε το "
-"σύστημα έχει ορίσει για εσάς έναν τυχαίο κωδικό. Παρακαλώ πατήστε το "
-"κουμπί που ακολουθεί για να σας σταλεί με email ένα αίτημα αλλαγής του "
-"κωδικού:"
+"λογαριασμό αυτό με την μέθοδο της εσωτερικής πιστοποίησης, τότε το σύστημα "
+"έχει ορίσει για εσάς έναν τυχαίο κωδικό. Παρακαλώ πατήστε το κουμπί που "
+"ακολουθεί για να σας σταλεί με email ένα αίτημα αλλαγής του κωδικού:"
 
 #: invenio/legacy/websession/webinterface.py:431
 msgid "Send Password"
@@ -11299,8 +11226,8 @@ msgid ""
 "Unable to switch to external login method %(x_name)s, because your email "
 "address is unknown."
 msgstr ""
-"Είναι αδύνατη η αλλαγή σε μέθοδο αυθεντικοποίησης %s, επειδή η διεύθυνση "
-"του email σας είναι άγνωστη."
+"Είναι αδύνατη η αλλαγή σε μέθοδο αυθεντικοποίησης %s, επειδή η διεύθυνση του "
+"email σας είναι άγνωστη."
 
 #: invenio/legacy/websession/webinterface.py:445
 #, fuzzy, python-format
@@ -11308,8 +11235,8 @@ msgid ""
 "Unable to switch to external login method %(x_meth)s, because your email "
 "address is unknown to the external login system."
 msgstr ""
-"Είναι αδύνατη η αλλαγή σε μέθοδο αυθεντικοποίησης %s, επειδή η διεύθυνση "
-"του email σας είναι άγνωστη στο εξωτερικό σύστημα αυθεντικοποίησης."
+"Είναι αδύνατη η αλλαγή σε μέθοδο αυθεντικοποίησης %s, επειδή η διεύθυνση του "
+"email σας είναι άγνωστη στο εξωτερικό σύστημα αυθεντικοποίησης."
 
 #: invenio/legacy/websession/webinterface.py:449
 msgid "Login method successfully selected."
@@ -11318,11 +11245,11 @@ msgstr "Η μέθοδος αυθεντικοποίησης επιλέχθηκε 
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
-"Η εξωτερική μέθοδος αυθεντικοποίησης %s δεν υποστηρίζει αυθεντικοποίηση "
-"με βάση το email.   Παρακαλώ επικοινωνήστε με τους διαχειριστές."
+"Η εξωτερική μέθοδος αυθεντικοποίησης %s δεν υποστηρίζει αυθεντικοποίηση με "
+"βάση το email.   Παρακαλώ επικοινωνήστε με τους διαχειριστές."
 
 #: invenio/legacy/websession/webinterface.py:464
 #, fuzzy
@@ -11339,8 +11266,8 @@ msgid ""
 "Note that if you have changed your email address, you will have to "
 "%(x_url_open)sreset your password%(x_url_close)s anew."
 msgstr ""
-"Επισημαίνεται οτι αν αλλάξατε την διεύθυνση του email σας, θα χρειαστεί "
-"να κάνετε %(x_url_open)sεπαναφορά του κωδικού σας%(x_url_close)s ξανά."
+"Επισημαίνεται οτι αν αλλάξατε την διεύθυνση του email σας, θα χρειαστεί να "
+"κάνετε %(x_url_open)sεπαναφορά του κωδικού σας%(x_url_close)s ξανά."
 
 #: invenio/legacy/websession/webinterface.py:487
 #: invenio/legacy/websession/webinterface.py:1003
@@ -11450,8 +11377,8 @@ msgid ""
 "Cannot send password reset request since you are using external "
 "authentication system."
 msgstr ""
-"Το αίτημα για επαναδημιουργία του κωδικού σας δεν μπορεί να αποσταλεί "
-"μέσω email διότι χρησιμοποιείτε σύστημα εξωτερικής αυθεντικοποίησης."
+"Το αίτημα για επαναδημιουργία του κωδικού σας δεν μπορεί να αποσταλεί μέσω "
+"email διότι χρησιμοποιείτε σύστημα εξωτερικής αυθεντικοποίησης."
 
 #: invenio/legacy/websession/webinterface.py:665
 msgid "The entered email address does not exist in the database."
@@ -11499,26 +11426,26 @@ msgid ""
 "In order to confirm its validity, an email message containing an account "
 "activation key has been sent to the given email address."
 msgstr ""
-"Για να επιβεβαιωθεί η πιστότητα του, έχει σταλεί ένα μήνυμα με τον κωδικό"
-" ενεργοποίησης στην διεύθυνση ηλεκτρονικού ταχυδρομίου που δώσατε."
+"Για να επιβεβαιωθεί η πιστότητα του, έχει σταλεί ένα μήνυμα με τον κωδικό "
+"ενεργοποίησης στην διεύθυνση ηλεκτρονικού ταχυδρομίου που δώσατε."
 
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
-"Παρακαλώ ακολουθήστε τις οδηγίες που αναφέρονται εκεί  για να "
-"ολοκληρώσετε την διαδικασία εγγραφής."
+"Παρακαλώ ακολουθήστε τις οδηγίες που αναφέρονται εκεί  για να ολοκληρώσετε "
+"την διαδικασία εγγραφής."
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
-"Ένα δεύτερο email θα σας σταλεί όταν ο λογαριασμός ενεργοποιηθεί και "
-"είναι έτοιμος για χρήση."
+"Ένα δεύτερο email θα σας σταλεί όταν ο λογαριασμός ενεργοποιηθεί και είναι "
+"έτοιμος για χρήση."
 
 #: invenio/legacy/websession/webinterface.py:989
 #, python-format
@@ -11559,8 +11486,8 @@ msgstr "Το επιθυμητό nickname %s υπάρχει ήδη στην βά�
 #: invenio/modules/accounts/views/accounts.py:143
 msgid "Users cannot register themselves, only admin can register them."
 msgstr ""
-"Οι χρήστες δεν μπορούν να εγγραφούν από μόνοι τους, πρέπει να τους "
-"εγγράψει ο διαχειριστής."
+"Οι χρήστες δεν μπορούν να εγγραφούν από μόνοι τους, πρέπει να τους εγγράψει "
+"ο διαχειριστής."
 
 #: invenio/legacy/websession/webinterface.py:1023
 #: invenio/modules/accounts/views/accounts.py:148
@@ -11568,8 +11495,8 @@ msgid ""
 "The site is having troubles in sending you an email for confirming your "
 "email address."
 msgstr ""
-"Υπήρξε πρόβλημα κατα την αποστολή του email που θα επιβεβαίωνε την "
-"διευθυνση του ηλεκτρονικού ταχυδρομίου σας."
+"Υπήρξε πρόβλημα κατα την αποστολή του email που θα επιβεβαίωνε την διευθυνση "
+"του ηλεκτρονικού ταχυδρομίου σας."
 
 #: invenio/legacy/websession/webinterface.py:1432
 msgid "Your tickets"
@@ -11635,7 +11562,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 "Δημιουργία εγγραφής %(x_date_creation)s, τελευταία τροποποίηση "
 "%(x_date_modification)s"
@@ -11656,78 +11584,78 @@ msgid ""
 "%(x_page)s of submission '%(x_sub)s%(x_subm)s' - Invalid Field Position "
 "Numbers"
 msgstr ""
-"Αδυναμία μετακίνησης του πεδίου από την θέση %s στην θέση %s στην σελίδα "
-"%s της υποβολής '%s%s' - Μη έγκυρες θέσεις πεδίου"
+"Αδυναμία μετακίνησης του πεδίου από την θέση %s στην θέση %s στην σελίδα %s "
+"της υποβολής '%s%s' - Μη έγκυρες θέσεις πεδίου"
 
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
-"Αδυναμία ανταλλαγής του πεδίου από την θέση %s στην θέση %s στην σελίδα "
-"%s της υποβολής %s - δεν ήταν δυνατό να μετακινηθεί το πεδίο από την θέση"
-" %s σε προσωρινή θέση"
+"Αδυναμία ανταλλαγής του πεδίου από την θέση %s στην θέση %s στην σελίδα %s "
+"της υποβολής %s - δεν ήταν δυνατό να μετακινηθεί το πεδίο από την θέση %s σε "
+"προσωρινή θέση"
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
-"Αδυναμία ανταλλαγής του πεδίου από την θέση %s στην θέση %s στην σελίδα "
-"%s της υποβολής %s - δεν ήταν δυνατό να μετακινηθεί το πεδίο από την θέση"
-" %s στην θέση %s. Παρακαλώ ζητήστε από τους διαχειριστές να ελέγξουν αν "
-"κάποιο πεδίο δεν χάθηκε σε κάποια προσωρινή θέση"
+"Αδυναμία ανταλλαγής του πεδίου από την θέση %s στην θέση %s στην σελίδα %s "
+"της υποβολής %s - δεν ήταν δυνατό να μετακινηθεί το πεδίο από την θέση %s "
+"στην θέση %s. Παρακαλώ ζητήστε από τους διαχειριστές να ελέγξουν αν κάποιο "
+"πεδίο δεν χάθηκε σε κάποια προσωρινή θέση"
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
-"Αδυναμία ανταλλαγής του πεδίου από την θέση %s στην θέση %s στην σελίδα "
-"%s της υποβολής %s - δεν ήταν δυνατό να μετακινηθεί το πεδίο της θέσης %s"
-" στην θέση %s από την προσωρινή θέση. Το πεδίο είναι τώρα χαμένο σε μια "
-"προσωρινή θέση και πρέπει να ελεγχθεί από κάποιον διαχειριστή"
+"Αδυναμία ανταλλαγής του πεδίου από την θέση %s στην θέση %s στην σελίδα %s "
+"της υποβολής %s - δεν ήταν δυνατό να μετακινηθεί το πεδίο της θέσης %s στην "
+"θέση %s από την προσωρινή θέση. Το πεδίο είναι τώρα χαμένο σε μια προσωρινή "
+"θέση και πρέπει να ελεγχθεί από κάποιον διαχειριστή"
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, fuzzy, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
-"Αδυναμία μετακίνησης του πεδίου από την θέση %s στην θέση %s στην σελίδα "
-"%s της υποβολής %s - δεν ήταν δυνατό να μειωθεί η θέση των πεδίων κάτω "
-"από την θέση %s. Έγινε προσπάθεια ανάκτησης - παρακαλώ ελέγξτε οτι η "
-"σειρά της αρίθμησης δεν έχει χαλάσει"
+"Αδυναμία μετακίνησης του πεδίου από την θέση %s στην θέση %s στην σελίδα %s "
+"της υποβολής %s - δεν ήταν δυνατό να μειωθεί η θέση των πεδίων κάτω από την "
+"θέση %s. Έγινε προσπάθεια ανάκτησης - παρακαλώ ελέγξτε οτι η σειρά της "
+"αρίθμησης δεν έχει χαλάσει"
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
 #, fuzzy, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
-"Αδυναμία μετακίνησης του πεδίου από την θέση %s στην θέση %s στην σελίδα "
-"%s της υποβολής %s%s - δεν ήταν δυνατό να αυξηθεί η θέση των πεδίων κάτω "
-"από την θέση %s. Το πεδίο που ήταν στην θέση %s είναι τώρα χαμένο σε μια "
+"Αδυναμία μετακίνησης του πεδίου από την θέση %s στην θέση %s στην σελίδα %s "
+"της υποβολής %s%s - δεν ήταν δυνατό να αυξηθεί η θέση των πεδίων κάτω από "
+"την θέση %s. Το πεδίο που ήταν στην θέση %s είναι τώρα χαμένο σε μια "
 "προσωρινή θέση."
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, fuzzy, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 "Μετακινήθηκε το πεδίο από την θέση %s στην θέση %s στην σελίδα %s της "
 "υποβολής '%s%s'."
@@ -11738,8 +11666,7 @@ msgid ""
 "Unable to delete field at position %(x_from)s from page %(x_to)s of "
 "submission '%(x_sub)s'"
 msgstr ""
-"Αδύνατο να διαγραφεί το πεδίο στην θέση %s της σελίδας %s της υποβολής "
-"'%s%s'"
+"Αδύνατο να διαγραφεί το πεδίο στην θέση %s της σελίδας %s της υποβολής '%s%s'"
 
 #: invenio/legacy/websubmit/admin_engine.py:4010
 #, fuzzy, python-format
@@ -11747,8 +11674,7 @@ msgid ""
 "Unable to delete field at position %(x_from)s from page %(x_to)s of "
 "submission '%(x_sub)s%(x_subm)s'"
 msgstr ""
-"Αδύνατο να διαγραφεί το πεδίο στην θέση %s της σελίδας %s της υποβολής "
-"'%s%s'"
+"Αδύνατο να διαγραφεί το πεδίο στην θέση %s της σελίδας %s της υποβολής '%s%s'"
 
 #: invenio/legacy/websubmit/engine.py:194
 #: invenio/legacy/websubmit/engine.py:871
@@ -11792,13 +11718,14 @@ msgstr "Άγνωστη ενέργεια"
 #: invenio/legacy/websubmit/engine.py:260
 #: invenio/legacy/websubmit/engine.py:952
 msgid "Unable to determine the number of submission pages."
-msgstr "Δεν είναι δυνατόν να προσδιορισθεί ο αριθμός των σελίδων που υποβάλετε."
+msgstr ""
+"Δεν είναι δυνατόν να προσδιορισθεί ο αριθμός των σελίδων που υποβάλετε."
 
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
 "Δεν είναι δυνατόν να δημιουργηθεί κατάλογος για την υποβολή αυτή.Έχει "
 "ειδοποιηθεί ο διαχειριστής του συστήματος."
@@ -11837,13 +11764,13 @@ msgstr "Υποβολή"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
-"Εντοπίστηκε ένα σημαντικό σφάλμα. Οι διαχειριστές έχουν ειδοποιηθεί. <br "
-"/><em>Λάβετε υπόψη σας οτι το σφάλμα μπορεί να οφείλεται σε "
-"προβληματικούς χαρακτήρες που εισήχθησαν στην φόρμα</em> (πχ από "
-"αντιγραφή και επικόλληση από κάποιο αρχείο PDF)."
+"Εντοπίστηκε ένα σημαντικό σφάλμα. Οι διαχειριστές έχουν ειδοποιηθεί. <br /"
+"><em>Λάβετε υπόψη σας οτι το σφάλμα μπορεί να οφείλεται σε προβληματικούς "
+"χαρακτήρες που εισήχθησαν στην φόρμα</em> (πχ από αντιγραφή και επικόλληση "
+"από κάποιο αρχείο PDF)."
 
 #: invenio/legacy/websubmit/engine.py:1501
 #, fuzzy, python-format
@@ -11889,11 +11816,11 @@ msgstr "Επιλέξτε μια κατηγορία και μετά κάντε κ
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
-"Για να συνεχίσετε κάποια υποβολή που διακόπηκε, πληκτρολογήστε στο "
-"παρακάτω πεδίο το access number:"
+"Για να συνεχίσετε κάποια υποβολή που διακόπηκε, πληκτρολογήστε στο παρακάτω "
+"πεδίο το access number:"
 
 #: invenio/legacy/websubmit/templates.py:366
 msgid "GO"
@@ -11912,8 +11839,7 @@ msgstr "Αριθμός υποβολής"
 #: invenio/legacy/websubmit/templates.py:983
 msgid "Are you sure you want to quit this submission?"
 msgstr ""
-"Είστε σίγουροι πως θέλετε να εγκαταλείψετε την παρούσα διαδικασία "
-"υποβολής;"
+"Είστε σίγουροι πως θέλετε να εγκαταλείψετε την παρούσα διαδικασία υποβολής;"
 
 #: invenio/legacy/websubmit/templates.py:544
 #: invenio/legacy/websubmit/templates.py:984
@@ -11923,15 +11849,16 @@ msgstr "Επιστροφή στο βασικό μενού"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 "Αυτός είναι ο αριθμός υποβολής σας. Μπορεί να χρησιμοποιηθεί για να "
 "ολοκληρώσετε κάποια μη ολοκληρωμένη υποβολή σε περίπτωση προβλήματος."
 
 #: invenio/legacy/websubmit/templates.py:548
 msgid "Mandatory fields appear in red in the SUMMARY window."
-msgstr "Τα υποχρεωτικά πεδία εμφανίζονται στο παράθυρο της ΠΕΡΙΛΗΨΗΣ με κόκκινο."
+msgstr ""
+"Τα υποχρεωτικά πεδία εμφανίζονται στο παράθυρο της ΠΕΡΙΛΗΨΗΣ με κόκκινο."
 
 #: invenio/legacy/websubmit/templates.py:695
 #: invenio/legacy/websubmit/templates.py:794
@@ -11975,8 +11902,8 @@ msgstr "Αριθμός υποβολής"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 "Ορίστε η %(x_action)s λίστα ενεργειών για τα %(x_doctype)s έγγραφα στο "
 "επίπεδο %(x_step)s"
@@ -12060,8 +11987,7 @@ msgstr "Λίστα από τύπους εγγράφων που αξιολογε�
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
 "Επιλέξτε έναν από τους παρακάτω τύπους εγγράφων για να ελέγξετε την "
 "κατάσταση του"
@@ -12200,7 +12126,8 @@ msgstr "Σημείωμα έγκρισης:"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr "Το έγγραφο αυτό %(x_fmt_open)sαναμένει έγκριση%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -12223,8 +12150,8 @@ msgid ""
 "You can send an approval request email again by clicking the following "
 "button:"
 msgstr ""
-"Μπορείτε να στείλετε email για αίτημα έγκρισης κάνοντας κλικ στο παρακάτω"
-" κουμπί:"
+"Μπορείτε να στείλετε email για αίτημα έγκρισης κάνοντας κλικ στο παρακάτω "
+"κουμπί:"
 
 #: invenio/legacy/websubmit/templates.py:2149
 #: invenio/legacy/websubmit/web/publiline.py:367
@@ -12234,8 +12161,7 @@ msgstr "Αποστολή εκ νέου"
 #: invenio/legacy/websubmit/templates.py:2150
 msgid "WARNING! Upon confirmation, an email will be sent to the referee."
 msgstr ""
-"ΠΡΟΕΙΔΟΠΟΙΗΣΗ! Μετά την επιβεβαίωση, θα αποσταλεί email στον αξιολογητή "
-"σας."
+"ΠΡΟΕΙΔΟΠΟΙΗΣΗ! Μετά την επιβεβαίωση, θα αποσταλεί email στον αξιολογητή σας."
 
 #: invenio/legacy/websubmit/templates.py:2153
 #, fuzzy
@@ -12243,8 +12169,8 @@ msgid ""
 "As a referee for this document, you may approve or reject it from the "
 "submission interface"
 msgstr ""
-"Ώς αξιολογητής του εγγράφου αυτού, μπορείτε να κάνετε κλίκ στο κουμπί "
-"αυτό για να το αποδεχτείτε ή να το απορρίψετε."
+"Ώς αξιολογητής του εγγράφου αυτού, μπορείτε να κάνετε κλίκ στο κουμπί αυτό "
+"για να το αποδεχτείτε ή να το απορρίψετε."
 
 #: invenio/legacy/websubmit/templates.py:2155
 msgid "Approve/Reject"
@@ -12281,7 +12207,8 @@ msgstr "Το πρώτο αίτημα για αξιολόγηση έγινε στ
 #: invenio/legacy/websubmit/templates.py:2264
 #: invenio/legacy/websubmit/templates.py:2318
 msgid "Last request e-mail was sent to the publication committee chair on the "
-msgstr "Το τελευταίο αίτημα μέσω email στάλθηκε στην επιτροπή δημοσίευσης στις "
+msgstr ""
+"Το τελευταίο αίτημα μέσω email στάλθηκε στην επιτροπή δημοσίευσης στις "
 
 #: invenio/legacy/websubmit/templates.py:2268
 msgid "A referee has been selected by the publication committee on the "
@@ -12299,11 +12226,11 @@ msgstr "Επιλέξτε έναν αξιολογητη"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
-"Ο αξιολογητής έστειλε τις τελευταίες υποδείξεις στην επιτροπή δημοσίευσης"
-" στις "
+"Ο αξιολογητής έστειλε τις τελευταίες υποδείξεις στην επιτροπή δημοσίευσης "
+"στις "
 
 #: invenio/legacy/websubmit/templates.py:2281
 #: invenio/legacy/websubmit/templates.py:2342
@@ -12321,8 +12248,8 @@ msgstr "Στείλτε μια σύσταση"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 "Η επιτροπή δημοσίευσης έστειλε τις τελευταίες διορθώσεις στον υπεύθυνο "
 "προγράμματος στις "
@@ -12365,7 +12292,8 @@ msgid "Take a decision"
 msgstr "Λήψη απόφασης"
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr "Έγινε επιλογή συντακτικής επιτροπής από την επιτροπή δημοσίευσης στις "
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12386,14 +12314,14 @@ msgstr "Ένας αξιολογητής επιλέχτηκε από την συ�
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
-msgstr "Ο αξιολογητής έστειλε τις τελικές συστάσεις στην συντακτική επιτροπή στις "
+"The referee has sent his final recommendations to the editorial board on the "
+msgstr ""
+"Ο αξιολογητής έστειλε τις τελικές συστάσεις στην συντακτική επιτροπή στις "
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 "Η συντακτική επιτροπή έστειλε τις τελικές συστάσεις στην επιτροπή "
 "δημοσίευσης στις "
@@ -12498,8 +12426,8 @@ msgid ""
 "Note that your submission has been inserted into the bibliographic task "
 "queue and is waiting for execution.\n"
 msgstr ""
-"Σημειώστε οτι η υποβολή σας έχει μπει στην ουρά εργασιών και περιμένει "
-"για την εκτέλεσή της.\n"
+"Σημειώστε οτι η υποβολή σας έχει μπει στην ουρά εργασιών και περιμένει για "
+"την εκτέλεσή της.\n"
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:206
 #, fuzzy, python-format
@@ -12509,22 +12437,20 @@ msgid ""
 "available within a few minutes and searchable within an hour or "
 "thereabouts.\n"
 msgstr ""
-"Η ουρά εργασιών βρίσκεται σε αυτόματη λειτουργία και αυτή τη στιγμή "
-"υπάρχουν %s εργασίες που περιμένουν να εκτελεστούν. Η εγγραφή σας θα "
-"είναι διαθέσιμη μέσα σε λίγα λεπτά και θα είναι αναζητήσιμη σε λιγότερο "
-"από μία ώρα.\n"
+"Η ουρά εργασιών βρίσκεται σε αυτόματη λειτουργία και αυτή τη στιγμή υπάρχουν "
+"%s εργασίες που περιμένουν να εκτελεστούν. Η εγγραφή σας θα είναι διαθέσιμη "
+"μέσα σε λίγα λεπτά και θα είναι αναζητήσιμη σε λιγότερο από μία ώρα.\n"
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
-"Εξαιτίας κάποιων διεργασιών συντήρησης ή κάποιου προσωρινού σφάλματος η "
-"ουρά εργασιών βρίσκεται σε χειροκίνητη λειτουργία. Η υποβολή σας έχει "
-"ληφθεί υπόψη, αλλά μπορεί να καθυστερήσει λίγο μέχρι να εισαχθεί στο "
-"σύστημα και να είναι αναζητήσιμη.\n"
+"Εξαιτίας κάποιων διεργασιών συντήρησης ή κάποιου προσωρινού σφάλματος η ουρά "
+"εργασιών βρίσκεται σε χειροκίνητη λειτουργία. Η υποβολή σας έχει ληφθεί "
+"υπόψη, αλλά μπορεί να καθυστερήσει λίγο μέχρι να εισαχθεί στο σύστημα και να "
+"είναι αναζητήσιμη.\n"
 
 #: invenio/legacy/websubmit/web/approve.py:53
 msgid "approve.py: cannot determine document reference"
@@ -12604,8 +12530,8 @@ msgstr "όριο"
 #: invenio/legacy/websubmit/web/publiline.py:749
 msgid "users in brackets are already attached to the role, try another one..."
 msgstr ""
-"οι χρήστες στις αγκύλες είναι ήδη συνδεδεμένοι με τον ρόλο, δοκιμάστε "
-"κάτι άλλο..."
+"οι χρήστες στις αγκύλες είναι ήδη συνδεδεμένοι με τον ρόλο, δοκιμάστε κάτι "
+"άλλο..."
 
 #: invenio/legacy/websubmit/web/publiline.py:755
 msgid "Removing users from the editorial board"
@@ -12644,8 +12570,8 @@ msgstr "Ο λογαριασμός σας στο '%s' ενεργοποιήθηκ�
 #, fuzzy, python-format
 msgid "Your account earlier created on '%(x_name)s' has been activated:"
 msgstr ""
-"Ο λογαριασμός σας που δημιουργήθηκε προηγουμένως στο '%s' ενεργοποιήθηκε "
-"με επιτυχία:"
+"Ο λογαριασμός σας που δημιουργήθηκε προηγουμένως στο '%s' ενεργοποιήθηκε με "
+"επιτυχία:"
 
 #: invenio/modules/access/admin_lib.py:3749
 #: invenio/modules/access/admin_lib.py:3762
@@ -12808,8 +12734,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12852,11 +12778,6 @@ msgstr "έγινε σύνδεση"
 #, fuzzy
 msgid "Role details"
 msgstr "Περισσότερες λεπτομέρειες"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Απόκρυψη"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12972,11 +12893,11 @@ msgstr "Το email %s που δώσατε υπάρχει ήδη στην βάσ�
 #: invenio/modules/accounts/forms.py:94
 #, fuzzy, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
-"Επισημαίνεται οτι αν αλλάξατε την διεύθυνση του email σας, θα χρειαστεί "
-"να κάνετε %(x_url_open)sεπαναφορά του κωδικού σας%(x_url_close)s ξανά."
+"Επισημαίνεται οτι αν αλλάξατε την διεύθυνση του email σας, θα χρειαστεί να "
+"κάνετε %(x_url_open)sεπαναφορά του κωδικού σας%(x_url_close)s ξανά."
 
 #: invenio/modules/accounts/forms.py:117
 #, fuzzy, python-format
@@ -13040,20 +12961,19 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, fuzzy, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 "Είστε ακόμα αναγνωρισμένος από το κεντρικό\n"
 "                σύστημα %(x_fmt_open)sSingle Sign-On%(x_fmt_close)s. "
 "Μπορείτε\n"
-"                αν επιθυμείτε να "
-"%(x_url_open)sαποσυνδεθείτε%(x_url_close)s."
+"                αν επιθυμείτε να %(x_url_open)sαποσυνδεθείτε%(x_url_close)s."
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
 #, fuzzy, python-format
 msgid "If you wish you can %(x_url_open)ssign in again%(x_url_close)s."
-msgstr "Αν επιθυμείτε μπορείτε να κάνετε %(x_url_open)slogin εδώ%(x_url_close)s."
+msgstr ""
+"Αν επιθυμείτε μπορείτε να κάνετε %(x_url_open)slogin εδώ%(x_url_close)s."
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:27
 #, fuzzy
@@ -13061,8 +12981,8 @@ msgid ""
 "Please enter your email address. You will receive a link to create a new "
 "password via email."
 msgstr ""
-"Παρακαλώ εισάγετε την διεύθυνση του email, το επιθυμητό ψευδώνυμο και τον"
-" κωδικό:"
+"Παρακαλώ εισάγετε την διεύθυνση του email, το επιθυμητό ψευδώνυμο και τον "
+"κωδικό:"
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:33
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:33
@@ -13073,11 +12993,11 @@ msgstr "Εισαγωγή νέου κωδικού"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
-"Παρακαλώ εισάγετε την διεύθυνση του email, το επιθυμητό ψευδώνυμο και τον"
-" κωδικό:"
+"Παρακαλώ εισάγετε την διεύθυνση του email, το επιθυμητό ψευδώνυμο και τον "
+"κωδικό:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
 #, fuzzy
@@ -13106,7 +13026,7 @@ msgid "Problem with login."
 msgstr "Σύγκριση με αρχικό"
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr " Έχετε τώρα πρόσβαση στον %(x_url_open)sλογαριασμό%(x_url_close)s σας."
 
@@ -13149,8 +13069,7 @@ msgstr "Η επεξεργασία της εξουσιοδότησης για τ�
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13222,13 +13141,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13237,9 +13155,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13411,8 +13329,7 @@ msgstr "συλλογές"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13466,8 +13383,8 @@ msgstr "Μη έγκυρος αριθμός σελίδας --> προβολή τ�
 #: invenio/modules/comments/api.py:176
 msgid "Bad number of results per page --> showing 10 results per page."
 msgstr ""
-"Μη έγκυρος αριθμός αποτελεσμάτων ανά σελίδα --> προβολή 10 αποτελεσμάτων "
-"ανά σελίδα."
+"Μη έγκυρος αριθμός αποτελεσμάτων ανά σελίδα --> προβολή 10 αποτελεσμάτων ανά "
+"σελίδα."
 
 #: invenio/modules/comments/api.py:185
 msgid "Bad display order --> showing most helpful first."
@@ -13501,8 +13418,8 @@ msgstr "Λυπούμαστε, έχετε ήδη ψηφίσει. Αυτή η ψή
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 "Εγγραφήκατε σε αυτήν τη συζήτηση. Από εδώ και στο εξής θα λαμβάνετε ένα "
 "email ειδοποίησης κάθε φορά που ένα νέο σχόλιο θα αναρτάται."
@@ -13562,17 +13479,19 @@ msgstr "Έχετε ήδη γράψει μια κριτική για αυτήν �
 
 #: invenio/modules/comments/api.py:1712
 msgid "You already posted a comment short ago. Please retry later."
-msgstr "Γράψατε ένα σχόλιο ήδη πριν από πολύ λίγο χρόνο. Παρακαλώ δοκιμάστε ξανά."
+msgstr ""
+"Γράψατε ένα σχόλιο ήδη πριν από πολύ λίγο χρόνο. Παρακαλώ δοκιμάστε ξανά."
 
 #: invenio/modules/comments/api.py:1724
 msgid "Failed to insert your comment to the database. Please try again."
 msgstr ""
-"Αποτυχία εισαγωγής του σχολίου σας στη βάση δεδομένων. Παρακαλώ δοκιμάστε"
-" αργότερα."
+"Αποτυχία εισαγωγής του σχολίου σας στη βάση δεδομένων. Παρακαλώ δοκιμάστε "
+"αργότερα."
 
 #: invenio/modules/comments/api.py:1738
 msgid "Unknown action --> showing you the default add comment form."
-msgstr "Άγνωστη ενέργεια --> προβολή της προεπιλεγμένης φόρμας εισαγωγής σχολίου"
+msgstr ""
+"Άγνωστη ενέργεια --> προβολή της προεπιλεγμένης φόρμας εισαγωγής σχολίου"
 
 #: invenio/modules/comments/api.py:1865
 #, fuzzy, python-format
@@ -13594,10 +13513,10 @@ msgid "Record ID %(recid)s is not a number."
 msgstr "Η ταυτότητα εγγραφής %s δεν είναι αριθμός."
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
 "Το μήνυμά σας είναι πολύ μεγάλο, παρακαλώ διορθώστε το. Το μέγιστο "
 "επιτρεπόμενο μήκος είναι %i χαρακτήρες."
@@ -13643,12 +13562,12 @@ msgid "Review was sent"
 msgstr "Γράψτε ένα σχόλιο"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Αυτό το σχόλιο έχει αναφερθεί ως ύποπτο %i φορές"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Αυτό το σχόλιο έχει αναφερθεί ως ύποπτο %i φορές"
 
@@ -13701,9 +13620,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13722,8 +13640,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13733,7 +13651,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "Ένα αρχείο με όνομα %s υπάρχει ήδη. Παρακαλώ επιλέξτε ένα άλλο όνομα."
 
@@ -13789,8 +13707,7 @@ msgstr "κριτική"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13830,8 +13747,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13878,7 +13794,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "Η λειτουργία %s δεν υπάρχει."
 
@@ -13964,11 +13880,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "Κατάσταση harversing"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Τα tickets μου"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -14003,8 +13914,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -14025,8 +13936,8 @@ msgstr "Δεν υπάρχει ευρετήριο λέξεων για το %s."
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -14042,8 +13953,7 @@ msgstr "Επικύρωση Στοιχείου Μορφής %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14165,7 +14075,7 @@ msgstr "Εμφάνιση και των %i συγγραφέων"
 msgid "Manage Files of This Record"
 msgstr "Διαχείριση αρχείων της παρούσας εγγραφής"
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr "Επεξεργασία της παρούσας εγγραφής"
 
@@ -14263,10 +14173,6 @@ msgstr "1 κριτική"
 msgid "Authors"
 msgstr "συγγραφέας"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14359,8 +14265,8 @@ msgstr "Διαχείριση δικαιωμάτων ομάδας"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "Δεν έχετε τα απαιτούμενα δικαιώματα για αυτή την ομάδα."
 
 #: invenio/modules/groups/views.py:279
@@ -14373,12 +14279,12 @@ msgstr "Δεν είστε διαχειριστής σε καμία ομάδα."
 msgid "Members"
 msgstr "Χωρίς μέλη."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Λείπει το όνομα της γνωσιακής βάσης"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14388,11 +14294,11 @@ msgstr "Κανένα"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "οποιοδήποτε πεδίο"
@@ -14438,13 +14344,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "Δεν υπάρχουν εγγραφές που να παραπέμπονται από το %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "Δεν υπάρχουν εγγραφές που να παραπέμπονται από το %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14600,28 +14507,28 @@ msgstr "Άγνωστος τύπος εγγράφου"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14686,8 +14593,8 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 "Εάν επιθυμείτε να ολοκληρώσετε την διαδικασία εγγραφής, παρακαλώ "
 "επισκευτείτε το:"
@@ -15063,7 +14970,7 @@ msgid "Tag name"
 msgstr "Ψευδώνυμο"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "Το επιθυμητό nickname %s χρησιμοποιείται ήδη."
 
@@ -15169,11 +15076,6 @@ msgstr ""
 msgid "Saving..."
 msgstr "Ανέβασμα"
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "Κανένα"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15215,8 +15117,7 @@ msgstr "Επιλογές δανεισμού"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15425,7 +15326,7 @@ msgid "just now"
 msgstr "Πρέπει τώρα"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s δευτερόλεπτα"
 
@@ -15484,6 +15385,57 @@ msgstr "οποιουδήποτε έτους"
 msgid " years ago"
 msgstr "έτος"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "Διαχείριση BibCheck"
+
+#~ msgid "Not authorized"
+#~ msgstr "Χωρίς εξουσιοδότηση"
+
+#~ msgid "Limit to knowledge bases containing string:"
+#~ msgstr "Περιορισμός σε γνωσιακές βάσεις που περιέχουν τη φράση:"
+
+#~ msgid "Really delete"
+#~ msgstr "Επιβεβαίωση διαγραφής"
+
+#~ msgid "Verify syntax"
+#~ msgstr "Επαλήθευση σύνταξης"
+
+#~ msgid "Calling bibcheck -verify failed."
+#~ msgstr "Η εκτέλεση του bibcheck -verify απέτυχε."
+
+#~ msgid "Verify BibCheck config file"
+#~ msgstr "Επιβεβαίωση του αρχείου παραμέτρων του BibCheck"
+
+#~ msgid "Verify problem"
+#~ msgstr "Επιβεβαίωση προβλήματος"
+
+#~ msgid "File"
+#~ msgstr "Αρχείο"
+
+#~ msgid "Edit BibCheck config file"
+#~ msgstr "Τροποποίηση του αρχείου παραμέτρων του BibCheck"
+
+#~ msgid "Save BibCheck config file"
+#~ msgstr "Αποθήκευση αρχείου παραμέτρων του BibCheck"
+
+#~ msgid "Delete BibCheck config file"
+#~ msgstr "Διαγραφή αρχείου παραμέτρων του BibCheck"
+
+#~ msgid "niceName"
+#~ msgstr "niceName"
+
+#~ msgid "Id"
+#~ msgstr "Id"
+
+#~ msgid "Tickets"
+#~ msgstr "Tickets"
+
+#~ msgid "by"
+#~ msgstr "από"
+
+#~ msgid "Done"
+#~ msgstr "Υποβολή"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Προσοχή: Παρακαλώ, επιλέξτε μια σωστή τιμή για τον χρόνο"
 
@@ -15495,9 +15447,6 @@ msgstr "έτος"
 
 #~ msgid "Warning: Please, select a valid date"
 #~ msgstr "Προσοχή: Παρακαλώ, επιλέξτε μια σωστή ημερομηνία"
-
-#~ msgid ""
-#~ msgstr ""
 
 #~ msgid "Invalid MARCXML"
 #~ msgstr "Μη έγκυρο MARCXML"
@@ -15516,9 +15465,6 @@ msgstr "έτος"
 
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "Πρόσθετα στατιστικά αναφορών"
-
-#~ msgid "Sorry, you must log in to perform this action."
-#~ msgstr ""
 
 #~ msgid "Please log in first."
 #~ msgstr "Παρακαλώ κάντε login πρώτα."
@@ -15610,12 +15556,6 @@ msgstr "έτος"
 #~ msgid "now"
 #~ msgstr "τώρα"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "Διαχείριση BibCheck"
-
-#~ msgid "Not authorized"
-#~ msgstr "Χωρίς εξουσιοδότηση"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "Σφάλμα: το %s δεν υπάρχει"
 
@@ -15624,30 +15564,6 @@ msgstr "έτος"
 
 #~ msgid "ERROR: %s is not writable"
 #~ msgstr "Σφάλμα: το %s δεν είναι εγγράψιμο"
-
-#~ msgid "Limit to knowledge bases containing string:"
-#~ msgstr "Περιορισμός σε γνωσιακές βάσεις που περιέχουν τη φράση:"
-
-#~ msgid "Really delete"
-#~ msgstr "Επιβεβαίωση διαγραφής"
-
-#~ msgid "Verify syntax"
-#~ msgstr "Επαλήθευση σύνταξης"
-
-#~ msgid "Calling bibcheck -verify failed."
-#~ msgstr "Η εκτέλεση του bibcheck -verify απέτυχε."
-
-#~ msgid "Verify BibCheck config file"
-#~ msgstr "Επιβεβαίωση του αρχείου παραμέτρων του BibCheck"
-
-#~ msgid "Verify problem"
-#~ msgstr "Επιβεβαίωση προβλήματος"
-
-#~ msgid "File"
-#~ msgstr "Αρχείο"
-
-#~ msgid "Edit BibCheck config file"
-#~ msgstr "Τροποποίηση του αρχείου παραμέτρων του BibCheck"
 
 #~ msgid "File %s already exists."
 #~ msgstr "Το αρχείο %s υπάρχει ήδη."
@@ -15658,20 +15574,11 @@ msgstr "έτος"
 #~ msgid "File %s: write failed."
 #~ msgstr "Αρχείο %s: η εγγραφή απέτυχε."
 
-#~ msgid "Save BibCheck config file"
-#~ msgstr "Αποθήκευση αρχείου παραμέτρων του BibCheck"
-
 #~ msgid "File %s deleted."
 #~ msgstr "Το αρχείο %s έχει διαγραφεί."
 
 #~ msgid "File %s: delete failed."
 #~ msgstr "Αρχείο %s: η διαγραφή απέτυχε"
-
-#~ msgid "Delete BibCheck config file"
-#~ msgstr "Διαγραφή αρχείου παραμέτρων του BibCheck"
-
-#~ msgid "Guests are not authorized to run batchuploader"
-#~ msgstr ""
 
 #~ msgid "The user '%s' is not authorized to run batchuploader"
 #~ msgstr "Ο χρήστης '%s' δεν έχει δικαίωμα να χρησιμοποιήσει το batchuploader"
@@ -15796,9 +15703,6 @@ msgstr "έτος"
 #~ msgid "Tickes you created about this person"
 #~ msgstr "Tickets που δημιουργήσατε για αυτό το άτομο"
 
-#~ msgid "Tickets"
-#~ msgstr "Tickets"
-
 #~ msgid "Request Tickets"
 #~ msgstr "Ticket Αιτήσεων"
 
@@ -15877,9 +15781,6 @@ msgstr "έτος"
 #~ msgid "This book is sent to you ..."
 #~ msgstr "Το βιβλίο έχει αποσταλλεί σε εσάς ..."
 
-#~ msgid "Id"
-#~ msgstr "Id"
-
 #~ msgid "0 borrower(s) found."
 #~ msgstr "0 δανειζόμενοι βρέθηκαν."
 
@@ -15891,9 +15792,6 @@ msgstr "έτος"
 
 #~ msgid "There %s request(s) on the book who has been returned."
 #~ msgstr "Υπάρχουν %s αιτήσεις σχετικά με το βιβλίο που έχει επιστραφεί."
-
-#~ msgid "There are no requests waiting on the item <strong>%s</strong>."
-#~ msgstr ""
 
 #~ msgid "Hold requests and loans overview on"
 #~ msgstr "Αιτήσεις κρατήσεων και δανεισμών για το"
@@ -15948,9 +15846,6 @@ msgstr "έτος"
 
 #~ msgid "Check if the book already exists on Invenio,"
 #~ msgstr "Έλεγχος αν το βιβλίο υπάρχει στο σύστημα,"
-
-#~ msgid "Book does not exists on Invenio. Please fill the following form."
-#~ msgstr ""
 
 #~ msgid "No fulltext"
 #~ msgstr "Δίχως πλήρες κείμενο"
@@ -16024,9 +15919,6 @@ msgstr "έτος"
 #~ msgid "In"
 #~ msgstr "Σε"
 
-#~ msgid "by"
-#~ msgstr "από"
-
 #~ msgid "on"
 #~ msgstr "στις"
 
@@ -16057,9 +15949,6 @@ msgstr "έτος"
 #~ msgid " of "
 #~ msgstr " απο "
 
-#~ msgid "niceName"
-#~ msgstr "niceName"
-
 #~ msgid "Apply Changes"
 #~ msgstr "Αποθήκευση Αλλαγών"
 
@@ -16074,9 +15963,6 @@ msgstr "έτος"
 
 #~ msgid "Edit record %(x_recid)s, field %(x_field)s"
 #~ msgstr "Επεξεργασία εγγραφής %(x_recid)s, πεδίο %(x_field)s"
-
-#~ msgid "Edit record %(x_recid)s, field %(x_field)s - Add a subfield"
-#~ msgstr ""
 
 #~ msgid "Submit and save record %s"
 #~ msgstr "Υποβολή και αποθήκευση εγγραφής %s"
@@ -16177,9 +16063,6 @@ msgstr "έτος"
 #~ msgid "Verbose"
 #~ msgstr "Πιο Αναλυτικά"
 
-#~ msgid "Done"
-#~ msgstr "Υποβολή"
-
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "Οι αλλαγές σας είναι ΠΡΟΣΩΡΙΝΕΣ."
 
@@ -16231,9 +16114,6 @@ msgstr "έτος"
 #~ msgid "Cannot edit deleted record."
 #~ msgstr "Δεν είναι δυνατό να επεξεργαστείτε μια διαγραμμένη εγγραφή."
 
-#~ msgid "There are record revisions not yet synchronized with the database."
-#~ msgstr ""
-
 #~ msgid "Please try again in a few minutes."
 #~ msgstr "Παρακαλώ ξαναδοκιμάστε αργότερα."
 
@@ -16257,9 +16137,6 @@ msgstr "έτος"
 
 #~ msgid "Here is comment/review %s"
 #~ msgstr "Ορίστε το σχόλιο/κριτική %s"
-
-#~ msgid "Here is comment/review %(x_cmtID)s written by user %(x_user)s"
-#~ msgstr ""
 
 #~ msgid "Delete Comment"
 #~ msgstr "Διαγραφή Σχολίου"
@@ -16327,15 +16204,6 @@ msgstr "έτος"
 #~ msgid "Specific Approval and Refereeing Workflow"
 #~ msgstr "Ροή εργασίας ειδικών εγκρίσεων και αξιολογήσεων"
 
-#~ msgid "There is no format configured for this journals index page"
-#~ msgstr ""
-
-#~ msgid "There is no format configured for this journals search page"
-#~ msgstr ""
-
-#~ msgid "There is no format configured for this journals popup page"
-#~ msgstr ""
-
 #~ msgid "We could not find a current issue in the Database"
 #~ msgstr "Δεν μπόρεσε να βρεθεί ένα τρέχον τεύχος στην Βάση"
 
@@ -16374,9 +16242,6 @@ msgstr "έτος"
 
 #~ msgid "Available journals"
 #~ msgstr "Διαθέσιμα περιοδικά"
-
-#~ msgid "Please note that this URL will remain valid for about %s days only."
-#~ msgstr ""
 
 #~ msgid "   Username/Email: %s\n"
 #~ msgstr "   Όνομα χρήστη/Email:"
@@ -16597,12 +16462,6 @@ msgstr "έτος"
 #~ msgid "click here"
 #~ msgstr "κάντε κλίκ εδώ"
 
-#~ msgid "This Document has been <strong class=\"headline\">approved</strong>."
-#~ msgstr ""
-
-#~ msgid "This Document has been <strong class=\"headline\">rejected</strong>."
-#~ msgstr ""
-
 #~ msgid "%s"
 #~ msgstr "%s"
 
@@ -16696,28 +16555,8 @@ msgstr "έτος"
 #~ msgid "Quit searching."
 #~ msgstr "Άκύρωση έρευνας."
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Ακυρώθηκε"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr " Αναζήτηση ατόμου για την ανάθεση της δημοσίευσης αυτής"
@@ -16733,9 +16572,6 @@ msgstr "έτος"
 
 #~ msgid "Hide successful claims"
 #~ msgstr "Απόκρυψη επιτυχημένων διεκδικήσεων"
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
 
 #~ msgid "Author Name"
 #~ msgstr "Συγγραφέας"
@@ -16776,11 +16612,6 @@ msgstr "έτος"
 #~ msgid "They will be regarded in the next run of the author "
 #~ msgstr "Θα εξετασθούν στην επόμενη εκτέλεση του αλγορίθμου "
 
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-#~ "αποσαφήνισης συγγραφέα και ενδέχεται να "
-#~ "εξαφανιστούν από αυτόν τον κατάλογο."
-
 #~ msgid "No comments"
 #~ msgstr "Δίχως σχόλια"
 
@@ -16796,26 +16627,12 @@ msgstr "έτος"
 #~ msgid "No title available"
 #~ msgstr "Μη διαθέσιμο"
 
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
+#~ msgid ""
+#~ "Please select an author on each of the records that will be assigned."
 #~ msgstr "Παρακαλώ επιλέξτε έναν συγγραφέα για τις εν λόγω εγγραφές."
 
 #~ msgid "Papers without a name selected will be ignored in the process."
 #~ msgstr "Τα κουτιά που δεν επιλέχθηκαν, θα αγνοηθούν στην διαδικασία."
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Επιλέξτε όνομα για"
@@ -16847,29 +16664,8 @@ msgstr "έτος"
 #~ msgid "Confirmation needed to continue"
 #~ msgstr "Χρειάζεται επιβεβαίωση για συνέχεια"
 
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-#~ "Το αποτέλεσμα του αιτήματος αυτού θα "
-#~ "είναι άμεσα ορατό, αλλά χρειαζόμαστε "
-#~ "επιβεβαίωση του αιτήματος επειδή η "
-#~ "δημοσίευση αυτή έχει διεκδικηθεί χειροκίνητα"
-#~ " στο παρελθόν"
-
 #~ msgid "This will create a change request for the operators"
 #~ msgstr "Αυτό θα δημιουργήσει ένα αίτημα αλλάγής προς τους διαχειριστές"
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-#~ "Το αποτέλεσμα του αιτήματος αυτού θα "
-#~ "γίνει ορατό μετά από επιβεβαίωση ενός"
-#~ " διαχειριστή"
 
 #~ msgid "Selected name on paper"
 #~ msgstr "Επιλεγμένο όνομα στην δημοσίευση"
@@ -16897,16 +16693,6 @@ msgstr "έτος"
 
 #~ msgid "Please provide your eMail address"
 #~ msgstr "Παρακαλώ δώστε τη διεύθυνση ηλεκτρονικού ταχυδρομείου σας"
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-#~ "Αυτή η διεύθυνση email χρησιμοποιείται "
-#~ "ήδη από κάποιον χρήστη. Παρακαλώ κάντε"
-#~ " login ή δώστε κάποια εναλλακτική "
-#~ "διεύθυνση email"
 
 #~ msgid "Your eMail:"
 #~ msgstr "Το email σας:"
@@ -16941,23 +16727,6 @@ msgstr "έτος"
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Επισήμανση ως _μη_ δικά τους έγγραφα"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-#~ " * Μπορείτε να επιστρέψετε αργότερα "
-#~ "στην σελίδα αυτή. Τίποδα δεν θα "
-#~ "χαθεί. <br />"
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-#~ "  ** Εκτελεί όλες τις αιτούμενες "
-#~ "αλλαγές. Αλλαγές που χρειάζονται άδεια, "
-#~ "θα αποσταλλούν σε κάποιο διαχειριστή για"
-#~ " έλεγχο."
-
 #~ msgid "Create a new Person"
 #~ msgstr "δημιουργία νέου"
 
@@ -16970,15 +16739,6 @@ msgstr "έτος"
 #~ msgid "Add to merge list"
 #~ msgstr "Προσθήκη σε χρήστες"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Πρόσφατες Δημοσιεύσεις"
 
@@ -16988,128 +16748,17 @@ msgstr "έτος"
 #~ msgid "most recent documents:"
 #~ msgstr "πιο πρόσφατων εγγράφων:"
 
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Διαχείριση Αρχείων της Εγγραφής"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Επιλέξτε ένα αρχείο"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Λίστα δημοσιεύσεων "
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "εξωτερικός σύνδεσμος"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "υποβολές"
@@ -17117,69 +16766,9 @@ msgstr "έτος"
 #~ msgid "Choose system"
 #~ msgstr "Επιλογή προτύπου"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Τα παρακάτω αρχεία μπήκαν επιτυχώς στην ουρά:"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
 #~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr "Σφάλμα: η χρήση του Author ID έχουν απενεργοποιηθεί σε αυτό το σύστημα."
+#~ msgstr ""
+#~ "Σφάλμα: η χρήση του Author ID έχουν απενεργοποιηθεί σε αυτό το σύστημα."
 
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Σφάλμα: Δεν έχετε δικαίωμα να χρησιμοποιήσετε αυτή την λειτουργία."
@@ -17187,58 +16776,11 @@ msgstr "έτος"
 #~ msgid "Claim this paper"
 #~ msgstr "Διεκδικήστε την δημοσίευση αυτή"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-#~ "<p>Λυπούμαστε, αλλά συνέβει ένα σφάλμα "
-#~ "κατά την διαχείριση της αίτησής σας. "
-#~ "Παρακαλώ δείτε παρακάτω επιπλέον "
-#~ "πληροφορίες:</p>"
-
 #~ msgid "This page is not accessible directly."
 #~ msgstr "Η σελίδα αυτή δεν είναι προσβάσιμη άμεσα."
 
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Παραπέμπεται από: %s εγγραφές"
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
 
 #~ msgid "Comparison of:"
 #~ msgstr "Σύγκριση των:"
@@ -17248,27 +16790,6 @@ msgstr "έτος"
 
 #~ msgid "Failed to create a ticket"
 #~ msgstr "Αδυναμία δημιουργίας ticket"
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Τροποποίηση Χαρακτηριστικών Προτύπων"
@@ -17348,89 +16869,20 @@ msgstr "έτος"
 #~ msgid "No Record Found for %s."
 #~ msgstr "Η εγγραφή δεν βρέθηκε"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Το αρχείο %s δεν υπάρχει."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "Χαρακτηριστικά Μορφής Αποτελέσματος %s"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "Συσχετισμοί Προτύπου Μορφής %s"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "Επικύρωση Στοιχείου Μορφής %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "Συσχετισμοί Στοιχείου Μορφής %s"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Περιορισμένη Μορφή Αποτελεσμάτων"
@@ -17486,61 +16938,17 @@ msgstr "έτος"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Επικύρωση Στοιχείου Μορφής %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "Επικύρωση Μορφής"
 
 #~ msgid "Knowledge Base %s"
 #~ msgstr "Γνωσιακή Βάση %s"
 
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
-
 #~ msgid "Not Set"
 #~ msgstr "Μη Ορισμένο"
 
 #~ msgid "never"
 #~ msgstr "ποτέ"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
 
 #~ msgid "Name variants"
 #~ msgstr "Παραλλαγές του ονόματος"
@@ -17575,17 +16983,11 @@ msgstr "έτος"
 #~ msgid "Affiliations"
 #~ msgstr "Affiliations"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
 #~ msgid "No Frequent Co-authors"
 #~ msgstr "Κανένας συχνά εμφανιζόμενος πρόσθετος συγγραφέα"
 
 #~ msgid "Citations%s"
 #~ msgstr "Παραπομπές"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Ημ/νία έκδοσης"
@@ -17595,15 +16997,6 @@ msgstr "έτος"
 
 #~ msgid "No publications available"
 #~ msgstr "Δεν υπάρχει διαθέσιμη πληροφορία"
-
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
 
 #~ msgid "Cited by 1 record"
 #~ msgstr "Παραπέμπεται από 1 εγγραφή"
@@ -17632,23 +17025,8 @@ msgstr "έτος"
 #~ msgid "No Citation Information available"
 #~ msgstr "Δεν υπάρχουν διαθέσιμες πληροφορίες για παραπομπές"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Συζήτηση"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Οι Ειδοποιήσεις μου"
@@ -17671,22 +17049,8 @@ msgstr "έτος"
 #~ msgid "Group: %s"
 #~ msgstr "Ομάδα: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "Η Σελίδα %s Δεν Βρέθηκε"
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "Το πεδίο %s είναι υποχρεωτικό."
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
-#~ msgstr ""
-#~ "Αδύνατο να διαγραφεί το πεδίο στην "
-#~ "θέση %s της σελίδας %s της "
-#~ "υποβολής '%s'"
-

--- a/invenio/base/translations/en/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/en/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2006-10-12 17:50+0200\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:57+0200\n"
 "Last-Translator: Tibor Simko <tibor.simko@cern.ch>\n"
 "Language-Team: EN <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -55,8 +55,8 @@ msgstr ""
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -199,7 +199,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr ""
 
@@ -220,17 +220,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -256,45 +256,49 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+msgid "Provided data is not valid"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 msgid "Authorization failure"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 msgid "Please sign in to continue."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 msgid "Authorization failure."
 msgstr ""
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -493,7 +497,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -694,7 +699,8 @@ msgid "The following errors have occurred:"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -711,8 +717,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -794,7 +800,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -836,8 +842,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr ""
@@ -852,8 +858,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr ""
 
@@ -1062,7 +1068,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1111,8 +1118,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1125,25 +1132,23 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1167,13 +1172,14 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1201,9 +1207,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1268,8 +1273,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1277,8 +1282,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1300,9 +1305,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1343,8 +1347,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1399,11 +1403,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1414,11 +1418,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1431,8 +1435,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1522,8 +1526,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1542,29 +1546,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1573,9 +1577,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr ""
 
@@ -1892,16 +1896,14 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -1921,8 +1923,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2066,8 +2068,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2174,7 +2176,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr ""
 
@@ -2366,8 +2368,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2637,9 +2639,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2690,7 +2691,7 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr ""
 
@@ -2698,8 +2699,8 @@ msgstr ""
 #, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3150,8 +3151,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr ""
 
@@ -3939,8 +3940,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -3958,8 +3959,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4018,17 +4019,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4378,25 +4379,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4455,15 +4456,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4474,10 +4475,10 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4490,15 +4491,15 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4509,7 +4510,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4528,17 +4530,15 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4556,14 +4556,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4614,8 +4613,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4665,8 +4664,8 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -4777,9 +4776,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -4792,8 +4791,8 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -4918,11 +4917,10 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5046,7 +5044,7 @@ msgid "Total"
 msgstr ""
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr ""
 
@@ -5202,8 +5200,8 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5258,56 +5256,56 @@ msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5345,7 +5343,7 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5395,15 +5393,15 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5618,8 +5616,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -5693,8 +5690,8 @@ msgstr ""
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -5708,8 +5705,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr ""
 
@@ -5867,8 +5864,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -5894,8 +5891,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -5906,8 +5903,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -5917,108 +5913,108 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 msgid "No match found, please enter different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6032,11 +6028,11 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
 
@@ -6079,10 +6075,9 @@ msgstr ""
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
 
 #: invenio/legacy/webalert/htmlparser.py:186
@@ -6272,15 +6267,15 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:453
@@ -6338,7 +6333,7 @@ msgstr ""
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6402,7 +6397,7 @@ msgstr ""
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6462,7 +6457,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6484,7 +6480,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6511,7 +6508,8 @@ msgid "You do not have permission to delete this note."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6541,8 +6539,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6562,8 +6560,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6594,8 +6592,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -6665,8 +6663,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
@@ -6692,8 +6689,7 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -6853,8 +6849,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7034,15 +7030,16 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2131
@@ -7052,7 +7049,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr ""
 
@@ -7213,7 +7210,7 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7344,207 +7341,207 @@ msgstr ""
 msgid "Record ID %(x_rec)s does not exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, python-format
 msgid "%(x_nb)i Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, python-format
 msgid "View all %(x_name)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 msgid "Be the first to review this document.</div>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 msgid "Close"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7553,487 +7550,489 @@ msgstr ""
 msgid "Record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, python-format
 msgid "Max %(maxfiles)i files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, python-format
 msgid "Here is review %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, python-format
 msgid "Here is comment %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
+msgstr ""
+
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 msgid "Your comment will be lost."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 msgid "Oldest comment first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 msgid "Latest comment first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 msgid "Group by record, latest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 msgid "Records and comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 msgid "Records only"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 msgid "Comments only"
 msgstr ""
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, python-format
 msgid "%(x_i)s items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 msgid "All items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 msgid "Order by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 msgid "Per page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 msgid "Display options"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8041,98 +8040,98 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 msgid "(in reply to a comment)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, python-format
 msgid "%(x_num)i items found in total"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 msgid "You do not have access to the specified comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 msgid "You cannot report a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 msgid "You are not authorized to use comments."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 msgid "Your Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr ""
@@ -8247,8 +8246,8 @@ msgstr ""
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8312,8 +8311,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8340,8 +8339,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -8515,9 +8514,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8538,8 +8536,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9004,14 +9001,14 @@ msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9141,8 +9138,7 @@ msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3357
@@ -9168,8 +9164,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3832
@@ -9351,7 +9347,8 @@ msgid "in"
 msgstr ""
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr ""
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9440,8 +9437,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9450,8 +9447,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:271
@@ -9468,14 +9465,14 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:327
@@ -9513,8 +9510,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:343
 #, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:346
@@ -9601,10 +9598,9 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:559
@@ -9621,15 +9617,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:573
@@ -9642,10 +9638,10 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:611
@@ -9665,8 +9661,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:636
@@ -9681,22 +9677,22 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:785
@@ -9713,8 +9709,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:799
@@ -9726,8 +9722,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:805
@@ -9738,8 +9734,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:811
@@ -9785,7 +9781,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -9833,15 +9830,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1027
@@ -9877,8 +9874,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -9903,8 +9900,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1228
@@ -9921,24 +9918,24 @@ msgstr ""
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1235
 #, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1267
@@ -10065,8 +10062,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1378
@@ -10285,7 +10282,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2400
@@ -10327,71 +10325,66 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:127
@@ -10400,14 +10393,14 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -10416,8 +10409,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -10429,8 +10422,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -10499,8 +10492,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -10563,8 +10555,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -10627,10 +10618,10 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -10658,8 +10649,8 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:452
 #, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -10834,15 +10825,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:989
@@ -10956,7 +10947,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:707
@@ -10979,37 +10971,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11017,15 +11009,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11089,8 +11081,8 @@ msgstr ""
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11125,8 +11117,8 @@ msgstr ""
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11172,8 +11164,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:366
@@ -11202,8 +11194,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:548
@@ -11252,8 +11244,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1041
@@ -11335,8 +11327,7 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -11473,7 +11464,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -11565,8 +11557,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -11585,8 +11577,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -11627,7 +11619,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -11648,14 +11641,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -11766,10 +11758,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12040,8 +12031,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12188,8 +12179,8 @@ msgstr ""
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -12248,9 +12239,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -12271,8 +12261,8 @@ msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -12338,8 +12328,7 @@ msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -12402,13 +12391,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -12417,9 +12405,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -12581,8 +12569,7 @@ msgstr ""
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -12664,8 +12651,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -12754,8 +12741,8 @@ msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:55
@@ -12845,9 +12832,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -12866,8 +12852,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -12925,8 +12911,7 @@ msgstr ""
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -12963,8 +12948,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13114,8 +13098,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13136,8 +13120,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13153,8 +13137,7 @@ msgstr ""
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -13270,7 +13253,7 @@ msgstr ""
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr ""
 
@@ -13452,8 +13435,8 @@ msgstr ""
 #: invenio/modules/groups/views.py:223
 #, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr ""
 
 #: invenio/modules/groups/views.py:279
@@ -13465,11 +13448,11 @@ msgstr ""
 msgid "Members"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 msgid "Knowledge base name"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 msgid "-None-"
 msgstr ""
@@ -13478,11 +13461,11 @@ msgstr ""
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 msgid "Index fields"
 msgstr ""
 
@@ -13528,7 +13511,7 @@ msgid "Create new record \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
+msgid "Create KB \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
@@ -13665,28 +13648,28 @@ msgstr ""
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -13747,8 +13730,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -14202,8 +14185,7 @@ msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -14451,1706 +14433,3 @@ msgstr ""
 #: invenio/utils/date.py:581
 msgid " years ago"
 msgstr ""
-
-#~ msgid "Export as"
-#~ msgstr ""
-
-#~ msgid "Search Services"
-#~ msgstr ""
-
-#~ msgid "Citation Metrics"
-#~ msgstr ""
-
-#~ msgid "WebSearch Admin Guide"
-#~ msgstr ""
-
-#~ msgid "Submit Guide"
-#~ msgstr ""
-
-#~ msgid "Add to personal basket"
-#~ msgstr ""
-
-#~ msgid "WebSubmit Admin Guide"
-#~ msgstr ""
-
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
-#~ msgid "Quit searching."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
-#~ msgid "Cancel merging"
-#~ msgstr ""
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Your options"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
-
-#~ msgid "Search for a person to assign the paper to"
-#~ msgstr ""
-
-#~ msgid "Select All"
-#~ msgstr ""
-
-#~ msgid "Select None"
-#~ msgstr ""
-
-#~ msgid "Invert Selection"
-#~ msgstr ""
-
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
-#~ msgid "Author Name"
-#~ msgstr ""
-
-#~ msgid "Experiment"
-#~ msgstr ""
-
-#~ msgid "Not assigned"
-#~ msgstr ""
-
-#~ msgid "No status information found."
-#~ msgstr ""
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
-
-#~ msgid "Review Transaction"
-#~ msgstr ""
-
-#~ msgid "On all pages"
-#~ msgstr ""
-
-#~ msgid "With selected do"
-#~ msgstr ""
-
-#~ msgid "View name variants"
-#~ msgstr ""
-
-#~ msgid "The author has an internal ID!"
-#~ msgstr ""
-
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
-#~ msgid "Not provided"
-#~ msgstr ""
-
-#~ msgid "Not available"
-#~ msgstr ""
-
-#~ msgid "No comments"
-#~ msgstr ""
-
-#~ msgid "Not Available"
-#~ msgstr ""
-
-#~ msgid " Delete this ticket"
-#~ msgstr ""
-
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
-#~ msgid "No title available"
-#~ msgstr ""
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
-
-#~ msgid "Select name for"
-#~ msgstr ""
-
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
-#~ msgid "Paper title: "
-#~ msgstr ""
-
-#~ msgid "Ignore"
-#~ msgstr ""
-
-#~ msgid "The following names have been automatically chosen:"
-#~ msgstr ""
-
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
-#~ msgid "Selected name on paper"
-#~ msgstr ""
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
-
-#~ msgid "Please provide your information"
-#~ msgstr ""
-
-#~ msgid "Please provide your first name"
-#~ msgstr ""
-
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
-#~ msgid "Your last name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
-#~ msgid "Your eMail:"
-#~ msgstr ""
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
-
-#~ msgid "!Delete the entire request!"
-#~ msgstr ""
-
-#~ msgid "Mark as your documents"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
-#~ msgid "Mark as their documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ their documents"
-#~ msgstr ""
-
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
-#~ msgid "Create new profile"
-#~ msgstr ""
-
-#~ msgid "Create a new Person"
-#~ msgstr ""
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
-
-#~ msgid "Add to merge list"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
-#~ msgid "Recent Papers"
-#~ msgstr ""
-
-#~ msgid "Publication List "
-#~ msgstr ""
-
-#~ msgid "Showing the"
-#~ msgstr ""
-
-#~ msgid "most recent documents:"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
-#~ msgid "Manage your profile"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
-
-#~ msgid "Choose your profile"
-#~ msgstr ""
-
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
-#~ msgid "Manage publication list"
-#~ msgstr ""
-
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
-#~ msgid "add external id"
-#~ msgstr ""
-
-#~ msgid "delete selected ids"
-#~ msgstr ""
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
-
-#~ msgid "suggest missing ids"
-#~ msgstr ""
-
-#~ msgid "Choose system"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr ""
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
-#~ msgid "Fatal: You are not allowed to access this functionality."
-#~ msgstr ""
-
-#~ msgid "Claim this paper"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "You have %i tickets."
-#~ msgstr ""
-
-#~ msgid "The publication date of this book is %s."
-#~ msgstr ""
-
-#~ msgid "You can see your library account %(x_url_open)shere%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid "%i items found."
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
-#~ msgid "Unweighted %s keywords:"
-#~ msgstr ""
-
-#~ msgid "Weighted %s keywords:"
-#~ msgstr ""
-
-#~ msgid "Unknown type: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file named %s already exists. Please choose another name."
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Record #%i"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
-#~ msgid "Revision"
-#~ msgstr ""
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Could not find format element named %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s could not be found."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
-
-#~ msgid "Output format with code %s could not be found."
-#~ msgstr ""
-
-#~ msgid "Could not find output format named %s."
-#~ msgstr ""
-
-#~ msgid "Could not find a fresh name for output format %s."
-#~ msgstr ""
-
-#~ msgid "Modify Template Attributes"
-#~ msgstr ""
-
-#~ msgid "Template Editor"
-#~ msgstr ""
-
-#~ msgid "Check Dependencies"
-#~ msgstr ""
-
-#~ msgid "Update Format Attributes"
-#~ msgstr ""
-
-#~ msgid "Show Documentation"
-#~ msgstr ""
-
-#~ msgid "Hide Documentation"
-#~ msgstr ""
-
-#~ msgid "Last Modification Date"
-#~ msgstr ""
-
-#~ msgid "Manage Output Formats"
-#~ msgstr ""
-
-#~ msgid "Manage Format Templates"
-#~ msgstr ""
-
-#~ msgid "Format Elements Documentation"
-#~ msgstr ""
-
-#~ msgid "Add New Format Template"
-#~ msgstr ""
-
-#~ msgid "Check Format Templates Extensively"
-#~ msgstr ""
-
-#~ msgid "Code"
-#~ msgstr ""
-
-#~ msgid "Add New Output Format"
-#~ msgstr ""
-
-#~ msgid "menu"
-#~ msgstr ""
-
-#~ msgid "Close Output Format"
-#~ msgstr ""
-
-#~ msgid "Rules"
-#~ msgstr ""
-
-#~ msgid "Modify Output Format Attributes"
-#~ msgstr ""
-
-#~ msgid "Remove Rule"
-#~ msgstr ""
-
-#~ msgid "Add New Rule"
-#~ msgstr ""
-
-#~ msgid "No problem found with format"
-#~ msgstr ""
-
-#~ msgid "An error has been found"
-#~ msgstr ""
-
-#~ msgid "The following errors have been found"
-#~ msgstr ""
-
-#~ msgid "BibFormat Admin"
-#~ msgstr ""
-
-#~ msgid "Test with record:"
-#~ msgstr ""
-
-#~ msgid "Enter a search query here."
-#~ msgstr ""
-
-#~ msgid "No Record Found for %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
-#~ msgid "Template \"%s\" does not exist at line %s."
-#~ msgstr ""
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
-
-#~ msgid "Output format %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
-#~ msgid "Format template %s calls undefined element \"%s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
-
-#~ msgid "Error in format element %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Show all %i authors"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
-
-#~ msgid "Restricted Output Format"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Rules"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Output Format"
-#~ msgstr ""
-
-#~ msgid "Cannot create output format"
-#~ msgstr ""
-
-#~ msgid "Format template %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Element %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Test Format Element %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Output Format %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Element"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Element %s"
-#~ msgstr ""
-
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
-#~ msgid "Format Validation"
-#~ msgstr ""
-
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid "Your rule: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Download history:"
-#~ msgstr ""
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid "Cannot send error request, %s parameter missing."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Not Set"
-#~ msgstr ""
-
-#~ msgid "never"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Your account on '%s' has been activated"
-#~ msgstr ""
-
-#~ msgid "Your account earlier created on '%s' has been activated:"
-#~ msgstr ""
-
-#~ msgid "Account created on '%s'"
-#~ msgstr ""
-
-#~ msgid "An account has been created for you on '%s':"
-#~ msgstr ""
-
-#~ msgid "Account rejected on '%s'"
-#~ msgstr ""
-
-#~ msgid "Your request for an account has been rejected on '%s':"
-#~ msgstr ""
-
-#~ msgid "Username/Email: %s"
-#~ msgstr ""
-
-#~ msgid "Account deleted on '%s'"
-#~ msgstr ""
-
-#~ msgid "Your account on '%s' has been deleted:"
-#~ msgstr ""
-
-#~ msgid "You already have an alert named %s."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been added to your profile."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been successfully updated."
-#~ msgstr ""
-
-#~ msgid "You have defined %s alerts."
-#~ msgstr ""
-
-#~ msgid "Here are the %s most popular searches."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display searches"
-#~ msgstr ""
-
-#~ msgid "%s, personalize"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Set a new alert"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Modify alert settings"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display alerts"
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
-
-#~ msgid "times"
-#~ msgstr ""
-
-#~ msgid "Papers"
-#~ msgstr ""
-
-#~ msgid "No Keywords"
-#~ msgstr ""
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
-
-#~ msgid "No Subject categories"
-#~ msgstr ""
-
-#~ msgid "Subject categories"
-#~ msgstr ""
-
-#~ msgid "No Collaborations"
-#~ msgstr ""
-
-#~ msgid "Collaborations"
-#~ msgstr ""
-
-#~ msgid "unknown affiliation"
-#~ msgstr ""
-
-#~ msgid "No Affiliations"
-#~ msgstr ""
-
-#~ msgid "Affiliations"
-#~ msgstr ""
-
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
-#~ msgid "Citations%s"
-#~ msgstr ""
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
-
-#~ msgid "No Publication Graph"
-#~ msgstr ""
-
-#~ msgid "<strong> Publications list </strong>"
-#~ msgstr ""
-
-#~ msgid "No publications available"
-#~ msgstr ""
-
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "Sorry, you do not have sufficient rights to add record #%i."
-#~ msgstr ""
-
-#~ msgid "%i matching items"
-#~ msgstr ""
-
-#~ msgid "%i items have been successfully added to your basket"
-#~ msgstr ""
-
-#~ msgid "Adding %i items to your baskets"
-#~ msgstr ""
-
-#~ msgid "%i users are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "%i user groups are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "You have set %i alerts on this basket."
-#~ msgstr ""
-
-#~ msgid "%i items"
-#~ msgstr ""
-
-#~ msgid "%i notes"
-#~ msgstr ""
-
-#~ msgid "%i subscribers"
-#~ msgstr ""
-
-#~ msgid "Record %i"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s does not exist in the database."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is an invalid ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "Showing the latest %i comments:"
-#~ msgstr ""
-
-#~ msgid "Sorry, the record %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "Sorry, %s is not a valid ID value."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s"
-#~ msgstr ""
-
-#~ msgid "Readers found the following %s reviews to be most helpful."
-#~ msgstr ""
-
-#~ msgid "View all %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s comments"
-#~ msgstr ""
-
-#~ msgid "Note: Your nickname, %s, will be displayed as author of this comment."
-#~ msgstr ""
-
-#~ msgid "Max %i files"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Note: Your nickname, %s, will be "
-#~ "displayed as the author of this "
-#~ "review."
-#~ msgstr ""
-
-#~ msgid "View all %s reported comments"
-#~ msgstr ""
-
-#~ msgid "View all %s reported reviews"
-#~ msgstr ""
-
-#~ msgid "This review has been reported %i times"
-#~ msgstr ""
-
-#~ msgid "This comment has been reported %i times"
-#~ msgstr ""
-
-#~ msgid "Here are the reported reviews of user %s"
-#~ msgstr ""
-
-#~ msgid "Here are the reported comments of user %s"
-#~ msgstr ""
-
-#~ msgid "Here is review %s"
-#~ msgstr ""
-
-#~ msgid "Here is comment %s"
-#~ msgstr ""
-
-#~ msgid "Here are all reviews for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "Here are all comments for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "%s items"
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid "%i items found in total"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "%s View your previously submitted comments"
-#~ msgstr ""
-
-#~ msgid "Comment ID %s does not exist."
-#~ msgstr ""
-
-#~ msgid "Record ID %s does not exist."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your message is too long, please "
-#~ "shorten it. Maximum size allowed is "
-#~ "%i characters."
-#~ msgstr ""
-
-#~ msgid "Group %s does not exist."
-#~ msgstr ""
-
-#~ msgid "User %s does not exist."
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
-#~ msgid "There are no records referring to %s."
-#~ msgstr ""
-
-#~ msgid "There are no records modified by %s."
-#~ msgstr ""
-
-#~ msgid "There are no records cited by %s."
-#~ msgstr ""
-
-#~ msgid "No word index is available for %s."
-#~ msgstr ""
-
-#~ msgid "No phrase index is available for %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Search term %s did not match any"
-#~ " record. Nearest terms in any "
-#~ "collection are:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, %s does not seem to be "
-#~ "a valid sort option. The records "
-#~ "will not be sorted."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, sorting is allowed on sets "
-#~ "of up to %d records only. Using"
-#~ " default sort order."
-#~ msgstr ""
-
-#~ msgid "The record %d replaces it."
-#~ msgstr ""
-
-#~ msgid "%s results found"
-#~ msgstr ""
-
-#~ msgid "%s seconds"
-#~ msgstr ""
-
-#~ msgid "Search %s records for"
-#~ msgstr ""
-
-#~ msgid "Cited by %i records"
-#~ msgstr ""
-
-#~ msgid "%s records found"
-#~ msgstr ""
-
-#~ msgid "Search took %s seconds."
-#~ msgstr ""
-
-#~ msgid "Cited by 1 record"
-#~ msgstr ""
-
-#~ msgid "%i comments"
-#~ msgstr ""
-
-#~ msgid "%i reviews"
-#~ msgstr ""
-
-#~ msgid "Collection %s Not Found"
-#~ msgstr ""
-
-#~ msgid "Sorry, collection %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s."
-#~ msgstr ""
-
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid "Cited by: %s records"
-#~ msgstr ""
-
-#~ msgid "Co-cited with: %s records"
-#~ msgstr ""
-
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
-#~ msgid "No Papers"
-#~ msgstr ""
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
-
-#~ msgid "Citations:"
-#~ msgstr ""
-
-#~ msgid "No Citation Information available"
-#~ msgstr ""
-
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Sorry, DOI %s could not be resolved."
-#~ msgstr ""
-
-#~ msgid "DOI \"%s\" Not Found"
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
-#~ msgid "Discussion"
-#~ msgstr ""
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If you are using a lightweight CERN account you can\n"
-#~ "                %(x_url_open)sreset the password%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Alternatively, you can ask %s to "
-#~ "change your login system from external"
-#~ " to internal."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "%s offers you the possibility to "
-#~ "personalize the interface, to set up "
-#~ "your own personal library of documents,"
-#~ " or to set up an automatic "
-#~ "alert query that would run periodically"
-#~ " and would notify you of search "
-#~ "results by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid "Okay, a password reset link has been emailed to %s."
-#~ msgstr ""
-
-#~ msgid "If you don't own an account yet, please contact %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please do not use valuable passwords "
-#~ "such as your Unix, AFS or NICE "
-#~ "passwords with this service. Your email"
-#~ " address will stay strictly confidential"
-#~ " and will not be disclosed to "
-#~ "any third party. It will be used"
-#~ " to identify you for personal "
-#~ "services of %s. For example, you "
-#~ "may set up an automatic alert "
-#~ "search that will look for new "
-#~ "preprints and will notify you daily "
-#~ "of new arrivals by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "It is not possible to create an"
-#~ " account yourself. Contact %s if you"
-#~ " want an account."
-#~ msgstr ""
-
-#~ msgid "Your alerts"
-#~ msgstr ""
-
-#~ msgid "Your approvals"
-#~ msgstr ""
-
-#~ msgid "Your baskets"
-#~ msgstr ""
-
-#~ msgid "Your comments"
-#~ msgstr ""
-
-#~ msgid "Your groups"
-#~ msgstr ""
-
-#~ msgid "Your loans"
-#~ msgstr ""
-
-#~ msgid "Your submissions"
-#~ msgstr ""
-
-#~ msgid "Your searches"
-#~ msgstr ""
-
-#~ msgid "Administration"
-#~ msgstr ""
-
-#~ msgid "Statistics"
-#~ msgstr ""
-
-#~ msgid "Edit %s members"
-#~ msgstr ""
-
-#~ msgid "Edit group %s"
-#~ msgstr ""
-
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
-#~ msgid "Group: %s"
-#~ msgstr ""
-
-#~ msgid "Group %s: New membership request"
-#~ msgstr ""
-
-#~ msgid "A user wants to join the group %s."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been accepted"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been accepted."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been rejected"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been rejected."
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted"
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted by its administrator."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Your Settings"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown to the external login "
-#~ "system."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The external login method %s does "
-#~ "not support email address based logins."
-#~ "  Please contact the site administrators."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is already in use."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "Sorry, page %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
-#~ msgid "Page %s Not Found"
-#~ msgstr ""
-
-#~ msgid "Please contact %s quoting the following information:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
-
-#~ msgid "Unable to find the submission directory for the action: %s"
-#~ msgstr ""
-
-#~ msgid "Unable to find document type: %s"
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory."
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory. Please fill it in."
-#~ msgstr ""
-
-#~ msgid "Function %s does not exist."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s%s'"
-#~ msgstr ""
-

--- a/invenio/base/translations/es/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/es/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.1.1\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2013-02-25 11:40+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:57+0200\n"
 "Last-Translator: Ferran Jorba <Ferran.Jorba@uab.cat>\n"
 "Language-Team: ES <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -58,8 +58,8 @@ msgstr "Páginas principal"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -205,7 +205,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Hola:"
 
@@ -226,17 +226,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, fuzzy, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr "El sistema no intenta enviar un mensaje de %s, a %s, amb el texto %s."
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -262,48 +262,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr "Error al enviar un mensaje de %s, a %s, con el texto %s."
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "La url que ha dado no es válida."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr "Petición de reiniciar la contraseña de"
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "No está autorizado a hacer uso del préstamo."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Ha fallado el alta"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Seleccione uno o más:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Petición de rol de autorización"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, fuzzy, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr "Puede bajarse una versión más reciente de Invenio.  Visite "
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -503,7 +508,8 @@ msgstr "No tiene permiso para subir documentos a la colección «%s»"
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 "El usuario «%(x_user)s» no está autorizado a modificar la colección "
 "«%(x_coll)s»"
@@ -578,9 +584,9 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"Su fichero está en cola. Ahora puede comprobar su "
-"%(x_url1_open)shistórico de cargas%(x_url1_close)s o "
-"%(x_url2_open)senviar otro fichero%(x_url2_close)s"
+"Su fichero está en cola. Ahora puede comprobar su %(x_url1_open)shistórico "
+"de cargas%(x_url1_close)s o %(x_url2_open)senviar otro fichero"
+"%(x_url2_close)s"
 
 #: invenio/legacy/batchuploader/templates.py:282
 msgid "No metadata files have been uploaded yet."
@@ -713,7 +719,8 @@ msgid "The following errors have occurred:"
 msgstr "Se han encontrado los siguientes errores:"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 "Algunos ficheros no se han podido pasar al directorio DONE.  Bórrelos "
 "manualmente."
@@ -728,17 +735,17 @@ msgid ""
 "Using %(x_fmt_open)sweb interface upload%(x_fmt_close)s, actions are "
 "executed a single time."
 msgstr ""
-"Usando la %(x_fmt_open)sinterfaz web de subir ficheros%(x_fmt_close)s, "
-"las acciones sólo se ejecutan una vez."
+"Usando la %(x_fmt_open)sinterfaz web de subir ficheros%(x_fmt_close)s, las "
+"acciones sólo se ejecutan una vez."
 
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
-"Consulte la %(x_url_open)spágina de ayuda del Batch Uploader "
-"daemon%(x_url_close)s para ejecutar estas acciones periódicamente."
+"Consulte la %(x_url_open)spágina de ayuda del Batch Uploader daemon"
+"%(x_url_close)s para ejecutar estas acciones periódicamente."
 
 #: invenio/legacy/batchuploader/templates.py:602
 msgid "Metadata folders"
@@ -819,7 +826,7 @@ msgstr "Id"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -861,8 +868,8 @@ msgstr "Tiene %i tareas."
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Anterior"
@@ -877,8 +884,8 @@ msgstr "cerrar"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Siguiente"
 
@@ -894,18 +901,6 @@ msgstr "Siguiente"
 msgid "Admin Area"
 msgstr "Zona de administración"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "autor"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
 msgid "ERROR: %(x_name)s does not exist"
@@ -920,15 +915,6 @@ msgstr ""
 #, python-format
 msgid "ERROR: %(x_name)s is not writable"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
-msgid "Limit to knowledge bases containing string:"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "suprimido correctamente"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -958,10 +944,6 @@ msgstr "suprimido correctamente"
 msgid "Delete"
 msgstr "Suprimir"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:140
-msgid "Verify syntax"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:145
 #: invenio/modules/communities/views.py:258
 #, fuzzy
@@ -973,31 +955,9 @@ msgstr "Crear una llave nueva"
 msgid "File %(x_name)s does not exist."
 msgstr "El usuario %s no existe"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:174
-msgid "Calling bibcheck -verify failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
-msgid "Verify BibCheck config file"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Problema en la base de datos"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "archivo(s)"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
 msgstr "Guardar cambios"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:240
-msgid "Edit BibCheck config file"
-msgstr ""
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:268
 #, fuzzy, python-format
@@ -1014,10 +974,6 @@ msgstr ""
 msgid "File %(x_name)s: write failed."
 msgstr ""
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:279
-msgid "Save BibCheck config file"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:312
 #, python-format
 msgid "File %(x_name)s deleted."
@@ -1026,10 +982,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:314
 #, python-format
 msgid "File %(x_name)s: delete failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:316
-msgid "Delete BibCheck config file"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:195
@@ -1097,7 +1049,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1152,8 +1105,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1169,9 +1122,8 @@ msgstr "Código de barras"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
 "Se ha devuelto correctamente el elemento %(x_title)s, con el código de "
 "barras %(x_barcode)s."
@@ -1179,17 +1131,16 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
 "Se ha devuelto correctamente el elemento %(x_title)s, con el código de "
 "barras %(x_barcode)s."
@@ -1216,15 +1167,16 @@ msgstr "Crear otro"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
 "Se ha devuelto correctamente el elemento %(x_title)s, con el código de "
 "barras %(x_barcode)s."
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1256,9 +1208,8 @@ msgstr "Período de préstamo"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
 "Se ha devuelto correctamente el elemento %(x_title)s, con el código de "
 "barras %(x_barcode)s."
@@ -1327,8 +1278,8 @@ msgstr "Nueva petición"
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1336,8 +1287,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1359,9 +1310,8 @@ msgstr "Nuevo préstamo"
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
 "Se ha devuelto correctamente el elemento %(x_title)s, con el código de "
 "barras %(x_barcode)s."
@@ -1405,8 +1355,8 @@ msgstr "No se ha encontrado ningún usuario."
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1465,11 +1415,11 @@ msgstr "Su registrado correctamente la nueva petición."
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1480,11 +1430,11 @@ msgstr "Sí"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1497,8 +1447,8 @@ msgstr "No"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1593,8 +1543,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1614,29 +1564,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1645,9 +1595,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr "El registro solicitado no existe."
 
@@ -2007,16 +1957,14 @@ msgstr "Este registro no tiene ejemplares."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2037,8 +1985,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2200,8 +2148,8 @@ msgstr "Petición de préstamo interbibliotecario"
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2308,7 +2256,7 @@ msgstr "Lugar"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Descripción"
 
@@ -2501,8 +2449,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2776,9 +2724,8 @@ msgstr "Confirmar"
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "Si lo desea puede %(x_url_open)sidentificarse aquí%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2832,7 +2779,7 @@ msgstr "Reiniciar"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "De acuerdo"
 
@@ -2840,8 +2787,8 @@ msgstr "De acuerdo"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
 "Se ha devuelto correctamente el elemento %(x_title)s, con el código de "
 "barras %(x_barcode)s."
@@ -3303,8 +3250,8 @@ msgstr "Buzón"
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "Dirección electrónica"
 
@@ -3779,8 +3726,8 @@ msgstr "Detalles de la nueva copia"
 #, fuzzy, python-format
 msgid "A %(x_url_open)snew copy%(x_url_close)s has been added."
 msgstr ""
-"Debería %(x_url_open)saceptar o rechazar%(x_url_close)s la petición de "
-"este usuario."
+"Debería %(x_url_open)saceptar o rechazar%(x_url_close)s la petición de este "
+"usuario."
 
 #: invenio/legacy/bibcirculation/templates.py:7443
 #, fuzzy
@@ -4029,7 +3976,8 @@ msgstr "Comentario adicionales"
 msgid ""
 "I accept the %(x_url_open)sconditions%(x_url_close)s of the service in "
 "particular the return of books in due time."
-msgstr "Acepto los %s del servicio, en particular devolver los libros a tiempo."
+msgstr ""
+"Acepto los %s del servicio, en particular devolver los libros a tiempo."
 
 #: invenio/legacy/bibcirculation/templates.py:9491
 msgid "I want this edition only."
@@ -4112,11 +4060,11 @@ msgstr "Período de interés (hasta)"
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, fuzzy, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
-"El lector acepta el %s del servicio, en particular devolver los libros en"
-" el plazo."
+"El lector acepta el %s del servicio, en particular devolver los libros en el "
+"plazo."
 
 #: invenio/legacy/bibcirculation/templates.py:9721
 msgid "Borrower wants this edition only."
@@ -4133,11 +4081,11 @@ msgstr "Solamente esta edición"
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, fuzzy, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
-"Compruebe si el libro existe en Invenio antes de solicitar una petición "
-"de PI."
+"Compruebe si el libro existe en Invenio antes de solicitar una petición de "
+"PI."
 
 #: invenio/legacy/bibcirculation/templates.py:10332
 msgid "0 items found."
@@ -4195,17 +4143,17 @@ msgstr "ISSN"
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4581,36 +4529,36 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "El registro se ha suprimido."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 "Generado automáticamente <span class=\"keyword single\">sencillo</span>, "
-"<span class=\"keyword composite\">compuesto</span>, <span class=\"keyword"
-" author-kw\">autor</span>, i <span class=\"keyword other-kw\">otras "
-"palabras clave</span>."
+"<span class=\"keyword composite\">compuesto</span>, <span class=\"keyword "
+"author-kw\">autor</span>, i <span class=\"keyword other-kw\">otras palabras "
+"clave</span>."
 
 #: invenio/legacy/bibclassify/templates.py:230
 msgid "Automated keyword extraction wasn't run for this document yet."
 msgstr ""
-"Para este documento todavía no se han extraído automáticamente las "
-"palabras clave."
+"Para este documento todavía no se han extraído automáticamente las palabras "
+"clave."
 
 #: invenio/legacy/bibclassify/templates.py:230
 msgid "Generate keywords"
@@ -4666,20 +4614,20 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
-"Su petición se ha registrado.  La extracción automática de palabras clave"
-" se ejecutará pronto.  Vuelva dentro de un rato."
+"Su petición se ha registrado.  La extracción automática de palabras clave se "
+"ejecutará pronto.  Vuelva dentro de un rato."
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
-"Por desgracia, no existe una copia local del texto completo en PDF. No es"
-" posible generar automáticamente las palabras clave."
+"Por desgracia, no existe una copia local del texto completo en PDF. No es "
+"posible generar automáticamente las palabras clave."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:463
@@ -4689,10 +4637,10 @@ msgstr "Escoja el fichero"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4705,20 +4653,20 @@ msgstr "Acceso"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
-"El fichero que quiere editar está protegido contra modificaciones. "
-"Vuestra acción no se ha realizado"
+"El fichero que quiere editar está protegido contra modificaciones. Vuestra "
+"acción no se ha realizado"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, fuzzy, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
-"El archivo que ha subido es demasiado pequeño (<%i o) y por tanto no se "
-"ha tenido en cuenta"
+"El archivo que ha subido es demasiado pequeño (<%i o) y por tanto no se ha "
+"tenido en cuenta"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
 #, fuzzy, python-format
@@ -4726,14 +4674,15 @@ msgid ""
 "The uploaded file is too big (>%(x_size)i o) and has therefore not been "
 "considered"
 msgstr ""
-"El archivo que ha subido es demasiado grande (>%i o) y por tanto no se ha"
-" tenido en cuenta"
+"El archivo que ha subido es demasiado grande (>%i o) y por tanto no se ha "
+"tenido en cuenta"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
-"El nombre del archivo que ha subido es demasiado largo y por tanto no se "
-"ha tenido en cuenta"
+"El nombre del archivo que ha subido es demasiado largo y por tanto no se ha "
+"tenido en cuenta"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
 msgid ""
@@ -4751,22 +4700,20 @@ msgstr "Ya existe un fichero con el nombre %s.  Escoja otro, por favor."
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "Ya existe un archivo con el formato '%s'.  Súbalo en otro formato."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
-"No se puede usar el punto '.', barra '/', o barra inversa '\\\\\\\\' en "
-"los nombres de ficheros.  Escoja un nombre diferente o vuelva a subir su "
-"fichero.  En particular, tenga en cuenta de no incluir la extensión en el"
-" nuevo nombre."
+"No se puede usar el punto '.', barra '/', o barra inversa '\\\\\\\\' en los "
+"nombres de ficheros.  Escoja un nombre diferente o vuelva a subir su "
+"fichero.  En particular, tenga en cuenta de no incluir la extensión en el "
+"nuevo nombre."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
 msgid "Choose how you want to restrict access to this file."
@@ -4783,17 +4730,16 @@ msgstr "Puede decidir esconder o no versiones anteriores de este archivo."
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 "Cuando revise un archivo, los formatos adicionales que haya subido "
-"previamente serán borrados, ya que no estarían sincronizados con el nuevo"
-" archivo."
+"previamente serán borrados, ya que no estarían sincronizados con el nuevo "
+"archivo."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 "Los formatos alternativos para la versión actual de este archivo serán "
 "borrados"
@@ -4854,8 +4800,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 "Tiene problemas al añadir o revisar un fichero? Envíe la versión nueva o "
 "revisada a %(mailto_link)s."
@@ -4907,11 +4853,11 @@ msgstr "El registro solicitado no parece haber sido integrado."
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
-"El sistema ha encontrado un error recuperando la lista de los archivos de"
-" este documento."
+"El sistema ha encontrado un error recuperando la lista de los archivos de "
+"este documento."
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
 #: invenio/legacy/websession/webinterface.py:1023
@@ -4920,8 +4866,7 @@ msgid ""
 "The error has been logged and will be taken in consideration as soon as "
 "possible."
 msgstr ""
-"El error ha sido anotado y será tenido en cuenta tan pronto como sea "
-"posible."
+"El error ha sido anotado y será tenido en cuenta tan pronto como sea posible."
 
 #: invenio/legacy/bibdocfile/webinterface.py:202
 #, fuzzy, python-format
@@ -4934,7 +4879,8 @@ msgstr "Este archivo es de acceso restringido."
 
 #: invenio/legacy/bibdocfile/webinterface.py:228
 msgid "An error has happened in trying to stream the request file."
-msgstr "Este archivo está escondido y usted no tiene permiso para acceder a él."
+msgstr ""
+"Este archivo está escondido y usted no tiene permiso para acceder a él."
 
 #: invenio/legacy/bibdocfile/webinterface.py:231
 msgid "The requested file is hidden and can not be accessed."
@@ -5023,13 +4969,12 @@ msgstr "1. Escoja los criterios de búsqueda"
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
-"Especifique los criterios que quiera para filtrar los registros a "
-"cambiar.  Use «Buscar» para ver qué registros se filtrarían con estos "
-"criterios."
+"Especifique los criterios que quiera para filtrar los registros a cambiar.  "
+"Use «Buscar» para ver qué registros se filtrarían con estos criterios."
 
 #: invenio/legacy/bibeditmulti/templates.py:361
 msgid "Preview results"
@@ -5041,8 +4986,8 @@ msgstr "2. Definición de los cambios"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 "Especifique los campos y subcampos a cambiar para cada registro que "
 "concuerde con los criterios de búsqueda."
@@ -5171,16 +5116,15 @@ msgstr "Volver a los resultados"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
-"ATENCIÓN: los siguientes registros están pendentes de actualizar en la "
-"cola de taresa pendientes.  Si sigue con los cambios, se perderán las "
-"modificaciones hechas con la otra herramienta (es decir, BibEdit) sobre "
-"este registro."
+"ATENCIÓN: los siguientes registros están pendentes de actualizar en la cola "
+"de taresa pendientes.  Si sigue con los cambios, se perderán las "
+"modificaciones hechas con la otra herramienta (es decir, BibEdit) sobre este "
+"registro."
 
 #: invenio/legacy/bibeditmulti/templates.py:736
 #: invenio/legacy/websearch/templates.py:2669
@@ -5303,7 +5247,7 @@ msgid "Total"
 msgstr "Total"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Seleccionar"
 
@@ -5459,8 +5403,8 @@ msgstr "Suprimir la base de conocimiento"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 "Limitar la visualización a las bases de conocimiento con el texto "
 "%(keyword_field)s en sus reglas y descripciones"
@@ -5517,73 +5461,71 @@ msgstr "Es necesario configurarla"
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 "Un base de conocimiento dinámico es una lista de valores de un campo. La "
-"lista se genera dinámicamente a medida que se buscan registros a partir "
-"de un valor de búsqueda."
+"lista se genera dinámicamente a medida que se buscan registros a partir de "
+"un valor de búsqueda."
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 "Por ejemplo: los registros tienen el campo 270__a para el nombre y la "
-"dirección de la institución del autor.  Si pone como valor de campo "
-"«270__a» y la expresión «270__a:*Paris*», creará una lista de "
-"instituciones en París."
+"dirección de la institución del autor.  Si pone como valor de campo «270__a» "
+"y la expresión «270__a:*Paris*», creará una lista de instituciones en París."
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
-"Si deja la expresión vacía, creará una lista con todos los valores del "
-"campo 270__a."
+"Si deja la expresión vacía, creará una lista con todos los valores del campo "
+"270__a."
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, fuzzy, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 "Si la expresión contiene «%», como «270__a:*%*», será remplazado por el "
 "valor creado cuando se use la base de conocimiento."
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
-"Puede entrar un nombre de colección si la expresión se ha de evaluar en "
-"una colección específica."
+"Puede entrar un nombre de colección si la expresión se ha de evaluar en una "
+"colección específica."
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 "Ejemplo 1: los registros tienen el campo 270__a para el nombre y la "
-"dirección de la institución del autor.  Si pone como valor de campo "
-"«270__a» y la expresión «270__a:*Paris*», creará una lista "
-"d'instituciones en París."
+"dirección de la institución del autor.  Si pone como valor de campo «270__a» "
+"y la expresión «270__a:*Paris*», creará una lista d'instituciones en París."
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, fuzzy, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 "Ejemplo 2: mostrar el nombre del instituto (100__a) cuando el usuario "
 "informe del código postal (270__a): escriba 100__a en el campo, y la "
@@ -5624,7 +5566,7 @@ msgstr "Dependencias de la base de conocimiento"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5637,8 +5579,8 @@ msgid ""
 "Here you can add new mappings to this base                         and "
 "change the base attributes."
 msgstr ""
-"Aquí puede añadir nuevas asignaciones a esta base y cambiar los atributos"
-" de la base."
+"Aquí puede añadir nuevas asignaciones a esta base y cambiar los atributos de "
+"la base."
 
 #: invenio/legacy/bibknowledge/templates.py:364
 msgid "Map From"
@@ -5678,8 +5620,8 @@ msgstr "Su regla: %s"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, fuzzy, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 "La parte izquierda de la regla (%s) ya aparece en estas bases de "
 "conocimiento:"
@@ -5687,11 +5629,10 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:709
 #, fuzzy, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
-"La parte derecha de la regla (%s) ya aparece en estas bases de "
-"conocimiento:"
+"La parte derecha de la regla (%s) ya aparece en estas bases de conocimiento:"
 
 #: invenio/legacy/bibknowledge/templates.py:722
 msgid "Please select action"
@@ -5714,8 +5655,8 @@ msgid ""
 "It is not possible to have two rules with the same left side in the same "
 "knowledge base."
 msgstr ""
-"No es posible tener dos reglas con la misma parte izquierda en la misma "
-"base de conocimiento."
+"No es posible tener dos reglas con la misma parte izquierda en la misma base "
+"de conocimiento."
 
 #: invenio/legacy/bibrank/citation_grapher.py:207
 msgid "Citation history:"
@@ -5787,8 +5728,7 @@ msgstr "Muchas gracias por ayudarnos a mejorar el servicio."
 #: invenio/legacy/errorlib/webinterface.py:155
 msgid "Use the back button of your browser to return to the previous page."
 msgstr ""
-"Use el botón de retroceso de su navegador para volver a la página "
-"anterior."
+"Use el botón de retroceso de su navegador para volver a la página anterior."
 
 #: invenio/legacy/errorlib/webinterface.py:158
 msgid "Thank you!"
@@ -5912,11 +5852,9 @@ msgstr "Error al recuperar el registro"
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
-"Error al formatear la entrada en espera.  Probablemente su contenido esté"
-" mal"
+"Error al formatear la entrada en espera.  Probablemente su contenido esté mal"
 
 #: invenio/legacy/oaiharvest/admin.py:1326
 msgid "Accept Holding Pen version"
@@ -5989,8 +5927,8 @@ msgstr "Volver a la selección principal"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6005,8 +5943,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Resultados de la búsqueda"
 
@@ -6165,8 +6103,8 @@ msgstr "No se han encontrado valores."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6175,9 +6113,9 @@ msgid ""
 "Warning: figure caption search is only available for a subset of papers "
 "mostly from %(x_range_from_year)s-%(x_range_to_year)s."
 msgstr ""
-"Atención: la búsqueda en los pies de imágenes sólo está disponible para "
-"un subconjunto de documentos, mayoritariamente de entre "
-"%(x_range_from_year)s-%(x_range_to_year)s."
+"Atención: la búsqueda en los pies de imágenes sólo está disponible para un "
+"subconjunto de documentos, mayoritariamente de entre %(x_range_from_year)s-"
+"%(x_range_to_year)s."
 
 #: invenio/legacy/search_engine/__init__.py:2151
 #, fuzzy, python-format
@@ -6192,17 +6130,17 @@ msgstr "En cambio se buscará %s."
 #: invenio/legacy/search_engine/__init__.py:2161
 msgid "Search term too generic, displaying only partial results..."
 msgstr ""
-"Término de búsqueda demasiado genérico, solo se mostrarán unos resultados"
-" parciales..."
+"Término de búsqueda demasiado genérico, solo se mostrarán unos resultados "
+"parciales..."
 
 #: invenio/legacy/search_engine/__init__.py:2165
 #, fuzzy
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
-"Término de búsqueda demasiado genérico, solo se mostrarán unos resultados"
-" parciales..."
+"Término de búsqueda demasiado genérico, solo se mostrarán unos resultados "
+"parciales..."
 
 #: invenio/legacy/search_engine/__init__.py:2169
 #, fuzzy
@@ -6210,13 +6148,12 @@ msgid ""
 "Search term after citedby operator too generic, displaying only partial "
 "results..."
 msgstr ""
-"Término de búsqueda demasiado genérico, solo se mostrarán unos resultados"
-" parciales..."
+"Término de búsqueda demasiado genérico, solo se mostrarán unos resultados "
+"parciales..."
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 "Todavía no hay índice de frases para el texto completo, buscando por "
 "combinación de palabras..."
@@ -6225,91 +6162,91 @@ msgstr ""
 #, python-format
 msgid "No exact match found for %(x_query1)s, using %(x_query2)s instead..."
 msgstr ""
-"No se han encontrado coincidencias con %(x_query1)s, pero utilizando en "
-"su lugar %(x_query2)s..."
+"No se han encontrado coincidencias con %(x_query1)s, pero utilizando en su "
+"lugar %(x_query2)s..."
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 "No se entiende la sintaxis de su búsqueda.  Se ignorarán todos los "
-"paréntesis de la búsqueda.  Si así no funciona, repase su búsqueda y "
-"vuelva a intentarlo."
+"paréntesis de la búsqueda.  Si así no funciona, repase su búsqueda y vuelva "
+"a intentarlo."
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
-"No se ha encontrado ninguna coincidencia en la colección "
-"%(x_collection)s. Las otras colecciones públicas dieron "
-"%(x_url_open)s%(x_nb_hits)d resultados%(x_url_close)s."
+"No se ha encontrado ninguna coincidencia en la colección %(x_collection)s. "
+"Las otras colecciones públicas dieron %(x_url_open)s%(x_nb_hits)d resultados"
+"%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 "Ninguna colección pública coincide con su búsqueda. Si estaba buscando "
-"documentos no públicos, por favor escoja primero la colección restringida"
-" deseada."
+"documentos no públicos, por favor escoja primero la colección restringida "
+"deseada."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
 "Ninguna colección pública coincide con su búsqueda. Si estaba buscando "
-"documentos no públicos, por favor escoja primero la colección restringida"
-" deseada."
+"documentos no públicos, por favor escoja primero la colección restringida "
+"deseada."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 msgid "Your search did not match any records.  Please try again."
 msgstr "Su búsqueda no ha encontrado ningún registro. Vuelva a intentarlo."
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 msgid "No match found, please enter different search terms."
 msgstr "No se han encontrado resultados. Use términos de búsqueda distintos."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "No hay registros que se refieran a %s."
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "No hay registros citados por a %s."
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "No hay registros citados por a %s."
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "No hay índices de palabras disponible para %s."
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "No hay índices de frases disponible para %s."
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 "El término de búsqueda %(x_term)s en el índice %(x_index)s no se ha "
 "encontrado en ningún registro. Los términos aproximados en cualquier "
 "colección son:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
@@ -6318,40 +6255,40 @@ msgstr ""
 "El término de búsqueda %s no se ha encontrado en ningún registro. Los "
 "términos aproximados, en cualquier las colección, son:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr "No es posible ordenar por %s.  No se ordenarán los registros."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 "Sólo se puede ordenar en conjuntos de hasta %d registros.  Ordenado por "
 "defecto (\"primero los más recientes\")."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr "No es posible ordenar por %s.  No se ordenarán los registros."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "El registro %d lo reemplaza."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Use términos de búsqueda distintos."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6365,13 +6302,13 @@ msgstr "Use términos de búsqueda distintos."
 msgid "Browse"
 msgstr "Índice"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 "No se han encontrado resultados dentro de los límites de tiempo "
 "especificados. Descartando esta condición..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
 "No se han encontrado resultados dentro de los límites especificados, "
@@ -6416,15 +6353,14 @@ msgstr "La alerta %s se ha actualizado correctamente."
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Ha hecho %(x_nb)s búsquedas.  Hay una "
-"%(x_url_open)sdetailed_list%(x_url_close)s disponible con la posibilidad "
-"de (a) ver los resultados de la búsqueda y (b) subscribirse para recibir "
-"notificaciones por correo electrónico de estas búsquedas"
+"Ha hecho %(x_nb)s búsquedas.  Hay una %(x_url_open)sdetailed_list"
+"%(x_url_close)s disponible con la posibilidad de (a) ver los resultados de "
+"la búsqueda y (b) subscribirse para recibir notificaciones por correo "
+"electrónico de estas búsquedas"
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6498,8 +6434,8 @@ msgid ""
 "This alert will notify you each time/only if a new item satisfies the "
 "following query:"
 msgstr ""
-"Esta alerta le notificará cada vez/sólo si un nuevo elemento satisface la"
-" siguiente búsqueda:"
+"Esta alerta le notificará cada vez/sólo si un nuevo elemento satisface la "
+"siguiente búsqueda:"
 
 #: invenio/legacy/webalert/templates.py:173
 msgid "QUERY"
@@ -6565,9 +6501,9 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"Definir una nueva alerta a partir de %(x_url1_open)ssus "
-"búsquedas%(x_url1_close)s, las %(x_url2_open)sbúsquedas más "
-"habituales%(x_url2_close)s, o el formulario de datos."
+"Definir una nueva alerta a partir de %(x_url1_open)ssus búsquedas"
+"%(x_url1_close)s, las %(x_url2_open)sbúsquedas más habituales"
+"%(x_url2_close)s, o el formulario de datos."
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6618,8 +6554,8 @@ msgstr "Usted ha definido %s alertas."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 "Todavía no ha ejecutado ninguna búsqueda. Vaya primero a la "
 "%(x_url_open)sinterfaz de búsqueda%(x_url_close)s."
@@ -6627,11 +6563,11 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
-"Ha ejecutado %(x_nb1)s búsquedas (%(x_nb2)s cuestiones diferentes) "
-"durante los últimos 30 días aproximadamente."
+"Ha ejecutado %(x_nb1)s búsquedas (%(x_nb2)s cuestiones diferentes) durante "
+"los últimos 30 días aproximadamente."
 
 #: invenio/legacy/webalert/templates.py:453
 #, fuzzy, python-format
@@ -6688,7 +6624,7 @@ msgstr "Sus búsquedas"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6752,7 +6688,7 @@ msgstr "%s personalizar, definir una nueva alerta"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6812,7 +6748,8 @@ msgstr "%s personalizar, mostrar alertas"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr "La cesta pública que ha seleccionado no existe o no tiene acceso."
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6834,7 +6771,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "No tiene permisos para escribir notas en este elemento."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr "La nota que cita no existe o no tiene acceso."
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6861,7 +6799,8 @@ msgid "You do not have permission to delete this note."
 msgstr "No tiene permisos para borrar esta nota."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr "La nota que ha seleccionado no existe o no tiene acceso."
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6893,19 +6832,18 @@ msgstr "La url que ha dado no es válida."
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
-"Esta url no es válida: la sintaxis no es correcta o no se puede "
-"satisfacer."
+"Esta url no es válida: la sintaxis no es correcta o no se puede satisfacer."
 
 #: invenio/legacy/webbasket/api.py:1849
 msgid ""
 "The url you have provided is not valid: The server failed to fulfil an "
 "apparently valid request."
 msgstr ""
-"Esta url no es válida: el servidor no contestó una petición aparentemente"
-" válida."
+"Esta url no es válida: el servidor no contestó una petición aparentemente "
+"válida."
 
 #: invenio/legacy/webbasket/api.py:1898 invenio/legacy/webbasket/api.py:1910
 #: invenio/legacy/webbasket/api.py:2042 invenio/legacy/webbasket/api.py:2111
@@ -6918,15 +6856,15 @@ msgstr "Ningún registro a añadir."
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
 msgid "Cannot add items to the selected basket. Invalid parameters."
 msgstr ""
-"No se han podido añadir elementos a la cesta seleccionada.  Los "
-"parámetros no son válidos."
+"No se han podido añadir elementos a la cesta seleccionada.  Los parámetros "
+"no son válidos."
 
 #: invenio/legacy/webbasket/api.py:1979
 msgid "Untitled basket"
@@ -6941,8 +6879,8 @@ msgid ""
 "A default topic and basket have been automatically created. Edit them to "
 "rename them as you see fit."
 msgstr ""
-"Se ha creado automáticamente una nueva cesta y un tema por defecto. "
-"Edítelo para cambiar el nombre al que más le convenga."
+"Se ha creado automáticamente una nueva cesta y un tema por defecto. Edítelo "
+"para cambiar el nombre al que más le convenga."
 
 #: invenio/legacy/webbasket/api.py:2262
 msgid "Please provide a name for the new basket."
@@ -6954,19 +6892,19 @@ msgstr "Seleccione uno de los temas existentes o cree uno de nuevo."
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
-"No puede suscribir-se a esta cesta, bien porque usted es el propietario o"
-" porque ya está subscrito."
+"No puede suscribir-se a esta cesta, bien porque usted es el propietario o "
+"porque ya está subscrito."
 
 #: invenio/legacy/webbasket/api.py:2337
 msgid ""
 "You cannot unsubscribe from this basket, you are the either owner or you "
 "have already unsubscribed."
 msgstr ""
-"No se puede dar de baja de esta cesta, bien porque usted es el "
-"propietario o porque ya no estaba subscrito."
+"No se puede dar de baja de esta cesta, bien porque usted es el propietario o "
+"porque ya no estaba subscrito."
 
 #: invenio/legacy/webbasket/api.py:2429 invenio/legacy/webbasket/api.py:2547
 #: invenio/legacy/webbasket/templates.py:120
@@ -7029,8 +6967,7 @@ msgstr "Cestas públicas"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 "Tiene %(x_nb_perso)s cestas personales, está subscrito a %(x_nb_group)s "
 "cestas de grupo, y a %(x_nb_public)s cestas públicas de otros usuarios."
@@ -7040,8 +6977,7 @@ msgid ""
 "The category you have selected does not exist. Please select a valid "
 "category."
 msgstr ""
-"La categoría que ha seleccionado no existe.  Seleccione una categoría "
-"válida."
+"La categoría que ha seleccionado no existe.  Seleccione una categoría válida."
 
 #: invenio/legacy/webbasket/api.py:2861
 msgid "The selected group does not exist or you do not have access to it."
@@ -7056,14 +6992,13 @@ msgid ""
 "You have no personal or group baskets or are subscribed to any public "
 "baskets."
 msgstr ""
-"No tiene cestas personales ni de grupo, ni está subscrito a ninguna cesta"
-" pública"
+"No tiene cestas personales ni de grupo, ni está subscrito a ninguna cesta "
+"pública"
 
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr "Puede empezar %(x_url_open)screando una nueva cesta%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -7225,8 +7160,8 @@ msgstr "Registro externo"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 "Escriba una url para el elemento externo que desea añadir y póngale un "
 "título y descripción"
@@ -7410,20 +7345,21 @@ msgstr "Compartir la cesta con un nuevo grupo"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
-"Ahora usted está identificado como usuario visitante, con lo que sus "
-"cestas desaparecerán al final de esta sesión."
+"Ahora usted está identificado como usuario visitante, con lo que sus cestas "
+"desaparecerán al final de esta sesión."
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
-"Si lo desea, puede %(x_url_open)sidentificarse o darse de alta "
-"aquí%(x_url_close)s."
+"Si lo desea, puede %(x_url_open)sidentificarse o darse de alta aquí"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7432,7 +7368,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Esta funcionalidad no está permitida a los usuarios visitantes."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Volver al resultado de la búsqueda"
 
@@ -7482,7 +7418,8 @@ msgstr "Darse de baja de esta cesta"
 
 #: invenio/legacy/webbasket/templates.py:2431
 msgid "This basket is publicly accessible at the following address:"
-msgstr "Se puede acceder públicamente a esta cesta desde la siguiente dirección:"
+msgstr ""
+"Se puede acceder públicamente a esta cesta desde la siguiente dirección:"
 
 #: invenio/legacy/webbasket/templates.py:2485
 msgid "This basket does not contain any records yet."
@@ -7594,7 +7531,7 @@ msgstr "Añadir nota"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7726,211 +7663,209 @@ msgstr "El comentario %s no existe."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "El registro %s no existe."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Escriba un comentario"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i comentarios por la vuelta «%(x_name)s»"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, python-format
 msgid "%(x_nb)i Comments"
 msgstr "%(x_nb)i comentarios"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Mostrar los últimos %i comentarios:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Comente este documento"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Inicie un debate sobre cualquier aspecto de este documento."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Parece ser que el registro %s no existe."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "%s no es un identificador válido."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "No ha dado el número de registro."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Puede comenzar a visualizar desde %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i comentarios por la vuelta «%(x_name)s»"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "¿Ha sido útil esta reseña?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Escriba una reseña"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr "Puntuación media: %(x_nb_score)s, basada en %(x_nb_reviews)s reseñas"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr ""
-"Los lectores han encontrado que las siguientes %s reseñas son las más "
-"útiles."
+"Los lectores han encontrado que las siguientes %s reseñas son las más útiles."
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Visualizar todas las %s reseñas"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Valore este documento"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 msgid "Be the first to review this document.</div>"
 msgstr "Sea el primero a escribir una reseña de este documento.</div>"
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 msgid "Close"
 msgstr "Cerrar"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Denuncie un abuso"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr "Recupera el comentario suprimido"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Suprimir comentario"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr "Suprimir la denuncia al comentario"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr "Fichero adjunto"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr "Ficheros adjuntos"
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr "Abrir"
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Reseñado por %(x_nickname)s el %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
-"%(x_nb_people)s de %(x_nb_total)s personas han encontrado esta reseña  "
-"útil"
+"%(x_nb_people)s de %(x_nb_total)s personas han encontrado esta reseña  útil"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr "Recupera la reseña suprimido"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr "Eliminar la reseña"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr "Suprimir la denuncia a la reseña"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Comentarios"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Reseñas"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Hay un total de %s reseñas"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Hay un total de %s comentarios"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Sea el primero a escribir una reseña de este documento."
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Subscribirse"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr "Darse de baja"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7939,44 +7874,42 @@ msgstr "Darse de baja"
 msgid "Record"
 msgstr "Registro"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "reseña"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "comentario"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Reseña"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Visualización"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Página:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr "No está autorizado a hacer comentarios o reseñas."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
-"Atención: su alias, %s, será el que se muestre como autor de este "
-"comentario"
+"Atención: su alias, %s, será el que se muestre como autor de este comentario"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
@@ -7985,464 +7918,471 @@ msgstr ""
 "Atención: todavía no ha %(x_url_open)sdefinido su alias%(x_url_close)s. "
 "%(x_nickname)s, será el que se muestre como autor de este comentario"
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 "Una vez identificados, los usuarios autorizados también pueden añadir "
 "ficheros."
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr "Opcionalmente, añada un fichero a este comentario"
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr "Opcionalmente, añada ficheros a este comentario"
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr "Máximo un fichero"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "Máximo %i ficheros"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr "Máximo %(x_nb_bytes)s por fichero"
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr "Envíame un correo electrónico cuando se publique un nuevo comentario"
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Artículo"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "Añadir comentario"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
-msgstr "Atención: su alias, %s, será el que se muestre como autor de esta reseña."
+msgstr ""
+"Atención: su alias, %s, será el que se muestre como autor de esta reseña."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Valore este artículo"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Seleccione una puntuación"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Dé un título a su reseña"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Escriba su reseña"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr "Añadir una reseña"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Añadir una reseña"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Su reseña se ha añadido correctamente."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Su comentario se ha añadido correctamente."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Volver al registro"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr "Puede consultar la lista de %(x_url_open)ssus tareas%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr "Ver los registros más comentados"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr "Ver los registros con los comentarios más recientes"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr "Visualizar todos los comentarios denunciados"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr "Ver los registros con más reseñas"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr "Ver los registros con las reseñas más recientes"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr "Visualizar todas las reseñas denunciadas"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Ver todos los usuarios que han sido denunciados"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Guía"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Los comentarios y las reseñas están desactivadas"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"Introduzca el número del comentario o reseña; así puede visualizarlo "
-"antes de decidir si lo suprime o no"
+"Introduzca el número del comentario o reseña; así puede visualizarlo antes "
+"de decidir si lo suprime o no"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "Número del comentario:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 "O entre el número de registro para ver todos los comentarios y reseñas "
 "asociadas:"
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr "Registro: "
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Visualizar el comentario"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "De momento no hay denuncias."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Visualizar todos los %s comentarios denunciados"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Visualizar todas las %s reseñas denunciadas"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-"Esta es la lista, ordenada por el número de denuncias, de los usuarios "
-"que han tenido al menos una denuncia a alguno de sus comentarios."
+"Esta es la lista, ordenada por el número de denuncias, de los usuarios que "
+"han tenido al menos una denuncia a alguno de sus comentarios."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Alias"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "Número de usuario"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Número de votos positivos"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Número de votos negativos"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Número total de votos"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Número total de denuncias"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Visualizar todos los comentarios/reseñas denunciadas de este usuario"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Esta reseña ha sido denunciada %i veces"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Este comentario ha sido denunciado %i veces"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Escrita por"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Informaciones generales"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Eliminar las reseñas seleccionadas"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Suprimir el informe de abuso seleccionado"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr "Recuperar las reseñas eliminadas"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr "Recuperar los comentarios eliminados"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Suprimir los comentarios seleccionados"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Estas son las reseñes denunciadas del usuario %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Estos son los comentarios denunciados del usuario %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Ésta es la reseña %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Éste es el comentario %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Ésta es la reseña %(x_cmtID)s escrita por el usuario %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Éste es el comentario %(x_cmtID)s escrito por el usuario %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "Estas son todas las reseñas denunciadas, ordenadas de más a menos"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "Estos son todos los comentarios denunciados, ordenados de más a menos"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr "Reseñas del registro %i, ordenadas de más a menos denuncias"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr "Ver comentarios"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr "Comentarios al registro %i, ordenados de más a menos denuncias"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr "Visualizar las reseñas"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "número de comentario"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "suprimido correctamente"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr "recuperado correctamente"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "eliminada correctamente la denuncia de abuso"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Sin ninguna reseña"
 
-#: invenio/legacy/webcomment/templates.py:2257
+#: invenio/legacy/webcomment/templates.py:2256
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr "Se ha enviado esta reseña a %(CFG_SITE_NAME)s por %(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2258
+#: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr "Se ha enviado este comentario a %(CFG_SITE_NAME)s por %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+"Se ha enviado este comentario a %(CFG_SITE_NAME)s por %(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr "Este es un mensaje automático, no lo responda."
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr "Para publicar otro comentario, debe ir a <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
-msgstr "Para contestar específicamente a este comentario, debe ir a <%(x_url)s>."
+msgstr ""
+"Para contestar específicamente a este comentario, debe ir a <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr "Para darse de baja de esta discusión, debe ir a <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
-msgstr "Para resolver dudas, póngase en contacto con <%(CFG_SITE_SUPPORT_EMAIL)s>"
+msgstr ""
+"Para resolver dudas, póngase en contacto con <%(CFG_SITE_SUPPORT_EMAIL)s>"
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 msgid "Your comment will be lost."
 msgstr "Su comentario se perderá."
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Suprimir comentarios"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "el último primero"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "Ver los registros con los comentarios más recientes"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "añadir comentarios"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "registros encontrados"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Comentarios"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "%i elementos"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Añadir elementos"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 #, fuzzy
 msgid "Display"
 msgstr "Mostrar alertas:"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Fecha de petición"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Página siguiente"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Mostrar alertas:"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8450,103 +8390,103 @@ msgstr "Mostrar alertas:"
 msgid "Refresh"
 msgstr "Refrescar"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Suprimir la denuncia al comentario"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "%i elementos encontrados"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "No se ha encontrado el registro"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr "El comentario especificado no pertenece a este registro"
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 msgid "You do not have access to the specified comment"
 msgstr "No tiene acceso al comentario especificado"
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, fuzzy, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
-"El tamaño del fichero \\\"%s\\\" (%s) es mayor que el máximo permitido "
-"(%s). Vuelva a seleccionar los ficheros."
+"El tamaño del fichero \\\"%s\\\" (%s) es mayor que el máximo permitido (%s). "
+"Vuelva a seleccionar los ficheros."
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Añadir comentario"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr "No puede votar a un comentario borrado"
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 msgid "You cannot report a deleted comment"
 msgstr "No puede denunciar a un comentario borrado"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr "No se ha encontrado la página"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr "No se ha encontrado el comentario solicitado"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr "No puede acceder a los ficheros de un comentario borrado"
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr "No se ha encontrado el fichero solicitado"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "No está autorizado a hacer uso del préstamo."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Comentarios"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr ""
@@ -8661,11 +8601,11 @@ msgstr "Parece ser que la página %s no existe."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
-"Le puede interesar consultar las %(x_url_open)spágines "
-"%(x_category)s%(x_url_close)s."
+"Le puede interesar consultar las %(x_url_open)spágines %(x_category)s"
+"%(x_url_close)s."
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
 #, fuzzy, python-format
@@ -8728,11 +8668,11 @@ msgstr "No ha sido posible ofrecerle ninguna revista"
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
-"Parece ser que no hay ninguna revista definida en este servidor. Contacte"
-" con el soporte si no es así."
+"Parece ser que no hay ninguna revista definida en este servidor. Contacte "
+"con el soporte si no es así."
 
 #: invenio/legacy/webjournal/config.py:239
 msgid "Select a journal on this server"
@@ -8758,11 +8698,11 @@ msgstr "No existe ninguna información en el número actual"
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
-"Parece que la configuración del número actual está vacía.  Pruebe de "
-"escoger un número en concreto o póngase en contacte con soporte."
+"Parece que la configuración del número actual está vacía.  Pruebe de escoger "
+"un número en concreto o póngase en contacte con soporte."
 
 #: invenio/legacy/webjournal/config.py:298
 msgid "Issue number badly formed"
@@ -8816,8 +8756,8 @@ msgstr "Error del código de revista"
 #: invenio/legacy/webjournal/config.py:495
 msgid "We could not find the id for this journal in the Database"
 msgstr ""
-"No ha sido posible encontrar el identificador interno de esta revista en "
-"la base de datos"
+"No ha sido posible encontrar el identificador interno de esta revista en la "
+"base de datos"
 
 #: invenio/legacy/webjournal/config.py:527
 #: invenio/legacy/webjournal/config.py:529
@@ -8944,9 +8884,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8968,8 +8907,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9081,8 +9019,8 @@ msgid ""
 "Your message is too long, please shorten it. Maximum size allowed is "
 "%(x_size)i characters."
 msgstr ""
-"Su mensaje es demasiado largo, edítelo por favor.  El tamaño máximo es de"
-" %i caracteres."
+"Su mensaje es demasiado largo, edítelo por favor.  El tamaño máximo es de %i "
+"caracteres."
 
 #: invenio/legacy/webmessage/api.py:402
 #, fuzzy, python-format
@@ -9107,8 +9045,8 @@ msgid ""
 "Your message could not be sent to the following recipients as it would "
 "exceed their quotas:"
 msgstr ""
-"No se ha podido enviar su mensaje a los siguientes destinatarios debido a"
-" su cuota:"
+"No se ha podido enviar su mensaje a los siguientes destinatarios debido a su "
+"cuota:"
 
 #: invenio/legacy/webmessage/api.py:457
 msgid "Your message has been sent."
@@ -9448,19 +9386,19 @@ msgstr "Busque también:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
-"Esta colección es restringida.  Si tiene acceso, haga clic en el botón de"
-" Buscar."
+"Esta colección es restringida.  Si tiene acceso, haga clic en el botón de "
+"Buscar."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
-"Esta es una colección externa alojada.  Pulse el botón de búsqueda para "
-"ver su contenido."
+"Esta es una colección externa alojada.  Pulse el botón de búsqueda para ver "
+"su contenido."
 
 #: invenio/legacy/websearch/templates.py:1619
 msgid "This collection does not contain any document yet."
@@ -9556,8 +9494,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found %(x_nb_records)s "
 "records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sResultados globales:%(x_fmt_close)s %(x_nb_records)s "
-"registros encontrados en %(x_nb_seconds)s segundos."
+"%(x_fmt_open)sResultados globales:%(x_fmt_close)s %(x_nb_records)s registros "
+"encontrados en %(x_nb_seconds)s segundos."
 
 #: invenio/legacy/websearch/templates.py:3132
 #, python-format
@@ -9570,8 +9508,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found at least "
 "%(x_nb_records)s records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sResultados globales:%(x_fmt_close)s Al menos "
-"%(x_nb_records)s registros encontrados en %(x_nb_seconds)s segundos."
+"%(x_fmt_open)sResultados globales:%(x_fmt_close)s Al menos %(x_nb_records)s "
+"registros encontrados en %(x_nb_seconds)s segundos."
 
 #: invenio/legacy/websearch/templates.py:3184
 #, fuzzy
@@ -9598,8 +9536,7 @@ msgstr "Más detalles"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 "La combinación booleana no ha dado resultados. Por favor combine los "
 "términos de búsqueda de otra manera."
@@ -9627,8 +9564,8 @@ msgstr "Puede comenzar las búsquedas desde %s."
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "Defina una %(x_url1_open)salerta personal%(x_url1_close)s vía correo "
 "electrónico o subscríbase al %(x_url2_open)scanal RSS%(x_url2_close)s."
@@ -9817,7 +9754,8 @@ msgid "in"
 msgstr "en"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "¿No ha encontrado lo que estaba buscando? Intente su búsqueda en:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9910,11 +9848,11 @@ msgstr "obligatorio"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
-"La descripción debería ser algo significativo para que pueda reconocer la"
-" nueva llave API"
+"La descripción debería ser algo significativo para que pueda reconocer la "
+"nueva llave API"
 
 #: invenio/legacy/websession/templates.py:208
 msgid "Create new key"
@@ -9922,11 +9860,11 @@ msgstr "Crear una llave nueva"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
-"Si desea cambiar su dirección de correo electrónico o contraseña, ponga "
-"nos nuevos valores en este formulario."
+"Si desea cambiar su dirección de correo electrónico o contraseña, ponga nos "
+"nuevos valores en este formulario."
 
 #: invenio/legacy/websession/templates.py:271
 msgid "Edit login credentials"
@@ -9942,19 +9880,19 @@ msgstr "Guardar los nuevos valores"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
-"Ya que se considera una firma para comentarios y reseñas, una vez "
-"definido no se puede cambiar."
+"Ya que se considera una firma para comentarios y reseñas, una vez definido "
+"no se puede cambiar."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
-"Si desea cambiar su contraseña, ponga nos valores antiguo y nuevo en este"
-" formulario."
+"Si desea cambiar su contraseña, ponga nos valores antiguo y nuevo en este "
+"formulario."
 
 #: invenio/legacy/websession/templates.py:327
 msgid "Old password"
@@ -9978,7 +9916,8 @@ msgstr "La contraseña puede contener puntuación, espacios, etc."
 
 #: invenio/legacy/websession/templates.py:333
 msgid "You must fill the old password in order to set a new one."
-msgstr "Tiene que entrar la contraseña antigua para cambiarla por una de nueva."
+msgstr ""
+"Tiene que entrar la contraseña antigua para cambiarla por una de nueva."
 
 #: invenio/legacy/websession/templates.py:334
 msgid "Retype password"
@@ -9991,11 +9930,11 @@ msgstr "Ponga la contraseña nueva"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
-"Si está utilizando una cuenta CERN ligera puede %(x_url_open)sreiniciar "
-"la contraseña%(x_url_close)s."
+"Si está utilizando una cuenta CERN ligera puede %(x_url_open)sreiniciar la "
+"contraseña%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:346
 #, python-format
@@ -10084,15 +10023,14 @@ msgstr "Seleccione el método"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"Si ha perdido la contraseña de la %(x_fmt_open)scuenta "
-"interna%(x_fmt_close)s de %(sitename)s, escriba su dirección de correo "
-"electrónico en este formulario para que le enviemos un enlace para "
-"reiniciar su contraseña."
+"Si ha perdido la contraseña de la %(x_fmt_open)scuenta interna"
+"%(x_fmt_close)s de %(sitename)s, escriba su dirección de correo electrónico "
+"en este formulario para que le enviemos un enlace para reiniciar su "
+"contraseña."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10108,18 +10046,18 @@ msgstr "Enviar el enlace para reiniciar la contraseña"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
-"Si su cuenta utiliza el %(x_fmt_open)ssistema de identificación del "
-"CERN%(x_fmt_close)s, puede recuperar su contraseña a través del "
+"Si su cuenta utiliza el %(x_fmt_open)ssistema de identificación del CERN"
+"%(x_fmt_close)s, puede recuperar su contraseña a través del "
 "%(x_url_open)ssistema de autenticación del CERN%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 "Tenga en cuenta que si ha estado utilizando un sistema de identificación "
 "externo, sentimos no podemos hacer nada. Tendrá que preguntarlo allí."
@@ -10136,10 +10074,10 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 "%s le ofrece la posibilidad de personalizar la interfaz, crear su propia "
 "biblioteca de documentos, o crear alertas automáticas que se ejecuten "
@@ -10165,12 +10103,11 @@ msgstr "Vea todas las búsquedas que ha realizado durante los últimos 30 días.
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
-"Las cestas le permiten definir colecciones específicas de elemento, "
-"guardar registros interesantes para acceder más adelante o compartir con "
-"otros."
+"Las cestas le permiten definir colecciones específicas de elemento, guardar "
+"registros interesantes para acceder más adelante o compartir con otros."
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10182,31 +10119,31 @@ msgid ""
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
 "Subscríbase a una búsqueda para que se ejecute periódicamente en nuestro "
-"servicio.  Podrá recibir el resultado por correo electrónico o guardarlo "
-"en una de sus cestas."
+"servicio.  Podrá recibir el resultado por correo electrónico o guardarlo en "
+"una de sus cestas."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
-"Compruebe los libros que tiene en préstamo, solicite reservas, etc. "
-"Requiere el ID del CERN."
+"Compruebe los libros que tiene en préstamo, solicite reservas, etc. Requiere "
+"el ID del CERN."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
-"Ahora usted está identificado como usuario visitante, con lo que sus "
-"alertas desaparecerán al final de esta sesión."
+"Ahora usted está identificado como usuario visitante, con lo que sus alertas "
+"desaparecerán al final de esta sesión."
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 "Usted se ha identificado como %(x_user)s. Ahora puede a) "
 "%(x_url1_open)sdesconectarse%(x_url1_close)s; b) modificar las "
@@ -10226,8 +10163,8 @@ msgstr "Sus alertas"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 "Puede consultar la lista de %(x_url_open)slos grupos%(x_url_close)s que "
 "administra o de los que forma parte."
@@ -10241,8 +10178,8 @@ msgstr "Sus grupos"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
 "Puede consultar la lista de %(x_url_open)ssus envíos%(x_url_close)s e "
 "informarse de su estado."
@@ -10255,11 +10192,11 @@ msgstr "Sus envíos"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"Puede consultar la lista de %(x_url_open)ssus aprobaciones%(x_url_close)s"
-" con los documentos que ha aprobado o revisado."
+"Puede consultar la lista de %(x_url_open)ssus aprobaciones%(x_url_close)s "
+"con los documentos que ha aprobado o revisado."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10307,8 +10244,10 @@ msgstr "para confirmar la validez de esta petición."
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
-msgstr "Tenga en cuenta que esta URL sólo será válida durante unos %(days)s días."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
+msgstr ""
+"Tenga en cuenta que esta URL sólo será válida durante unos %(days)s días."
 
 #: invenio/legacy/websession/templates.py:909
 #, fuzzy, python-format
@@ -10318,8 +10257,8 @@ msgid ""
 "for the email address \"%(x_email)s\".x_sitename"
 msgstr ""
 "Alguien (posiblemente usted), desde a dirección %(x_ip_address)s, ha "
-"solicitado una cuenta nueva en %(x_sitename)s para la dirección de correo"
-" electrónico %(x_email)s."
+"solicitado una cuenta nueva en %(x_sitename)s para la dirección de correo "
+"electrónico %(x_email)s."
 
 #: invenio/legacy/websession/templates.py:914
 msgid "If you want to complete this account registration, please go to:"
@@ -10329,8 +10268,8 @@ msgstr "Para completar el alta de la cuenta, vaya a:"
 #, fuzzy, python-format
 msgid "Okay, a password reset link has been emailed to %(x_email)s."
 msgstr ""
-"El enlace para reiniciar la contraseña se ha enviado por correo "
-"electrónico a %s."
+"El enlace para reiniciar la contraseña se ha enviado por correo electrónico "
+"a %s."
 
 #: invenio/legacy/websession/templates.py:955
 msgid "Deleting your account"
@@ -10347,9 +10286,9 @@ msgid ""
 "                %(x_fmt_open)sSSO%(x_fmt_close)s system. You can\n"
 "                %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
-"Usted todavía está reconocido por el sistema central de "
-"%(x_fmt_open)sSSO%(x_fmt_close)s. También puede %(x_url_open)sdesconectar"
-" del SSO%(x_url_close)s."
+"Usted todavía está reconocido por el sistema central de %(x_fmt_open)sSSO"
+"%(x_fmt_close)s. También puede %(x_url_open)sdesconectar del SSO"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:978
 #, python-format
@@ -10363,8 +10302,8 @@ msgstr "Si ya tiene una cuenta, identifíquese por favor en este formulario."
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 "Si todavía no dispone de una cuenta en el CERN, puede crear una "
 "%(x_url_open)scuenta CERN ligera%(x_url_close)s."
@@ -10372,11 +10311,11 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"Si todavía no tiene una cuenta, puede %(x_url_open)sdarse de "
-"alta%(x_url_close)s en una cuenta interna."
+"Si todavía no tiene una cuenta, puede %(x_url_open)sdarse de alta"
+"%(x_url_close)s en una cuenta interna."
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
@@ -10408,13 +10347,12 @@ msgstr "¿Ha perdido su contraseña?"
 #: invenio/legacy/websession/templates.py:1094
 msgid "You can use your nickname or your email address to login."
 msgstr ""
-"Para identificarse puede usar su alias o su dirección de correo "
-"electrónico."
+"Para identificarse puede usar su alias o su dirección de correo electrónico."
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 "Su petición ha sido validada.  Escriba la nueva contraseña en este "
 "formulario."
@@ -10438,14 +10376,14 @@ msgstr "Definir la nueva contraseña"
 #: invenio/legacy/websession/templates.py:1175
 msgid "Please enter your email address and desired nickname and password:"
 msgstr ""
-"Introduzca su dirección de correo electrónico así como el alias y "
-"contraseña:"
+"Introduzca su dirección de correo electrónico así como el alias y contraseña:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
-msgstr "No será posible usar esta cuenta hasta que se haya verificado y activado."
+"It will not be possible to use the account before it has been verified and "
+"activated."
+msgstr ""
+"No será posible usar esta cuenta hasta que se haya verificado y activado."
 
 #: invenio/legacy/websession/templates.py:1228
 msgid "Retype Password"
@@ -10461,24 +10399,23 @@ msgstr "darse de alta"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
-"No escoja contraseñas valiosas como las de sus cuentas personales de "
-"correo electrónico o acceso a datos profesionales.  Su dirección de "
-"correo electrónico será estrictamente confidencial y no se pasará a "
-"terceros.  Será usada para identificar sus servicios personales en %s. "
-"Por ejemplo, puede activar un servicio de alerta automático que busque "
-"nuevos registros y le notifique diariamente de las nuevas entradas por "
-"correo electrónico."
+"No escoja contraseñas valiosas como las de sus cuentas personales de correo "
+"electrónico o acceso a datos profesionales.  Su dirección de correo "
+"electrónico será estrictamente confidencial y no se pasará a terceros.  Será "
+"usada para identificar sus servicios personales en %s. Por ejemplo, puede "
+"activar un servicio de alerta automático que busque nuevos registros y le "
+"notifique diariamente de las nuevas entradas por correo electrónico."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 "No es posible que usted cree una cuenta.  Póngase en contacto con %s si "
 "quiere una."
@@ -10486,8 +10423,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
 "Usted parece ser un usuario visitante.  Antes tiene que "
 "%(x_url_open)sidentificarse%(x_url_close)s."
@@ -10619,8 +10556,8 @@ msgstr "Aquí tiene algunos enlaces de administración interesantes:"
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "Para más actividades administrativas, vea toda la %(x_url_open)sZona de "
 "administración%(x_url_close)s."
@@ -10849,10 +10786,11 @@ msgstr "Un usuario desea unirse al grupo %s."
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
-"Debería %(x_url_open)saceptar o rechazar%(x_url_close)s la petición de "
-"este usuario."
+"Debería %(x_url_open)saceptar o rechazar%(x_url_close)s la petición de este "
+"usuario."
 
 #: invenio/legacy/websession/templates.py:2400
 #, fuzzy, python-format
@@ -10893,92 +10831,86 @@ msgstr "El grupo %s ha sido suprimido por su administrador."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"Puede consultar la lista de los %(x_url_open)s%(x_nb_total)i "
-"grupos%(x_url_close)s de los que usted es miembro (%(x_nb_member)i) o "
+"Puede consultar la lista de los %(x_url_open)s%(x_nb_total)i grupos"
+"%(x_url_close)s de los que usted es miembro (%(x_nb_member)i) o "
 "administrador(%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
-"Atención: la contraseña que ha establecido para el usuario root de MySQL "
-"es la misma que la de lleva Invenio por defecto.  Por motivos de "
-"seguridad, es preferible cambiarla."
+"Atención: la contraseña que ha establecido para el usuario root de MySQL es "
+"la misma que la de lleva Invenio por defecto.  Por motivos de seguridad, es "
+"preferible cambiarla."
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
-"Atención: la contraseña que ha establecido para el usuario MySQL de "
-"Invenio es la misma que lleva por defecto la aplicación.  Por motivos de "
-"seguridad, es preferible cambiarla."
+"Atención: la contraseña que ha establecido para el usuario MySQL de Invenio "
+"es la misma que lleva por defecto la aplicación.  Por motivos de seguridad, "
+"es preferible cambiarla."
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 "Atención: la contraseña para el usuario admin de Invenio está vacía. Por "
 "motivos de seguridad, es necesario establecer una."
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
-"Atención: la dirección configurada para soporte electrónico es info"
-"@invenio-software.org. Es conveniente cambiarla a su dirección "
-"particular."
+"Atención: la dirección configurada para soporte electrónico es info@invenio-"
+"software.org. Es conveniente cambiarla a su dirección particular."
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr "Puede bajarse una versión más reciente de Invenio.  Visite "
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
-"No ha sido posible descargar o leer las notas versión desde http"
-"://invenio-software.org/repo/invenio/tree/RELEASE-NOTES"
+"No ha sido posible descargar o leer las notas versión desde http://invenio-"
+"software.org/repo/invenio/tree/RELEASE-NOTES"
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
-"Está conectado como visitante.  Quizás quiera "
-"%(x_url_open)sidentificarse%(x_url_close)s como usuario conocido"
+"Está conectado como visitante.  Quizás quiera %(x_url_open)sidentificarse"
+"%(x_url_close)s como usuario conocido"
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
-"Los %(x_fmt_open)svisitantes%(x_fmt_close)s antes han de "
-"%(x_url_open)sdarse de alta%(x_url_close)s."
+"Los %(x_fmt_open)svisitantes%(x_fmt_close)s antes han de %(x_url_open)sdarse "
+"de alta%(x_url_close)s."
 
 #: invenio/legacy/websession/webaccount.py:127
 msgid "No queries found"
@@ -10986,16 +10918,16 @@ msgstr "No se ha encontrado ninguna búsqueda"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 "Esta colección es restringida.  Si cree que tiene derecho a ella, "
 "identifíquese."
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 "Esta documento es restringido.  Si cree que tiene derecho a él, "
 "identifíquese."
@@ -11006,8 +10938,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11019,8 +10951,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11089,8 +11021,7 @@ msgstr "Escoja el miembro que desee borrar del grupo."
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr "Escoja una persona de la lista para añadirla al grupo."
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11101,7 +11032,8 @@ msgstr "El usuario ya es miembro del grupo."
 msgid ""
 "Please choose a user from the list if you want him to be removed from "
 "waiting list."
-msgstr "Escoja el miembro de la lista que desee eliminar de la lista de espera."
+msgstr ""
+"Escoja el miembro de la lista que desee eliminar de la lista de espera."
 
 #: invenio/legacy/websession/webgroup.py:731
 msgid "The user request for joining group has already been rejected."
@@ -11127,8 +11059,8 @@ msgid ""
 "browser if you are a guest user."
 msgstr ""
 "Ya tiene una autorización válida para ejercer el rol de %(x_role)s. Esta "
-"autorización durará hasta %(x_expiration)s y, si usted es usuario "
-"invitado, hasta que cierre su navegador."
+"autorización durará hasta %(x_expiration)s y, si usted es usuario invitado, "
+"hasta que cierre su navegador."
 
 #: invenio/legacy/websession/webinterface.py:128
 msgid "You have confirmed the validity of your email address!"
@@ -11156,8 +11088,7 @@ msgstr "¡Ya ha confirmado la validez de su dirección de correo electrónico!"
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 "Esta petición de confirmación de la validez de su dirección de correo "
 "electrónico no es válida o ha expirado."
@@ -11222,15 +11153,15 @@ msgstr "El método de identificación ha cambiado al interno."
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
-"Tenga en cuenta que si es la primera vez que está usando esta cuenta con "
-"el método de identificación interno, el sistema le ha definido una "
-"contraseña aleatoria.  Haga clic en el botón siguiente para a que le "
-"envíe, vía correo electrónico, un enlace para reiniciarla:"
+"Tenga en cuenta que si es la primera vez que está usando esta cuenta con el "
+"método de identificación interno, el sistema le ha definido una contraseña "
+"aleatoria.  Haga clic en el botón siguiente para a que le envíe, vía correo "
+"electrónico, un enlace para reiniciarla:"
 
 #: invenio/legacy/websession/webinterface.py:431
 msgid "Send Password"
@@ -11261,11 +11192,11 @@ msgstr "Método de identificación seleccionado correctamente."
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
-"El método de identificación externo %s no acepta identificaciones basadas"
-" en direcciones de correo electrónico.  Póngase en contacto con los "
+"El método de identificación externo %s no acepta identificaciones basadas en "
+"direcciones de correo electrónico.  Póngase en contacto con los "
 "administradores de la instalación."
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -11405,8 +11336,8 @@ msgid ""
 "The entered email address is incorrect, please check that it is written "
 "correctly (e.g. johndoe@example.com)."
 msgstr ""
-"La dirección de correo electrónico facilitada es incorrecta. Compruebe "
-"que está correctamente escrita (por ej., danielgarcia@ejemplo.es)."
+"La dirección de correo electrónico facilitada es incorrecta. Compruebe que "
+"está correctamente escrita (por ej., danielgarcia@ejemplo.es)."
 
 #: invenio/legacy/websession/webinterface.py:684
 msgid "Incorrect email address"
@@ -11448,8 +11379,8 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 "Siga las instrucciones indicadas para completar el proceso de alta de la "
 "cuenta."
@@ -11457,8 +11388,8 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 "Se enviará un segundo mensaje cuando la cuenta se haya activado y pueda "
 "usarse."
@@ -11502,15 +11433,16 @@ msgstr "El alias solicitado %s ya existe en la base de datos."
 #: invenio/modules/accounts/views/accounts.py:143
 msgid "Users cannot register themselves, only admin can register them."
 msgstr ""
-"Los usuarios no pueden darse de alta ellos mismos; sólo lo puede hacer el"
-" administrador."
+"Los usuarios no pueden darse de alta ellos mismos; sólo lo puede hacer el "
+"administrador."
 
 #: invenio/legacy/websession/webinterface.py:1023
 #: invenio/modules/accounts/views/accounts.py:148
 msgid ""
 "The site is having troubles in sending you an email for confirming your "
 "email address."
-msgstr "Tenemos problemas para enviarle un correo de confirmación de su dirección."
+msgstr ""
+"Tenemos problemas para enviarle un correo de confirmación de su dirección."
 
 #: invenio/legacy/websession/webinterface.py:1432
 msgid "Your tickets"
@@ -11576,7 +11508,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 "Registro creado el %(x_date_creation)s, última modificación el "
 "%(x_date_modification)s"
@@ -11597,82 +11530,80 @@ msgid ""
 "%(x_page)s of submission '%(x_sub)s%(x_subm)s' - Invalid Field Position "
 "Numbers"
 msgstr ""
-"No ha sido posible mover el campo de la posición %s a la %s de la página "
-"%s del envío '%s%s' - Números de posición no válidos"
+"No ha sido posible mover el campo de la posición %s a la %s de la página %s "
+"del envío '%s%s' - Números de posición no válidos"
 
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
-"No ha sido posible intercambiar el campo de la posición %s con el campo "
-"de la posición %s en la página %s del envío %s - no se ha podido mover el"
-" campo de la posición %s al campo temporal"
+"No ha sido posible intercambiar el campo de la posición %s con el campo de "
+"la posición %s en la página %s del envío %s - no se ha podido mover el campo "
+"de la posición %s al campo temporal"
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
-"No ha sido posible intercambiar el campo de la posición %s con el campo "
-"de la posición %s en la página %s del envío %s - no se ha podido mover el"
-" campo de la posición %s a la posición %s.  Pida al administrador que "
-"compruebe si el campo no ha quedado encallado en una posición temporal."
+"No ha sido posible intercambiar el campo de la posición %s con el campo de "
+"la posición %s en la página %s del envío %s - no se ha podido mover el campo "
+"de la posición %s a la posición %s.  Pida al administrador que compruebe si "
+"el campo no ha quedado encallado en una posición temporal."
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
-"No ha sido posible intercambiar el campo de la posición %s con el campo "
-"de la posición %s en la página %s del envío %s - no se ha podido mover el"
-" campo de la posición %s a la posición %s.  El campo no ha quedado "
-"encallado en una posición temporal y el administrador tiene que "
-"corregirlo manualmente."
+"No ha sido posible intercambiar el campo de la posición %s con el campo de "
+"la posición %s en la página %s del envío %s - no se ha podido mover el campo "
+"de la posición %s a la posición %s.  El campo no ha quedado encallado en una "
+"posición temporal y el administrador tiene que corregirlo manualmente."
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, fuzzy, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
-"No ha sido posible mover el campo de la posición %s a la %s en la página "
-"%s del envío %s - no se ha podido colocar en una posición menor que %s.  "
-"Se ha intentado recuperar. Compruebe que el orden de los campos sea el "
-"correcto."
+"No ha sido posible mover el campo de la posición %s a la %s en la página %s "
+"del envío %s - no se ha podido colocar en una posición menor que %s.  Se ha "
+"intentado recuperar. Compruebe que el orden de los campos sea el correcto."
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
 #, fuzzy, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
-"No ha sido posible mover el campo de la posición %s a la %s en la página "
-"%s del envío %s%s - no se ha podido colocar en una posición mayor que y "
-"debajo de la %s.  El campo que estaba en la posición %s está ahora en una"
-" posición temporal."
+"No ha sido posible mover el campo de la posición %s a la %s en la página %s "
+"del envío %s%s - no se ha podido colocar en una posición mayor que y debajo "
+"de la %s.  El campo que estaba en la posición %s está ahora en una posición "
+"temporal."
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, fuzzy, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
-"Campo movido de la posición %s a la posición %s de la página %s del envío"
-" '%s%s'."
+"Campo movido de la posición %s a la posición %s de la página %s del envío '%s"
+"%s'."
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
 #, fuzzy, python-format
@@ -11680,8 +11611,8 @@ msgid ""
 "Unable to delete field at position %(x_from)s from page %(x_to)s of "
 "submission '%(x_sub)s'"
 msgstr ""
-"No ha sido posible eliminar el campo en la posición %s de la página %s "
-"del envío '%s%s'."
+"No ha sido posible eliminar el campo en la posición %s de la página %s del "
+"envío '%s%s'."
 
 #: invenio/legacy/websubmit/admin_engine.py:4010
 #, fuzzy, python-format
@@ -11689,8 +11620,8 @@ msgid ""
 "Unable to delete field at position %(x_from)s from page %(x_to)s of "
 "submission '%(x_sub)s%(x_subm)s'"
 msgstr ""
-"No ha sido posible eliminar el campo en la posición %s de la página %s "
-"del envío '%s%s'."
+"No ha sido posible eliminar el campo en la posición %s de la página %s del "
+"envío '%s%s'."
 
 #: invenio/legacy/websubmit/engine.py:194
 #: invenio/legacy/websubmit/engine.py:871
@@ -11739,11 +11670,11 @@ msgstr "No ha sido posible determinar el número de páginas del envío."
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
-"No ha sido posible crear el directorio para este envío.  Se ha avisado al"
-" administrador."
+"No ha sido posible crear el directorio para este envío.  Se ha avisado al "
+"administrador."
 
 #: invenio/legacy/websubmit/engine.py:440
 #: invenio/legacy/websubmit/engine.py:1058
@@ -11779,13 +11710,13 @@ msgstr "Enviar"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 "Se ha encontrado un error de funcionamiento serio.  Se ha avisado a los "
-"administradores. <br /><em>Seguramente la causa sea que se hayan "
-"insertado caracteres erróneos en el formulario</em> (p. ej., copiando y "
-"pegando algún texto de un archivo PDF)."
+"administradores. <br /><em>Seguramente la causa sea que se hayan insertado "
+"caracteres erróneos en el formulario</em> (p. ej., copiando y pegando algún "
+"texto de un archivo PDF)."
 
 #: invenio/legacy/websubmit/engine.py:1501
 #, fuzzy, python-format
@@ -11799,13 +11730,14 @@ msgstr "No está autorizado a acceder a este recurso."
 
 #: invenio/legacy/websubmit/engine.py:1812
 msgid "The chosen action is not supported by the document type."
-msgstr "La acción que ha escogido no está soportada para este tipo de documento."
+msgstr ""
+"La acción que ha escogido no está soportada para este tipo de documento."
 
 #: invenio/legacy/websubmit/templates.py:67
 msgid "Login to display all document types you can access"
 msgstr ""
-"Identifíquese para visualizar todos los tipos de documento a los que "
-"tiene acceso"
+"Identifíquese para visualizar todos los tipos de documento a los que tiene "
+"acceso"
 
 #: invenio/legacy/websubmit/templates.py:93
 msgid "Document types available for submission"
@@ -11833,11 +11765,11 @@ msgstr "Seleccione una categoría y después seleccione una acción."
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
-"Pera continuar un envío interrumpido, introduzca el número de acceso en "
-"la siguiente celda:"
+"Pera continuar un envío interrumpido, introduzca el número de acceso en la "
+"siguiente celda:"
 
 #: invenio/legacy/websubmit/templates.py:366
 msgid "GO"
@@ -11865,11 +11797,11 @@ msgstr "Volver al menú principal"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
-"Este es su número de acceso de envío.  Lo puede utilizar para continuar "
-"un envío interrumpido en caso de haber problemas."
+"Este es su número de acceso de envío.  Lo puede utilizar para continuar un "
+"envío interrumpido en caso de haber problemas."
 
 #: invenio/legacy/websubmit/templates.py:548
 msgid "Mandatory fields appear in red in the SUMMARY window."
@@ -11917,11 +11849,11 @@ msgstr "Envío nº"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
-"Lista de funciones %(x_action)s para los documentos de tipo %(x_doctype)s"
-" en el nivel %(x_step)s"
+"Lista de funciones %(x_action)s para los documentos de tipo %(x_doctype)s en "
+"el nivel %(x_step)s"
 
 #: invenio/legacy/websubmit/templates.py:1041
 msgid "Function"
@@ -12002,8 +11934,7 @@ msgstr "Lista de tipos de documentos revisados"
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
 "Seleccione uno de los tipos de documentos siguientes para comprobar el "
 "estado de los documentos"
@@ -12142,10 +12073,11 @@ msgstr "Nota de aprobación:"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
-"Este documento todavía está %(x_fmt_open)sesperando su "
-"aprobación%(x_fmt_close)s."
+"Este documento todavía está %(x_fmt_open)sesperando su aprobación"
+"%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
 #: invenio/legacy/websubmit/templates.py:2163
@@ -12178,8 +12110,7 @@ msgstr "Volverlo a enviar"
 #: invenio/legacy/websubmit/templates.py:2150
 msgid "WARNING! Upon confirmation, an email will be sent to the referee."
 msgstr ""
-"¡ATENCIÓN! Se enviará un correo electrónico a su revisor cuando lo "
-"confirme."
+"¡ATENCIÓN! Se enviará un correo electrónico a su revisor cuando lo confirme."
 
 #: invenio/legacy/websubmit/templates.py:2153
 msgid ""
@@ -12244,11 +12175,11 @@ msgstr "Seleccione un revisor"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
-"El revisor ha enviado sus recomendaciones finales al comité de "
-"publicación el "
+"El revisor ha enviado sus recomendaciones finales al comité de publicación "
+"el "
 
 #: invenio/legacy/websubmit/templates.py:2281
 #: invenio/legacy/websubmit/templates.py:2342
@@ -12266,8 +12197,8 @@ msgstr "Envíe una recomendación"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 "El comité de publicación ha enviado sus recomendaciones finales al "
 "responsable de proyecto el "
@@ -12310,8 +12241,10 @@ msgid "Take a decision"
 msgstr "Tome una decisión"
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
-msgstr "Un consejo editor ha sido seleccionado por el comité de publicación el "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
+msgstr ""
+"Un consejo editor ha sido seleccionado por el comité de publicación el "
 
 #: invenio/legacy/websubmit/templates.py:2323
 msgid "Add an author list"
@@ -12331,14 +12264,14 @@ msgstr "Un revisor ha sido seleccionado por el consejo editor el "
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
-msgstr "El revisor ha enviado sus recomendaciones finales al consejo editor el "
+"The referee has sent his final recommendations to the editorial board on the "
+msgstr ""
+"El revisor ha enviado sus recomendaciones finales al consejo editor el "
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 "El consejo editor ha enviado sus recomendaciones finales al comité de "
 "publicación el"
@@ -12349,7 +12282,8 @@ msgstr "Todavía no hay ninguna recomendación del consejo editor"
 
 #: invenio/legacy/websubmit/templates.py:2381
 msgid "Last request e-mail was sent to the project leader on the "
-msgstr "El último mensaje de petición fue enviado al responsable del proyecto el "
+msgstr ""
+"El último mensaje de petición fue enviado al responsable del proyecto el "
 
 #: invenio/legacy/websubmit/templates.py:2475
 msgid "Comments overview"
@@ -12443,8 +12377,8 @@ msgid ""
 "Note that your submission has been inserted into the bibliographic task "
 "queue and is waiting for execution.\n"
 msgstr ""
-"Su contribución ha sido enviada a la cola de tareas bibliográficas y está"
-" esperando su ejecución.\n"
+"Su contribución ha sido enviada a la cola de tareas bibliográficas y está "
+"esperando su ejecución.\n"
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:206
 #, fuzzy, python-format
@@ -12454,21 +12388,19 @@ msgid ""
 "available within a few minutes and searchable within an hour or "
 "thereabouts.\n"
 msgstr ""
-"La cola de tareas se está ejecutando automáticamente, y en estos momentos"
-" hay %s tareas esperando su ejecución.  Su registro estará a punto dentro"
-" de poco, y buscable en una hora, aproximadamente.\n"
+"La cola de tareas se está ejecutando automáticamente, y en estos momentos "
+"hay %s tareas esperando su ejecución.  Su registro estará a punto dentro de "
+"poco, y buscable en una hora, aproximadamente.\n"
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
-"Debido a una intervención humana o a un problema temporal, la cola de "
-"tareas está en modo manual.  Su contribución ha quedado registrada, pero "
-"puede tardar más de lo habitual hasta que esté bien integrado y buscable."
-"\n"
+"Debido a una intervención humana o a un problema temporal, la cola de tareas "
+"está en modo manual.  Su contribución ha quedado registrada, pero puede "
+"tardar más de lo habitual hasta que esté bien integrado y buscable.\n"
 
 #: invenio/legacy/websubmit/web/approve.py:53
 msgid "approve.py: cannot determine document reference"
@@ -12547,7 +12479,8 @@ msgstr "límite"
 
 #: invenio/legacy/websubmit/web/publiline.py:749
 msgid "users in brackets are already attached to the role, try another one..."
-msgstr "los usuarios entre corchetes ya tienen asignado este rol, escoja otro..."
+msgstr ""
+"los usuarios entre corchetes ya tienen asignado este rol, escoja otro..."
 
 #: invenio/legacy/websubmit/web/publiline.py:755
 msgid "Removing users from the editorial board"
@@ -12748,8 +12681,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12792,11 +12725,6 @@ msgstr "conectado"
 #, fuzzy
 msgid "Role details"
 msgstr "Más detalles"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Esconder"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12912,8 +12840,8 @@ msgstr "La dirección electrónica facilitada %s ya existe en la base de datos."
 #: invenio/modules/accounts/forms.py:94
 #, fuzzy, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 "Si ha cambiado su dirección, tendrá que %(x_url_open)svolver a poner su "
 "contraseña%(x_url_close)s otra vez."
@@ -12980,13 +12908,12 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, fuzzy, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
-"Usted todavía está reconocido por el sistema central de "
-"%(x_fmt_open)sSSO%(x_fmt_close)s. También puede %(x_url_open)sdesconectar"
-" del SSO%(x_url_close)s."
+"Usted todavía está reconocido por el sistema central de %(x_fmt_open)sSSO"
+"%(x_fmt_close)s. También puede %(x_url_open)sdesconectar del SSO"
+"%(x_url_close)s."
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
 #, fuzzy, python-format
@@ -12999,8 +12926,7 @@ msgid ""
 "Please enter your email address. You will receive a link to create a new "
 "password via email."
 msgstr ""
-"Introduzca su dirección de correo electrónico así como el alias y "
-"contraseña:"
+"Introduzca su dirección de correo electrónico así como el alias y contraseña:"
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:33
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:33
@@ -13011,11 +12937,10 @@ msgstr "Ponga la contraseña nueva"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
-"Introduzca su dirección de correo electrónico así como el alias y "
-"contraseña:"
+"Introduzca su dirección de correo electrónico así como el alias y contraseña:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
 #, fuzzy
@@ -13044,7 +12969,7 @@ msgid "Problem with login."
 msgstr "Comparar con el original"
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "Ya puede acceder a su %(x_url_open)scuenta%(x_url_close)s."
 
@@ -13079,8 +13004,8 @@ msgstr ""
 #, fuzzy, python-format
 msgid "A password reset link has been sent to %(whom)s"
 msgstr ""
-"El enlace para reiniciar la contraseña se ha enviado por correo "
-"electrónico a %s."
+"El enlace para reiniciar la contraseña se ha enviado por correo electrónico "
+"a %s."
 
 #: invenio/modules/accounts/views/accounts.py:320
 #, fuzzy
@@ -13089,8 +13014,7 @@ msgstr "Ha fallado la edición de la autorización de bibcatalog"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13162,13 +13086,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13177,9 +13100,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13352,8 +13275,7 @@ msgstr "colecciones"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13406,7 +13328,8 @@ msgstr "Número de página incorrecta --> se muestra la primera."
 
 #: invenio/modules/comments/api.py:176
 msgid "Bad number of results per page --> showing 10 results per page."
-msgstr "Número de resultados por página incorrecto --> se mostrarán 10 por página."
+msgstr ""
+"Número de resultados por página incorrecto --> se mostrarán 10 por página."
 
 #: invenio/modules/comments/api.py:185
 msgid "Bad display order --> showing most helpful first."
@@ -13419,7 +13342,8 @@ msgstr "Orden incorrecto --> se ordenará por antigüedad."
 #: invenio/modules/comments/api.py:238 invenio/modules/comments/api.py:1597
 #: invenio/modules/comments/api.py:1650
 msgid "Comments on records have been disallowed by the administrator."
-msgstr "El administrador ha deshabilitado la opción de comentar en los registros."
+msgstr ""
+"El administrador ha deshabilitado la opción de comentar en los registros."
 
 #: invenio/modules/comments/api.py:246 invenio/modules/comments/api.py:269
 #: invenio/modules/comments/api.py:1437 invenio/modules/comments/api.py:1458
@@ -13440,8 +13364,8 @@ msgstr "Ya había votado, de manera que este voto no se ha contabilizado."
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 "Se ha subscrito a esta discusión.  A partir de ahora recibirá un correo "
 "electrónico cada vez que se publique un nuevo comentario."
@@ -13472,7 +13396,8 @@ msgstr "%s no es un número válido de registro"
 
 #: invenio/modules/comments/api.py:1444 invenio/modules/comments/api.py:1465
 msgid "Your feedback could not be recorded, please try again."
-msgstr "No ha sido posible guardar su contribución.  Por favor inténtelo de nuevo."
+msgstr ""
+"No ha sido posible guardar su contribución.  Por favor inténtelo de nuevo."
 
 #: invenio/modules/comments/api.py:1573
 #, fuzzy, python-format
@@ -13502,16 +13427,18 @@ msgstr "Ya ha escrito una reseña para este registro."
 #: invenio/modules/comments/api.py:1712
 msgid "You already posted a comment short ago. Please retry later."
 msgstr ""
-"Hace poco ya ha publicado un comentario.  Por favor vuelva a intentarlo "
-"más tarde."
+"Hace poco ya ha publicado un comentario.  Por favor vuelva a intentarlo más "
+"tarde."
 
 #: invenio/modules/comments/api.py:1724
 msgid "Failed to insert your comment to the database. Please try again."
-msgstr "No ha sido posible guardar su comentario.  Por favor inténtelo de nuevo."
+msgstr ""
+"No ha sido posible guardar su comentario.  Por favor inténtelo de nuevo."
 
 #: invenio/modules/comments/api.py:1738
 msgid "Unknown action --> showing you the default add comment form."
-msgstr "Acción desconocida --> se muestra el formulario de añadir un comentario."
+msgstr ""
+"Acción desconocida --> se muestra el formulario de añadir un comentario."
 
 #: invenio/modules/comments/api.py:1865
 #, fuzzy, python-format
@@ -13533,13 +13460,13 @@ msgid "Record ID %(recid)s is not a number."
 msgstr "El registro %s no es numérico."
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
-"Su mensaje es demasiado largo, edítelo por favor.  El tamaño máximo es de"
-" %i caracteres."
+"Su mensaje es demasiado largo, edítelo por favor.  El tamaño máximo es de %i "
+"caracteres."
 
 #: invenio/modules/comments/forms.py:55
 #, fuzzy
@@ -13582,12 +13509,12 @@ msgid "Review was sent"
 msgstr "Escriba un comentario"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Este comentario ha sido denunciado %i veces"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Este comentario ha sido denunciado %i veces"
 
@@ -13640,9 +13567,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13661,8 +13587,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13672,7 +13598,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "Ya existe un fichero con el nombre %s.  Escoja otro, por favor."
 
@@ -13728,8 +13654,7 @@ msgstr "reseña"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13769,8 +13694,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13817,7 +13741,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "La función %s no existe."
 
@@ -13903,11 +13827,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "Estado de la recolección"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Sus tareas"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -13944,11 +13863,10 @@ msgstr "Puede comprobar el estado de su video aquí: %(record_url)s."
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
-"Puede echar un vistazo a %(guidelines_url)s y modificar o repetir su "
-"envío."
+"Puede echar un vistazo a %(guidelines_url)s y modificar o repetir su envío."
 
 #: invenio/modules/encoder/batch_engine.py:136
 #: invenio/modules/encoder/batch_engine.py:177
@@ -13958,7 +13876,8 @@ msgstr "las guías para los videos"
 #: invenio/modules/encoder/batch_engine.py:160
 #, python-format
 msgid "Your video submission%(submission_title)s was successfully processed."
-msgstr "Su video submission%(submission_title)s ha sido correctamente procesado."
+msgstr ""
+"Su video submission%(submission_title)s ha sido correctamente procesado."
 
 #: invenio/modules/encoder/batch_engine.py:164
 #, python-format
@@ -13968,11 +13887,11 @@ msgstr "Su video ahora está accesible en: %(record_url)s."
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
-"Si la cualidad de los videos no es la que espera, puede echar un vistazo "
-"a %(guidelines_url)s y modificar o repetir su envío."
+"Si la cualidad de los videos no es la que espera, puede echar un vistazo a "
+"%(guidelines_url)s y modificar o repetir su envío."
 
 #: invenio/modules/formatter/engine.py:374
 #, fuzzy, python-format
@@ -13987,8 +13906,7 @@ msgstr "No se ha encontrado el elemento de formato %s"
 #: invenio/modules/formatter/engine.py:878
 #, fuzzy, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr "Error al evaluar el elemento de formato %s con el parámetro %s."
 
 #: invenio/modules/formatter/engine.py:887
@@ -14004,8 +13922,8 @@ msgid ""
 "Escape mode for format element %(x_name)s could not be retrieved. Using "
 "default mode instead."
 msgstr ""
-"No se ha podido obtener el modo de escape para el elemento de formato %s."
-" Se usará el modo por defecto."
+"No se ha podido obtener el modo de escape para el elemento de formato %s. Se "
+"usará el modo por defecto."
 
 #: invenio/modules/formatter/engine.py:1003
 #, fuzzy, python-format
@@ -14040,7 +13958,8 @@ msgstr "No se ha podido encontrar el formato de salida %s."
 #: invenio/modules/formatter/engine.py:1932
 #, fuzzy, python-format
 msgid "Could not find a fresh name for output format %(x_code)s."
-msgstr "No ha sido posible encontrar un nuevo nombre para el formato de salida %s"
+msgstr ""
+"No ha sido posible encontrar un nuevo nombre para el formato de salida %s"
 
 #: invenio/modules/formatter/format_elements/bfe_aid_authors.py:285
 #: invenio/modules/formatter/format_elements/bfe_authors.py:238
@@ -14112,7 +14031,7 @@ msgstr "Mostrar todos los %i autores"
 msgid "Manage Files of This Record"
 msgstr "Gestionar los ficheros de este registro"
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr "Edite este registro"
 
@@ -14306,8 +14225,8 @@ msgstr "Gestionar los permisos de grupo"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "No tiene suficientes permisos en este grupo."
 
 #: invenio/modules/groups/views.py:279
@@ -14320,12 +14239,12 @@ msgstr "Usted no es administrador de ningún grupo."
 msgid "Members"
 msgstr "Sin miembros."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Falta el nombre de la base de conocimiento"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14335,11 +14254,11 @@ msgstr "Ninguno"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "cualquier campo"
@@ -14385,13 +14304,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "No hay registros citados por a %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "No hay registros citados por a %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14547,28 +14467,28 @@ msgstr "Tipo de documento desconocido"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14633,8 +14553,8 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr "Para completar el alta de la cuenta, vaya a:"
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -15008,7 +14928,7 @@ msgid "Tag name"
 msgstr "Alias"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "El alias solicitado %s ya está en uso."
 
@@ -15161,8 +15081,7 @@ msgstr "Opciones de préstamo"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15224,7 +15143,7 @@ msgid "Identifiers"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/styles/harvesting_record.html:45
-#, fuzzy, python-format
+#, fuzzy
 msgid "Categories"
 msgstr "Páginas de %(category)s"
 
@@ -15371,7 +15290,7 @@ msgid "just now"
 msgstr "Ahora usted debe"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s segundos"
 
@@ -15430,6 +15349,48 @@ msgstr "cualquier año"
 msgid " years ago"
 msgstr "año"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "Administración de BibCheck"
+
+#~ msgid "Not authorized"
+#~ msgstr "No autorizado"
+
+#~ msgid "Limit to knowledge bases containing string:"
+#~ msgstr "Limitarlo a las bases de conocimiento con el texto:"
+
+#~ msgid "Really delete"
+#~ msgstr "Confirmación para eliminar"
+
+#~ msgid "Verify syntax"
+#~ msgstr "Verifique la sintaxis"
+
+#~ msgid "Calling bibcheck -verify failed."
+#~ msgstr "La invocación bibcheck -verify ha fallado."
+
+#~ msgid "Verify BibCheck config file"
+#~ msgstr "Verifique el archivo de configuración de BibCheck"
+
+#~ msgid "Verify problem"
+#~ msgstr "Problema de verificación"
+
+#~ msgid "File"
+#~ msgstr "Fichero"
+
+#~ msgid "Edit BibCheck config file"
+#~ msgstr "Editar el fichero de configuración de BibCheck"
+
+#~ msgid "Save BibCheck config file"
+#~ msgstr "Guardar el fichero de configuración de BibCheck"
+
+#~ msgid "Delete BibCheck config file"
+#~ msgstr "Eliminar el fichero de configuración de BibCheck"
+
+#~ msgid "Id"
+#~ msgstr "Identificador"
+
+#~ msgid "Tickets"
+#~ msgstr "Tareas"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Atención: seleccione un tiempo válido"
 
@@ -15441,9 +15402,6 @@ msgstr "año"
 
 #~ msgid "Warning: Please, select a valid date"
 #~ msgstr "Atención: seleccione una fecha válida"
-
-#~ msgid ""
-#~ msgstr ""
 
 #~ msgid "Invalid MARCXML"
 #~ msgstr "MARCXML no válido"
@@ -15565,12 +15523,6 @@ msgstr "año"
 #~ msgid "now"
 #~ msgstr "ahora"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "Administración de BibCheck"
-
-#~ msgid "Not authorized"
-#~ msgstr "No autorizado"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "ERROR: %s no existe"
 
@@ -15580,32 +15532,8 @@ msgstr "año"
 #~ msgid "ERROR: %s is not writable"
 #~ msgstr "ERROR: no tiene permiso de escritura en %s"
 
-#~ msgid "Limit to knowledge bases containing string:"
-#~ msgstr "Limitarlo a las bases de conocimiento con el texto:"
-
-#~ msgid "Really delete"
-#~ msgstr "Confirmación para eliminar"
-
-#~ msgid "Verify syntax"
-#~ msgstr "Verifique la sintaxis"
-
 #~ msgid "File %s does not exist."
 #~ msgstr "El fichero %s no existe"
-
-#~ msgid "Calling bibcheck -verify failed."
-#~ msgstr "La invocación bibcheck -verify ha fallado."
-
-#~ msgid "Verify BibCheck config file"
-#~ msgstr "Verifique el archivo de configuración de BibCheck"
-
-#~ msgid "Verify problem"
-#~ msgstr "Problema de verificación"
-
-#~ msgid "File"
-#~ msgstr "Fichero"
-
-#~ msgid "Edit BibCheck config file"
-#~ msgstr "Editar el fichero de configuración de BibCheck"
 
 #~ msgid "File %s already exists."
 #~ msgstr "El fichero %s ya existe."
@@ -15616,20 +15544,11 @@ msgstr "año"
 #~ msgid "File %s: write failed."
 #~ msgstr "Archivo %s: no se ha podido escribir."
 
-#~ msgid "Save BibCheck config file"
-#~ msgstr "Guardar el fichero de configuración de BibCheck"
-
 #~ msgid "File %s deleted."
 #~ msgstr "Fichero %s eliminado."
 
 #~ msgid "File %s: delete failed."
 #~ msgstr "Fichero %s: no se ha podido eliminar."
-
-#~ msgid "Delete BibCheck config file"
-#~ msgstr "Eliminar el fichero de configuración de BibCheck"
-
-#~ msgid "Guests are not authorized to run batchuploader"
-#~ msgstr ""
 
 #~ msgid "The user '%s' is not authorized to run batchuploader"
 #~ msgstr "El usuario «%s» no está autorizado a efectuar cargas masivas"
@@ -15753,9 +15672,6 @@ msgstr "año"
 
 #~ msgid "Tickes you created about this person"
 #~ msgstr "Tareas que usted ha creado sobre esta persona"
-
-#~ msgid "Tickets"
-#~ msgstr "Tareas"
 
 #~ msgid "Request Tickets"
 #~ msgstr "Peticiones"
@@ -15892,17 +15808,8 @@ msgstr "año"
 #~ msgid "Check if the book already exists on Invenio,"
 #~ msgstr "Compruebe si el libro existe en Invenio,"
 
-#~ msgid "Book does not exists on Invenio. Please fill the following form."
-#~ msgstr ""
-
 #~ msgid "This book is sent to you ..."
 #~ msgstr "Se le ha enviado este libro..."
-
-#~ msgid "Id"
-#~ msgstr "Identificador"
-
-#~ msgid "More than one templates found in the document. No format found."
-#~ msgstr ""
 
 #~ msgid "Note for programmer: you have not implemented operator %s."
 #~ msgstr "Nota para el programador: no ha implementado el operador %s."
@@ -15918,9 +15825,6 @@ msgstr "año"
 
 #~ msgid "No description entered for the template."
 #~ msgstr "No se ha entrado ninguna descripción para la plantilla."
-
-#~ msgid "No content type specified for the template. Using default: text/xml."
-#~ msgstr ""
 
 #~ msgid "Missing attribute \"name\" in TEMPLATE_REF."
 #~ msgstr "Falta el atributo \"name\" en TEMPLATE_REF."
@@ -16069,28 +15973,8 @@ msgstr "año"
 #~ msgid "Quit searching."
 #~ msgstr "Abandona la búsqueda"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Cancelado"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr " Buscar a una persona para atribuirle el documento"
@@ -16107,9 +15991,6 @@ msgstr "año"
 #~ msgid "Hide successful claims"
 #~ msgstr "Esconder las reivindicaciones satisfechas"
 
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Autor"
 
@@ -16123,7 +16004,8 @@ msgstr "año"
 #~ msgstr "No se ha encontrado información del estado."
 
 #~ msgid "Operator review of user actions pending"
-#~ msgstr "Revisión por parte del operador de las acciones de usuario pendientes"
+#~ msgstr ""
+#~ "Revisión por parte del operador de las acciones de usuario pendientes"
 
 #~ msgid "Sorry, there are currently no records to be found in this category."
 #~ msgstr "No hay ningún registro de esta categoría."
@@ -16170,26 +16052,9 @@ msgstr "año"
 #~ msgid "Make sure we match the right names!"
 #~ msgstr "¡Asegúrese que los nombres se correspondan!"
 
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-#~ "Seleccione un autor para cada uno "
-#~ "de los los registros que se le "
-#~ "asignen."
-
 #~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr "En el proceso, se ignoraran los documentos sin un nombre seleccionado."
-
-#~ msgid "Claim for person with id"
 #~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
+#~ "En el proceso, se ignoraran los documentos sin un nombre seleccionado."
 
 #~ msgid "Select name for"
 #~ msgstr "Seleccione el nombre para"
@@ -16221,28 +16086,8 @@ msgstr "año"
 #~ msgid "Confirmation needed to continue"
 #~ msgstr "Hace falta la confirmación para continuar"
 
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-#~ "El resultado de esta petición será "
-#~ "visible, imediatamente pero es necesaria "
-#~ "su confirmación, porque este document ya"
-#~ " había sido reivindicado manualmente"
-
 #~ msgid "This will create a change request for the operators"
 #~ msgstr "Esto creará una petición de cambio a los operadores"
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-#~ "El resultado de esta petición será "
-#~ "visible una vez sea confirmado por "
-#~ "un operador"
 
 #~ msgid "Selected name on paper"
 #~ msgstr "Nombre seleccionado en el documento"
@@ -16270,16 +16115,6 @@ msgstr "año"
 
 #~ msgid "Please provide your eMail address"
 #~ msgstr "Su dirección de correo electrónico"
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-#~ "Esta dirección de correo electrónico "
-#~ "está reservada por otro usuario. Por "
-#~ "favor, dese de alta o ofrezca una"
-#~ " dirección alternativa"
 
 #~ msgid "Your eMail:"
 #~ msgstr "Su dirección de correo electrónico:"
@@ -16314,23 +16149,6 @@ msgstr "año"
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Marcarlo como a documentos _no_ suyos"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-#~ "  * Puede volver a esta página "
-#~ "mas adelante.  No se perderá nada. "
-#~ "<Br />"
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-#~ "  ** Ejecuta todos los cambios "
-#~ "solicitados. Los cambios sujetos a "
-#~ "restricciones de permisos se enviaran a"
-#~ " un operador para la revisión manual."
-
 #~ msgid "Create a new Person"
 #~ msgstr "Crear un nuevo grupo"
 
@@ -16343,15 +16161,6 @@ msgstr "año"
 #~ msgid "Add to merge list"
 #~ msgstr "Añadir a los usuarios"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Documentos recientes"
 
@@ -16361,201 +16170,20 @@ msgstr "año"
 #~ msgid "most recent documents:"
 #~ msgstr "los documentos más recientes"
 
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Gestionar los ficheros de los documentos"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Escoja el fichero"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Lista de publicaciones"
-
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
 
 #~ msgid "add external id"
 #~ msgstr "enlace externo"
 
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
-
-#~ msgid "suggest missing ids"
-#~ msgstr ""
-
 #~ msgid "Choose system"
 #~ msgstr "Escoja la plantilla"
-
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Ficheros que están correctamente en la cola:"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-#~ "Fatal: no están habilitadas las opciones"
-#~ " de identificación de autor (Author "
-#~ "ID) en este sistema."
 
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Fatal: no está autorizado a acceder a esta funcionalidad."
@@ -16563,60 +16191,8 @@ msgstr "año"
 #~ msgid "Claim this paper"
 #~ msgstr "Reivindicar este documento"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-#~ "<p>Desgraciadamente, ha ocurrido un error "
-#~ "mientras se gestionaba su petición.  Vea"
-#~ " aquí más información:</p>"
-
 #~ msgid "This page is not accessible directly."
 #~ msgstr "No puede acceder a esta página directamente."
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The publication date of this book is %s."
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
 
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Palabras clave sospesades de tipo %s"
@@ -16631,7 +16207,8 @@ msgstr "año"
 #~ msgstr "No se ha podido crear un ticket"
 
 #~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr "El elemento de formato %s no tiene ninguna función llamada \"format\"."
+#~ msgstr ""
+#~ "El elemento de formato %s no tiene ninguna función llamada \"format\"."
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Modificar los atributos de la plantilla"
@@ -16711,18 +16288,6 @@ msgstr "año"
 #~ msgid "No Record Found for %s."
 #~ msgstr "No se ha encontrado ningún registro para %s."
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-#~ "La especificación para la etiqueta "
-#~ "\"%s\" debe acabar en la columna "
-#~ "\":\", linea %s."
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-#~ "La especificación para la etiqueta "
-#~ "\"%s\" debe comenzar con \"tag\", linea"
-#~ " %s."
-
 #~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
 #~ msgstr "\"tag\" debe estar en minúscula en \"%s\", linea %s."
 
@@ -16731,12 +16296,6 @@ msgstr "año"
 
 #~ msgid "Invalid tag \"%s\" at line %s."
 #~ msgstr "Etiqueta \"%s\" no válida, linea %s."
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-#~ "La condición \"%s\" ocurre fuera de "
-#~ "una especificación de etiqueta, linea "
-#~ "%s."
 
 #~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
 #~ msgstr "La condición \"%s\" solo puede tenir un solo carácter, linea %s."
@@ -16747,17 +16306,9 @@ msgstr "año"
 #~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
 #~ msgstr "Falta la columna \":\" después de \"default\" en \"%s\", linea %s."
 
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-#~ "La especificación de la plantilla por"
-#~ " defecto \"%s\" debe comenzar por "
-#~ "\"default :\", linea %s."
-
 #~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr "La palabra \"default\" debe estar en minúsculas en \"%s\", linea %s."
+#~ msgstr ""
+#~ "La palabra \"default\" debe estar en minúsculas en \"%s\", linea %s."
 
 #~ msgid "Line %s could not be understood at line %s."
 #~ msgstr "No se puede entender la linea %s, linea %s."
@@ -16765,49 +16316,8 @@ msgstr "año"
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "No se ha podido leer el format de salida %s. %s"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-#~ "No se ha podido encontrar el "
-#~ "nombre especificado en la etiqueta "
-#~ "\"<name>\" en la plantilla de formato"
-#~ " %s."
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-#~ "No se ha podido econtrar la "
-#~ "descripción especificada en la etiqueta "
-#~ "\"<description>\" en la plantilla de "
-#~ "formato %s."
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "La plantilla de formato %s llama al elemento no definido \"%s\"."
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-#~ "La plantilla de formato %s llama "
-#~ "al elemento ilegible \"%s\". Compruebe "
-#~ "los permisos de fichero del elemento."
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-#~ "No se ha podido cargar el elemento"
-#~ " \"%s\" en la plantilla %s. Compruebe"
-#~ " el código del elemento."
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-#~ "El elemento de formato %s usa el"
-#~ " parámetro desconocido \"%s\" en la "
-#~ "plantilla de formato %s."
 
 #~ msgid "Could not read format template named %s. %s"
 #~ msgstr "No se ha podido leer la plantilla de formato %s. %s"
@@ -16817,16 +16327,6 @@ msgstr "año"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "No se ha podido leer el elemento de formato %s. %s"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
-#~ "No se ha podido escribir en el "
-#~ "directorio etc/bibformat de su instalación "
-#~ "de Invenio. Compruebe los permisos del"
-#~ " directorio."
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Formato de salida restringido"
@@ -16882,59 +16382,17 @@ msgstr "año"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Validación del elemento de formato %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-#~ "No se ha especificado ningún formato "
-#~ "para la validación.  Especifique uno."
-
 #~ msgid "Format Validation"
 #~ msgstr "Validación del formato"
 
 #~ msgid "Knowledge Base %s"
 #~ msgstr "Base de conocimiento %s"
 
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-#~ "Error en la conexión con el "
-#~ "servidor SMPT esperando %s segundos. La"
-#~ " excepción es %s, al intentar enviar"
-#~ " el mensaje de %s a %s con "
-#~ "el texto %s."
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
 #~ msgid "Not Set"
 #~ msgstr "Sin definir"
 
 #~ msgid "never"
 #~ msgstr "nunca"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
 
 #~ msgid "Name variants"
 #~ msgstr "Variantes del nombre"
@@ -16953,12 +16411,6 @@ msgstr "año"
 
 #~ msgid "Frequent keywords"
 #~ msgstr "Palabras clave frecuentes"
-
-#~ msgid "No Subject categories"
-#~ msgstr ""
-
-#~ msgid "Subject categories"
-#~ msgstr ""
 
 #~ msgid "No Collaborations"
 #~ msgstr "Sin colaboraciones"
@@ -16981,9 +16433,6 @@ msgstr "año"
 #~ msgid "Citations%s"
 #~ msgstr "Citaciones%s:"
 
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
-
 #~ msgid "No Publication Graph"
 #~ msgstr "Fecha de publicación"
 
@@ -16995,15 +16444,6 @@ msgstr "año"
 
 #~ msgid "Recompute Now!"
 #~ msgstr "¡Recalcular ahora!"
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid "%s View your previously submitted comments"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
 
 #~ msgid "Cited by 1 record"
 #~ msgstr "Citado por 1 registro"
@@ -17032,23 +16472,8 @@ msgstr "año"
 #~ msgid "No Citation Information available"
 #~ msgstr "No hay información de citas disponible"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Discusión"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Sus alertas"
@@ -17071,22 +16496,8 @@ msgstr "año"
 #~ msgid "Group: %s"
 #~ msgstr "Grupo: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "No se ha encontrado la página %s"
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "El campo %s es obligatorio."
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
-#~ msgstr ""
-#~ "No ha sido posible eliminar el "
-#~ "campo en la posición %s de la "
-#~ "página %s del envío '%s'."
-

--- a/invenio/base/translations/fr/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/fr/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
 "PO-Revision-Date: 2014-08-26 15:42+0200\n"
 "Last-Translator: Jérôme Caffaro <jerome.caffaro@cern.ch>\n"
 "Language-Team: FR <info@invenio-software.org>\n"
@@ -24,7 +24,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -58,8 +58,8 @@ msgstr "Page principale"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -205,7 +205,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Bonjour:"
 
@@ -226,17 +226,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -262,48 +262,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "L'URL fournie n'est pas valide."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr "Demande de réinitialisation du mot de passe sur %s"
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Vous n'êtes pas autorisé à faire des emprunts."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Échec lors de l'enregistrement"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Veuillez choisir un ou plusieurs:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Demande d'autorisation de rôles"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, fuzzy, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr "Une nouvelle version d'Invenio est disponible à "
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -503,7 +508,8 @@ msgstr "Aucun droit pour envoyer vers la collection '%s'"
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 "L'utilisateur '%(x_user)s' n'est pas autorisé à modifier la collection "
 "'%(x_coll)s'"
@@ -560,7 +566,8 @@ msgstr "Éditer la méthode d'identification"
 #: invenio/legacy/batchuploader/templates.py:475
 #, python-format
 msgid "All fields with %(x_fmt_open)s*%(x_fmt_close)s are mandatory"
-msgstr "Tous les champs marqués %(x_fmt_open)s*%(x_fmt_close)s sont obligatoires"
+msgstr ""
+"Tous les champs marqués %(x_fmt_open)s*%(x_fmt_close)s sont obligatoires"
 
 #: invenio/legacy/batchuploader/templates.py:245
 #: invenio/legacy/batchuploader/templates.py:466
@@ -578,8 +585,7 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"Votre fichier a été inséré dans la file d'attente avec succès. Vous "
-"pouvez\n"
+"Votre fichier a été inséré dans la file d'attente avec succès. Vous pouvez\n"
 "affichier votre %(x_url1_open)shistorique d'envois%(x_url1_close)s ou \n"
 "%(x_url2_open)ssoumettre un autre fichier%(x_url2_close)s"
 
@@ -708,14 +714,16 @@ msgstr "<b>%s documents</b> ont été trouvés."
 
 #: invenio/legacy/batchuploader/templates.py:571
 msgid "The following files have been successfully queued:"
-msgstr "Les fichiers suivants ont été placés dans la file d'attente avec succès:"
+msgstr ""
+"Les fichiers suivants ont été placés dans la file d'attente avec succès:"
 
 #: invenio/legacy/batchuploader/templates.py:576
 msgid "The following errors have occurred:"
 msgstr "Les erreurs suivantes sont survenues:"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 "Quelques fichiers n'ont pas pu être déplacés dans le dossier \"Done\". "
 "Veuillez les enlever manuellement."
@@ -736,11 +744,11 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
-"Veuillez vous référer à la %(x_url_open)spage d'aide de \"Batch "
-"Uploader\"%(x_url_close)s pour exécuter ces actions périodiquement."
+"Veuillez vous référer à la %(x_url_open)spage d'aide de \"Batch Uploader"
+"\"%(x_url_close)s pour exécuter ces actions périodiquement."
 
 #: invenio/legacy/batchuploader/templates.py:602
 msgid "Metadata folders"
@@ -821,7 +829,7 @@ msgstr "ID"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -863,8 +871,8 @@ msgstr "Vous avez %i tickets."
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Précédent"
@@ -879,8 +887,8 @@ msgstr "fermer"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Suivant"
 
@@ -896,18 +904,6 @@ msgstr "Suivant"
 msgid "Admin Area"
 msgstr "Zone d'administration"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "auteur"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
 msgid "ERROR: %(x_name)s does not exist"
@@ -922,15 +918,6 @@ msgstr ""
 #, python-format
 msgid "ERROR: %(x_name)s is not writable"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
-msgid "Limit to knowledge bases containing string:"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "supprimé"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -960,10 +947,6 @@ msgstr "supprimé"
 msgid "Delete"
 msgstr "Supprimer"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:140
-msgid "Verify syntax"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:145
 #: invenio/modules/communities/views.py:258
 #, fuzzy
@@ -975,31 +958,9 @@ msgstr "Créer un nouveau panier"
 msgid "File %(x_name)s does not exist."
 msgstr "L'utilisateur %s n'existe pas."
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:174
-msgid "Calling bibcheck -verify failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
-msgid "Verify BibCheck config file"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Problème de base de données"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "fichier(s)"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
 msgstr "Enregistrer les modifications"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:240
-msgid "Edit BibCheck config file"
-msgstr ""
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:268
 #, fuzzy, python-format
@@ -1016,10 +977,6 @@ msgstr ""
 msgid "File %(x_name)s: write failed."
 msgstr ""
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:279
-msgid "Save BibCheck config file"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:312
 #, python-format
 msgid "File %(x_name)s deleted."
@@ -1028,10 +985,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:314
 #, python-format
 msgid "File %(x_name)s: delete failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:316
-msgid "Delete BibCheck config file"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:195
@@ -1099,7 +1052,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1137,8 +1091,8 @@ msgid ""
 "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s status is "
 "%(x_strong_tag_open)s%(x_status)s%(x_strong_tag_close)s"
 msgstr ""
-"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné "
-"avec succès."
+"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné avec "
+"succès."
 
 #: invenio/legacy/bibcirculation/adminlib.py:399
 #: invenio/legacy/bibcirculation/adminlib.py:896
@@ -1148,20 +1102,20 @@ msgid ""
 "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s location is "
 "%(x_strong_tag_open)s%(x_location)s%(x_strong_tag_close)s"
 msgstr ""
-"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné "
-"avec succès."
+"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné avec "
+"succès."
 
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
 msgstr ""
-"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné "
-"avec succès."
+"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné avec "
+"succès."
 
 #: invenio/legacy/bibcirculation/adminlib.py:411
 #, fuzzy
@@ -1171,30 +1125,28 @@ msgstr "Code-barres"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
-"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné "
-"avec succès."
+"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné avec "
+"succès."
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
-"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné "
-"avec succès."
+"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné avec "
+"succès."
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
 msgid "You could enter the barcode for this user's next loan, if any."
@@ -1218,15 +1170,16 @@ msgstr "Nouveau"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
-"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné "
-"avec succès."
+"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné avec "
+"succès."
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1258,12 +1211,11 @@ msgstr "Période de prêt"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
-"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné "
-"avec succès."
+"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné avec "
+"succès."
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
 msgid "Claim return"
@@ -1329,8 +1281,8 @@ msgstr "Nouvelle réservation"
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1338,8 +1290,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1361,12 +1313,11 @@ msgstr "Nouveau prêt"
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
-"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné "
-"avec succès."
+"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné avec "
+"succès."
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
 #: invenio/legacy/bibcirculation/adminlib.py:2332
@@ -1407,8 +1358,8 @@ msgstr "0 emprunteur trouvé"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1467,11 +1418,11 @@ msgstr "Un nouvelle réservation a été enregistrée avec succès."
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1482,11 +1433,11 @@ msgstr "Oui"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1499,8 +1450,8 @@ msgstr "Non"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1595,8 +1546,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1616,29 +1567,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1647,9 +1598,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr "Désolé, cette notice n'existe pas."
 
@@ -2009,16 +1960,14 @@ msgstr "Cette notice n'a pas d'exemplaires."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2039,8 +1988,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2202,8 +2151,8 @@ msgstr "Demande PEB"
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2310,7 +2259,7 @@ msgstr "Emplacement"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Description"
 
@@ -2503,8 +2452,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2779,12 +2728,11 @@ msgstr "Confirmer"
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr ""
-"Si vous le souhaitez, vous pouvez vous "
-"%(x_url_open)sidentifier%(x_url_close)s."
+"Si vous le souhaitez, vous pouvez vous %(x_url_open)sidentifier"
+"%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
 #, fuzzy
@@ -2837,7 +2785,7 @@ msgstr "Réinitialiser"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "OK"
 
@@ -2845,11 +2793,11 @@ msgstr "OK"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
-"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné "
-"avec succès."
+"L'exemplaire %(x_title)s avec code-barres %(x_barcode)s a été retourné avec "
+"succès."
 
 #: invenio/legacy/bibcirculation/templates.py:1588
 msgid "The next(pending) request on the returned book is shown below."
@@ -3308,8 +3256,8 @@ msgstr "Boîte aux lettres"
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "Email"
 
@@ -3784,8 +3732,8 @@ msgstr "Détails nouvel exemplaire"
 #, fuzzy, python-format
 msgid "A %(x_url_open)snew copy%(x_url_close)s has been added."
 msgstr ""
-"Veuillez %(x_url_open)saccepter ou rejeter%(x_url_close)s la demande de "
-"cet utilisateur."
+"Veuillez %(x_url_open)saccepter ou rejeter%(x_url_close)s la demande de cet "
+"utilisateur."
 
 #: invenio/legacy/bibcirculation/templates.py:7443
 #, fuzzy
@@ -4035,8 +3983,8 @@ msgid ""
 "I accept the %(x_url_open)sconditions%(x_url_close)s of the service in "
 "particular the return of books in due time."
 msgstr ""
-"J'accepte les %s de ce service, en particulier de retourner les livres "
-"avant leur échéance."
+"J'accepte les %s de ce service, en particulier de retourner les livres avant "
+"leur échéance."
 
 #: invenio/legacy/bibcirculation/templates.py:9491
 msgid "I want this edition only."
@@ -4119,11 +4067,11 @@ msgstr "Période souhaitée (À)"
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, fuzzy, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
-"L'emprunteur accepte les %s du service, en particulier le retour des "
-"livres avant leur échéance."
+"L'emprunteur accepte les %s du service, en particulier le retour des livres "
+"avant leur échéance."
 
 #: invenio/legacy/bibcirculation/templates.py:9721
 msgid "Borrower wants this edition only."
@@ -4140,8 +4088,8 @@ msgstr "Uniquement cette édition"
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, fuzzy, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 "Vérifiez si le livre existe déjà sur Invenio avant de transmettre votre "
 "demande de PEB."
@@ -4202,17 +4150,17 @@ msgstr "ISSN"
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4588,25 +4536,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "La notice a été supprimée."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4666,15 +4614,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4685,10 +4633,10 @@ msgstr "Choisir un fichier"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4701,8 +4649,8 @@ msgstr "Accès"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 "Le fichier que vous voulez éditer est protégé contre les modifications. "
 "Votre action n'a pas été prise en compte."
@@ -4710,19 +4658,22 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, fuzzy, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
-msgstr "Le fichier chargé est trop petit (<%i o) et a par conséquence été ignoré"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+"Le fichier chargé est trop petit (<%i o) et a par conséquence été ignoré"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
 #, fuzzy, python-format
 msgid ""
 "The uploaded file is too big (>%(x_size)i o) and has therefore not been "
 "considered"
-msgstr "Le fichier chargé est trop grand (>%i o) et a par conséquence été ignoré"
+msgstr ""
+"Le fichier chargé est trop grand (>%i o) et a par conséquence été ignoré"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr "Le nom du fichier chargé est trop long et a par conséquence été ignoré"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4730,8 +4681,7 @@ msgid ""
 "You have already reached the maximum number of files for this type of "
 "document"
 msgstr ""
-"Vous avez déjà atteint le nombre de fichier maximum pour ce type de "
-"document"
+"Vous avez déjà atteint le nombre de fichier maximum pour ce type de document"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:627
 #: invenio/legacy/bibdocfile/managedocfiles.py:637
@@ -4743,22 +4693,21 @@ msgstr "Un fichier nommé %s existe déjà. Choisissez un autre nom."
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
-msgstr "Un fichier au format '%s' existe déjà. Veuillez charger un autre format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
+msgstr ""
+"Un fichier au format '%s' existe déjà. Veuillez charger un autre format."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
-"Vous n'êtes pas autorisé à utiliser des points '.', slash '/', ou "
-"backslash '\\\\\\\\' dans les noms de fichier. Choisissez un autre nom et"
-" chargez à nouveau votre fichier. En particulier, faites attention à ne "
-"pas inclure l'extension de fichier dans le nom."
+"Vous n'êtes pas autorisé à utiliser des points '.', slash '/', ou backslash "
+"'\\\\\\\\' dans les noms de fichier. Choisissez un autre nom et chargez à "
+"nouveau votre fichier. En particulier, faites attention à ne pas inclure "
+"l'extension de fichier dans le nom."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
 msgid "Choose how you want to restrict access to this file."
@@ -4771,23 +4720,21 @@ msgstr "Ajouter un fichier"
 #: invenio/legacy/bibdocfile/managedocfiles.py:900
 msgid "You can decide to hide or not previous version(s) of this file."
 msgstr ""
-"Vous pouvez choisir de cacher ou non les précédentes versions de ce "
-"fichier."
+"Vous pouvez choisir de cacher ou non les précédentes versions de ce fichier."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
-"Lors de la révision d'un fichier, les formats additionnels que vous "
-"pourriez avoir chargés auparavant sont enlevés, puisqu'ils ne "
-"correspondent plus à la dernière version du fichier."
+"Lors de la révision d'un fichier, les formats additionnels que vous pourriez "
+"avoir chargés auparavant sont enlevés, puisqu'ils ne correspondent plus à la "
+"dernière version du fichier."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 "Les formats alternatifs chargés pour la version courante de ce fichier "
 "seront enlevés"
@@ -4821,7 +4768,8 @@ msgstr "Appliquer les modifications"
 #: invenio/legacy/bibdocfile/managedocfiles.py:925
 #, python-format
 msgid "Need help revising or adding files to record %(recid)s"
-msgstr "Besoin d'aide pour réviser ou ajouter des fichiers à la notice %(recid)s"
+msgstr ""
+"Besoin d'aide pour réviser ou ajouter des fichiers à la notice %(recid)s"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:927
 #, python-format
@@ -4849,11 +4797,11 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
-"Besoin d'aide pour réviser ou ajouter un fichier? Envoyez le fichier "
-"révisé à %(mailto_link)s."
+"Besoin d'aide pour réviser ou ajouter un fichier? Envoyez le fichier révisé "
+"à %(mailto_link)s."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
 msgid "revise"
@@ -4902,11 +4850,11 @@ msgstr "La notice demandée ne semble pas avoir déjà intégrée."
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
-"Le système a rencontré une erreur lors de la recherche des fichiers de ce"
-" document."
+"Le système a rencontré une erreur lors de la recherche des fichiers de ce "
+"document."
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
 #: invenio/legacy/websession/webinterface.py:1023
@@ -4915,8 +4863,7 @@ msgid ""
 "The error has been logged and will be taken in consideration as soon as "
 "possible."
 msgstr ""
-"L'erreur a été enregistrée et sera prise en considération dès que "
-"possible."
+"L'erreur a été enregistrée et sera prise en considération dès que possible."
 
 #: invenio/legacy/bibdocfile/webinterface.py:202
 #, python-format
@@ -5018,13 +4965,13 @@ msgstr "1. Choisissez un critère de recherche"
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 "Spécifiez le critère à utiliser pour filtrer les notices à modifier.\n"
-"Utiliser \"Recherche\" pour afficher les notices qui seraient filtrées en"
-" utilisant ce critère."
+"Utiliser \"Recherche\" pour afficher les notices qui seraient filtrées en "
+"utilisant ce critère."
 
 #: invenio/legacy/bibeditmulti/templates.py:361
 msgid "Preview results"
@@ -5036,8 +4983,8 @@ msgstr "2. Définir les modifications"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 "Spécifiez les champs et sous-champs à modifier dans chaque notice "
 "correspondant au critère de recherche"
@@ -5166,11 +5113,10 @@ msgstr "Retour aux Résultats"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5294,7 +5240,7 @@ msgid "Total"
 msgstr "Total"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Choisir"
 
@@ -5450,11 +5396,11 @@ msgstr "Supprimer la base de connaissances"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
-"Limiter l'affichage aux bases de connaissance avec %(keyword_field)s dans"
-" leurs règles et description"
+"Limiter l'affichage aux bases de connaissance avec %(keyword_field)s dans "
+"leurs règles et description"
 
 #: invenio/legacy/bibknowledge/templates.py:84
 #: invenio/legacy/webalert/templates.py:328
@@ -5508,10 +5454,9 @@ msgstr "Veuillez configurer"
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 "Une base de connaissance dynamique est une liste de valeur\n"
 "donnée par un champ. La liste est générée dynamiquement en\n"
@@ -5519,11 +5464,11 @@ msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 "Exemple: votre notice contient un champ 270__a pour le nom et l'adresse\n"
 "d'une institution. Si vous assignez au champ '270__a' l'expression \n"
@@ -5531,16 +5476,16 @@ msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr "Si l'expression est vide, la liste des valeurs dans 270__a sera créée."
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, fuzzy, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 "Si l'expression contient '%' comme dans '270__a:*%*',\n"
 "le caractère sera remplacé par la recherche lorsque\n"
@@ -5548,19 +5493,19 @@ msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 "Vous pouvez entre un nom de collection si l'expression\n"
 "doit être évaluée dans une collection spécifique."
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 "Exemple: votre notice contient un champ 270__a pour le nom et l'adresse\n"
 "de l'institution d'un auteur. Si vous assignez au champ '270__a' "
@@ -5570,13 +5515,14 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:258
 #, fuzzy, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 "Exemple 2: Pour retourner le nom de l'institution (100__a) quand "
-"l'utilisateur fournit le code postal (270__a): indiquez le champ 100__a, "
-"et l'expression 270__a:*%s*."
+"l'utilisateur fournit le code postal (270__a): indiquez le champ 100__a, et "
+"l'expression 270__a:*%s*."
 
 #: invenio/legacy/bibknowledge/templates.py:262
 msgid "Any collection"
@@ -5613,7 +5559,7 @@ msgstr "Dépendances de la base de connaissances"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5653,7 +5599,8 @@ msgstr "Mettre à jour les attributs de la base"
 
 #: invenio/legacy/bibknowledge/templates.py:672
 msgid "This knowledge base is not used in any format elements."
-msgstr "Cette base de connaissance n'est utilisée dans aucun élément de formatage."
+msgstr ""
+"Cette base de connaissance n'est utilisée dans aucun élément de formatage."
 
 #: invenio/legacy/bibknowledge/templates.py:703
 #, fuzzy, python-format
@@ -5663,8 +5610,8 @@ msgstr "Votre règle: %s"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, fuzzy, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 "La partie gauche de la règle (%s) apparaît déjà dans ces bases de "
 "connaissances:"
@@ -5672,8 +5619,8 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:709
 #, fuzzy, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 "La partie droite de la règle (%s) apparaît déjà dans ces bases de "
 "connaissances:"
@@ -5760,7 +5707,8 @@ msgstr "Désolé"
 #: invenio/legacy/errorlib/webinterface.py:130
 #, fuzzy, python-format
 msgid "Cannot send error request, %(x_name)s parameter missing."
-msgstr "Impossible d'envoyer le rapport d'erreur, le paramètre %s est manquant."
+msgstr ""
+"Impossible d'envoyer le rapport d'erreur, le paramètre %s est manquant."
 
 #: invenio/legacy/errorlib/webinterface.py:150
 msgid "The error report has been sent."
@@ -5773,8 +5721,8 @@ msgstr "Merci beaucoup de nous aider à améliorer le service."
 #: invenio/legacy/errorlib/webinterface.py:155
 msgid "Use the back button of your browser to return to the previous page."
 msgstr ""
-"Utiliser le bouton de retour de votre navigateur pour retourner à la page"
-" précédente."
+"Utiliser le bouton de retour de votre navigateur pour retourner à la page "
+"précédente."
 
 #: invenio/legacy/errorlib/webinterface.py:158
 msgid "Thank you!"
@@ -5898,8 +5846,7 @@ msgstr "Erreur lors de l'accès à la notice"
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 "Erreur lors du formatage de l'entrée de la liste d'attente. L'entrée est "
 "probablement corrompue"
@@ -5976,8 +5923,8 @@ msgstr "Retour à la sélection principale"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -5992,8 +5939,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Résultats de la recherche"
 
@@ -6152,8 +6099,8 @@ msgstr "Pas de résultat"
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6162,8 +6109,8 @@ msgid ""
 "Warning: figure caption search is only available for a subset of papers "
 "mostly from %(x_range_from_year)s-%(x_range_to_year)s."
 msgstr ""
-"Attention: la recherche dans les légendes des figures n'est disponible "
-"que pour un sous-ensemble des papiers, principalement pour 2008-2011."
+"Attention: la recherche dans les légendes des figures n'est disponible que "
+"pour un sous-ensemble des papiers, principalement pour 2008-2011."
 
 #: invenio/legacy/search_engine/__init__.py:2151
 #, fuzzy, python-format
@@ -6178,17 +6125,15 @@ msgstr "Recherche %s à la place."
 #: invenio/legacy/search_engine/__init__.py:2161
 msgid "Search term too generic, displaying only partial results..."
 msgstr ""
-"Recherche trop générique, affichage d'une partie des résultats "
-"seulement..."
+"Recherche trop générique, affichage d'une partie des résultats seulement..."
 
 #: invenio/legacy/search_engine/__init__.py:2165
 #, fuzzy
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
-"Recherche trop générique, affichage d'une partie des résultats "
-"seulement..."
+"Recherche trop générique, affichage d'une partie des résultats seulement..."
 
 #: invenio/legacy/search_engine/__init__.py:2169
 #, fuzzy
@@ -6196,16 +6141,14 @@ msgid ""
 "Search term after citedby operator too generic, displaying only partial "
 "results..."
 msgstr ""
-"Recherche trop générique, affichage d'une partie des résultats "
-"seulement..."
+"Recherche trop générique, affichage d'une partie des résultats seulement..."
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
-"Aucun index de phrase disponible pour le texte intégral, recherche pour "
-"une combinaison de mots..."
+"Aucun index de phrase disponible pour le texte intégral, recherche pour une "
+"combinaison de mots..."
 
 #: invenio/legacy/search_engine/__init__.py:2213
 #, python-format
@@ -6216,86 +6159,83 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
-"Syntaxe de recherche non reconnue. Les parenthèses sont ignorées. En cas "
-"de doute vérifiez votre recherche et réessayez."
+"Syntaxe de recherche non reconnue. Les parenthèses sont ignorées. En cas de "
+"doute vérifiez votre recherche et réessayez."
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
 "Aucun résultat n'a été trouvé dans la collection %(x_collection)s. Les "
-"autres collections publiques ont donné %(x_url_open)s%(x_nb_hits)d "
-"résultats%(x_url_close)s."
+"autres collections publiques ont donné %(x_url_open)s%(x_nb_hits)d résultats"
+"%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
-"Aucune collection publique ne satisfait votre requête. Si vous recherchez"
-" des documents non publics, veuillez d'abord choisir la collection "
-"restreinte."
+"Aucune collection publique ne satisfait votre requête. Si vous recherchez "
+"des documents non publics, veuillez d'abord choisir la collection restreinte."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
-"Aucune collection publique ne satisfait votre requête. Si vous recherchez"
-" des documents non publics, veuillez d'abord choisir la collection "
-"restreinte."
+"Aucune collection publique ne satisfait votre requête. Si vous recherchez "
+"des documents non publics, veuillez d'abord choisir la collection restreinte."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr "Votre appréciation n'a pu être enregistrée, veuillez réessayer."
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 msgid "No match found, please enter different search terms."
 msgstr "Aucun résultat trouvé, veuillez utiliser d'autres termes de recherche"
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Il n'y a aucune notice se référant à %s."
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Il n'y a aucune notice citée par %s."
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Il n'y a aucune notice citée par %s."
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Aucun index des mots n'est disponible pour %s."
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Aucun index des phrases n'est disponible pour %s."
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
-"Le terme de recherche %(x_term)s dans l'index %(x_index)s ne se trouve "
-"dans aucune notice. Les termes les plus proches parmi toutes les "
-"collections sont:"
+"Le terme de recherche %(x_term)s dans l'index %(x_index)s ne se trouve dans "
+"aucune notice. Les termes les plus proches parmi toutes les collections sont:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
@@ -6304,44 +6244,44 @@ msgstr ""
 "Le terme de recherche %s ne se trouve dans aucune notice. Les termes les "
 "plus proches parmi toutes les collections sont:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
-"Désolé, %s n'est pas une option de tri valide. Le tri par titre est "
-"utilisé à la place."
+"Désolé, %s n'est pas une option de tri valide. Le tri par titre est utilisé "
+"à la place."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
-"Désolé, le tri n'est pas autorisé sur un ensemble de plus de %d notices. "
-"Les notices les plus récentes sont affichées en premier."
+"Désolé, le tri n'est pas autorisé sur un ensemble de plus de %d notices. Les "
+"notices les plus récentes sont affichées en premier."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
-"Désolé, %s n'est pas une option de tri valide. Le tri par titre est "
-"utilisé à la place."
+"Désolé, %s n'est pas une option de tri valide. Le tri par titre est utilisé "
+"à la place."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "La page demandée n'existe pas."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Utiliser d'autres termes de recherche"
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6355,17 +6295,17 @@ msgstr "Utiliser d'autres termes de recherche"
 msgid "Browse"
 msgstr "Liste"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
-"Pas de résultat pour l'intervalle de temps spécifé, la condition n'est "
-"pas prise en compte..."
+"Pas de résultat pour l'intervalle de temps spécifé, la condition n'est pas "
+"prise en compte..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
-"Pas de résultat pour les limites spécifiées, la condition n'est pas prise"
-" en compte..."
+"Pas de résultat pour les limites spécifiées, la condition n'est pas prise en "
+"compte..."
 
 #: invenio/legacy/webalert/api.py:54
 #, fuzzy, python-format
@@ -6406,10 +6346,9 @@ msgstr "L'alerte %s a été mise à jour."
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
 "Vous avez effectué %(x_nb)s recherches. Une %(x_url_open)sliste\n"
 "détaillée%(x_url_close)s est disponible, offrant la possibilité de (a)\n"
@@ -6488,8 +6427,8 @@ msgid ""
 "This alert will notify you each time/only if a new item satisfies the "
 "following query:"
 msgstr ""
-"Cette alerte vous préviendra dès qu'un nouvel article satisfera la "
-"recherche suivante:"
+"Cette alerte vous préviendra dès qu'un nouvel article satisfera la recherche "
+"suivante:"
 
 #: invenio/legacy/webalert/templates.py:173
 msgid "QUERY"
@@ -6535,7 +6474,8 @@ msgstr "non"
 #: invenio/legacy/webalert/templates.py:225
 #, python-format
 msgid "if %(x_fmt_open)sno%(x_fmt_close)s you must specify a basket"
-msgstr "si %(x_fmt_open)snon%(x_fmt_close)s vous devez indiquer un nom de panier"
+msgstr ""
+"si %(x_fmt_open)snon%(x_fmt_close)s vous devez indiquer un nom de panier"
 
 #: invenio/legacy/webalert/templates.py:227
 msgid "Store results in basket?"
@@ -6555,9 +6495,9 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"Créer une nouvelle alerte depuis %(x_url1_open)svos "
-"recherches%(x_url1_close)s, les %(x_url2_open)srecherches "
-"populaires%(x_url2_close)s, ou le formulaire."
+"Créer une nouvelle alerte depuis %(x_url1_open)svos recherches"
+"%(x_url1_close)s, les %(x_url2_open)srecherches populaires%(x_url2_close)s, "
+"ou le formulaire."
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6608,8 +6548,8 @@ msgstr "Vous avez défini %s alertes."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 "Vous n'avez pas encore effectué de recherche. Vous pouvez aller sur "
 "%(x_url_open)sl'interface de recherche%(x_url_close)s."
@@ -6617,11 +6557,11 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
-"Vous avez effectué %(x_nb1)s recherches (%(x_nb2)s différentes questions)"
-" durant les 30 derniers jours."
+"Vous avez effectué %(x_nb1)s recherches (%(x_nb2)s différentes questions) "
+"durant les 30 derniers jours."
 
 #: invenio/legacy/webalert/templates.py:453
 #, fuzzy, python-format
@@ -6678,7 +6618,7 @@ msgstr "Vos Recherches"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6742,7 +6682,7 @@ msgstr "%s Personnaliser, Définir une nouvelle alerte"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6802,7 +6742,8 @@ msgstr "%s Personnaliser, Afficher les alertes"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr "Le panier sélectionné n'existe pas ou vous n'y avez pas accès."
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6824,7 +6765,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "Vous n'avez pas l'autorisation d'écrire des notes pour cet élément."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr "La note que vous citez n'existe pas ou vous n'y avez pas accès."
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6851,19 +6793,20 @@ msgid "You do not have permission to delete this note."
 msgstr "Vous n'avez pas l'autorisation d'effacer cette note."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr "La note à effacer n'existe pas ou vous n'y avez pas accès."
 
 #: invenio/legacy/webbasket/api.py:1791
 #, fuzzy, python-format
 msgid "Sorry, you do not have sufficient rights to add record #%(x_id)i."
-msgstr "Désolé, vous n'avez pas suffisamment de droits pour ajouter la notice #%i."
+msgstr ""
+"Désolé, vous n'avez pas suffisamment de droits pour ajouter la notice #%i."
 
 #: invenio/legacy/webbasket/api.py:1797
 msgid "Some of the items were not added due to lack of sufficient rights."
 msgstr ""
-"Certains éléments n'ont pas été ajoutés par manque de privilèges "
-"nécessaires."
+"Certains éléments n'ont pas été ajoutés par manque de privilèges nécessaires."
 
 #: invenio/legacy/webbasket/api.py:1814
 msgid "Please provide a title for the external source."
@@ -6883,8 +6826,8 @@ msgstr "L'URL fournie n'est pas valide."
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 "L'URL fournie n'est pas valide: la syntaxe de la requête est mauvaise ou "
 "elle ne peut pas aboutir."
@@ -6894,8 +6837,8 @@ msgid ""
 "The url you have provided is not valid: The server failed to fulfil an "
 "apparently valid request."
 msgstr ""
-"L'URL fournie n'est pas valide: le serveur n'a pas pu répondre à une "
-"requête en apparence correcte."
+"L'URL fournie n'est pas valide: le serveur n'a pas pu répondre à une requête "
+"en apparence correcte."
 
 #: invenio/legacy/webbasket/api.py:1898 invenio/legacy/webbasket/api.py:1910
 #: invenio/legacy/webbasket/api.py:2042 invenio/legacy/webbasket/api.py:2111
@@ -6908,8 +6851,8 @@ msgstr "Aucune notice à ajouter."
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6933,8 +6876,8 @@ msgid ""
 "A default topic and basket have been automatically created. Edit them to "
 "rename them as you see fit."
 msgstr ""
-"Un thème et un panier par défaut ont été automatiquement créés. Vous "
-"pouvez au besoin les renommer."
+"Un thème et un panier par défaut ont été automatiquement créés. Vous pouvez "
+"au besoin les renommer."
 
 #: invenio/legacy/webbasket/api.py:2262
 msgid "Please provide a name for the new basket."
@@ -6946,8 +6889,8 @@ msgstr "Veuillez sélectionner un thème existant ou en créer un nouveau."
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 "Vous ne pouvez pas vous abonner à ce panier, vous en êtes soit le "
 "propriétaire, soit déjà abonné."
@@ -7021,8 +6964,7 @@ msgstr "Paniers publics"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 "Vous possédez %(x_nb_perso)s paniers personnels et êtes abonnés à "
 "%(x_nb_group)s paniers de groupes et à %(x_nb_public)s paniers publics."
@@ -7032,8 +6974,7 @@ msgid ""
 "The category you have selected does not exist. Please select a valid "
 "category."
 msgstr ""
-"La catégorie sélectionnée n'existe pas. Veuillez en sélectionner une "
-"valide."
+"La catégorie sélectionnée n'existe pas. Veuillez en sélectionner une valide."
 
 #: invenio/legacy/webbasket/api.py:2861
 msgid "The selected group does not exist or you do not have access to it."
@@ -7041,24 +6982,24 @@ msgstr "Le groupe sélectionné n'existe pas ou vous n'y avez pas accès."
 
 #: invenio/legacy/webbasket/api.py:2914
 msgid "The selected output format is not available or is invalid."
-msgstr "Le format de sortie sélectionné n'est pas disponible ou n'est pas valide."
+msgstr ""
+"Le format de sortie sélectionné n'est pas disponible ou n'est pas valide."
 
 #: invenio/legacy/webbasket/templates.py:106
 msgid ""
 "You have no personal or group baskets or are subscribed to any public "
 "baskets."
 msgstr ""
-"Vous n'avez pas de panier personnel ou de groupe, ni souscrit à un panier"
-" public."
+"Vous n'avez pas de panier personnel ou de groupe, ni souscrit à un panier "
+"public."
 
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
-"Vous pouvez commencer par %(x_url_open)scréer un nouveau "
-"panier%(x_url_close)s."
+"Vous pouvez commencer par %(x_url_open)scréer un nouveau panier"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
 #: invenio/legacy/webbasket/templates.py:198
@@ -7219,11 +7160,11 @@ msgstr "Notice externe"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
-"Spécifiez l'URL de l'élément externe à ajouter, et indiquez un titre et "
-"une description"
+"Spécifiez l'URL de l'élément externe à ajouter, et indiquez un titre et une "
+"description"
 
 #: invenio/legacy/webbasket/templates.py:1612
 #: invenio/modules/linkbacks/templates/linkbacks/index_base.html:44
@@ -7404,8 +7345,8 @@ msgstr "Partager le panier avec un nouveau groupe"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 "Vous êtes actuellement enregistré en tant qu'invité. Vos paniers "
 "disparaîtront à la fin de la session."
@@ -7414,7 +7355,8 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
 "Si vous le souhaitez, vous pouvez vous %(x_url_open)sidentifier ou vous "
 "enregistrer ici%(x_url_close)s."
@@ -7426,7 +7368,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Cette fonctionnalité est indisponible pour les invités."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Retour aux résultats de recherche"
 
@@ -7589,7 +7531,7 @@ msgstr "Ajouter la note"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7725,211 +7667,211 @@ msgstr "Le commentaire avec l'identifiant %s n'existe pas."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "La notice avec l'identifiant %s n'existe pas."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Écrire un commentaire"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i commentaires au tour \"%(x_name)s\""
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "%i commentaires"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Affichage des derniers %i commentaires:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Discuter ce document"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Commencer la discussion sur n'importe quel aspect de ce document."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Désolé, la notice %s n'existe pas."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "Désolé, %s n'est pas un identifiant valide."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "Désolé, aucun identifiant de notice n'a été fourni."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Vous pouvez recommencer à chercher depuis %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i commentaires au tour \"%(x_name)s\""
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Est-ce que cette évaluation a été utile?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Écrire une évaluation"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr "Note moyenne: %(x_nb_score)s basée sur %(x_nb_reviews)s évaluations"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "Les lecteurs ont trouvé les %s évaluations suivantes les plus utiles."
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Visualiser toutes les %s évaluations"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Évaluer ce document"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Soyez le premier à évaluer ce document."
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "fermer"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Signaler un abus"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr "Rétablir le commentaire"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Supprimer le commentaire"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr "Supprimer le rapport du commentaire"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr "Fichier attaché"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr "Fichiers attachés"
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Évalué par %(x_nickname)s le %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
-"%(x_nb_people)s sur %(x_nb_total)s utilisateurs ont trouvé cette "
-"évaluation utile"
+"%(x_nb_people)s sur %(x_nb_total)s utilisateurs ont trouvé cette évaluation "
+"utile"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr "Rétablir l'évaluation"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr "Effacer l'évaluation"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr "Supprimer le rapport sur l'évaluation"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Commentaires"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Évaluations"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Il y a un total de %s évaluations"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Il y a un total de %s commentaires"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Soyez le premier à évaluer ce document."
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "S'abonner"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr "Se désabonner"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7938,44 +7880,43 @@ msgstr "Se désabonner"
 msgid "Record"
 msgstr "Notice"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "évaluation"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "commentaire"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Évaluation"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Affichage"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Page:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr "Vous n'êtes pas autorisé à comment ou évaluer."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 "Note: Votre pseudonyme, %s, sera affiché en temps qu'auteur de ce "
 "commentaire "
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
@@ -7984,48 +7925,48 @@ msgstr ""
 "Note: Vous n'avez pas %(x_url_open)sdéfini de pseudonyme%(x_url_close)s. "
 "%(x_nickname)s sera affiché en temps qu'auteur de ce commentaire."
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 "Les utilisateurs connectés et autorisés peuvent également attacher des "
 "fichiers."
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr "Optionnellement attachez un fichier à ce commentaire"
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr "Optionnellement attachez des fichiers à ce commentaire"
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr "Maximum un fichier"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "Max %i fichiers"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr "Max %(x_nb_bytes)s par fichier"
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr "M'envoyez un email lorsqu'un nouveau commentaire est posté"
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Article"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "Ajouter un commentaire"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
@@ -8034,425 +7975,427 @@ msgstr ""
 "Note: Votre pseudonyme, %s, sera affiché en temps qu'auteur de cette "
 "évaluation."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Évaluer ce document"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Choisir une note"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Donner un titre à cette évaluation"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Ecrire votre évaluation"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr "Ajouter une évaluation"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Ajouter une évaluation"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Votre évaluation à été ajoutée."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Votre commentaire a été ajouté."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Revenir à la notice"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr ""
-"Vous pouvez consulter la liste de %(x_url_open)svos "
-"tickets%(x_url_close)s."
+"Vous pouvez consulter la liste de %(x_url_open)svos tickets%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr "Voir les notices les plus commentées"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr "Voir les notices dernièrement commentées"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr "Voir tous les commentaires rapportés comme abus"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr "Voir les notices les plus évaluées"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr "Voir les dernières notices évaluées"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr "Voir toutes les évaluations rapportées comme abus"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Voir tous les utilisateurs qui ont été signalés"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Guide"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Les commentaires et évaluations sont désactivés"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"Veuillez entrer l'identifiant du commentaire ou de l'évaluation pour le "
-"voir avant de le supprimer"
+"Veuillez entrer l'identifiant du commentaire ou de l'évaluation pour le voir "
+"avant de le supprimer"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "Identifiant du commentaire:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
-"Ou entrez l'identifiant d'une notice pour lister les "
-"commentaires/évaluations associés:"
+"Ou entrez l'identifiant d'une notice pour lister les commentaires/"
+"évaluations associés:"
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr "Identifiant de la notice:"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Afficher le commentaire"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Aucun commentaire n'a, jusqu'à maintenant, été signalé."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Afficher tous les %s commentaires signalés"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Afficher toutes les %s évaluations signalées"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-"Liste des utilisateurs ayant été signalés au moins une fois. Cette liste "
-"est triée par nombre de signalement d'abus."
+"Liste des utilisateurs ayant été signalés au moins une fois. Cette liste est "
+"triée par nombre de signalement d'abus."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Pseudonyme"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "Identifiant d'utilisateur"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Nombre de votes positifs"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Nombre de votes négatifs"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Nombre total de votes"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Nombre total de signalements"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Afficher tous les commentaires/évaluations signalés de cet utilisateur"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Cette évaluation a été signalée %i fois"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Ce commentaire a été signalé %i fois"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Écrit par"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Informations générales"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Effacer les évaluations sélectionnées"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Supprimer les signalements d'abus sélectionnés"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr "Rétablir les évaluations sélectionnées"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr "Rétablir les commentaires sélectionnés"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Effacer les commentaires sélectionnés"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Évaluations signalées de l'utilisateur %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Commentaires signalés de l'utilisateur %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Évaluation %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Commentaire %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Évaluation %(x_cmtID)s écrit par l'utilisateur %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Commentaire %(x_cmtID)s écrit par l'utilisateur %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "Toutes les évaluations signalées triées par ordre décroissant"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "Tous les commentaires signalés triés par ordre décroissant"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
 "Toutes les évaluations signalées pour la notice %i, triées par ordre "
 "décroissant"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr "Voir les commentaires"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
-"Tous les commentaires signalés pour la notice %i, triés par ordre "
-"décroissant"
+"Tous les commentaires signalés pour la notice %i, triés par ordre décroissant"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr "Voir les évaluations"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "Identifiant du commentaire"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "supprimé"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr "rétablic avec succès"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "signalement d'abus supprimé"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Pas encore évalué"
 
-#: invenio/legacy/webcomment/templates.py:2257
+#: invenio/legacy/webcomment/templates.py:2256
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 "L'évaluation suivante a été soumise sur %(CFG_SITE_NAME)s par "
 "%(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2258
+#: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 "Le commentaire suivant a été soumis sur %(CFG_SITE_NAME)s par "
 "%(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr "Ceci est un message automatique, merci de ne pas y répondre."
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr "Pour poster un nouveau commentaire, allez à <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr "Pour répondre spécifiquement à ce commentaire, allez à <%(x_url)s>"
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr "Pour vous désinscrire de cette discussion, allez à <%(x_url)s>"
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
-msgstr "Pour d'autres questions, veuillez contacter <%(CFG_SITE_SUPPORT_EMAIL)s>"
+msgstr ""
+"Pour d'autres questions, veuillez contacter <%(CFG_SITE_SUPPORT_EMAIL)s>"
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 msgid "Your comment will be lost."
 msgstr "Votre commentaire sera perdu."
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Effacer des commentaires"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "les plus récents en premier"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "Voir les notices dernièrement commentées"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "Détails et commentaires"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "notices trouvées"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Commentaires"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "%i notices"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Ajouter les notices"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "Affichage"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Date de commande"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Page suivante"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Afficher les alertes"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8460,52 +8403,52 @@ msgstr "Afficher les alertes"
 msgid "Refresh"
 msgstr "Rafraichir"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Supprimer le rapport du commentaire"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "%i résultats"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Notice introuvable"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "Vous n'avez pas l'autorisation d'effacer cette note."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, fuzzy, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
@@ -8514,51 +8457,51 @@ msgstr ""
 "La taille du fichier \\\"%s\\\" (%s) dépasse le maximum autorisé (%s). "
 "Sélectionnez à nouveau un fichier."
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Ajouter un commentaire"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "Voir tous les commentaires signalés"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr "Page Introuvable"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr "Le commentaire demandé n'a pas été trouvé"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr "Le fichier demandé n'a pas été trouvé"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Vous n'êtes pas autorisé à faire des emprunts."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Commentaires"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "Voir tous les commentaires signalés"
@@ -8673,11 +8616,10 @@ msgstr "Désolé, la page %s n'existe pas."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
-"Vous pouvez consulter %(x_url_open)sles page "
-"%(x_category)s%(x_url_close)s."
+"Vous pouvez consulter %(x_url_open)sles page %(x_category)s%(x_url_close)s."
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
 #, fuzzy, python-format
@@ -8740,8 +8682,8 @@ msgstr "Aucun journal trouvé"
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 "Il semble qu'il n'y a pas de journal défini sur ce serveur. Veuillez "
 "contacter le support si c'est incorrect."
@@ -8759,8 +8701,8 @@ msgid ""
 "You did not provide an argument for a journal name. Please select the "
 "journal you want to read in the list below."
 msgstr ""
-"Vous n'avez pas fourni de nom de journal. Veuillez sélectionner un "
-"journal dans la liste ci-dessous."
+"Vous n'avez pas fourni de nom de journal. Veuillez sélectionner un journal "
+"dans la liste ci-dessous."
 
 #: invenio/legacy/webjournal/config.py:268
 msgid "No current issue"
@@ -8772,11 +8714,11 @@ msgstr "Nous n'avons trouvé aucune information concernant l'édition actuelle"
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
-"La configuration pour l'édition actuelle semble vierge. Fournissez le "
-"numéro d'une édition ou contactez le support."
+"La configuration pour l'édition actuelle semble vierge. Fournissez le numéro "
+"d'une édition ou contactez le support."
 
 #: invenio/legacy/webjournal/config.py:298
 msgid "Issue number badly formed"
@@ -8860,24 +8802,18 @@ msgid ""
 "The issue could not be correctly regenerated. Please contact your "
 "administrator."
 msgstr ""
-"L'édition n'a pas pu être correctement régénérée. Veuillez contacter "
-"votre administrateur."
+"L'édition n'a pas pu être correctement régénérée. Veuillez contacter votre "
+"administrateur."
 
 #: invenio/legacy/webjournal/templates.py:308
 #, python-format
 msgid "If you cannot read this email please go to %(x_journal_link)s"
 msgstr ""
-"Si vous ne pouvez pas lire cet email, veuillez consulter "
-"%(x_journal_link)s"
+"Si vous ne pouvez pas lire cet email, veuillez consulter %(x_journal_link)s"
 
 #: invenio/legacy/webjournal/templates.py:699
 msgid "Apply"
 msgstr "Appliquer"
-
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "Pseudonyme"
 
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 msgid "WebJournal Admin"
@@ -8958,9 +8894,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8982,8 +8917,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9095,8 +9029,8 @@ msgid ""
 "Your message is too long, please shorten it. Maximum size allowed is "
 "%(x_size)i characters."
 msgstr ""
-"Votre message est trop long, veuillez l'éditer. La taille maximale est de"
-" %i caractères."
+"Votre message est trop long, veuillez l'éditer. La taille maximale est de %i "
+"caractères."
 
 #: invenio/legacy/webmessage/api.py:402
 #, fuzzy, python-format
@@ -9232,8 +9166,7 @@ msgstr "SUPPRIMER"
 #: invenio/modules/messages/templates/messages/confirm_delete_base.html:25
 msgid "Are you sure you want to empty your whole mailbox?"
 msgstr ""
-"Êtes-vous sûr de vouloir effacer tout le contenu de votre boîte de "
-"réception?"
+"Êtes-vous sûr de vouloir effacer tout le contenu de votre boîte de réception?"
 
 #: invenio/legacy/webmessage/templates.py:582
 #, python-format
@@ -9466,8 +9399,8 @@ msgstr "Rechercher également dans:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 "L'accès à cette collection est restreint. Si vous êtes autorisé à y "
 "accéder,\n"
@@ -9475,11 +9408,11 @@ msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
-"Ceci est une collection externe. Merci de cliquer sur le bouton "
-"\"Recherche\" pour afficher son contenu."
+"Ceci est une collection externe. Merci de cliquer sur le bouton \"Recherche"
+"\" pour afficher son contenu."
 
 #: invenio/legacy/websearch/templates.py:1619
 msgid "This collection does not contain any document yet."
@@ -9494,13 +9427,14 @@ msgstr "Cité par: %i notices"
 #, python-format
 msgid "Words nearest to %(x_word)s inside %(x_field)s in any collection are:"
 msgstr ""
-"Les mots les plus proches de %(x_word)s dans %(x_field)s parmi toutes les"
-" collections sont:"
+"Les mots les plus proches de %(x_word)s dans %(x_field)s parmi toutes les "
+"collections sont:"
 
 #: invenio/legacy/websearch/templates.py:1859
 #, python-format
 msgid "Words nearest to %(x_word)s in any collection are:"
-msgstr "Les mots les plus proches de %(x_word)s parmi toutes les collections sont:"
+msgstr ""
+"Les mots les plus proches de %(x_word)s parmi toutes les collections sont:"
 
 #: invenio/legacy/websearch/templates.py:1961
 msgid "Hits"
@@ -9575,8 +9509,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found %(x_nb_records)s "
 "records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sAperçu des résultats:%(x_fmt_close)s Trouvé "
-"%(x_nb_records)s notices en %(x_nb_seconds)s secondes."
+"%(x_fmt_open)sAperçu des résultats:%(x_fmt_close)s Trouvé %(x_nb_records)s "
+"notices en %(x_nb_seconds)s secondes."
 
 #: invenio/legacy/websearch/templates.py:3132
 #, python-format
@@ -9617,8 +9551,7 @@ msgstr "Détails"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 "La requête booléenne n'a rien donné. Essayez de combiner les termes de "
 "recherche différemment."
@@ -9646,8 +9579,8 @@ msgstr "Vous pouvez recommencer à chercher depuis %s."
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "Abonnez-vous à une %(x_url1_open)salerte email%(x_url1_close)s "
 "personnalisée\n"
@@ -9839,10 +9772,11 @@ msgid "in"
 msgstr "dans"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr ""
-"Vous n'avez pas trouvé ce que vous avez cherché? Essayez votre requête "
-"sur d'autres serveurs:"
+"Vous n'avez pas trouvé ce que vous avez cherché? Essayez votre requête sur "
+"d'autres serveurs:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
 msgid "External collections results overview:"
@@ -9857,8 +9791,8 @@ msgid ""
 "The external search engine has not responded in time. You can check its "
 "results here:"
 msgstr ""
-"Le moteur de recherche externe n'a pas répondu dans les délais. Vous "
-"pouvez vérifier ses résultats ici:"
+"Le moteur de recherche externe n'a pas répondu dans les délais. Vous pouvez "
+"vérifier ses résultats ici:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:146
 #: invenio/legacy/websearch_external_collections/templates.py:154
@@ -9937,8 +9871,8 @@ msgstr "obligatoire"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9948,8 +9882,8 @@ msgstr "Créer un nouveau panier"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 "Pour changer votre adresse email ou choisir votre pseudonyme la première "
 "fois,\n"
@@ -9969,17 +9903,17 @@ msgstr "Enregistrer les nouvelles valeurs"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
-"Puisque ce nom est considéré comme une signature pour les commentaires et"
-" les évaluations, il n'est pas possible\n"
+"Puisque ce nom est considéré comme une signature pour les commentaires et "
+"les évaluations, il n'est pas possible\n"
 "de le changer une fois choisi."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
 "Pour changer votre adresse email ou votre mot de passe, utilisez le\n"
 "formulaire ci-dessous."
@@ -10019,8 +9953,8 @@ msgstr "Enregistrer nouveau mot de passe"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 "Si vous utilisez un compte CERN \"lightweight\", vous pouvez\n"
 "%(x_url_open)sréinitialiser le mot de passe%(x_url_close)s."
@@ -10113,10 +10047,9 @@ msgstr "Choisir la méthode"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
 "Si vous avez perdu le mot de passe de votre %(x_fmt_open)scompte\n"
 "interne%(x_fmt_close)s %(sitename)s, entrez votre adresse email\n"
@@ -10137,18 +10070,18 @@ msgstr "Envoyer le lien de réinitialisation"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
-"Si votre compte utilise le %(x_fmt_open)ssystème d'identification du "
-"CERN%(x_fmt_close)s, vous pouvez retrouver votre mot de passe sur la "
+"Si votre compte utilise le %(x_fmt_open)ssystème d'identification du CERN"
+"%(x_fmt_close)s, vous pouvez retrouver votre mot de passe sur la "
 "%(x_url_open)spage de gestion des comptes CERN%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 "Si vous utilisez un système d'identification externe, vous devez vous "
 "adresser directement aux responsables de ce système."
@@ -10159,21 +10092,21 @@ msgid ""
 "Alternatively, you can ask %(x_name)s to change your login system from "
 "external to internal."
 msgstr ""
-"Autrement vous pouvez demander à %s de changer le système "
-"d'enregistrement de externe à interne."
+"Autrement vous pouvez demander à %s de changer le système d'enregistrement "
+"de externe à interne."
 
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 "%s vous permet de pesonnaliser l'interface, de créer votre propre "
 "bibliothèque de documents personnels, ou de créer une alerte automatique "
-"tournant périodiquement et vous avertissant lorsque de nouveaux résultats"
-" de recherche sont disponibles."
+"tournant périodiquement et vous avertissant lorsque de nouveaux résultats de "
+"recherche sont disponibles."
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10185,8 +10118,8 @@ msgid ""
 "Set or change your account email address or password. Specify your "
 "preferences about the look and feel of the interface."
 msgstr ""
-"Inscrivez ou modifiez l'adresse email ou le mot de passe de votre compte."
-" Indiquez vos préférences pour l'affichage de l'interface."
+"Inscrivez ou modifiez l'adresse email ou le mot de passe de votre compte. "
+"Indiquez vos préférences pour l'affichage de l'interface."
 
 #: invenio/legacy/websession/templates.py:620
 msgid "View all the searches you performed during the last 30 days."
@@ -10196,12 +10129,12 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 "Les paniers vous permettent de définir des collections spécifiques de "
-"notices, d'enregistrer des notices que vous souhaiteriez revoir plus tard"
-" ou partager avec d'autres."
+"notices, d'enregistrer des notices que vous souhaiteriez revoir plus tard ou "
+"partager avec d'autres."
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10218,16 +10151,16 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
-"Vérifiez la liste des ouvrages que vous avez en prêt, soumettez des "
-"demandes d'emprunt, etc. Nécessite un CERN ID."
+"Vérifiez la liste des ouvrages que vous avez en prêt, soumettez des demandes "
+"d'emprunt, etc. Nécessite un CERN ID."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
 "Vous êtes actuellement enregistré en tant qu'invité. Vos alertes "
 "disparaîtront à la fin de la session."
@@ -10235,13 +10168,13 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
-"Vous êtes enregistré comme %(x_user)s. Vous pouvez a) %(x_url1_open)svous"
-" déconnecter%(x_url1_close)s; b) modifier vos %(x_url2_open)spréférences "
-"de compte%(x_url2_close)s."
+"Vous êtes enregistré comme %(x_user)s. Vous pouvez a) %(x_url1_open)svous "
+"déconnecter%(x_url1_close)s; b) modifier vos %(x_url2_open)spréférences de "
+"compte%(x_url2_close)s."
 
 #: invenio/legacy/websession/templates.py:785
 #, fuzzy, python-format
@@ -10249,8 +10182,7 @@ msgid ""
 "You can consult the list of %(x_url_open)syour comments%(x_url_close)s "
 "submitted so far."
 msgstr ""
-"Vous pouvez consulter la liste de %(x_url_open)svos "
-"tickets%(x_url_close)s."
+"Vous pouvez consulter la liste de %(x_url_open)svos tickets%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:790
 msgid "Your Alert Searches"
@@ -10259,11 +10191,11 @@ msgstr "Vos Alertes"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
-"Vous pouvez consulter la liste de %(x_url_open)svos "
-"groupes%(x_url_close)s pour lesquels vous êtes administrateur ou membre."
+"Vous pouvez consulter la liste de %(x_url_open)svos groupes%(x_url_close)s "
+"pour lesquels vous êtes administrateur ou membre."
 
 #: invenio/legacy/websession/templates.py:799
 #: invenio/legacy/websession/templates.py:2348
@@ -10274,11 +10206,11 @@ msgstr "Vos Groupes"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"Vous pouvez consulter la liste de %(x_url_open)svos "
-"soumissions%(x_url_close)s et vous informer sur leur statut."
+"Vous pouvez consulter la liste de %(x_url_open)svos soumissions"
+"%(x_url_close)s et vous informer sur leur statut."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -10288,12 +10220,12 @@ msgstr "Vos Soumissions"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"Vous pouvez consulter la liste de %(x_url_open)svos "
-"approbations%(x_url_close)s contenant les références des documents que "
-"vous avez approuvés ou relus."
+"Vous pouvez consulter la liste de %(x_url_open)svos approbations"
+"%(x_url_close)s contenant les références des documents que vous avez "
+"approuvés ou relus."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10304,8 +10236,7 @@ msgstr "Vos Approbations"
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour tickets%(x_url_close)s."
 msgstr ""
-"Vous pouvez consulter la liste de %(x_url_open)svos "
-"tickets%(x_url_close)s."
+"Vous pouvez consulter la liste de %(x_url_open)svos tickets%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:818
 msgid "Your Tickets"
@@ -10328,8 +10259,7 @@ msgid ""
 "for the account \"%(x_email)s\".x_sitename"
 msgstr ""
 "Quelqu'un (vous-même?) provenant de %(x_ip_address)s a demandé de "
-"réinitialiser le mot de passe %(x_sitename)s pour le compte "
-"\"%(x_email)s\"."
+"réinitialiser le mot de passe %(x_sitename)s pour le compte \"%(x_email)s\"."
 
 #: invenio/legacy/websession/templates.py:877
 msgid "If you want to reset the password for this account, please go to:"
@@ -10343,7 +10273,8 @@ msgstr "afin de confirmer la validité de cette demande."
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr "Notez que ce lien restera valide seulement %(days)s jours."
 
 #: invenio/legacy/websession/templates.py:909
@@ -10389,20 +10320,20 @@ msgstr ""
 #, python-format
 msgid "If you wish you can %(x_url_open)slogin here%(x_url_close)s."
 msgstr ""
-"Si vous le souhaitez, vous pouvez vous "
-"%(x_url_open)sidentifier%(x_url_close)s."
+"Si vous le souhaitez, vous pouvez vous %(x_url_open)sidentifier"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1011
 msgid "If you already have an account, please login using the form below."
 msgstr ""
-"Si vous possédez déjà un compte, veuillez utiliser le formulaire ci-"
-"dessous pour vous identifier."
+"Si vous possédez déjà un compte, veuillez utiliser le formulaire ci-dessous "
+"pour vous identifier."
 
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 "Si vous ne possédez pas encore de compte CERN, vous pouvez "
 "%(x_url_open)scréer un compte CERN \"lightweight\"%(x_url_close)s."
@@ -10410,8 +10341,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
 "Si vous ne possédez pas encore de compte, vous pouvez vous "
 "%(x_url_open)senregistrer%(x_url_close)s pour créer un compte interne."
@@ -10451,11 +10382,11 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
-"Votre demande a été vérifiée. Veuillez entrer le nouveau mot de passe "
-"désiré dans le formulaire ci-dessous."
+"Votre demande a été vérifiée. Veuillez entrer le nouveau mot de passe désiré "
+"dans le formulaire ci-dessous."
 
 #: invenio/legacy/websession/templates.py:1150
 msgid "Set a new password for"
@@ -10476,16 +10407,16 @@ msgstr "Appliquer le nouveau mot de passe"
 #: invenio/legacy/websession/templates.py:1175
 msgid "Please enter your email address and desired nickname and password:"
 msgstr ""
-"Veuillez entrer votre adresse email, ainsi que le nom d'utilisateur "
-"souhaité et le mot de passe:"
+"Veuillez entrer votre adresse email, ainsi que le nom d'utilisateur souhaité "
+"et le mot de passe:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
-"Le compte ne pourra pas être utilisé avant qu'il ait été vérifié et "
-"activé par nos services."
+"Le compte ne pourra pas être utilisé avant qu'il ait été vérifié et activé "
+"par nos services."
 
 #: invenio/legacy/websession/templates.py:1228
 msgid "Retype Password"
@@ -10501,36 +10432,36 @@ msgstr "s'enregistrer"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
-"Veuillez ne pas utiliser de mot de passe précieux, comme votre mot de "
-"passe Unix, AFS ou NICE avec ce service. Votre adresse email restera "
-"strictement confidentielle et ne sera en aucun cas donnée ou vendue à un "
-"tiers. Elle ne sera utilisée que pour vous identifier sur les services "
-"personnalisés de %s. Par exemple, vous pourriez créer une alerte "
-"automatique qui cherche des preprints et vous informe quotidiennement par"
-" email des nouveautés disponibles."
+"Veuillez ne pas utiliser de mot de passe précieux, comme votre mot de passe "
+"Unix, AFS ou NICE avec ce service. Votre adresse email restera strictement "
+"confidentielle et ne sera en aucun cas donnée ou vendue à un tiers. Elle ne "
+"sera utilisée que pour vous identifier sur les services personnalisés de %s. "
+"Par exemple, vous pourriez créer une alerte automatique qui cherche des "
+"preprints et vous informe quotidiennement par email des nouveautés "
+"disponibles."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
-"Il n'est pas possible de créer un compte vous-même. Veuillez contacter %s"
-" si vous désirez un compte."
+"Il n'est pas possible de créer un compte vous-même. Veuillez contacter %s si "
+"vous désirez un compte."
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
-"Vous n'êtes pas identifé. Vous devez d'abord vous "
-"%(x_url_open)sidentifier%(x_url_close)s."
+"Vous n'êtes pas identifé. Vous devez d'abord vous %(x_url_open)sidentifier"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1267
 msgid "You are not authorized to access administrative functions."
@@ -10660,8 +10591,8 @@ msgstr "Voici quelques liens administratifs intéressants pour vous:"
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "Pour plus d'activités administratives, affichez la %(x_url_open)szone "
 "d'administration%(x_url_close)s."
@@ -10835,8 +10766,8 @@ msgid ""
 msgstr ""
 "Bonjour,\n"
 "\n"
-"Je pense que vous pourriez être intéressé à rejoindre le groupe "
-"\"%(x_name)s\".\n"
+"Je pense que vous pourriez être intéressé à rejoindre le groupe \"%(x_name)s"
+"\".\n"
 "Vous pouvez vous y inscrire ici: %(x_url)s.\n"
 "\n"
 "Meilleures salutations.\n"
@@ -10848,8 +10779,8 @@ msgid ""
 "%(x_url_open)sweb message%(x_url_close)s system."
 msgstr ""
 "Si vous souhaitez inviter de nouveaux membres à rejoindre votre groupe, "
-"veuillez utiliser le %(x_url_open)ssystème de messagerie "
-"interne%(x_url_close)s."
+"veuillez utiliser le %(x_url_open)ssystème de messagerie interne"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:2100
 #, fuzzy, python-format
@@ -10892,10 +10823,11 @@ msgstr "Un utilisateur désire adhérer au groupe %s."
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
-"Veuillez %(x_url_open)saccepter ou rejeter%(x_url_close)s la demande de "
-"cet utilisateur."
+"Veuillez %(x_url_open)saccepter ou rejeter%(x_url_close)s la demande de cet "
+"utilisateur."
 
 #: invenio/legacy/websession/templates.py:2400
 #, fuzzy, python-format
@@ -10922,8 +10854,7 @@ msgstr "Votre demande d'adhésion au groupe %s a été rejetée."
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour groups%(x_url_close)s."
 msgstr ""
-"Vous pouvez consulter la liste de %(x_url_open)svos "
-"groupes%(x_url_close)s."
+"Vous pouvez consulter la liste de %(x_url_open)svos groupes%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:2422
 #, fuzzy, python-format
@@ -10938,48 +10869,45 @@ msgstr "Le groupe %s a été supprimé par son administrateur."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"Vous pouvez consulter la liste des %(x_url_open)s%(x_nb_total)i "
-"groupes%(x_url_close)s dont vous êtes membre (%(x_nb_member)i) ou "
+"Vous pouvez consulter la liste des %(x_url_open)s%(x_nb_total)i groupes"
+"%(x_url_close)s dont vous êtes membre (%(x_nb_member)i) ou "
 "administrateur(%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
-"Attention: le mot de passe pour l'utilisateur root de MySQL est le même "
-"mot de passe que celui de l'utilisateur d'Invenio sur MySQL. Pour des "
-"raisons de sécurité veuillez changer ce mot de passe."
+"Attention: le mot de passe pour l'utilisateur root de MySQL est le même mot "
+"de passe que celui de l'utilisateur d'Invenio sur MySQL. Pour des raisons de "
+"sécurité veuillez changer ce mot de passe."
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
-"Attention: le mot de passe pour l'utilisateur d'Invenio sur MySQL est "
-"resté celui par défaut d'Invenio. Pour des raisons de sécurité veuillez "
-"changer ce mot de passe."
+"Attention: le mot de passe pour l'utilisateur d'Invenio sur MySQL est resté "
+"celui par défaut d'Invenio. Pour des raisons de sécurité veuillez changer ce "
+"mot de passe."
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
-"Attention: le mot de passe de l'utilisateur admin est resté vide. Pour "
-"des raisons de sécurité veuillez changer ce mot de passe."
+"Attention: le mot de passe de l'utilisateur admin est resté vide. Pour des "
+"raisons de sécurité veuillez changer ce mot de passe."
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 "Attention: l'adresse email du support de cette installation est restée "
 "\"info@invenio-software.org\". Il est recommandé de saisir votre propre "
@@ -10987,14 +10915,13 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr "Une nouvelle version d'Invenio est disponible à "
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 "Impossible de charger ou lire les notes de version de http://invenio-"
 "software.org/repo/invenio/tree/RELEASE-NOTES"
@@ -11002,25 +10929,24 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
-"Vous êtes identifié comme invité. Vous pouvez vous "
-"%(x_url_open)sidentifier%(x_url_close)s en tant qu'utilisateur."
+"Vous êtes identifié comme invité. Vous pouvez vous %(x_url_open)sidentifier"
+"%(x_url_close)s en tant qu'utilisateur."
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 "Les %(x_fmt_open)sinvités%(x_fmt_close)s doivent d'abord "
 "%(x_url_open)s'enregistrer%(x_url_close)s."
@@ -11031,14 +10957,15 @@ msgstr "Pas de requête trouvée"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
-msgstr "Cette collection est restreinte d'accès. Identifiez-vous pour y accéder."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
+msgstr ""
+"Cette collection est restreinte d'accès. Identifiez-vous pour y accéder."
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr "L'accès à ce fichier est restreint. Identifiez-vous pour y accéder."
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -11047,8 +10974,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11060,8 +10987,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11128,15 +11055,14 @@ msgstr "Le groupe a déjà été supprimé."
 
 #: invenio/legacy/websession/webgroup.py:611
 msgid "Please choose a member if you want to remove him from the group."
-msgstr "Veuillez sélectionner un membre si vous souhaitez l'en retirer du groupe."
+msgstr ""
+"Veuillez sélectionner un membre si vous souhaitez l'en retirer du groupe."
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
-"Veuillez sélectionner un utilisateur de la liste pour l'ajouter à ce "
-"groupe."
+"Veuillez sélectionner un utilisateur de la liste pour l'ajouter à ce groupe."
 
 #: invenio/legacy/websession/webgroup.py:664
 msgid "The user is already member of the group."
@@ -11173,9 +11099,9 @@ msgid ""
 "authorization will last until %(x_expiration)s and until you close your "
 "browser if you are a guest user."
 msgstr ""
-"L'autorisation pour le rôle %(x_role)s vous a été donnée avec succès! "
-"Cette autorisation durera jusqu'au %(x_expiration)s, ou jusqu'à la "
-"fermeture de votre navigateur si vous êtes connecté en tant qu'invité."
+"L'autorisation pour le rôle %(x_role)s vous a été donnée avec succès! Cette "
+"autorisation durera jusqu'au %(x_expiration)s, ou jusqu'à la fermeture de "
+"votre navigateur si vous êtes connecté en tant qu'invité."
 
 #: invenio/legacy/websession/webinterface.py:128
 msgid "You have confirmed the validity of your email address!"
@@ -11190,7 +11116,8 @@ msgstr "Veuillez patienter le temps que l'administrateur active votre compte."
 #: invenio/legacy/websession/webinterface.py:144
 #, python-format
 msgid "You can now go to %(x_url_open)syour account page%(x_url_close)s."
-msgstr "Vous pouvez désormais accéder à %(x_url_open)svotre compte%(x_url_close)s."
+msgstr ""
+"Vous pouvez désormais accéder à %(x_url_open)svotre compte%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:136
 #: invenio/legacy/websession/webinterface.py:145
@@ -11203,9 +11130,9 @@ msgstr "Vous avez déjà confirmé la validité de votre adresse email!"
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
-msgstr "Cette demande de confirmation d'adresse email est invalide ou a expiré."
+"This request for confirmation of an email address is not valid or is expired."
+msgstr ""
+"Cette demande de confirmation d'adresse email est invalide ou a expiré."
 
 #: invenio/legacy/websession/webinterface.py:153
 msgid "This request for an authorization is not valid or is expired."
@@ -11222,14 +11149,12 @@ msgstr "Cette demande de réinitialisation de mot de passe a déjà été utilis
 #: invenio/legacy/websession/webinterface.py:175
 msgid "This request for resetting a password is not valid or is expired."
 msgstr ""
-"Cette demande de réinitialisation de mot de passe est invalide ou a "
-"expiré."
+"Cette demande de réinitialisation de mot de passe est invalide ou a expiré."
 
 #: invenio/legacy/websession/webinterface.py:180
 msgid "This request for resetting the password is not valid or is expired."
 msgstr ""
-"Cette demande de réinitialisation de mot de passe est invalide ou a "
-"expiré."
+"Cette demande de réinitialisation de mot de passe est invalide ou a expiré."
 
 #: invenio/legacy/websession/webinterface.py:193
 msgid "The two provided passwords aren't equal."
@@ -11273,15 +11198,15 @@ msgstr "Méthode d'identification interne activée."
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
-"Si vous utilisez ce compte avec la méthode d'identification interne pour "
-"la première fois, veuillez noter que le système vous a attribué un mot de"
-" passe par défaut. Cliquez sur le bouton ci-dessous pour recevoir un "
-"email vous permettant de changer ce mot de passe:"
+"Si vous utilisez ce compte avec la méthode d'identification interne pour la "
+"première fois, veuillez noter que le système vous a attribué un mot de passe "
+"par défaut. Cliquez sur le bouton ci-dessous pour recevoir un email vous "
+"permettant de changer ce mot de passe:"
 
 #: invenio/legacy/websession/webinterface.py:431
 msgid "Send Password"
@@ -11293,8 +11218,8 @@ msgid ""
 "Unable to switch to external login method %(x_name)s, because your email "
 "address is unknown."
 msgstr ""
-"Impossible d'activer la méthode d'identification externe %s, car "
-"l'adresse email n'est pas connue."
+"Impossible d'activer la méthode d'identification externe %s, car l'adresse "
+"email n'est pas connue."
 
 #: invenio/legacy/websession/webinterface.py:445
 #, fuzzy, python-format
@@ -11312,8 +11237,8 @@ msgstr "Méthode d'identification modifiée."
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 "La méthode d'identification externe %s ne supporte pas l'identification "
 "basée sur les adresses emails.\n"
@@ -11445,8 +11370,8 @@ msgid ""
 "Cannot send password reset request since you are using external "
 "authentication system."
 msgstr ""
-"Impossible d'envoyer un lien de réinitialisation de mot de passe car vous"
-" utilisez un système d'authentification externe."
+"Impossible d'envoyer un lien de réinitialisation de mot de passe car vous "
+"utilisez un système d'authentification externe."
 
 #: invenio/legacy/websession/webinterface.py:665
 msgid "The entered email address does not exist in the database."
@@ -11457,8 +11382,8 @@ msgid ""
 "The entered email address is incorrect, please check that it is written "
 "correctly (e.g. johndoe@example.com)."
 msgstr ""
-"L'adresse email est incorrecte. Veuillez vérifier qu'elle soit "
-"correctement écrite (par ex. jean.dupont@exemple.fr)"
+"L'adresse email est incorrecte. Veuillez vérifier qu'elle soit correctement "
+"écrite (par ex. jean.dupont@exemple.fr)"
 
 #: invenio/legacy/websession/webinterface.py:684
 msgid "Incorrect email address"
@@ -11494,31 +11419,32 @@ msgid ""
 "In order to confirm its validity, an email message containing an account "
 "activation key has been sent to the given email address."
 msgstr ""
-"Afin de confirmer sa validité, un email contenant une clé d'activation a "
-"été envoyée à l'adresse donnée."
+"Afin de confirmer sa validité, un email contenant une clé d'activation a été "
+"envoyée à l'adresse donnée."
 
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
-"Veuillez y suivre les instructions précisées afin de terminer le "
-"processus de création du compte."
+"Veuillez y suivre les instructions précisées afin de terminer le processus "
+"de création du compte."
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
-"Un deuxième email sera envoyé dès que le compte sera activé et pourra "
-"être utilisé."
+"Un deuxième email sera envoyé dès que le compte sera activé et pourra être "
+"utilisé."
 
 #: invenio/legacy/websession/webinterface.py:989
 #, python-format
 msgid "You can now access your %(x_url_open)saccount%(x_url_close)s."
-msgstr "Vous pouvez désormais accéder à %(x_url_open)svotre compte%(x_url_close)s."
+msgstr ""
+"Vous pouvez désormais accéder à %(x_url_open)svotre compte%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:996
 #: invenio/legacy/websession/webinterface.py:1001
@@ -11563,8 +11489,7 @@ msgid ""
 "The site is having troubles in sending you an email for confirming your "
 "email address."
 msgstr ""
-"Le site n'arrive pas à vous envoyer l'email de vérification de votre "
-"adresse."
+"Le site n'arrive pas à vous envoyer l'email de vérification de votre adresse."
 
 #: invenio/legacy/websession/webinterface.py:1432
 msgid "Your tickets"
@@ -11630,8 +11555,10 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
-msgstr "Notice créée le %(x_date_creation)s, modifiée le %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+"Notice créée le %(x_date_creation)s, modifiée le %(x_date_modification)s"
 
 #: invenio/legacy/webstyle/templates.py:707
 msgid "The server encountered an error while dealing with your request."
@@ -11649,68 +11576,68 @@ msgid ""
 "%(x_page)s of submission '%(x_sub)s%(x_subm)s' - Invalid Field Position "
 "Numbers"
 msgstr ""
-"Impossible de déplacer le champ de la position %s à la position %s sur la"
-" page %s de la soumission %s%s - Numéro de position non valide"
+"Impossible de déplacer le champ de la position %s à la position %s sur la "
+"page %s de la soumission %s%s - Numéro de position non valide"
 
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
-"Impossible d'échanger le champ à la position %s avec le champ à la "
-"position %s sur la page %s de la soumission %s - impossible de déplacer "
-"le champ %s à une position temporaire"
+"Impossible d'échanger le champ à la position %s avec le champ à la position "
+"%s sur la page %s de la soumission %s - impossible de déplacer le champ %s à "
+"une position temporaire"
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
-"Impossible d'échanger le champ à la position %s avec le champ à la "
-"position %s sur la page %s de la soumission %s - impossible de déplacer "
-"le champ %s à la position %s. Demandez à un administrateur si le champ "
-"n'est pas resté dans sa position temporaire"
+"Impossible d'échanger le champ à la position %s avec le champ à la position "
+"%s sur la page %s de la soumission %s - impossible de déplacer le champ %s à "
+"la position %s. Demandez à un administrateur si le champ n'est pas resté "
+"dans sa position temporaire"
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, fuzzy, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
-"Impossible d'échanger le champ à la position %s avec le champ à la "
-"position %s sur la page %s de la soumission %s - impossible de déplacer "
-"le champ qui était à la position %s vers la position %s depuis sa "
-"position temporaire. Le champ est maintenant bloqué dans sa position "
-"temporaire et doit être corrigé manuellement par un administrateur"
+"Impossible d'échanger le champ à la position %s avec le champ à la position "
+"%s sur la page %s de la soumission %s - impossible de déplacer le champ qui "
+"était à la position %s vers la position %s depuis sa position temporaire. Le "
+"champ est maintenant bloqué dans sa position temporaire et doit être corrigé "
+"manuellement par un administrateur"
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, fuzzy, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
-"Impossible d'échanger le champ à la position %s avec le champ à la "
-"position %s sur la page %s de la soumission %s - impossible de décroître "
-"la position des champs sous la position %s. Tentative de reprise - "
-"vérifiez avec un administrateur que l'ordre des champs est correct"
+"Impossible d'échanger le champ à la position %s avec le champ à la position "
+"%s sur la page %s de la soumission %s - impossible de décroître la position "
+"des champs sous la position %s. Tentative de reprise - vérifiez avec un "
+"administrateur que l'ordre des champs est correct"
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
 #, fuzzy, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 "Impossible de déplacer le champ à la position %s à la position %s sur la "
 "page %s de la soumission %s%s - impossible d'augmenter la position des "
@@ -11720,8 +11647,8 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, fuzzy, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 "Champ déplacé de la position %s à la position %s sur la page %s de la "
 "soumission '%s%s'."
@@ -11791,18 +11718,18 @@ msgstr "Impossible de déterminer le nombre de pages de la soumission."
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
-"Impossible de créer un répertoire pour cette soumission. L'administrateur"
-" a été alerté."
+"Impossible de créer un répertoire pour cette soumission. L'administrateur a "
+"été alerté."
 
 #: invenio/legacy/websubmit/engine.py:440
 #: invenio/legacy/websubmit/engine.py:1058
 msgid "Cannot create submission directory. The administrator has been alerted."
 msgstr ""
-"Impossible de créer le répertoire des soumissions. L'administrateur a été"
-" alerté."
+"Impossible de créer le répertoire des soumissions. L'administrateur a été "
+"alerté."
 
 #: invenio/legacy/websubmit/engine.py:462
 #: invenio/legacy/websubmit/engine.py:1080
@@ -11831,14 +11758,13 @@ msgstr "Soumettre"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 "Une erreur grave a été rencontrée. Les administrateurs ont été alertés.\n"
-"<br /><em>Notez que cela pourrait être dû à des caractères problématiques"
-"\n"
-"insérés dans le formulaire </em> (par ex. en copiant du texte d'un "
-"fichier PDF)."
+"<br /><em>Notez que cela pourrait être dû à des caractères problématiques\n"
+"insérés dans le formulaire </em> (par ex. en copiant du texte d'un fichier "
+"PDF)."
 
 #: invenio/legacy/websubmit/engine.py:1501
 #, fuzzy, python-format
@@ -11886,8 +11812,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 "Afin de poursuivre une soumission interrompue, entrez le numéro d'accès "
 "directement dans le champ ci-dessous:"
@@ -11918,15 +11844,16 @@ msgstr "Retourner au menu principal"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 "Ceci est votre numéro d'accès à la soumission. Il vous permettra de "
 "reprendre une soumission interrompue, en cas de problème."
 
 #: invenio/legacy/websubmit/templates.py:548
 msgid "Mandatory fields appear in red in the SUMMARY window."
-msgstr "Les champs obligatoires apparaissent en rouge dans le fenêtre de RÉSUMÉ."
+msgstr ""
+"Les champs obligatoires apparaissent en rouge dans le fenêtre de RÉSUMÉ."
 
 #: invenio/legacy/websubmit/templates.py:695
 #: invenio/legacy/websubmit/templates.py:794
@@ -11970,11 +11897,11 @@ msgstr "N° de soumission"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
-"Liste des fonctions %(x_action)s pour les documents de type %(x_doctype)s"
-" au niveau %(x_step)s"
+"Liste des fonctions %(x_action)s pour les documents de type %(x_doctype)s au "
+"niveau %(x_step)s"
 
 #: invenio/legacy/websubmit/templates.py:1041
 msgid "Function"
@@ -12055,11 +11982,10 @@ msgstr "Liste des types de documents relus"
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
-"Choisissez l'un des types de documents suivants pour vérifier le statut "
-"des documents"
+"Choisissez l'un des types de documents suivants pour vérifier le statut des "
+"documents"
 
 #: invenio/legacy/websubmit/templates.py:1447
 msgid "Go to specific approval workflow"
@@ -12195,10 +12121,11 @@ msgstr "Note d'approbation:"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
-"Ce document est toujours %(x_fmt_open)sen attente "
-"d'approbation%(x_fmt_close)s."
+"Ce document est toujours %(x_fmt_open)sen attente d'approbation"
+"%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
 #: invenio/legacy/websubmit/templates.py:2163
@@ -12238,8 +12165,8 @@ msgid ""
 "As a referee for this document, you may approve or reject it from the "
 "submission interface"
 msgstr ""
-"En tant que relecteur de ce document, vous pouvez cliquer sur le bouton "
-"pour l'approuver ou le rejeter"
+"En tant que relecteur de ce document, vous pouvez cliquer sur le bouton pour "
+"l'approuver ou le rejeter"
 
 #: invenio/legacy/websubmit/templates.py:2155
 msgid "Approve/Reject"
@@ -12296,11 +12223,11 @@ msgstr "Sélectionner un relecteur"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
-"Le relecteur a envoyé ses recommandations finales au comité de "
-"publication le "
+"Le relecteur a envoyé ses recommandations finales au comité de publication "
+"le "
 
 #: invenio/legacy/websubmit/templates.py:2281
 #: invenio/legacy/websubmit/templates.py:2342
@@ -12318,8 +12245,8 @@ msgstr "Envoyer une recommandation"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 "Le comité de publication a envoyé ses recommandations finales au chef de "
 "projet le "
@@ -12362,8 +12289,10 @@ msgid "Take a decision"
 msgstr "Prendre une décision"
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
-msgstr "Un comité rédactionnel a été sélectionné par le comité de publication le "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
+msgstr ""
+"Un comité rédactionnel a été sélectionné par le comité de publication le "
 
 #: invenio/legacy/websubmit/templates.py:2323
 msgid "Add an author list"
@@ -12383,16 +12312,14 @@ msgstr "Un relecteur a été sélectionné par le comité rédactionnel le "
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
-"Le relecteur a envoyé ses recommandations finales au comité rédactionnel "
-"le "
+"Le relecteur a envoyé ses recommandations finales au comité rédactionnel le "
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 "Le comité rédactionnel a envoyé ses recommandation finales au comité de "
 "publication le "
@@ -12497,8 +12424,8 @@ msgid ""
 "Note that your submission has been inserted into the bibliographic task "
 "queue and is waiting for execution.\n"
 msgstr ""
-"Notez que votre soumission a été insérée dans la file d'attente et est en"
-" attente d'exécution.\n"
+"Notez que votre soumission a été insérée dans la file d'attente et est en "
+"attente d'exécution.\n"
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:206
 #, fuzzy, python-format
@@ -12515,17 +12442,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
-"En raison d'une intervention humain ou d'un problème temporaire, la queue"
-"\n"
-"d'exécution des tâches tourne actuellement en mode manuel. Votre "
-"soumission\n"
-"a bien été enregistrée mais pourrait n'être intégrée et rendue disponible"
-" \n"
+"En raison d'une intervention humain ou d'un problème temporaire, la queue\n"
+"d'exécution des tâches tourne actuellement en mode manuel. Votre soumission\n"
+"a bien été enregistrée mais pourrait n'être intégrée et rendue disponible \n"
 "qu'après un temps plus long qu'à l'habitude.\n"
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12606,8 +12529,8 @@ msgstr "limite"
 #: invenio/legacy/websubmit/web/publiline.py:749
 msgid "users in brackets are already attached to the role, try another one..."
 msgstr ""
-"les utilisateurs entre crochets sont déjà assignés à ce rôle, choisissez-"
-"en un autre..."
+"les utilisateurs entre crochets sont déjà assignés à ce rôle, choisissez-en "
+"un autre..."
 
 #: invenio/legacy/websubmit/web/publiline.py:755
 msgid "Removing users from the editorial board"
@@ -12808,8 +12731,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12852,11 +12775,6 @@ msgstr "connecté"
 #, fuzzy
 msgid "Role details"
 msgstr "Détails"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Masquer"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12972,8 +12890,8 @@ msgstr "L'adresse email %s existe déjà dans la base de données."
 #: invenio/modules/accounts/forms.py:94
 #, fuzzy, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 "Notez que si vous avez changé votre adresse email, vous devrez "
 "%(x_url_open)sréinitialiser votre mot de passe%(x_url_close)s."
@@ -13040,9 +12958,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, fuzzy, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 "Vous êtes par contre toujours reconnu par le %(x_fmt_open)ssystème "
 "centralisé SSO%(x_fmt_close)s. Vous pouvez également vous "
@@ -13052,8 +12969,8 @@ msgstr ""
 #, fuzzy, python-format
 msgid "If you wish you can %(x_url_open)ssign in again%(x_url_close)s."
 msgstr ""
-"Si vous le souhaitez, vous pouvez vous "
-"%(x_url_open)sidentifier%(x_url_close)s."
+"Si vous le souhaitez, vous pouvez vous %(x_url_open)sidentifier"
+"%(x_url_close)s."
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:27
 #, fuzzy
@@ -13061,8 +12978,8 @@ msgid ""
 "Please enter your email address. You will receive a link to create a new "
 "password via email."
 msgstr ""
-"Veuillez entrer votre adresse email, ainsi que le nom d'utilisateur "
-"souhaité et le mot de passe:"
+"Veuillez entrer votre adresse email, ainsi que le nom d'utilisateur souhaité "
+"et le mot de passe:"
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:33
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:33
@@ -13073,11 +12990,11 @@ msgstr "Enregistrer nouveau mot de passe"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
-"Veuillez entrer votre adresse email, ainsi que le nom d'utilisateur "
-"souhaité et le mot de passe:"
+"Veuillez entrer votre adresse email, ainsi que le nom d'utilisateur souhaité "
+"et le mot de passe:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
 #, fuzzy
@@ -13106,9 +13023,10 @@ msgid "Problem with login."
 msgstr "Comparer à l'original"
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
-msgstr "Vous pouvez désormais accéder à %(x_url_open)svotre compte%(x_url_close)s."
+msgstr ""
+"Vous pouvez désormais accéder à %(x_url_open)svotre compte%(x_url_close)s."
 
 #: invenio/modules/accounts/views/accounts.py:152
 #, fuzzy, python-format
@@ -13149,8 +13067,7 @@ msgstr "Échec lors de la modification des préférences de BibCatalog"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13222,13 +13139,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13237,9 +13153,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13411,8 +13327,7 @@ msgstr "collections"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13466,12 +13381,12 @@ msgstr "Mauvais numéro de page --> affichage de la première page."
 #: invenio/modules/comments/api.py:176
 msgid "Bad number of results per page --> showing 10 results per page."
 msgstr ""
-"Mauvais nombre de résultats par page --> affichage de 10 résultats par "
-"page."
+"Mauvais nombre de résultats par page --> affichage de 10 résultats par page."
 
 #: invenio/modules/comments/api.py:185
 msgid "Bad display order --> showing most helpful first."
-msgstr "Mauvais ordre d'affichage --> affichage des plus recommandés en premier."
+msgstr ""
+"Mauvais ordre d'affichage --> affichage des plus recommandés en premier."
 
 #: invenio/modules/comments/api.py:194
 msgid "Bad display order --> showing oldest first."
@@ -13480,7 +13395,8 @@ msgstr "Mauvais ordre d'affichage --> affichage des plus anciens en premier."
 #: invenio/modules/comments/api.py:238 invenio/modules/comments/api.py:1597
 #: invenio/modules/comments/api.py:1650
 msgid "Comments on records have been disallowed by the administrator."
-msgstr "Les commentaires sur les notices ont été désactivés par l'administrateur."
+msgstr ""
+"Les commentaires sur les notices ont été désactivés par l'administrateur."
 
 #: invenio/modules/comments/api.py:246 invenio/modules/comments/api.py:269
 #: invenio/modules/comments/api.py:1437 invenio/modules/comments/api.py:1458
@@ -13501,11 +13417,11 @@ msgstr "Désolé, vous avez déjà voté. Ce vote n'a pas été enregistré."
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
-"Vous êtes maintenant abonné à cette discussion. Dorénavant vous recevrez "
-"un email pour chaque nouveau commentaire."
+"Vous êtes maintenant abonné à cette discussion. Dorénavant vous recevrez un "
+"email pour chaque nouveau commentaire."
 
 #: invenio/modules/comments/api.py:290
 msgid "You have been unsubscribed from this discussion."
@@ -13563,18 +13479,19 @@ msgstr "Vous avez déjà soumis une évaluation pour cette notice."
 #: invenio/modules/comments/api.py:1712
 msgid "You already posted a comment short ago. Please retry later."
 msgstr ""
-"Vous avez déjà posté un commentaire très récemment. Veuillez réessayer "
-"plus tard."
+"Vous avez déjà posté un commentaire très récemment. Veuillez réessayer plus "
+"tard."
 
 #: invenio/modules/comments/api.py:1724
 msgid "Failed to insert your comment to the database. Please try again."
 msgstr ""
-"Échec lors de l'insertion du commentaire dans la base de donnée. Veuillez"
-" réessayer."
+"Échec lors de l'insertion du commentaire dans la base de donnée. Veuillez "
+"réessayer."
 
 #: invenio/modules/comments/api.py:1738
 msgid "Unknown action --> showing you the default add comment form."
-msgstr "Action inconnue --> affichage du formulaire de soumission de commentaire."
+msgstr ""
+"Action inconnue --> affichage du formulaire de soumission de commentaire."
 
 #: invenio/modules/comments/api.py:1865
 #, fuzzy, python-format
@@ -13596,13 +13513,13 @@ msgid "Record ID %(recid)s is not a number."
 msgstr "L'identifiant de notice %s n'est pas un nombre."
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
-"Votre message est trop long, veuillez l'éditer. La taille maximale est de"
-" %i caractères."
+"Votre message est trop long, veuillez l'éditer. La taille maximale est de %i "
+"caractères."
 
 #: invenio/modules/comments/forms.py:55
 #, fuzzy
@@ -13645,12 +13562,12 @@ msgid "Review was sent"
 msgstr "Écrire un commentaire"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Ce commentaire a été signalé %i fois"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Ce commentaire a été signalé %i fois"
 
@@ -13703,9 +13620,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13724,8 +13640,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13735,7 +13651,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "Un fichier nommé %s existe déjà. Choisissez un autre nom."
 
@@ -13791,8 +13707,7 @@ msgstr "évaluation"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13832,8 +13747,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13880,7 +13794,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "la fonction %s n'existe pas."
 
@@ -13966,11 +13880,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "Statut du moissonnage"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Vos tickets"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -14005,8 +13914,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -14027,8 +13936,8 @@ msgstr "Aucun index des mots n'est disponible pour %s."
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -14044,8 +13953,7 @@ msgstr "Validation de l'élément de formatage %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14167,7 +14075,7 @@ msgstr "Afficher les %i auteurs"
 msgid "Manage Files of This Record"
 msgstr "Gérer les fichiers de cette notice"
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr "Editer cette notice"
 
@@ -14265,10 +14173,6 @@ msgstr "1 évaluation"
 msgid "Authors"
 msgstr "auteur"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14361,8 +14265,8 @@ msgstr "Gérer les permissions des groupes"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "Désolé, vous n'êtes pas suffisamment de droits pour ce groupe."
 
 #: invenio/modules/groups/views.py:279
@@ -14375,12 +14279,12 @@ msgstr "Vous n'êtes administrateur d'aucun groupe."
 msgid "Members"
 msgstr "Aucun membre."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Base de connaissances manquante"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14390,11 +14294,11 @@ msgstr "Aucun"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "tous les champs"
@@ -14440,13 +14344,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "Il n'y a aucune notice citée par %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "Il n'y a aucune notice citée par %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14564,8 +14469,7 @@ msgstr "Écrire un message"
 #, fuzzy
 msgid "Could not empty your mailbox."
 msgstr ""
-"Êtes-vous sûr de vouloir effacer tout le contenu de votre boîte de "
-"réception?"
+"Êtes-vous sûr de vouloir effacer tout le contenu de votre boîte de réception?"
 
 #: invenio/modules/messages/templates/messages/menu_base.html:23
 #, fuzzy
@@ -14604,28 +14508,28 @@ msgstr "Type de document inconnu"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14690,8 +14594,8 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr "Pour procéder à l'enregistrement de ce compte, allez ici:"
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -15065,7 +14969,7 @@ msgid "Tag name"
 msgstr "Pseudonyme"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "Le pseudonyme %s est déjà utilisé."
 
@@ -15171,11 +15075,6 @@ msgstr ""
 msgid "Saving..."
 msgstr "Envoyer"
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "Aucun"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15217,8 +15116,7 @@ msgstr "Options de prêt"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15427,7 +15325,7 @@ msgid "just now"
 msgstr "Vous devez maintenant"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s secondes"
 
@@ -15486,6 +15384,57 @@ msgstr "année quelconque"
 msgid " years ago"
 msgstr "année"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "Administration de BibCheck"
+
+#~ msgid "Not authorized"
+#~ msgstr "Non autorisé"
+
+#~ msgid "Limit to knowledge bases containing string:"
+#~ msgstr "Limiter aux bases de connaissance contenant le texte:"
+
+#~ msgid "Really delete"
+#~ msgstr "Réellement supprimer"
+
+#~ msgid "Verify syntax"
+#~ msgstr "Vérifiez la syntaxe"
+
+#~ msgid "Calling bibcheck -verify failed."
+#~ msgstr "L'appel à bibcheck -verify a échoué"
+
+#~ msgid "Verify BibCheck config file"
+#~ msgstr "Vérifiez le fichier de config de BibCheck"
+
+#~ msgid "Verify problem"
+#~ msgstr "Vérifiez le problème"
+
+#~ msgid "File"
+#~ msgstr "Fichier"
+
+#~ msgid "Edit BibCheck config file"
+#~ msgstr "Édition du fichier de config de BibCheck"
+
+#~ msgid "Save BibCheck config file"
+#~ msgstr "Enregistrement du fichier de config de BibCheck"
+
+#~ msgid "Delete BibCheck config file"
+#~ msgstr "Suppression du fichier de config de BibCheck"
+
+#~ msgid "niceName"
+#~ msgstr "Nom"
+
+#~ msgid "Id"
+#~ msgstr "Identifiant"
+
+#~ msgid "Tickets"
+#~ msgstr "Tickets"
+
+#~ msgid "by"
+#~ msgstr "par"
+
+#~ msgid "Done"
+#~ msgstr "Valider"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Attention: veuillez spécifier une heure valide"
 
@@ -15498,9 +15447,6 @@ msgstr "année"
 #~ msgid "Warning: Please, select a valid date"
 #~ msgstr "Attention: veuillez sélectionner une date valide"
 
-#~ msgid ""
-#~ msgstr ""
-
 #~ msgid "Invalid MARCXML"
 #~ msgstr "MARCXML non valide"
 
@@ -15510,17 +15456,11 @@ msgstr "année"
 #~ msgid "*** basket name ***"
 #~ msgstr "*** nom du panier ***"
 
-#~ msgid "<div class=\"webcomment_comment_round_header\">%(x_nb)i Comments"
-#~ msgstr ""
-
 #~ msgid "%(x_name)s"
 #~ msgstr "%(x_name)s"
 
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "Métriques de Citations Additionnelles"
-
-#~ msgid "Sorry, you must log in to perform this action."
-#~ msgstr ""
 
 #~ msgid "Please log in first."
 #~ msgstr "Veuillez d'abord vous identifier."
@@ -15609,12 +15549,6 @@ msgstr "année"
 #~ msgid "Purchase information updated with success."
 #~ msgstr "Les détails d'achat ont été mis à jour avec succès."
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "Administration de BibCheck"
-
-#~ msgid "Not authorized"
-#~ msgstr "Non autorisé"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "ERREUR: %s n'existe pas"
 
@@ -15623,30 +15557,6 @@ msgstr "année"
 
 #~ msgid "ERROR: %s is not writable"
 #~ msgstr "ERREUR: %s est protégé en écriture"
-
-#~ msgid "Limit to knowledge bases containing string:"
-#~ msgstr "Limiter aux bases de connaissance contenant le texte:"
-
-#~ msgid "Really delete"
-#~ msgstr "Réellement supprimer"
-
-#~ msgid "Verify syntax"
-#~ msgstr "Vérifiez la syntaxe"
-
-#~ msgid "Calling bibcheck -verify failed."
-#~ msgstr "L'appel à bibcheck -verify a échoué"
-
-#~ msgid "Verify BibCheck config file"
-#~ msgstr "Vérifiez le fichier de config de BibCheck"
-
-#~ msgid "Verify problem"
-#~ msgstr "Vérifiez le problème"
-
-#~ msgid "File"
-#~ msgstr "Fichier"
-
-#~ msgid "Edit BibCheck config file"
-#~ msgstr "Édition du fichier de config de BibCheck"
 
 #~ msgid "File %s already exists."
 #~ msgstr "Le fichier %s existe déjà."
@@ -15657,17 +15567,11 @@ msgstr "année"
 #~ msgid "File %s: write failed."
 #~ msgstr "Fichier %s: enregistrement échoué."
 
-#~ msgid "Save BibCheck config file"
-#~ msgstr "Enregistrement du fichier de config de BibCheck"
-
 #~ msgid "File %s deleted."
 #~ msgstr "Le fichier %s est effacé."
 
 #~ msgid "File %s: delete failed."
 #~ msgstr "Fichier %s: la suppression a échoué."
-
-#~ msgid "Delete BibCheck config file"
-#~ msgstr "Suppression du fichier de config de BibCheck"
 
 #~ msgid "Guests are not authorized to run batchuploader"
 #~ msgstr "Vous n'êtes pas autorisé à utiliser batchuploader."
@@ -15795,9 +15699,6 @@ msgstr "année"
 #~ msgid "Tickes you created about this person"
 #~ msgstr "Ticket créés sur cette personne"
 
-#~ msgid "Tickets"
-#~ msgstr "Tickets"
-
 #~ msgid "Request Tickets"
 #~ msgstr "Tickets/Requêtes"
 
@@ -15809,9 +15710,6 @@ msgstr "année"
 
 #~ msgid "Person search for assignment in progress!"
 #~ msgstr "Recherche en cours d'une personne pour attribution!"
-
-#~ msgid "You are searching for a person to assign the following papers:"
-#~ msgstr ""
 
 #~ msgid "You are going to claim papers for: %s"
 #~ msgstr "Vous allez revendiquer les articles de: %s"
@@ -15876,9 +15774,6 @@ msgstr "année"
 #~ msgid "This book is sent to you ..."
 #~ msgstr "Ce livre vous a été envoyé..."
 
-#~ msgid "Id"
-#~ msgstr "Identifiant"
-
 #~ msgid "0 borrower(s) found."
 #~ msgstr "0 emprunteur trouvé"
 
@@ -15929,9 +15824,6 @@ msgstr "année"
 
 #~ msgid "Check if the book already exists on Invenio,"
 #~ msgstr "Vérifiez si le libre existe déjà sur Invenio,"
-
-#~ msgid "Book does not exists on Invenio. Please fill the following form."
-#~ msgstr ""
 
 #~ msgid "No fulltext"
 #~ msgstr "Aucun fichier"
@@ -15999,9 +15891,6 @@ msgstr "année"
 #~ msgid "creating a new basket"
 #~ msgstr "Créer un nouveau panier"
 
-#~ msgid "by"
-#~ msgstr "par"
-
 #~ msgid "on"
 #~ msgstr "sur"
 
@@ -16020,9 +15909,6 @@ msgstr "année"
 #~ msgid "Editing topic"
 #~ msgstr "Édition du panier"
 
-#~ msgid "niceName"
-#~ msgstr "Nom"
-
 #~ msgid "Apply Changes"
 #~ msgstr "Enregistrer les modifications"
 
@@ -16037,9 +15923,6 @@ msgstr "année"
 
 #~ msgid "Edit record %(x_recid)s, field %(x_field)s"
 #~ msgstr "Édition de la notice %(x_recid)s, champ %(x_field)s"
-
-#~ msgid "Edit record %(x_recid)s, field %(x_field)s - Add a subfield"
-#~ msgstr ""
 
 #~ msgid "Submit and save record %s"
 #~ msgstr "Soumettre et enregistrer la notice %s"
@@ -16107,9 +15990,6 @@ msgstr "année"
 #~ msgid "The collection to which this file belong is restricted: "
 #~ msgstr "La collection à laquelle ce fichier appartient est restreinte:"
 
-#~ msgid "You will also lose any unsubmitted changes for this record!"
-#~ msgstr ""
-
 #~ msgid "This record does not exist. Please try another record ID."
 #~ msgstr "Veuillez essayer avec un autre identifiant de notice."
 
@@ -16118,9 +15998,6 @@ msgstr "année"
 
 #~ msgid "The record will be deleted as soon as the task queue is empty."
 #~ msgstr "La notice sera supprimée dès que la liste de tâches sera vide."
-
-#~ msgid "Please enter the ID of the record you want to edit"
-#~ msgstr ""
 
 #~ msgid "Move up"
 #~ msgstr "Remonter"
@@ -16139,9 +16016,6 @@ msgstr "année"
 
 #~ msgid "Verbose"
 #~ msgstr "Textuel"
-
-#~ msgid "Done"
-#~ msgstr "Valider"
 
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "Vos modifications sont TEMPORAIRES."
@@ -16185,9 +16059,6 @@ msgstr "année"
 #~ msgid "from"
 #~ msgstr "De:"
 
-#~ msgid "There are record revisions not yet synchronized with the database."
-#~ msgstr ""
-
 #~ msgid "Please try again in a few minutes."
 #~ msgstr "Veuillez réessayer ultérieurement."
 
@@ -16215,9 +16086,6 @@ msgstr "année"
 #~ msgid "approvals"
 #~ msgstr "approbations"
 
-#~ msgid "Unknown form field found on one of the submission pages."
-#~ msgstr ""
-
 #~ msgid "List of direct approval categories"
 #~ msgstr "Liste des catégories d'approbation directe"
 
@@ -16226,9 +16094,6 @@ msgstr "année"
 
 #~ msgid "There is no format configured for this journals index page"
 #~ msgstr "Il n'y a pas de format configuré pour l'index de ces journaux"
-
-#~ msgid "There is no format configured for this journals search page"
-#~ msgstr ""
 
 #~ msgid "There is no format configured for this journals popup page"
 #~ msgstr "Il n'y a pas de format configuré pour le \"popup\" de ces journaux"
@@ -16392,28 +16257,8 @@ msgstr "année"
 #~ msgid "Quit searching."
 #~ msgstr "Arrêter la recherche"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Annulé"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr " Rechercher une personne à qui attribuer cet article"
@@ -16429,9 +16274,6 @@ msgstr "année"
 
 #~ msgid "Hide successful claims"
 #~ msgstr "Masquer les revendications réussies"
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
 
 #~ msgid "Author Name"
 #~ msgstr "Auteur"
@@ -16472,11 +16314,6 @@ msgstr "année"
 #~ msgid "They will be regarded in the next run of the author "
 #~ msgstr "Elles seront considérées lors de la prochaine exécution "
 
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-#~ "la l'algorithme de désambiguation, et "
-#~ "pourrait disparaître de cette liste."
-
 #~ msgid "No comments"
 #~ msgstr "Aucun commentaire"
 
@@ -16492,26 +16329,12 @@ msgstr "année"
 #~ msgid "No title available"
 #~ msgstr "Non disponible"
 
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
+#~ msgid ""
+#~ "Please select an author on each of the records that will be assigned."
 #~ msgstr "Veuillez sélectionner un auteur pour les notices en question."
 
 #~ msgid "Papers without a name selected will be ignored in the process."
 #~ msgstr "Les options non sélectionnées seront ignorées dans le processus."
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Choisir un nom pour"
@@ -16543,28 +16366,8 @@ msgstr "année"
 #~ msgid "Confirmation needed to continue"
 #~ msgstr "Confirmation demandée pour continuer"
 
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-#~ "Le résultat de cette requête sera "
-#~ "visible immédiatement, mais nous avons "
-#~ "besoin de votre confirmation puisque cet"
-#~ " articles a été revendiqués auparavant"
-
 #~ msgid "This will create a change request for the operators"
 #~ msgstr "Cela générera une requête de modification pour les opérateurs"
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-#~ "Le résultat de cette requête sera "
-#~ "visible après confirmation par un "
-#~ "opérateur"
 
 #~ msgid "Selected name on paper"
 #~ msgstr "Nom sélectionné sur l'article"
@@ -16592,15 +16395,6 @@ msgstr "année"
 
 #~ msgid "Please provide your eMail address"
 #~ msgstr "Veuillez indiquer votre adresse email"
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-#~ "Cette adresse email est déjà allouée "
-#~ "à quelqu'un. Connectez-vous ou indiquer"
-#~ " une autre adresse email"
 
 #~ msgid "Your eMail:"
 #~ msgstr "Votre email:"
@@ -16635,23 +16429,6 @@ msgstr "année"
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Marquer comme n'étant _pas_ leurs documents"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-#~ "  * Vous pouvez revenir sur cette"
-#~ " page plus tard. Rien ne sera "
-#~ "perdu <br />"
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-#~ "  ** Applique tous les changements "
-#~ "demandés. Les changements sujets à des"
-#~ " autorisations seront transmis à un "
-#~ "opérateur pour vérification."
-
 #~ msgid "Create a new Person"
 #~ msgstr "ou en créer un nouveau"
 
@@ -16664,15 +16441,6 @@ msgstr "année"
 #~ msgid "Add to merge list"
 #~ msgstr "Ajouter aux utilisateurs"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Articles Récents"
 
@@ -16682,128 +16450,17 @@ msgstr "année"
 #~ msgid "most recent documents:"
 #~ msgstr "plus récents documents:"
 
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Gérer les fichiers"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Choisir un fichier"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Liste de Publications "
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "lien externe"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "soumissions"
@@ -16811,138 +16468,17 @@ msgstr "année"
 #~ msgid "Choose system"
 #~ msgstr "Choisir un modèle"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr ""
-#~ "Les fichiers suivants ont été placés "
-#~ "dans la file d'attente avec succès:"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-#~ "Erreur fatale: les fonctionnalités liées "
-#~ "aux identifiants des auteurs sont "
-#~ "désactivées sur ce système."
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Vous n'êtes pas autorisé à accéder à cette fonctionnalité."
 
 #~ msgid "Claim this paper"
 #~ msgstr "Revendiquer cet article"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-#~ "<p>Désolé. Une erreur s'est produite "
-#~ "lors du traitement de cette requête. "
-#~ "Plus d'informations ci-dessous:</p>"
-
 #~ msgid "This page is not accessible directly."
 #~ msgstr "Cette page n'est pas accessible directement."
 
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Cité par: %s notices"
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
 
 #~ msgid "Comparison of:"
 #~ msgstr "Comparaison de:"
@@ -16952,27 +16488,6 @@ msgstr "année"
 
 #~ msgid "Failed to create a ticket"
 #~ msgstr "Échec lors de la création d'un ticket"
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Modifier les attributs du modèle"
@@ -17052,89 +16567,20 @@ msgstr "année"
 #~ msgid "No Record Found for %s."
 #~ msgstr "Notice introuvable"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Le fichier %s n'existe pas."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "Attributs du format de sortie %s"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "Dépendances du modèle de formatage %s"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "Validation de l'élément de formatage %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "Dépendances de l'élément de formatage %s"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Format de sortie à accès restreint"
@@ -17190,61 +16636,17 @@ msgstr "année"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Validation de l'élément de formatage %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "Validation du format"
 
 #~ msgid "Knowledge Base %s"
 #~ msgstr "Base de connaissances %s"
 
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
-
 #~ msgid "Not Set"
 #~ msgstr "Non Spécifié"
 
 #~ msgid "never"
 #~ msgstr "jamais"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
 
 #~ msgid "Name variants"
 #~ msgstr "Variantes du nom"
@@ -17279,17 +16681,11 @@ msgstr "année"
 #~ msgid "Affiliations"
 #~ msgstr "Affiliations"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
 #~ msgid "No Frequent Co-authors"
 #~ msgstr "Aucun co-auteur fréquent"
 
 #~ msgid "Citations%s"
 #~ msgstr "Citations"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Date de publication"
@@ -17299,15 +16695,6 @@ msgstr "année"
 
 #~ msgid "No publications available"
 #~ msgstr "Aucune information disponible"
-
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
 
 #~ msgid "Cited by 1 record"
 #~ msgstr "Cité par 1 notice"
@@ -17336,23 +16723,8 @@ msgstr "année"
 #~ msgid "No Citation Information available"
 #~ msgstr "Aucune information de citation disponible"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Discussion"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Vos alertes"
@@ -17375,22 +16747,8 @@ msgstr "année"
 #~ msgid "Group: %s"
 #~ msgstr "Groupe: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "Page %s introuvable"
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "Le champ %s est obligatoire."
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
-#~ msgstr ""
-#~ "Impossible de supprimer le champ à "
-#~ "la position %s sur la page %s "
-#~ "de la soumission '%s'"
-

--- a/invenio/base/translations/gl/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/gl/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2006-10-12 17:50+0200\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:57+0200\n"
 "Last-Translator: Pablo Vazquez Caderno <pablo.vazquez.caderno@cern.ch>\n"
 "Language-Team: GL <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -55,8 +55,8 @@ msgstr ""
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -199,7 +199,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr ""
 
@@ -220,17 +220,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -256,45 +256,49 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+msgid "Provided data is not valid"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 msgid "Authorization failure"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 msgid "Please sign in to continue."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 msgid "Authorization failure."
 msgstr ""
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -493,7 +497,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -694,7 +699,8 @@ msgid "The following errors have occurred:"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -711,8 +717,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -794,7 +800,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -836,8 +842,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr ""
@@ -852,8 +858,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr ""
 
@@ -1062,7 +1068,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1111,8 +1118,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1125,25 +1132,23 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1167,13 +1172,14 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1201,9 +1207,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1268,8 +1273,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1277,8 +1282,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1300,9 +1305,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1343,8 +1347,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1399,11 +1403,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1414,11 +1418,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1431,8 +1435,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1522,8 +1526,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1542,29 +1546,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1573,9 +1577,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr ""
 
@@ -1892,16 +1896,14 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -1921,8 +1923,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2066,8 +2068,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2174,7 +2176,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr ""
 
@@ -2366,8 +2368,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2637,9 +2639,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2690,7 +2691,7 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr ""
 
@@ -2698,8 +2699,8 @@ msgstr ""
 #, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3150,8 +3151,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr ""
 
@@ -3939,8 +3940,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -3958,8 +3959,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4018,17 +4019,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4378,25 +4379,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4455,15 +4456,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4474,10 +4475,10 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4490,15 +4491,15 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4509,7 +4510,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4528,17 +4530,15 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4556,14 +4556,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4614,8 +4613,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4665,8 +4664,8 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -4777,9 +4776,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -4792,8 +4791,8 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -4918,11 +4917,10 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5046,7 +5044,7 @@ msgid "Total"
 msgstr ""
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr ""
 
@@ -5202,8 +5200,8 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5258,56 +5256,56 @@ msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5345,7 +5343,7 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5395,15 +5393,15 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5618,8 +5616,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -5693,8 +5690,8 @@ msgstr ""
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -5708,8 +5705,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr ""
 
@@ -5867,8 +5864,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -5894,8 +5891,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -5906,8 +5903,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -5917,108 +5913,108 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 msgid "No match found, please enter different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6032,11 +6028,11 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
 
@@ -6079,10 +6075,9 @@ msgstr ""
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
 
 #: invenio/legacy/webalert/htmlparser.py:186
@@ -6272,15 +6267,15 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:453
@@ -6338,7 +6333,7 @@ msgstr ""
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6402,7 +6397,7 @@ msgstr ""
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6462,7 +6457,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6484,7 +6480,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6511,7 +6508,8 @@ msgid "You do not have permission to delete this note."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6541,8 +6539,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6562,8 +6560,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6594,8 +6592,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -6665,8 +6663,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
@@ -6692,8 +6689,7 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -6853,8 +6849,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7034,15 +7030,16 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2131
@@ -7052,7 +7049,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr ""
 
@@ -7213,7 +7210,7 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7344,207 +7341,207 @@ msgstr ""
 msgid "Record ID %(x_rec)s does not exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, python-format
 msgid "%(x_nb)i Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, python-format
 msgid "View all %(x_name)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 msgid "Be the first to review this document.</div>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 msgid "Close"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7553,487 +7550,489 @@ msgstr ""
 msgid "Record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, python-format
 msgid "Max %(maxfiles)i files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, python-format
 msgid "Here is review %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, python-format
 msgid "Here is comment %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
+msgstr ""
+
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 msgid "Your comment will be lost."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 msgid "Oldest comment first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 msgid "Latest comment first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 msgid "Group by record, latest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 msgid "Records and comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 msgid "Records only"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 msgid "Comments only"
 msgstr ""
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, python-format
 msgid "%(x_i)s items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 msgid "All items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 msgid "Order by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 msgid "Per page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 msgid "Display options"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8041,98 +8040,98 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 msgid "(in reply to a comment)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, python-format
 msgid "%(x_num)i items found in total"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 msgid "You do not have access to the specified comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 msgid "You cannot report a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 msgid "You are not authorized to use comments."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 msgid "Your Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr ""
@@ -8247,8 +8246,8 @@ msgstr ""
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8312,8 +8311,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8340,8 +8339,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -8515,9 +8514,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8538,8 +8536,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9004,14 +9001,14 @@ msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9141,8 +9138,7 @@ msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3357
@@ -9168,8 +9164,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3832
@@ -9351,7 +9347,8 @@ msgid "in"
 msgstr ""
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr ""
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9440,8 +9437,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9450,8 +9447,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:271
@@ -9468,14 +9465,14 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:327
@@ -9513,8 +9510,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:343
 #, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:346
@@ -9601,10 +9598,9 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:559
@@ -9621,15 +9617,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:573
@@ -9642,10 +9638,10 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:611
@@ -9665,8 +9661,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:636
@@ -9681,22 +9677,22 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:785
@@ -9713,8 +9709,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:799
@@ -9726,8 +9722,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:805
@@ -9738,8 +9734,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:811
@@ -9785,7 +9781,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -9833,15 +9830,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1027
@@ -9877,8 +9874,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -9903,8 +9900,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1228
@@ -9921,24 +9918,24 @@ msgstr ""
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1235
 #, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1267
@@ -10065,8 +10062,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1378
@@ -10285,7 +10282,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2400
@@ -10327,71 +10325,66 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:127
@@ -10400,14 +10393,14 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -10416,8 +10409,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -10429,8 +10422,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -10499,8 +10492,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -10563,8 +10555,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -10627,10 +10618,10 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -10658,8 +10649,8 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:452
 #, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -10834,15 +10825,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:989
@@ -10956,7 +10947,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:707
@@ -10979,37 +10971,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11017,15 +11009,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11089,8 +11081,8 @@ msgstr ""
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11125,8 +11117,8 @@ msgstr ""
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11172,8 +11164,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:366
@@ -11202,8 +11194,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:548
@@ -11252,8 +11244,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1041
@@ -11335,8 +11327,7 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -11473,7 +11464,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -11565,8 +11557,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -11585,8 +11577,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -11627,7 +11619,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -11648,14 +11641,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -11766,10 +11758,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12040,8 +12031,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12188,8 +12179,8 @@ msgstr ""
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -12248,9 +12239,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -12271,8 +12261,8 @@ msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -12338,8 +12328,7 @@ msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -12402,13 +12391,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -12417,9 +12405,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -12581,8 +12569,7 @@ msgstr ""
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -12664,8 +12651,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -12754,8 +12741,8 @@ msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:55
@@ -12845,9 +12832,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -12866,8 +12852,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -12925,8 +12911,7 @@ msgstr ""
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -12963,8 +12948,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13114,8 +13098,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13136,8 +13120,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13153,8 +13137,7 @@ msgstr ""
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -13270,7 +13253,7 @@ msgstr ""
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr ""
 
@@ -13452,8 +13435,8 @@ msgstr ""
 #: invenio/modules/groups/views.py:223
 #, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr ""
 
 #: invenio/modules/groups/views.py:279
@@ -13465,11 +13448,11 @@ msgstr ""
 msgid "Members"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 msgid "Knowledge base name"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 msgid "-None-"
 msgstr ""
@@ -13478,11 +13461,11 @@ msgstr ""
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 msgid "Index fields"
 msgstr ""
 
@@ -13528,7 +13511,7 @@ msgid "Create new record \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
+msgid "Create KB \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
@@ -13665,28 +13648,28 @@ msgstr ""
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -13747,8 +13730,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -14202,8 +14185,7 @@ msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -14451,1706 +14433,3 @@ msgstr ""
 #: invenio/utils/date.py:581
 msgid " years ago"
 msgstr ""
-
-#~ msgid "Export as"
-#~ msgstr ""
-
-#~ msgid "Search Services"
-#~ msgstr ""
-
-#~ msgid "Citation Metrics"
-#~ msgstr ""
-
-#~ msgid "WebSearch Admin Guide"
-#~ msgstr ""
-
-#~ msgid "Submit Guide"
-#~ msgstr ""
-
-#~ msgid "Add to personal basket"
-#~ msgstr ""
-
-#~ msgid "WebSubmit Admin Guide"
-#~ msgstr ""
-
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
-#~ msgid "Quit searching."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
-#~ msgid "Cancel merging"
-#~ msgstr ""
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Your options"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
-
-#~ msgid "Search for a person to assign the paper to"
-#~ msgstr ""
-
-#~ msgid "Select All"
-#~ msgstr ""
-
-#~ msgid "Select None"
-#~ msgstr ""
-
-#~ msgid "Invert Selection"
-#~ msgstr ""
-
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
-#~ msgid "Author Name"
-#~ msgstr ""
-
-#~ msgid "Experiment"
-#~ msgstr ""
-
-#~ msgid "Not assigned"
-#~ msgstr ""
-
-#~ msgid "No status information found."
-#~ msgstr ""
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
-
-#~ msgid "Review Transaction"
-#~ msgstr ""
-
-#~ msgid "On all pages"
-#~ msgstr ""
-
-#~ msgid "With selected do"
-#~ msgstr ""
-
-#~ msgid "View name variants"
-#~ msgstr ""
-
-#~ msgid "The author has an internal ID!"
-#~ msgstr ""
-
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
-#~ msgid "Not provided"
-#~ msgstr ""
-
-#~ msgid "Not available"
-#~ msgstr ""
-
-#~ msgid "No comments"
-#~ msgstr ""
-
-#~ msgid "Not Available"
-#~ msgstr ""
-
-#~ msgid " Delete this ticket"
-#~ msgstr ""
-
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
-#~ msgid "No title available"
-#~ msgstr ""
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
-
-#~ msgid "Select name for"
-#~ msgstr ""
-
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
-#~ msgid "Paper title: "
-#~ msgstr ""
-
-#~ msgid "Ignore"
-#~ msgstr ""
-
-#~ msgid "The following names have been automatically chosen:"
-#~ msgstr ""
-
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
-#~ msgid "Selected name on paper"
-#~ msgstr ""
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
-
-#~ msgid "Please provide your information"
-#~ msgstr ""
-
-#~ msgid "Please provide your first name"
-#~ msgstr ""
-
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
-#~ msgid "Your last name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
-#~ msgid "Your eMail:"
-#~ msgstr ""
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
-
-#~ msgid "!Delete the entire request!"
-#~ msgstr ""
-
-#~ msgid "Mark as your documents"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
-#~ msgid "Mark as their documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ their documents"
-#~ msgstr ""
-
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
-#~ msgid "Create new profile"
-#~ msgstr ""
-
-#~ msgid "Create a new Person"
-#~ msgstr ""
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
-
-#~ msgid "Add to merge list"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
-#~ msgid "Recent Papers"
-#~ msgstr ""
-
-#~ msgid "Publication List "
-#~ msgstr ""
-
-#~ msgid "Showing the"
-#~ msgstr ""
-
-#~ msgid "most recent documents:"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
-#~ msgid "Manage your profile"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
-
-#~ msgid "Choose your profile"
-#~ msgstr ""
-
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
-#~ msgid "Manage publication list"
-#~ msgstr ""
-
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
-#~ msgid "add external id"
-#~ msgstr ""
-
-#~ msgid "delete selected ids"
-#~ msgstr ""
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
-
-#~ msgid "suggest missing ids"
-#~ msgstr ""
-
-#~ msgid "Choose system"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr ""
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
-#~ msgid "Fatal: You are not allowed to access this functionality."
-#~ msgstr ""
-
-#~ msgid "Claim this paper"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "You have %i tickets."
-#~ msgstr ""
-
-#~ msgid "The publication date of this book is %s."
-#~ msgstr ""
-
-#~ msgid "You can see your library account %(x_url_open)shere%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid "%i items found."
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
-#~ msgid "Unweighted %s keywords:"
-#~ msgstr ""
-
-#~ msgid "Weighted %s keywords:"
-#~ msgstr ""
-
-#~ msgid "Unknown type: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file named %s already exists. Please choose another name."
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Record #%i"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
-#~ msgid "Revision"
-#~ msgstr ""
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Could not find format element named %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s could not be found."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
-
-#~ msgid "Output format with code %s could not be found."
-#~ msgstr ""
-
-#~ msgid "Could not find output format named %s."
-#~ msgstr ""
-
-#~ msgid "Could not find a fresh name for output format %s."
-#~ msgstr ""
-
-#~ msgid "Modify Template Attributes"
-#~ msgstr ""
-
-#~ msgid "Template Editor"
-#~ msgstr ""
-
-#~ msgid "Check Dependencies"
-#~ msgstr ""
-
-#~ msgid "Update Format Attributes"
-#~ msgstr ""
-
-#~ msgid "Show Documentation"
-#~ msgstr ""
-
-#~ msgid "Hide Documentation"
-#~ msgstr ""
-
-#~ msgid "Last Modification Date"
-#~ msgstr ""
-
-#~ msgid "Manage Output Formats"
-#~ msgstr ""
-
-#~ msgid "Manage Format Templates"
-#~ msgstr ""
-
-#~ msgid "Format Elements Documentation"
-#~ msgstr ""
-
-#~ msgid "Add New Format Template"
-#~ msgstr ""
-
-#~ msgid "Check Format Templates Extensively"
-#~ msgstr ""
-
-#~ msgid "Code"
-#~ msgstr ""
-
-#~ msgid "Add New Output Format"
-#~ msgstr ""
-
-#~ msgid "menu"
-#~ msgstr ""
-
-#~ msgid "Close Output Format"
-#~ msgstr ""
-
-#~ msgid "Rules"
-#~ msgstr ""
-
-#~ msgid "Modify Output Format Attributes"
-#~ msgstr ""
-
-#~ msgid "Remove Rule"
-#~ msgstr ""
-
-#~ msgid "Add New Rule"
-#~ msgstr ""
-
-#~ msgid "No problem found with format"
-#~ msgstr ""
-
-#~ msgid "An error has been found"
-#~ msgstr ""
-
-#~ msgid "The following errors have been found"
-#~ msgstr ""
-
-#~ msgid "BibFormat Admin"
-#~ msgstr ""
-
-#~ msgid "Test with record:"
-#~ msgstr ""
-
-#~ msgid "Enter a search query here."
-#~ msgstr ""
-
-#~ msgid "No Record Found for %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
-#~ msgid "Template \"%s\" does not exist at line %s."
-#~ msgstr ""
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
-
-#~ msgid "Output format %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
-#~ msgid "Format template %s calls undefined element \"%s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
-
-#~ msgid "Error in format element %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Show all %i authors"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
-
-#~ msgid "Restricted Output Format"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Rules"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Output Format"
-#~ msgstr ""
-
-#~ msgid "Cannot create output format"
-#~ msgstr ""
-
-#~ msgid "Format template %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Element %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Test Format Element %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Output Format %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Element"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Element %s"
-#~ msgstr ""
-
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
-#~ msgid "Format Validation"
-#~ msgstr ""
-
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid "Your rule: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Download history:"
-#~ msgstr ""
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid "Cannot send error request, %s parameter missing."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Not Set"
-#~ msgstr ""
-
-#~ msgid "never"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Your account on '%s' has been activated"
-#~ msgstr ""
-
-#~ msgid "Your account earlier created on '%s' has been activated:"
-#~ msgstr ""
-
-#~ msgid "Account created on '%s'"
-#~ msgstr ""
-
-#~ msgid "An account has been created for you on '%s':"
-#~ msgstr ""
-
-#~ msgid "Account rejected on '%s'"
-#~ msgstr ""
-
-#~ msgid "Your request for an account has been rejected on '%s':"
-#~ msgstr ""
-
-#~ msgid "Username/Email: %s"
-#~ msgstr ""
-
-#~ msgid "Account deleted on '%s'"
-#~ msgstr ""
-
-#~ msgid "Your account on '%s' has been deleted:"
-#~ msgstr ""
-
-#~ msgid "You already have an alert named %s."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been added to your profile."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been successfully updated."
-#~ msgstr ""
-
-#~ msgid "You have defined %s alerts."
-#~ msgstr ""
-
-#~ msgid "Here are the %s most popular searches."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display searches"
-#~ msgstr ""
-
-#~ msgid "%s, personalize"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Set a new alert"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Modify alert settings"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display alerts"
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
-
-#~ msgid "times"
-#~ msgstr ""
-
-#~ msgid "Papers"
-#~ msgstr ""
-
-#~ msgid "No Keywords"
-#~ msgstr ""
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
-
-#~ msgid "No Subject categories"
-#~ msgstr ""
-
-#~ msgid "Subject categories"
-#~ msgstr ""
-
-#~ msgid "No Collaborations"
-#~ msgstr ""
-
-#~ msgid "Collaborations"
-#~ msgstr ""
-
-#~ msgid "unknown affiliation"
-#~ msgstr ""
-
-#~ msgid "No Affiliations"
-#~ msgstr ""
-
-#~ msgid "Affiliations"
-#~ msgstr ""
-
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
-#~ msgid "Citations%s"
-#~ msgstr ""
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
-
-#~ msgid "No Publication Graph"
-#~ msgstr ""
-
-#~ msgid "<strong> Publications list </strong>"
-#~ msgstr ""
-
-#~ msgid "No publications available"
-#~ msgstr ""
-
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "Sorry, you do not have sufficient rights to add record #%i."
-#~ msgstr ""
-
-#~ msgid "%i matching items"
-#~ msgstr ""
-
-#~ msgid "%i items have been successfully added to your basket"
-#~ msgstr ""
-
-#~ msgid "Adding %i items to your baskets"
-#~ msgstr ""
-
-#~ msgid "%i users are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "%i user groups are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "You have set %i alerts on this basket."
-#~ msgstr ""
-
-#~ msgid "%i items"
-#~ msgstr ""
-
-#~ msgid "%i notes"
-#~ msgstr ""
-
-#~ msgid "%i subscribers"
-#~ msgstr ""
-
-#~ msgid "Record %i"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s does not exist in the database."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is an invalid ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "Showing the latest %i comments:"
-#~ msgstr ""
-
-#~ msgid "Sorry, the record %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "Sorry, %s is not a valid ID value."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s"
-#~ msgstr ""
-
-#~ msgid "Readers found the following %s reviews to be most helpful."
-#~ msgstr ""
-
-#~ msgid "View all %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s comments"
-#~ msgstr ""
-
-#~ msgid "Note: Your nickname, %s, will be displayed as author of this comment."
-#~ msgstr ""
-
-#~ msgid "Max %i files"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Note: Your nickname, %s, will be "
-#~ "displayed as the author of this "
-#~ "review."
-#~ msgstr ""
-
-#~ msgid "View all %s reported comments"
-#~ msgstr ""
-
-#~ msgid "View all %s reported reviews"
-#~ msgstr ""
-
-#~ msgid "This review has been reported %i times"
-#~ msgstr ""
-
-#~ msgid "This comment has been reported %i times"
-#~ msgstr ""
-
-#~ msgid "Here are the reported reviews of user %s"
-#~ msgstr ""
-
-#~ msgid "Here are the reported comments of user %s"
-#~ msgstr ""
-
-#~ msgid "Here is review %s"
-#~ msgstr ""
-
-#~ msgid "Here is comment %s"
-#~ msgstr ""
-
-#~ msgid "Here are all reviews for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "Here are all comments for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "%s items"
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid "%i items found in total"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "%s View your previously submitted comments"
-#~ msgstr ""
-
-#~ msgid "Comment ID %s does not exist."
-#~ msgstr ""
-
-#~ msgid "Record ID %s does not exist."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your message is too long, please "
-#~ "shorten it. Maximum size allowed is "
-#~ "%i characters."
-#~ msgstr ""
-
-#~ msgid "Group %s does not exist."
-#~ msgstr ""
-
-#~ msgid "User %s does not exist."
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
-#~ msgid "There are no records referring to %s."
-#~ msgstr ""
-
-#~ msgid "There are no records modified by %s."
-#~ msgstr ""
-
-#~ msgid "There are no records cited by %s."
-#~ msgstr ""
-
-#~ msgid "No word index is available for %s."
-#~ msgstr ""
-
-#~ msgid "No phrase index is available for %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Search term %s did not match any"
-#~ " record. Nearest terms in any "
-#~ "collection are:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, %s does not seem to be "
-#~ "a valid sort option. The records "
-#~ "will not be sorted."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, sorting is allowed on sets "
-#~ "of up to %d records only. Using"
-#~ " default sort order."
-#~ msgstr ""
-
-#~ msgid "The record %d replaces it."
-#~ msgstr ""
-
-#~ msgid "%s results found"
-#~ msgstr ""
-
-#~ msgid "%s seconds"
-#~ msgstr ""
-
-#~ msgid "Search %s records for"
-#~ msgstr ""
-
-#~ msgid "Cited by %i records"
-#~ msgstr ""
-
-#~ msgid "%s records found"
-#~ msgstr ""
-
-#~ msgid "Search took %s seconds."
-#~ msgstr ""
-
-#~ msgid "Cited by 1 record"
-#~ msgstr ""
-
-#~ msgid "%i comments"
-#~ msgstr ""
-
-#~ msgid "%i reviews"
-#~ msgstr ""
-
-#~ msgid "Collection %s Not Found"
-#~ msgstr ""
-
-#~ msgid "Sorry, collection %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s."
-#~ msgstr ""
-
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid "Cited by: %s records"
-#~ msgstr ""
-
-#~ msgid "Co-cited with: %s records"
-#~ msgstr ""
-
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
-#~ msgid "No Papers"
-#~ msgstr ""
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
-
-#~ msgid "Citations:"
-#~ msgstr ""
-
-#~ msgid "No Citation Information available"
-#~ msgstr ""
-
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Sorry, DOI %s could not be resolved."
-#~ msgstr ""
-
-#~ msgid "DOI \"%s\" Not Found"
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
-#~ msgid "Discussion"
-#~ msgstr ""
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If you are using a lightweight CERN account you can\n"
-#~ "                %(x_url_open)sreset the password%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Alternatively, you can ask %s to "
-#~ "change your login system from external"
-#~ " to internal."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "%s offers you the possibility to "
-#~ "personalize the interface, to set up "
-#~ "your own personal library of documents,"
-#~ " or to set up an automatic "
-#~ "alert query that would run periodically"
-#~ " and would notify you of search "
-#~ "results by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid "Okay, a password reset link has been emailed to %s."
-#~ msgstr ""
-
-#~ msgid "If you don't own an account yet, please contact %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please do not use valuable passwords "
-#~ "such as your Unix, AFS or NICE "
-#~ "passwords with this service. Your email"
-#~ " address will stay strictly confidential"
-#~ " and will not be disclosed to "
-#~ "any third party. It will be used"
-#~ " to identify you for personal "
-#~ "services of %s. For example, you "
-#~ "may set up an automatic alert "
-#~ "search that will look for new "
-#~ "preprints and will notify you daily "
-#~ "of new arrivals by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "It is not possible to create an"
-#~ " account yourself. Contact %s if you"
-#~ " want an account."
-#~ msgstr ""
-
-#~ msgid "Your alerts"
-#~ msgstr ""
-
-#~ msgid "Your approvals"
-#~ msgstr ""
-
-#~ msgid "Your baskets"
-#~ msgstr ""
-
-#~ msgid "Your comments"
-#~ msgstr ""
-
-#~ msgid "Your groups"
-#~ msgstr ""
-
-#~ msgid "Your loans"
-#~ msgstr ""
-
-#~ msgid "Your submissions"
-#~ msgstr ""
-
-#~ msgid "Your searches"
-#~ msgstr ""
-
-#~ msgid "Administration"
-#~ msgstr ""
-
-#~ msgid "Statistics"
-#~ msgstr ""
-
-#~ msgid "Edit %s members"
-#~ msgstr ""
-
-#~ msgid "Edit group %s"
-#~ msgstr ""
-
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
-#~ msgid "Group: %s"
-#~ msgstr ""
-
-#~ msgid "Group %s: New membership request"
-#~ msgstr ""
-
-#~ msgid "A user wants to join the group %s."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been accepted"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been accepted."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been rejected"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been rejected."
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted"
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted by its administrator."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Your Settings"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown to the external login "
-#~ "system."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The external login method %s does "
-#~ "not support email address based logins."
-#~ "  Please contact the site administrators."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is already in use."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "Sorry, page %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
-#~ msgid "Page %s Not Found"
-#~ msgstr ""
-
-#~ msgid "Please contact %s quoting the following information:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
-
-#~ msgid "Unable to find the submission directory for the action: %s"
-#~ msgstr ""
-
-#~ msgid "Unable to find document type: %s"
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory."
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory. Please fill it in."
-#~ msgstr ""
-
-#~ msgid "Function %s does not exist."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s%s'"
-#~ msgstr ""
-

--- a/invenio/base/translations/hr/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/hr/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,16 +16,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2008-02-29 15:34+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:57+0200\n"
 "Last-Translator: Alen Vodopijevec <alen@irb.hr>\n"
 "Language-Team: HR <info@invenio-software.org>\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -59,8 +59,8 @@ msgstr "Administracija"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -206,7 +206,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 #, fuzzy
 msgid "Hello:"
 msgstr "Pozdrav"
@@ -228,17 +228,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -264,48 +264,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Taj unos ne postoji"
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Vi niste vlasnik ove košarice."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Registracija nije uspjela"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Molimo odaberite jedan ili više:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Registracija nije uspjela"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -509,7 +514,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -586,9 +592,9 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"Prijavljeni ste kao %(x_user)s. Možda želite a) %(x_url1_open)sodjaviti "
-"se%(x_url1_close)s; b) urediti %(x_url2_open)spostavke svog korisničkog "
-"računa%(x_url2_close)s."
+"Prijavljeni ste kao %(x_user)s. Možda želite a) %(x_url1_open)sodjaviti se"
+"%(x_url1_close)s; b) urediti %(x_url2_open)spostavke svog korisničkog računa"
+"%(x_url2_close)s."
 
 #: invenio/legacy/batchuploader/templates.py:282
 #, fuzzy
@@ -732,7 +738,8 @@ msgid "The following errors have occurred:"
 msgstr "Pronađene su slijedeće greške"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -749,8 +756,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -832,7 +839,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -875,8 +882,8 @@ msgstr "Vaša košarica"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Prethodni"
@@ -892,8 +899,8 @@ msgstr "Rezultat"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Slijedeći"
 
@@ -908,18 +915,6 @@ msgstr "Slijedeći"
 #: invenio/legacy/weblinkback/adminlib.py:55
 msgid "Admin Area"
 msgstr "Administracija"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "autor"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
@@ -939,11 +934,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
 msgid "Limit to knowledge bases containing string:"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "uspješno izbrisano"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -995,16 +985,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
 msgid "Verify BibCheck config file"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Problem sa bazom podataka"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "dokument(i)"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
@@ -1111,7 +1091,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1162,8 +1143,8 @@ msgstr "Vaš korisnički račun je uspješno kreiran."
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1177,25 +1158,23 @@ msgstr "Pregledaj"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "Vaš korisnički račun je uspješno kreiran."
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "Vaš korisnički račun je uspješno kreiran."
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1220,13 +1199,14 @@ msgstr "Kreiraj novu temu"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "Vaš korisnički račun je uspješno kreiran."
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1258,9 +1238,8 @@ msgstr "trenutno stanje:"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "Vaš korisnički račun je uspješno kreiran."
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1327,8 +1306,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1336,8 +1315,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1359,9 +1338,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "Vaš korisnički račun je uspješno kreiran."
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1403,8 +1381,8 @@ msgstr "Pronađeno je %s zapisa"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1463,11 +1441,11 @@ msgstr "Vaš korisnički račun je uspješno kreiran."
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1478,11 +1456,11 @@ msgstr "Da"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1495,8 +1473,8 @@ msgstr "Ne"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1593,8 +1571,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1614,29 +1592,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1645,9 +1623,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 #, fuzzy
 msgid "Requested record does not seem to exist."
 msgstr "Nažalost, zapis %s ne postoji."
@@ -2009,16 +1987,14 @@ msgstr "Zapis je obrisan."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2039,8 +2015,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2202,8 +2178,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2312,7 +2288,7 @@ msgstr "Akcija"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Opis"
 
@@ -2507,8 +2483,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2794,9 +2770,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "Ako želite možete se prijaviti %(x_url_open)sovdje%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2852,7 +2827,7 @@ msgstr "Odbijeno"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "OK"
 
@@ -2860,8 +2835,8 @@ msgstr "OK"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "Vaš korisnički račun je uspješno kreiran."
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3334,8 +3309,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "Email"
 
@@ -3842,8 +3817,7 @@ msgstr ""
 #, fuzzy, python-format
 msgid "A %(x_url_open)snew copy%(x_url_close)s has been added."
 msgstr ""
-"Molimo %(x_url_open)sprihvatite ili odbijte%(x_url_close)s zahtjev "
-"korisnika."
+"Molimo %(x_url_open)sprihvatite ili odbijte%(x_url_close)s zahtjev korisnika."
 
 #: invenio/legacy/bibcirculation/templates.py:7443
 #, fuzzy
@@ -4188,8 +4162,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4207,8 +4181,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4274,17 +4248,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4673,25 +4647,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "Zapis je obrisan."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4751,15 +4725,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4771,10 +4745,10 @@ msgstr "Izaberi temu"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4788,15 +4762,15 @@ msgstr "Pravila"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4807,7 +4781,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4826,17 +4801,15 @@ msgstr "Uneseni nadimak %s već postoji u bazi podataka."
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "Uneseni nadimak %s već postoji u bazi podataka."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4855,14 +4828,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4916,8 +4888,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4972,8 +4944,8 @@ msgstr "Nažalost, zapis %s ne postoji."
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -5094,9 +5066,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -5111,8 +5083,8 @@ msgstr "Sačuvaj izmjene"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -5256,11 +5228,10 @@ msgstr "Natrag na rezultate pretrage"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5397,7 +5368,7 @@ msgid "Total"
 msgstr "neobavezno"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Odaberi"
 
@@ -5568,8 +5539,8 @@ msgstr "Izbriši bazu znanja"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5628,56 +5599,56 @@ msgstr "Molimo prvo se prijavite."
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5717,7 +5688,7 @@ msgstr "Zavisnosti baze znanje"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5771,15 +5742,15 @@ msgstr "Vaša upozorenja"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -6011,8 +5982,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -6091,8 +6061,8 @@ msgstr "Referenca još nije dana"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6107,8 +6077,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Pretraži rezultate"
 
@@ -6269,8 +6239,8 @@ msgstr "Nema pronađenih vrijednosti"
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6296,8 +6266,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6308,24 +6278,22 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
 #, python-format
 msgid "No exact match found for %(x_query1)s, using %(x_query2)s instead..."
 msgstr ""
-"Nema rezultata za %(x_query1)s, umjesto traženog koristi se "
-"%(x_query2)s..."
+"Nema rezultata za %(x_query1)s, umjesto traženog koristi se %(x_query2)s..."
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
@@ -6334,16 +6302,16 @@ msgstr ""
 "Nije pronađeno u kolekciji %(x_collection)s. Pretraživanje drugih javnih "
 "kolekcija dalo je %(x_url_open)s%(x_nb_hits)d rezultate%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 "Vaš upit nije pronađen niti u jednoj javnoj kolekciji. Ako ste tražili "
 "privatni dokument, molimo prvo odaberite željenu ograničenu kolekciju."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
@@ -6351,95 +6319,97 @@ msgstr ""
 "Vaš upit nije pronađen niti u jednoj javnoj kolekciji. Ako ste tražili "
 "privatni dokument, molimo prvo odaberite željenu ograničenu kolekciju."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
-msgstr "Traženi pojam %s nije pronađen. Najsličniji pojmovi u svim kolekcijama su:"
+msgstr ""
+"Traženi pojam %s nije pronađen. Najsličniji pojmovi u svim kolekcijama su:"
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "Koristite druge pojmove za pretragu."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "%i košarica"
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "%i košarica"
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "%i košarica"
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Indeks riječi nije dostupan za"
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Indeks fraza nije dostupan za"
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, fuzzy, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 "Traženi pojam %(x_term)s u popisu %(x_index)s nije pronađen. Najsličniji "
 "pojmovi u svim kolekcijama su:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
-msgstr "Traženi pojam %s nije pronađen. Najsličniji pojmovi u svim kolekcijama su:"
+msgstr ""
+"Traženi pojam %s nije pronađen. Najsličniji pojmovi u svim kolekcijama su:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
-"Nažalost, %s nije valjana opcija za sortiranje. Umjesto toga, izabrano je"
-" sortiranje prema naslovu."
+"Nažalost, %s nije valjana opcija za sortiranje. Umjesto toga, izabrano je "
+"sortiranje prema naslovu."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
-"Nažalost, sortiranje je dozvoljeno samo na skupovima od više od %d "
-"zapisa. Koristi se uobičajeno sortiranje."
+"Nažalost, sortiranje je dozvoljeno samo na skupovima od više od %d zapisa. "
+"Koristi se uobičajeno sortiranje."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
-"Nažalost, %s nije valjana opcija za sortiranje. Umjesto toga, izabrano je"
-" sortiranje prema naslovu."
+"Nažalost, %s nije valjana opcija za sortiranje. Umjesto toga, izabrano je "
+"sortiranje prema naslovu."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Taj unos ne postoji"
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Koristite druge pojmove za pretragu."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6453,12 +6423,12 @@ msgstr "Koristite druge pojmove za pretragu."
 msgid "Browse"
 msgstr "Pregledaj"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 #, fuzzy
 msgid "No match within your time limits, discarding this condition..."
 msgstr "Nema rezultata u traženim vremenskim okvirima, zahtjev je odbačen..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr "Nema rezultata u traženim okvirima, zahtjev je odbačen..."
 
@@ -6502,15 +6472,13 @@ msgstr "Upozorenje %s je uspješno osvježeno. "
 #: invenio/legacy/webalert/api.py:428
 #, fuzzy, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Napravili ste %(x_nb)s upit(a). %(x_url_open)sOpširnija "
-"lista%(x_url_close)s je dostupna s mogućnostima (a) pregleda rezultata "
-"pretraživanja i (b) predbilježbe na uslugu automatskih email obavijesti "
-"za te upite."
+"Napravili ste %(x_nb)s upit(a). %(x_url_open)sOpširnija lista%(x_url_close)s "
+"je dostupna s mogućnostima (a) pregleda rezultata pretraživanja i (b) "
+"predbilježbe na uslugu automatskih email obavijesti za te upite."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6652,9 +6620,8 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"Postavite novo upozorenje iz %(x_url1_open)svaših "
-"pretraga%(x_url1_close)s, %(x_url2_open)spopularnih "
-"pretraga%(x_url2_close)s ili putem obrasca za unos."
+"Postavite novo upozorenje iz %(x_url1_open)svaših pretraga%(x_url1_close)s, "
+"%(x_url2_open)spopularnih pretraga%(x_url2_close)s ili putem obrasca za unos."
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6705,20 +6672,20 @@ msgstr "Definirali ste %s upozorenja."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
-"Još niste izvršili pretraživanje. Molimo otiđite na %(x_url_open)ssučelje"
-" za pretraživanje%(x_url_close)s."
+"Još niste izvršili pretraživanje. Molimo otiđite na %(x_url_open)ssučelje za "
+"pretraživanje%(x_url_close)s."
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
-"Izvršili ste %(x_nb1)s pretraživanja (%(x_nb2)s različitih upita) tijekom"
-" poslijednjih 30 dana."
+"Izvršili ste %(x_nb1)s pretraživanja (%(x_nb2)s različitih upita) tijekom "
+"poslijednjih 30 dana."
 
 #: invenio/legacy/webalert/templates.py:453
 #, fuzzy, python-format
@@ -6777,7 +6744,7 @@ msgstr "Vaše pretrage"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6841,7 +6808,7 @@ msgstr "Postavi novo upozorenje"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6901,7 +6868,8 @@ msgstr "Prikaži upozorenja"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6925,7 +6893,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "Nemate ovlaštenja pogledati sadržaj košarice."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6953,7 +6922,8 @@ msgid "You do not have permission to delete this note."
 msgstr "Nemate ovlaštenja pogledati sadržaj košarice."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6984,8 +6954,8 @@ msgstr "Taj unos ne postoji"
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -7007,8 +6977,8 @@ msgstr "Kopiraj zapis u košaricu"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -7041,8 +7011,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7115,12 +7085,10 @@ msgstr "Javna košarica"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
-"Imate %(x_nb_perso)s osobnih košarica i predbilježeni ste na "
-"%(x_nb_group)s grupnih košarica i %(x_nb_public)s javnih košarica drugih "
-"korisnika"
+"Imate %(x_nb_perso)s osobnih košarica i predbilježeni ste na %(x_nb_group)s "
+"grupnih košarica i %(x_nb_public)s javnih košarica drugih korisnika"
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
 #, fuzzy
@@ -7147,11 +7115,9 @@ msgstr "%i grupa korisnika je predbilježeno na ovu košaricu."
 #: invenio/legacy/webbasket/templates.py:108
 #, fuzzy, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
-"Sada možete pristupiti %(x_url_open)sVašem korisničkom "
-"računu%(x_url_close)s."
+"Sada možete pristupiti %(x_url_open)sVašem korisničkom računu%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
 #: invenio/legacy/webbasket/templates.py:198
@@ -7323,8 +7289,8 @@ msgstr "Vanjski zapis"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7346,8 +7312,7 @@ msgstr "Ako želite možete se prijaviti %(x_url_open)sovdje%(x_url_close)s."
 #, fuzzy, python-format
 msgid " or return to your %(x_url_open)sprevious basket%(x_url_close)s"
 msgstr ""
-"Sada možete pristupiti %(x_url_open)sVašem korisničkom "
-"računu%(x_url_close)s."
+"Sada možete pristupiti %(x_url_open)sVašem korisničkom računu%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:1653
 #, fuzzy, python-format
@@ -7511,18 +7476,19 @@ msgstr "Zajednička košarica za novu grupu"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr "Prijavljeni ste kao gost, pa će vaša košarica nestati kad se odjavite."
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
-"Ako želite, možete se %(x_url_open)sprijaviti ili registrirati "
-"ovdje%(x_url_close)s."
+"Ako želite, možete se %(x_url_open)sprijaviti ili registrirati ovdje"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7531,7 +7497,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Ova funkcionalnost nije dostupna za goste."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Natrag na rezultate pretrage"
 
@@ -7706,7 +7672,7 @@ msgstr "Dodaj u korisnike"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7853,217 +7819,218 @@ msgstr "Korisnik %s ne postoji."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "Korisnik %s ne postoji."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Unesi komentar"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_name)s je napisao/la datuma %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "komentari"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Prikaz poslijednjih %i komentara:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Raspravi o ovom dokumentu"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Započni raspravu vezanu uz ovaj dokument."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Nažalost, zapis %s ne postoji."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "Nažalost, %s nije ispravan ID."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "Nažalost, nije upisan ID zapisa."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Započnite pregledavanje od %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_name)s je napisao/la datuma %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Da lije ovo izvješće bilo korisno?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Napiši izvješće"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, fuzzy, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 "Prosječna ocjena izvješća: %(x_nb_score)s bazirana na %(x_nb_reviews)s "
 "izvješća"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "Čitatelji su slijedećih %s izvješća ocijenili kao najkorisnije."
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Pogledajte svih %s izvješća"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Ocijeni ovaj dokument"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Prvi izvjestite o ovom dokumentu"
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "Rezultat"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Prijavi zloupotrebu"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 #, fuzzy
 msgid "Undelete comment"
 msgstr "obriši komentare"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Obriši komentar"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 #, fuzzy
 msgid "Unreport comment"
 msgstr "Obriši komentar"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Pregledao/la %(x_nickname)s datuma %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
-msgstr "%(x_nb_people)i od %(x_nb_total)i korisnika smatra ovo izvješće korisnim"
+msgstr ""
+"%(x_nb_people)i od %(x_nb_total)i korisnika smatra ovo izvješće korisnim"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 #, fuzzy
 msgid "Undelete review"
 msgstr "Obriši odabrana izvješća"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 #, fuzzy
 msgid "Delete review"
 msgstr "Obriši odabrana izvješća"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 #, fuzzy
 msgid "Unreport review"
 msgstr "Upiši svoje izvješće"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Komentari"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Pregledi (#)"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Ukupno ima %s izvješća"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Ukupno ima %s komentara"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Prvi izvjestite o ovom dokumentu"
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Predbilježba (#)"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 #, fuzzy
 msgid "Unsubscribe"
 msgstr "Predbilježba (#)"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -8072,44 +8039,43 @@ msgstr "Predbilježba (#)"
 msgid "Record"
 msgstr "Unos"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "izvješće"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "komentar"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Izvješće"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 #, fuzzy
 msgid "Viewing"
 msgstr "Pregled"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Stranica:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 #, fuzzy
 msgid "You are not authorized to comment or review."
 msgstr "Vi niste vlasnik ove košarice."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr "Napomena: Vaš nadimak, %s, bit će prikazan kao autor ovog komentara"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
@@ -8118,477 +8084,481 @@ msgstr ""
 "Napomena: niste %(x_url_open)sdefinirali svoj nadimak%(x_url_close)s. "
 "%(x_nickname)s ćebiti prikazano kao autor ovog komentara."
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 #, fuzzy
 msgid "Max one file"
 msgstr "Dodaj novo pravilo"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "dokument(i)"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Članak"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 #, fuzzy
 msgid "Add comment"
 msgstr "Dodaj komentar"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr "Napomena: Vaš nadimak, %s, bit će prikazan kao autor ovog izvješća."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Ocijeni ovaj članak"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 #, fuzzy
 msgid "Select a score"
 msgstr "Izaberi ocjenu"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Unesi naslov svog izvješća"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Upiši svoje izvješće"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 #, fuzzy
 msgid "Add review"
 msgstr "Dodaj izvješće"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Dodaj izvješće"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Vaše izvješće je uspješno dodano."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Vaš komentar je uspješno dodan."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Natrag na zapis"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
-msgstr "Možete se konzultirati listom %(x_url_open)sVaših grupa%(x_url_close)s."
+msgstr ""
+"Možete se konzultirati listom %(x_url_open)sVaših grupa%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 #, fuzzy
 msgid "View most commented records"
 msgstr "pogledaj komentare"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 #, fuzzy
 msgid "View latest commented records"
 msgstr "pogledaj komentare"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all comments reported as abuse"
 msgstr "Pogledaj sve prijavljene korisnike (#)"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 #, fuzzy
 msgid "View most reviewed records"
 msgstr "ukloni zapise"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 #, fuzzy
 msgid "View latest reviewed records"
 msgstr "Pogledajte svih %s izvješća"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all reviews reported as abuse"
 msgstr "Pogledaj sve prijavljene korisnike (#)"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Pogledaj sve prijavljene korisnike"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Vodič"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Komentari i izvješća su isključeni"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"Unesite ID komentara/izvješća kako biste ih mogli pogledati prije nego "
-"što odlučite hoćete li ih obrisati"
+"Unesite ID komentara/izvješća kako biste ih mogli pogledati prije nego što "
+"odlučite hoćete li ih obrisati"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "ID komentara:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 #, fuzzy
 msgid "Record ID:"
 msgstr "ID unosa"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Pogledaj komentar"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Za sada nema izvještaja."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Pogledaj svih %s komentara"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Pogledaj svih %s izvješća"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-"Ovdje je lista, sortirana prema ukupnom broju prijava, svih korisnika "
-"koji imaju prijavljen barem jedan komentar."
+"Ovdje je lista, sortirana prema ukupnom broju prijava, svih korisnika koji "
+"imaju prijavljen barem jedan komentar."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Nadimak"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "Korisničko ime"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Broj pozitivnih glasova"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Broj negativnih glasova"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Ukupan broj glasova"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Ukupan broj prijava"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Pogledaj sve korisnikove komentare/izvješća"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Ovo izvješće je prijavljeno %i puta"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Ovaj komentar je prijavljen %i puta"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Napisao/la"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Opći podaci"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Obriši odabrana izvješća"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Izostavi označene izvještaje o zloupotrebi"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 #, fuzzy
 msgid "Undelete selected reviews"
 msgstr "Obriši odabrana izvješća"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 #, fuzzy
 msgid "Undelete selected comments"
 msgstr "Briši označene komentare"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Briši označene komentare"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Ovdje su izvješća korisnika %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Ovdje su komentari korisnika %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Ovdje je komentar/pregled %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Ovdje je komentar/pregled %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, fuzzy, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Ovdje je komentar/pregled koji je %(x_cmtID)s napisao/la %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, fuzzy, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Ovdje je komentar/pregled koji je %(x_cmtID)s napisao/la %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "Sva prijavljena izvješća sortirana prema učastalosti prijave"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "Svi prijavljeni komentari sortirani prema učastalosti prijave"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr "Sva prijavljena izvješća sortirana prema učastalosti prijave"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 #, fuzzy
 msgid "Show comments"
 msgstr "pogledaj komentare"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr "Svi prijavljeni komentari sortirani prema učastalosti prijave"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 #, fuzzy
 msgid "Show reviews"
 msgstr "izvješće"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "ID komentara"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "uspješno izbrisano"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 #, fuzzy
 msgid "successfully undeleted"
 msgstr "uspješno izbrisano"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "uspješno onemogućeno izvještavanje o zloupotrebi"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 #, fuzzy
 msgid "Not yet reviewed"
 msgstr "Upiši svoje izvješće"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "Vaš komentar je uspješno poslan"
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Briši komentare"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "prvo najnovije"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "pogledaj komentare"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "Detalji i komentari"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "Pronađeno je %s zapisa"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Komentari"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "Vrijeme"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Dodaj u korisnike"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "Prikaži"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Datum stvaranja"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Slijedeća stranica"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Prikaži upozorenja"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8597,106 +8567,106 @@ msgstr "Prikaži upozorenja"
 msgid "Refresh"
 msgstr "Referenca"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Obriši komentar"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "Nema pronađenih vrijednosti"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Zapis nije pronađen"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "Nemate ovlaštenja pogledati sadržaj košarice."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Dodaj komentar"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "Pogledaj sve prijavljene komentare"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 #, fuzzy
 msgid "Page Not Found"
 msgstr "Kolekcija %s nije pronađena"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 #, fuzzy
 msgid "The requested comment could not be found"
 msgstr "Taj unos ne postoji"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 #, fuzzy
 msgid "The requested file could not be found"
 msgstr "Taj unos ne postoji"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Vi niste vlasnik ove košarice."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Komentari"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "Pogledaj sve prijavljene komentare"
@@ -8819,11 +8789,10 @@ msgstr "Nažalost, zapis %s ne postoji."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, fuzzy, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
-"Sada možete pristupiti %(x_url_open)sVašem korisničkom "
-"računu%(x_url_close)s."
+"Sada možete pristupiti %(x_url_open)sVašem korisničkom računu%(x_url_close)s."
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
 #, fuzzy, python-format
@@ -8894,8 +8863,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8923,8 +8892,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -9028,11 +8997,6 @@ msgstr ""
 msgid "Apply"
 msgstr "Travanj"
 
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "Nadimak"
-
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 #, fuzzy
 msgid "WebJournal Admin"
@@ -9117,9 +9081,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -9141,8 +9104,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9630,14 +9592,14 @@ msgstr "Također pretraži:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9652,7 +9614,8 @@ msgstr "Naveo/la: %s zapisa"
 #: invenio/legacy/websearch/templates.py:1856
 #, python-format
 msgid "Words nearest to %(x_word)s inside %(x_field)s in any collection are:"
-msgstr "Riječi najsličnije %(x_word)s unutar %(x_field)s u svim kolekcijama su:"
+msgstr ""
+"Riječi najsličnije %(x_word)s unutar %(x_field)s u svim kolekcijama su:"
 
 #: invenio/legacy/websearch/templates.py:1859
 #, python-format
@@ -9732,8 +9695,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found %(x_nb_records)s "
 "records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sPrikaz rezultata:%(x_fmt_close)s Pronađeno %(x_nb_records)s"
-" zapisa u %(x_nb_seconds)s sekunda."
+"%(x_fmt_open)sPrikaz rezultata:%(x_fmt_close)s Pronađeno %(x_nb_records)s "
+"zapisa u %(x_nb_seconds)s sekunda."
 
 #: invenio/legacy/websearch/templates.py:3132
 #, fuzzy, python-format
@@ -9746,8 +9709,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found at least "
 "%(x_nb_records)s records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sPrikaz rezultata:%(x_fmt_close)s Pronađeno %(x_nb_records)s"
-" zapisa u %(x_nb_seconds)s sekunda."
+"%(x_fmt_open)sPrikaz rezultata:%(x_fmt_close)s Pronađeno %(x_nb_records)s "
+"zapisa u %(x_nb_seconds)s sekunda."
 
 #: invenio/legacy/websearch/templates.py:3184
 #, fuzzy
@@ -9775,11 +9738,9 @@ msgstr "Vaše prijavke"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
-"Logički upit nije dao rezultate. Molimo drugačije povežite tražene "
-"pojmove."
+"Logički upit nije dao rezultate. Molimo drugačije povežite tražene pojmove."
 
 #: invenio/legacy/websearch/templates.py:3357
 msgid "See also: similar author names"
@@ -9804,8 +9765,8 @@ msgstr "Započni pregledavanje od %s. "
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3832
@@ -9999,8 +9960,10 @@ msgid "in"
 msgstr "u"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
-msgstr "Niste pronašli ono što ste htjeli? Pokušajte pretražiti na ovim serverima:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
+msgstr ""
+"Niste pronašli ono što ste htjeli? Pokušajte pretražiti na ovim serverima:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
 msgid "External collections results overview:"
@@ -10044,7 +10007,8 @@ msgstr "Postavke"
 msgid ""
 "You can consult the list of your external groups directly in the "
 "%(x_url_open)sgroups page%(x_url_close)s."
-msgstr "Možete se konzultirati listom %(x_url_open)sVaših grupa%(x_url_close)s."
+msgstr ""
+"Možete se konzultirati listom %(x_url_open)sVaših grupa%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:110
 #, fuzzy
@@ -10095,8 +10059,8 @@ msgstr "obavezno"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -10107,11 +10071,11 @@ msgstr "Kreiraj novu košaricu"
 #: invenio/legacy/websession/templates.py:270
 #, fuzzy
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
-"Ako želite promijeniti Vašu email adresu ili lozinku, molimo unesite nove"
-" vrijednosti dolje."
+"Ako želite promijeniti Vašu email adresu ili lozinku, molimo unesite nove "
+"vrijednosti dolje."
 
 #: invenio/legacy/websession/templates.py:271
 #, fuzzy
@@ -10128,18 +10092,18 @@ msgstr "Postavi nove vrijednosti"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:325
 #, fuzzy
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
-"Ako želite promijeniti Vašu email adresu ili lozinku, molimo unesite nove"
-" vrijednosti dolje."
+"Ako želite promijeniti Vašu email adresu ili lozinku, molimo unesite nove "
+"vrijednosti dolje."
 
 #: invenio/legacy/websession/templates.py:327
 #, fuzzy
@@ -10178,11 +10142,11 @@ msgstr "Nova lozinka"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
-"Ako želite, možete se %(x_url_open)sprijaviti ili registrirati "
-"ovdje%(x_url_close)s."
+"Ako želite, možete se %(x_url_open)sprijaviti ili registrirati ovdje"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:346
 #, fuzzy, python-format
@@ -10190,8 +10154,7 @@ msgid ""
 "You can change or reset your CERN account password by means of the "
 "%(x_url_open)sCERN account system%(x_url_close)s."
 msgstr ""
-"Sada možete pristupiti %(x_url_open)sVašem korisničkom "
-"računu%(x_url_close)s."
+"Sada možete pristupiti %(x_url_open)sVašem korisničkom računu%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:372
 #, fuzzy
@@ -10277,13 +10240,12 @@ msgstr "Izaberite način"
 #: invenio/legacy/websession/templates.py:537
 #, fuzzy, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"Ako ste zaboravili lozinku za Vaš Invenio korisnički račun, molimo "
-"unesite Vašu email adresu ispod. Lozinka će Vam biti poslana."
+"Ako ste zaboravili lozinku za Vaš Invenio korisnički račun, molimo unesite "
+"Vašu email adresu ispod. Lozinka će Vam biti poslana."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10300,16 +10262,16 @@ msgstr "Pošalji izgubljenu lozinku"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 #, fuzzy
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 "Primjetite da ako ste koristili vanjski sistem prijave (kao što je CERN "
 "NICE), tamo se morate obratiti sa pitanjima."
@@ -10320,21 +10282,20 @@ msgid ""
 "Alternatively, you can ask %(x_name)s to change your login system from "
 "external to internal."
 msgstr ""
-"Ili, možete zatražiti %s da se Vaš sistem prijave promijeni sa vanjskog u"
-" unutarnji."
+"Ili, možete zatražiti %s da se Vaš sistem prijave promijeni sa vanjskog u "
+"unutarnji."
 
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
-"%s nudi mogućnost personalizacije sučelja, postavljanja vlastite "
-"knjižnice dokumenata, ili postavljanje automatskog upozorenja koje će se "
-"pokretati periodički izvještavajući Vas o rezultatima pretrage putem "
-"email-a."
+"%s nudi mogućnost personalizacije sučelja, postavljanja vlastite knjižnice "
+"dokumenata, ili postavljanje automatskog upozorenja koje će se pokretati "
+"periodički izvještavajući Vas o rezultatima pretrage putem email-a."
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10355,8 +10316,8 @@ msgstr "Pogledajte sve svoje pretrage obavljene tijekom poslijednjih 30 dana."
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr "Pomoću košarice možete definirati specifične kolekcije stavki"
 
 #: invenio/legacy/websession/templates.py:636
@@ -10368,22 +10329,22 @@ msgid ""
 "Subscribe to a search which will be run periodically by our service. The "
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
-"Predbilježite se na pretraživanja koja će naš servis pokretati "
-"periodički. Rezultati će Vam ili biti poslani putem e-maila ili će biti "
-"spremljeni u neku od Vaših košarica."
+"Predbilježite se na pretraživanja koja će naš servis pokretati periodički. "
+"Rezultati će Vam ili biti poslani putem e-maila ili će biti spremljeni u "
+"neku od Vaših košarica."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
-msgstr ""
-"Odjavi posuđenu knjigu, prijevi zahtjev za posudbom, itd. Potreban je "
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
 "CERN ID."
+msgstr ""
+"Odjavi posuđenu knjigu, prijevi zahtjev za posudbom, itd. Potreban je CERN "
+"ID."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
 "Prijavljeni ste kao gost, pa će Vaša upozorenja nestati nakon što se "
 "odjavite."
@@ -10391,20 +10352,21 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
-"Prijavljeni ste kao %(x_user)s. Možda želite a) %(x_url1_open)sodjaviti "
-"se%(x_url1_close)s; b) urediti %(x_url2_open)spostavke svog korisničkog "
-"računa%(x_url2_close)s."
+"Prijavljeni ste kao %(x_user)s. Možda želite a) %(x_url1_open)sodjaviti se"
+"%(x_url1_close)s; b) urediti %(x_url2_open)spostavke svog korisničkog računa"
+"%(x_url2_close)s."
 
 #: invenio/legacy/websession/templates.py:785
 #, fuzzy, python-format
 msgid ""
 "You can consult the list of %(x_url_open)syour comments%(x_url_close)s "
 "submitted so far."
-msgstr "Možete se konzultirati listom %(x_url_open)sVaših grupa%(x_url_close)s."
+msgstr ""
+"Možete se konzultirati listom %(x_url_open)sVaših grupa%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:790
 #, fuzzy
@@ -10414,11 +10376,11 @@ msgstr "Vaše pretrage s upozorenjem"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
-"Možete se konzultirati listom %(x_url_open)sVaših grupa%(x_url_close)s "
-"koje administrirate ili ste im član."
+"Možete se konzultirati listom %(x_url_open)sVaših grupa%(x_url_close)s koje "
+"administrirate ili ste im član."
 
 #: invenio/legacy/websession/templates.py:799
 #: invenio/legacy/websession/templates.py:2348
@@ -10429,11 +10391,11 @@ msgstr "Vaše grupe"
 #: invenio/legacy/websession/templates.py:802
 #, fuzzy, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"Možete se konzultirati listom %(x_url_open)sVaših "
-"prijavaka%(x_url_close)sc i informirati se o njihovom statusu."
+"Možete se konzultirati listom %(x_url_open)sVaših prijavaka%(x_url_close)sc "
+"i informirati se o njihovom statusu."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -10444,11 +10406,11 @@ msgstr "Vaše prijavke"
 #: invenio/legacy/websession/templates.py:808
 #, fuzzy, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"Možete se konzultirati listom %(x_url_open)sVaših "
-"odobrenja%(x_url_close)s sa dokumentima koje ste odobrili ili moderirali."
+"Možete se konzultirati listom %(x_url_open)sVaših odobrenja%(x_url_close)s "
+"sa dokumentima koje ste odobrili ili moderirali."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10458,7 +10420,8 @@ msgstr "Vaša odobrenja"
 #: invenio/legacy/websession/templates.py:815
 #, fuzzy, python-format
 msgid "You can consult the list of %(x_url_open)syour tickets%(x_url_close)s."
-msgstr "Možete se konzultirati listom %(x_url_open)sVaših grupa%(x_url_close)s."
+msgstr ""
+"Možete se konzultirati listom %(x_url_open)sVaših grupa%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:818
 #, fuzzy
@@ -10494,7 +10457,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -10545,30 +10509,27 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1015
 #, fuzzy, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 "Ukoliko već nemate otvoren korisnički račun, molimo "
-"%(x_url_open)sregistrirajte se%(x_url_close)s na unutarnji korisnički "
-"račun."
+"%(x_url_open)sregistrirajte se%(x_url_close)s na unutarnji korisnički račun."
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
 "Ukoliko već nemate otvoren korisnički račun, molimo "
-"%(x_url_open)sregistrirajte se%(x_url_close)s na unutarnji korisnički "
-"račun."
+"%(x_url_open)sregistrirajte se%(x_url_close)s na unutarnji korisnički račun."
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
 msgid "If you don't own an account yet, please contact %(x_name)s."
 msgstr ""
 "Ukoliko već nemate otvoren korisnički račun, molimo "
-"%(x_url_open)sregistrirajte se%(x_url_close)s na unutarnji korisnički "
-"račun."
+"%(x_url_open)sregistrirajte se%(x_url_close)s na unutarnji korisnički račun."
 
 #: invenio/legacy/websession/templates.py:1051
 #, fuzzy
@@ -10599,8 +10560,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -10629,9 +10590,10 @@ msgstr "Molimo unesite svoju emailadresu i željeni nadimak i lozinku:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
-msgstr "Nećete moći koristiti korisnički račun prije verifikacije i aktivacije."
+"It will not be possible to use the account before it has been verified and "
+"activated."
+msgstr ""
+"Nećete moći koristiti korisnički račun prije verifikacije i aktivacije."
 
 #: invenio/legacy/websession/templates.py:1228
 msgid "Retype Password"
@@ -10647,22 +10609,22 @@ msgstr "registriraj se"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
 "Molimo da na ovom servisu ne koristite lozinke koje koristite na drugim "
-"servisima. Vaša email adresa ostat će tajna i nigdje neće biti "
-"objavljena. Bit će korištena samo za Vašu identifikaciju prilikom "
-"korištenja servisa %s. Na primjer, možete postaviti da Vam dnevno dolazi "
-"email sa rezultatima automatskog pretraživanja novih preprinata."
+"servisima. Vaša email adresa ostat će tajna i nigdje neće biti objavljena. "
+"Bit će korištena samo za Vašu identifikaciju prilikom korištenja servisa %s. "
+"Na primjer, možete postaviti da Vam dnevno dolazi email sa rezultatima "
+"automatskog pretraživanja novih preprinata."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 "Ne možete sami kreirati korisnički račun. Kontaktirajte %s za otvaranje "
 "računa."
@@ -10670,8 +10632,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr "Vi ste gost. Morate se prvo %(x_url_open)sprijaviti%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1267
@@ -10806,11 +10768,11 @@ msgstr "Neki zanimljivi linkovi za Vas:"
 #: invenio/legacy/websession/templates.py:1325
 #, fuzzy, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
-"Za još administracijskih aktivnosti, pogledajte %(x_url_open)sAdmin "
-"područje%(x_url_close)s."
+"Za još administracijskih aktivnosti, pogledajte %(x_url_open)sAdmin područje"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1378
 msgid "guest"
@@ -11033,10 +10995,10 @@ msgstr "Korisnik se želi pridružiti grupi %s."
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
-"Molimo %(x_url_open)sprihvatite ili odbijte%(x_url_close)s zahtjev "
-"korisnika."
+"Molimo %(x_url_open)sprihvatite ili odbijte%(x_url_close)s zahtjev korisnika."
 
 #: invenio/legacy/websession/templates.py:2400
 #, fuzzy, python-format
@@ -11062,7 +11024,8 @@ msgstr "Vaš zahtjev za priključenjem grupi %s je odbijen."
 #: invenio/legacy/websession/templates.py:2426
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour groups%(x_url_close)s."
-msgstr "Možete se konzultirati listom %(x_url_open)sVaših grupa%(x_url_close)s."
+msgstr ""
+"Možete se konzultirati listom %(x_url_open)sVaših grupa%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:2422
 #, fuzzy, python-format
@@ -11077,79 +11040,74 @@ msgstr "Grupa %s je obrisana od strane administratora."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"Možete se konzultirati listom %(x_url_open)s%(x_nb_total)i "
-"grupa%(x_url_close)s na koje ste predbilježeni (%(x_nb_member)i) ili ih "
+"Možete se konzultirati listom %(x_url_open)s%(x_nb_total)i grupa"
+"%(x_url_close)s na koje ste predbilježeni (%(x_nb_member)i) ili ih "
 "administrirate (%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
-"Prijavljeni ste kao gost. Možda se želite "
-"%(x_url_open)sprijaviti%(x_url_close)s kao redoviti korisnik."
+"Prijavljeni ste kao gost. Možda se želite %(x_url_open)sprijaviti"
+"%(x_url_close)s kao redoviti korisnik."
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
-"%(x_fmt_open)sGosti%(x_fmt_close)s se prvo trebaju "
-"%(x_url_open)sregistrirati%(x_url_close)s"
+"%(x_fmt_open)sGosti%(x_fmt_close)s se prvo trebaju %(x_url_open)sregistrirati"
+"%(x_url_close)s"
 
 #: invenio/legacy/websession/webaccount.py:127
 msgid "No queries found"
@@ -11157,14 +11115,14 @@ msgstr "Upiti nisu pronađeni"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -11173,8 +11131,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11186,8 +11144,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11267,8 +11225,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11321,8 +11278,7 @@ msgstr ""
 #, fuzzy, python-format
 msgid "You can now go to %(x_url_open)syour account page%(x_url_close)s."
 msgstr ""
-"Sada možete pristupiti %(x_url_open)sVašem korisničkom "
-"računu%(x_url_close)s."
+"Sada možete pristupiti %(x_url_open)sVašem korisničkom računu%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:136
 #: invenio/legacy/websession/webinterface.py:145
@@ -11336,8 +11292,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -11403,10 +11358,10 @@ msgstr "Uredi način prijave"
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -11435,8 +11390,8 @@ msgstr "Uspješno je izabran način prijave."
 #: invenio/legacy/websession/webinterface.py:452
 #, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -11570,8 +11525,8 @@ msgid ""
 "Cannot send password reset request since you are using external "
 "authentication system."
 msgstr ""
-"Nismou mogućnosti poslati lozinku putem email-a jer koristite vanjski "
-"sistem autentifikacije."
+"Nismou mogućnosti poslati lozinku putem email-a jer koristite vanjski sistem "
+"autentifikacije."
 
 #: invenio/legacy/websession/webinterface.py:665
 msgid "The entered email address does not exist in the database."
@@ -11624,25 +11579,24 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
-"Drugi email biti će poslan kad se korisnički račun aktivira i bude "
-"spreman za uporabu."
+"Drugi email biti će poslan kad se korisnički račun aktivira i bude spreman "
+"za uporabu."
 
 #: invenio/legacy/websession/webinterface.py:989
 #, python-format
 msgid "You can now access your %(x_url_open)saccount%(x_url_close)s."
 msgstr ""
-"Sada možete pristupiti %(x_url_open)sVašem korisničkom "
-"računu%(x_url_close)s."
+"Sada možete pristupiti %(x_url_open)sVašem korisničkom računu%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:996
 #: invenio/legacy/websession/webinterface.py:1001
@@ -11754,8 +11708,10 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
-msgstr "Zapis kreiran %(x_date_creation)s, zadnja izmjena %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+"Zapis kreiran %(x_date_creation)s, zadnja izmjena %(x_date_modification)s"
 
 #: invenio/legacy/webstyle/templates.py:707
 msgid "The server encountered an error while dealing with your request."
@@ -11777,37 +11733,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11815,15 +11771,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11891,8 +11847,8 @@ msgstr "Nije moguće odretiti broj prijavljenih stranica."
 #: invenio/legacy/websubmit/engine.py:931
 #, fuzzy
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr "Nije moguće kreirati direktorij."
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11929,8 +11885,8 @@ msgstr "Prihvati"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11978,8 +11934,8 @@ msgstr "Odaberite kategoriju i kliknite na gumb"
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr "Za nastavak prekinute prijave, unesite pristupni broj u polje ispod:"
 
 #: invenio/legacy/websubmit/templates.py:366
@@ -12008,8 +11964,8 @@ msgstr "Natrag na glavni izbornik"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 "Ovo je Vaš prijavni broj. Koristite ga za nastavak prekinute prijave u "
 "slučaju problema."
@@ -12060,11 +12016,11 @@ msgstr "Broj prijave"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
-"Ovdje je %(x_action)s lista funkcija %(x_doctype)s za dokumente na razini"
-" %(x_step)s"
+"Ovdje je %(x_action)s lista funkcija %(x_doctype)s za dokumente na razini "
+"%(x_step)s"
 
 #: invenio/legacy/websubmit/templates.py:1041
 msgid "Function"
@@ -12150,11 +12106,10 @@ msgstr "Lista moderiranih tipova dokumenata"
 #: invenio/legacy/websubmit/templates.py:1479
 #, fuzzy
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
-"Odaberite jedan od slijedećih tipova dokumenata kako biste provjerili "
-"status dokumenta."
+"Odaberite jedan od slijedećih tipova dokumenata kako biste provjerili status "
+"dokumenta."
 
 #: invenio/legacy/websubmit/templates.py:1447
 msgid "Go to specific approval workflow"
@@ -12297,7 +12252,8 @@ msgstr "Odobreno"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr "Ovaj dokument još %(x_fmt_open)sčeka na odobrenje%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -12320,8 +12276,8 @@ msgid ""
 "You can send an approval request email again by clicking the following "
 "button:"
 msgstr ""
-"Možete ponovno poslati zahtjev za odobrenjem tako da kliknete na "
-"slijedeći gumb:"
+"Možete ponovno poslati zahtjev za odobrenjem tako da kliknete na slijedeći "
+"gumb:"
 
 #: invenio/legacy/websubmit/templates.py:2149
 #: invenio/legacy/websubmit/web/publiline.py:367
@@ -12338,8 +12294,7 @@ msgid ""
 "As a referee for this document, you may approve or reject it from the "
 "submission interface"
 msgstr ""
-"Kao moderator ovog dokumenta, možete ga klikom na gumb odobriti ili "
-"odbiti."
+"Kao moderator ovog dokumenta, možete ga klikom na gumb odobriti ili odbiti."
 
 #: invenio/legacy/websubmit/templates.py:2155
 msgid "Approve/Reject"
@@ -12396,8 +12351,8 @@ msgstr "Izaberi ocjenu"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -12417,8 +12372,8 @@ msgstr "Unesi komentar"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -12459,7 +12414,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12481,14 +12437,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -12611,10 +12566,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12908,8 +12862,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12952,11 +12906,6 @@ msgstr "Odaberi košaricu"
 #, fuzzy
 msgid "Role details"
 msgstr "Članak"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Sakrij"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -13072,8 +13021,8 @@ msgstr "Unesena email adresa %s već postoji u bazi podataka."
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -13138,9 +13087,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -13164,8 +13112,8 @@ msgstr "Nova lozinka"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr "Molimo unesite svoju emailadresu i željeni nadimak i lozinku:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -13194,11 +13142,10 @@ msgid "Problem with login."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr ""
-"Sada možete pristupiti %(x_url_open)sVašem korisničkom "
-"računu%(x_url_close)s."
+"Sada možete pristupiti %(x_url_open)sVašem korisničkom računu%(x_url_close)s."
 
 #: invenio/modules/accounts/views/accounts.py:152
 #, fuzzy, python-format
@@ -13240,8 +13187,7 @@ msgstr "Uređivanje postavki nije uspjelo"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13313,13 +13259,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13328,9 +13273,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13507,8 +13452,7 @@ msgstr "kolekcije"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13598,8 +13542,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13691,10 +13635,10 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
 "Poruka je predugačka, molimo skratite ju. Dozvoljeno je maksimalno %i "
 "znakova."
@@ -13740,12 +13684,12 @@ msgid "Review was sent"
 msgstr "Unesi komentar"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Ovaj komentar je prijavljen %i puta"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Ovaj komentar je prijavljen %i puta"
 
@@ -13798,9 +13742,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13819,8 +13762,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13830,7 +13773,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "Uneseni nadimak %s već postoji u bazi podataka."
 
@@ -13886,8 +13829,7 @@ msgstr "izvješće"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13927,8 +13869,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13974,7 +13915,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "Funkcija %s ne postoji"
 
@@ -14057,11 +13998,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "trenutno stanje:"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Vaša košarica"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -14096,8 +14032,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -14118,8 +14054,8 @@ msgstr "Indeks riječi nije dostupan za"
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -14135,8 +14071,7 @@ msgstr "Potvrda elementa oblikovanja %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14256,7 +14191,7 @@ msgstr "Prikaži svih %i autora"
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 #, fuzzy
 msgid "Edit This Record"
 msgstr "Molimo pokušajte drugi ID unosa"
@@ -14359,10 +14294,6 @@ msgstr "izvješće"
 msgid "Authors"
 msgstr "autor"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14455,8 +14386,8 @@ msgstr "Uredi ovlaštenja grupe"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "Nemate ovlaštenja pogledati sadržaj košarice."
 
 #: invenio/modules/groups/views.py:279
@@ -14469,12 +14400,12 @@ msgstr "Niste administrator nijedne grupe."
 msgid "Members"
 msgstr "Nema članova."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Mapiranje baze znanja"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14484,11 +14415,11 @@ msgstr "na"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "bilo koje polje"
@@ -14534,13 +14465,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "%i košarica"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "%i košarica"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14696,28 +14628,28 @@ msgstr "Nepoznati tip dokumenta"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14781,8 +14713,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -15154,7 +15086,7 @@ msgid "Tag name"
 msgstr "Nadimak"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "Uneseni nadimak %s već je u upotrebi."
 
@@ -15258,11 +15190,6 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "na"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15304,8 +15231,7 @@ msgstr "Opcije za pretraživanje:"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15514,7 +15440,7 @@ msgid "just now"
 msgstr "Morate znati"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s sekundi"
 
@@ -15573,6 +15499,36 @@ msgstr "bilo koja godina"
 msgid " years ago"
 msgstr "godina"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "BibFormat Admin"
+
+#~ msgid "Not authorized"
+#~ msgstr "autor"
+
+#~ msgid "Really delete"
+#~ msgstr "uspješno izbrisano"
+
+#~ msgid "Verify problem"
+#~ msgstr "Problem sa bazom podataka"
+
+#~ msgid "File"
+#~ msgstr "naslov"
+
+#~ msgid "niceName"
+#~ msgstr "Ime"
+
+#~ msgid "Id"
+#~ msgstr "Id"
+
+#~ msgid "Tickets"
+#~ msgstr "Vrijeme"
+
+#~ msgid "by"
+#~ msgstr "po"
+
+#~ msgid "Done"
+#~ msgstr "na"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Molimo odaberite kategoriju"
 
@@ -15582,14 +15538,8 @@ msgstr "godina"
 #~ msgid "Warning: Please, select a valid date"
 #~ msgstr "Molimo odaberite kategoriju"
 
-#~ msgid " or return to your %(x_url_open)ssearch%(x_url_close)s"
-#~ msgstr ""
-
 #~ msgid "*** basket name ***"
 #~ msgstr "Naziv košarice"
-
-#~ msgid ""
-#~ msgstr "Na unesenu adresu je poslan email sa korisničkim podacima."
 
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "Uredi način prijave"
@@ -15651,23 +15601,8 @@ msgstr "godina"
 #~ msgid "now"
 #~ msgstr "ne"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "BibFormat Admin"
-
-#~ msgid "Not authorized"
-#~ msgstr "autor"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "Korisnik %s ne postoji."
-
-#~ msgid "Really delete"
-#~ msgstr "uspješno izbrisano"
-
-#~ msgid "Verify problem"
-#~ msgstr "Problem sa bazom podataka"
-
-#~ msgid "File"
-#~ msgstr "naslov"
 
 #~ msgid "File %s already exists."
 #~ msgstr "Korisnik %s ne postoji."
@@ -15720,9 +15655,6 @@ msgstr "godina"
 #~ msgid "Not Mine!"
 #~ msgstr "Napomena"
 
-#~ msgid "Tickets"
-#~ msgstr "Vrijeme"
-
 #~ msgid "Request Tickets"
 #~ msgstr "Pravila"
 
@@ -15758,9 +15690,6 @@ msgstr "godina"
 
 #~ msgid "Create a new Person for your search"
 #~ msgstr "Nema pronađenih rezultata."
-
-#~ msgid "Id"
-#~ msgstr "Id"
 
 #~ msgid "A %s has been added."
 #~ msgstr "Grupa %s je obrisana"
@@ -15813,9 +15742,6 @@ msgstr "godina"
 #~ msgid "creating a new basket"
 #~ msgstr "Kreiraj novu košaricu"
 
-#~ msgid "by"
-#~ msgstr "po"
-
 #~ msgid "on"
 #~ msgstr "na"
 
@@ -15833,9 +15759,6 @@ msgstr "godina"
 
 #~ msgid "Editing topic"
 #~ msgstr "Uredi košaricu"
-
-#~ msgid "niceName"
-#~ msgstr "Ime"
 
 #~ msgid "Apply Changes"
 #~ msgstr "Spremi promjene"
@@ -15944,9 +15867,6 @@ msgstr "godina"
 
 #~ msgid "Verbose"
 #~ msgstr "Prikaži"
-
-#~ msgid "Done"
-#~ msgstr "na"
 
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "Vaše  promjene su PRIVREMENE."
@@ -16119,9 +16039,6 @@ msgstr "godina"
 #~ msgid "Citation Metrics"
 #~ msgstr "Povijest citiranosti"
 
-#~ msgid "WebSearch Admin Guide"
-#~ msgstr ""
-
 #~ msgid "Submit Guide"
 #~ msgstr "Pomoć "
 
@@ -16131,34 +16048,11 @@ msgstr "godina"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "Administracija unosa"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "Pretraži"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Odustani"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "Član ste slijedećih grupa:"
@@ -16172,12 +16066,6 @@ msgstr "godina"
 #~ msgid "Invert Selection"
 #~ msgstr "Referenca još nije dana"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Autor:"
 
@@ -16189,12 +16077,6 @@ msgstr "godina"
 
 #~ msgid "No status information found."
 #~ msgstr "Više informacija:"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "odjel"
@@ -16208,18 +16090,6 @@ msgstr "godina"
 #~ msgid "View name variants"
 #~ msgstr "pogledaj komentare"
 
-#~ msgid "The author has an internal ID!"
-#~ msgstr ""
-
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "komentari"
 
@@ -16229,87 +16099,20 @@ msgstr "godina"
 #~ msgid " Delete this ticket"
 #~ msgstr "Obriši košaricu"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "Nema dostupnih tipova dokumenta."
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Izaberi ocjenu"
 
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
 #~ msgid "Paper title: "
 #~ msgstr "Stranica:"
-
-#~ msgid "Ignore"
-#~ msgstr ""
 
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "Pronađene su slijedeće greške"
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "Izaberi ocjenu"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "Više informacija:"
@@ -16317,35 +16120,11 @@ msgstr "godina"
 #~ msgid "Please provide your first name"
 #~ msgstr "Molimo prvo se prijavite."
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "Vaše posudbe"
 
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
 #~ msgid "Your eMail:"
 #~ msgstr "Vaša upozorenja"
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "Obriši odabrana izvješća"
@@ -16353,186 +16132,35 @@ msgstr "godina"
 #~ msgid "Mark as your documents"
 #~ msgstr "sve vrste dokumenata"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "Ocijeni ovaj dokument"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Ocijeni ovaj dokument"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "ili kreiraj novu"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "Dodaj u korisnike"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Stranica:"
-
-#~ msgid "Showing the"
-#~ msgstr ""
 
 #~ msgid "most recent documents:"
 #~ msgstr "Lista referiranih dokumenata"
 
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Predlošci oblikovanja (#)"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Izaberi temu"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Datum stvaranja"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "Postavke"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "prijave"
@@ -16540,190 +16168,17 @@ msgstr "godina"
 #~ msgid "Choose system"
 #~ msgstr "Izaberi temu"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Pronađene su slijedeće greške"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Niste ovlašteni za pristup administracijskim funkcijama."
 
 #~ msgid "Claim this paper"
 #~ msgstr "Dodaj u korisnike"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Naveo/la: %s zapisa"
 
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
 #~ msgid "Revision"
 #~ msgstr "odjel"
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Promijeni karakteristike predloška"
@@ -16803,89 +16258,20 @@ msgstr "godina"
 #~ msgid "No Record Found for %s."
 #~ msgstr "Zapis nije pronađen"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Korisnik %s ne postoji."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "Karakteristike oblikovanja izlaza %s"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "Oblikuj datoteke vezane uz predložak %s"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "Potvrda elementa oblikovanja %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "Oblikuj datoteke vezane uz element %s"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Ograničeno oblikovanje izlaznih podataka"
@@ -16941,113 +16327,17 @@ msgstr "godina"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Potvrda elementa oblikovanja %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "Potvrda oblikovanja"
 
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "Baza znanja %s"
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "Napomena"
 
 #~ msgid "never"
 #~ msgstr "Pretvori"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "Vrijeme"
@@ -17057,9 +16347,6 @@ msgstr "godina"
 
 #~ msgid "No Keywords"
 #~ msgstr "ključna riječ"
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
 
 #~ msgid "No Subject categories"
 #~ msgstr "Lista javnih košarica"
@@ -17076,17 +16363,8 @@ msgstr "godina"
 #~ msgid "Affiliations"
 #~ msgstr "Povijest citiranosti"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
 #~ msgid "Citations%s"
 #~ msgstr "Povijest citiranosti"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Datum stvaranja"
@@ -17097,42 +16375,6 @@ msgstr "godina"
 #~ msgid "No publications available"
 #~ msgstr "Nema dostupnih tipova dokumenta."
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr "Naveo/la: %s zapisa"
 
@@ -17142,20 +16384,8 @@ msgstr "godina"
 #~ msgid "%i reviews"
 #~ msgstr "izvješće"
 
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "Stranica:"
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "Povijest citiranosti"
@@ -17163,35 +16393,8 @@ msgstr "godina"
 #~ msgid "No Citation Information available"
 #~ msgstr "Nema dostupnih tipova dokumenta."
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "session"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Vaša upozorenja"
@@ -17211,127 +16414,15 @@ msgstr "godina"
 #~ msgid "Statistics"
 #~ msgstr "Status"
 
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
 #~ msgid "Group: %s"
 #~ msgstr "Grupa: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown to the external login "
-#~ "system."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The external login method %s does "
-#~ "not support email address based logins."
-#~ "  Please contact the site administrators."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "Kolekcija %s nije pronađena"
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "Polje %s je obavezno."
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "Nije moguće odretiti broj prijavljenih stranica."
-

--- a/invenio/base/translations/hu/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/hu/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2008-07-03 22:58+0200\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:57+0200\n"
 "Last-Translator: Eva Papp <Eva.Papp@cern.ch>\n"
 "Language-Team: HU <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -56,8 +56,8 @@ msgstr "Feltöltési Útmutató"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -200,7 +200,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr ""
 
@@ -221,17 +221,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -257,45 +257,49 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+msgid "Provided data is not valid"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 msgid "Authorization failure"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 msgid "Please sign in to continue."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 msgid "Authorization failure."
 msgstr ""
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -494,7 +498,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -696,7 +701,8 @@ msgid "The following errors have occurred:"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -713,8 +719,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -796,7 +802,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -838,8 +844,8 @@ msgstr "Kosarak"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr ""
@@ -854,8 +860,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr ""
 
@@ -1065,7 +1071,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1114,8 +1121,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1128,25 +1135,23 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1170,13 +1175,14 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1205,9 +1211,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1274,8 +1279,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1283,8 +1288,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1306,9 +1311,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1349,8 +1353,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1406,11 +1410,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1421,11 +1425,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1438,8 +1442,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1530,8 +1534,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1550,29 +1554,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1581,9 +1585,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr ""
 
@@ -1915,16 +1919,14 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -1944,8 +1946,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2091,8 +2093,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2199,7 +2201,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr ""
 
@@ -2391,8 +2393,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2664,9 +2666,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2718,7 +2719,7 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr ""
 
@@ -2726,8 +2727,8 @@ msgstr ""
 #, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3181,8 +3182,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr ""
 
@@ -3979,8 +3980,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -3998,8 +3999,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4059,17 +4060,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4425,25 +4426,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4502,15 +4503,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4521,10 +4522,10 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4537,15 +4538,15 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4556,7 +4557,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4575,17 +4577,15 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4603,14 +4603,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4661,8 +4660,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4712,8 +4711,8 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -4825,9 +4824,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -4840,8 +4839,8 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -4966,11 +4965,10 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5094,7 +5092,7 @@ msgid "Total"
 msgstr ""
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr ""
 
@@ -5250,8 +5248,8 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5306,56 +5304,56 @@ msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5393,7 +5391,7 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5443,15 +5441,15 @@ msgstr "Emlékeztetők"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5667,8 +5665,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -5742,8 +5739,8 @@ msgstr ""
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -5757,8 +5754,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr ""
 
@@ -5916,8 +5913,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -5943,8 +5940,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -5955,8 +5952,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -5966,108 +5962,108 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 msgid "No match found, please enter different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6081,11 +6077,11 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
 
@@ -6128,10 +6124,9 @@ msgstr ""
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
 
 #: invenio/legacy/webalert/htmlparser.py:186
@@ -6321,15 +6316,15 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:453
@@ -6387,7 +6382,7 @@ msgstr "Keresések"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6451,7 +6446,7 @@ msgstr ""
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6511,7 +6506,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6534,7 +6530,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6561,7 +6558,8 @@ msgid "You do not have permission to delete this note."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6591,8 +6589,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6612,8 +6610,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6644,8 +6642,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -6718,8 +6716,7 @@ msgstr "Kosarak"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
@@ -6745,8 +6742,7 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -6909,8 +6905,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7090,15 +7086,16 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2131
@@ -7108,7 +7105,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr ""
 
@@ -7270,7 +7267,7 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7409,207 +7406,207 @@ msgstr ""
 msgid "Record ID %(x_rec)s does not exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, python-format
 msgid "%(x_nb)i Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, python-format
 msgid "View all %(x_name)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 msgid "Be the first to review this document.</div>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 msgid "Close"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7618,487 +7615,489 @@ msgstr ""
 msgid "Record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, python-format
 msgid "Max %(maxfiles)i files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, python-format
 msgid "Here is review %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, python-format
 msgid "Here is comment %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
+msgstr ""
+
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 msgid "Your comment will be lost."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 msgid "Oldest comment first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 msgid "Latest comment first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 msgid "Group by record, latest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 msgid "Records and comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 msgid "Records only"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 msgid "Comments only"
 msgstr ""
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, python-format
 msgid "%(x_i)s items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 msgid "All items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 msgid "Order by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 msgid "Per page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 msgid "Display options"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8106,99 +8105,99 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 msgid "(in reply to a comment)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, python-format
 msgid "%(x_num)i items found in total"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 msgid "You do not have access to the specified comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 msgid "You cannot report a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 msgid "You are not authorized to use comments."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Emlékeztetők"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr ""
@@ -8313,8 +8312,8 @@ msgstr ""
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8378,8 +8377,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8406,8 +8405,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -8581,9 +8580,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8604,8 +8602,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9072,14 +9069,14 @@ msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9209,8 +9206,7 @@ msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3357
@@ -9236,8 +9232,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3832
@@ -9421,7 +9417,8 @@ msgid "in"
 msgstr ""
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr ""
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9510,8 +9507,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9520,8 +9517,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:271
@@ -9538,14 +9535,14 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:327
@@ -9583,8 +9580,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:343
 #, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:346
@@ -9671,10 +9668,9 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:559
@@ -9691,15 +9687,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:573
@@ -9712,10 +9708,10 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:611
@@ -9735,8 +9731,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:636
@@ -9751,22 +9747,22 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:785
@@ -9783,8 +9779,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:799
@@ -9796,8 +9792,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:805
@@ -9808,8 +9804,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:811
@@ -9856,7 +9852,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -9904,15 +9901,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1027
@@ -9948,8 +9945,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -9974,8 +9971,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1228
@@ -9992,24 +9989,24 @@ msgstr ""
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1235
 #, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1267
@@ -10136,8 +10133,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1378
@@ -10356,7 +10353,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2400
@@ -10398,71 +10396,66 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:127
@@ -10471,14 +10464,14 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -10487,8 +10480,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -10500,8 +10493,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -10570,8 +10563,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -10634,8 +10626,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -10698,10 +10689,10 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -10729,8 +10720,8 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:452
 #, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -10905,15 +10896,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:989
@@ -11028,7 +11019,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:707
@@ -11051,37 +11043,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11089,15 +11081,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11161,8 +11153,8 @@ msgstr ""
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11197,8 +11189,8 @@ msgstr "Elküld"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11244,8 +11236,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:366
@@ -11274,8 +11266,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:548
@@ -11324,8 +11316,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1041
@@ -11407,8 +11399,7 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -11545,7 +11536,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -11637,8 +11629,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -11657,8 +11649,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -11699,7 +11691,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -11720,14 +11713,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -11838,10 +11830,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12113,8 +12104,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12264,8 +12255,8 @@ msgstr ""
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -12324,9 +12315,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -12347,8 +12337,8 @@ msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -12416,8 +12406,7 @@ msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -12480,13 +12469,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -12495,9 +12483,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -12660,8 +12648,7 @@ msgstr "Emlékeztetők"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -12745,8 +12732,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -12835,8 +12822,8 @@ msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:55
@@ -12928,9 +12915,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -12949,8 +12935,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13008,8 +12994,7 @@ msgstr ""
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13046,8 +13031,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13163,11 +13147,6 @@ msgstr ""
 msgid "Checking status"
 msgstr ""
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Kosarak"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 msgid "loading"
 msgstr ""
@@ -13201,8 +13180,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13223,8 +13202,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13240,8 +13219,7 @@ msgstr ""
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -13358,7 +13336,7 @@ msgstr ""
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr ""
 
@@ -13543,8 +13521,8 @@ msgstr ""
 #: invenio/modules/groups/views.py:223
 #, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr ""
 
 #: invenio/modules/groups/views.py:279
@@ -13556,11 +13534,11 @@ msgstr ""
 msgid "Members"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 msgid "Knowledge base name"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 msgid "-None-"
 msgstr ""
@@ -13569,11 +13547,11 @@ msgstr ""
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 msgid "Index fields"
 msgstr ""
 
@@ -13619,7 +13597,7 @@ msgid "Create new record \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
+msgid "Create KB \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
@@ -13763,28 +13741,28 @@ msgstr ""
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -13847,8 +13825,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -14317,8 +14295,7 @@ msgstr "Emlékeztetők"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -14571,6 +14548,9 @@ msgstr ""
 msgid " years ago"
 msgstr ""
 
+#~ msgid "Tickets"
+#~ msgstr "Kosarak"
+
 #~ msgid "Open Tickets"
 #~ msgstr "Kosarak"
 
@@ -14579,9 +14559,6 @@ msgstr ""
 
 #~ msgid "Not your papers"
 #~ msgstr "Emlékeztetők"
-
-#~ msgid "Tickets"
-#~ msgstr "Kosarak"
 
 #~ msgid "Request Tickets"
 #~ msgstr "Kosarak"
@@ -14598,1681 +14575,26 @@ msgstr ""
 #~ msgid "previous basket"
 #~ msgstr "Kosarak"
 
-#~ msgid "Export as"
-#~ msgstr ""
-
-#~ msgid "Citation Metrics"
-#~ msgstr ""
-
-#~ msgid "WebSearch Admin Guide"
-#~ msgstr ""
-
 #~ msgid "Submit Guide"
 #~ msgstr "Feltöltési Útmutató"
-
-#~ msgid "Add to personal basket"
-#~ msgstr ""
-
-#~ msgid "WebSubmit Admin Guide"
-#~ msgstr ""
-
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
-#~ msgid "Quit searching."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
-#~ msgid "Cancel merging"
-#~ msgstr ""
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
-
-#~ msgid "Search for a person to assign the paper to"
-#~ msgstr ""
-
-#~ msgid "Select All"
-#~ msgstr ""
-
-#~ msgid "Select None"
-#~ msgstr ""
-
-#~ msgid "Invert Selection"
-#~ msgstr ""
-
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
-#~ msgid "Author Name"
-#~ msgstr ""
-
-#~ msgid "Experiment"
-#~ msgstr ""
-
-#~ msgid "Not assigned"
-#~ msgstr ""
-
-#~ msgid "No status information found."
-#~ msgstr ""
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
-
-#~ msgid "Review Transaction"
-#~ msgstr ""
-
-#~ msgid "On all pages"
-#~ msgstr ""
-
-#~ msgid "With selected do"
-#~ msgstr ""
-
-#~ msgid "View name variants"
-#~ msgstr ""
-
-#~ msgid "The author has an internal ID!"
-#~ msgstr ""
-
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
-#~ msgid "Not provided"
-#~ msgstr ""
-
-#~ msgid "Not available"
-#~ msgstr ""
-
-#~ msgid "No comments"
-#~ msgstr ""
-
-#~ msgid "Not Available"
-#~ msgstr ""
-
-#~ msgid " Delete this ticket"
-#~ msgstr ""
-
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
-#~ msgid "No title available"
-#~ msgstr ""
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Kosarak"
 
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
-#~ msgid "Paper title: "
-#~ msgstr ""
-
-#~ msgid "Ignore"
-#~ msgstr ""
-
-#~ msgid "The following names have been automatically chosen:"
-#~ msgstr ""
-
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
-#~ msgid "Selected name on paper"
-#~ msgstr ""
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
-
-#~ msgid "Please provide your information"
-#~ msgstr ""
-
-#~ msgid "Please provide your first name"
-#~ msgstr ""
-
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "Emlékeztetők"
-
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
 
 #~ msgid "Your eMail:"
 #~ msgstr "Emlékeztetők"
 
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
-
-#~ msgid "!Delete the entire request!"
-#~ msgstr ""
-
-#~ msgid "Mark as your documents"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
-#~ msgid "Mark as their documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ their documents"
-#~ msgstr ""
-
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
-#~ msgid "Create new profile"
-#~ msgstr ""
-
-#~ msgid "Create a new Person"
-#~ msgstr ""
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
-
 #~ msgid "Add to merge list"
 #~ msgstr "Kosarak"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
-#~ msgid "Recent Papers"
-#~ msgstr ""
-
-#~ msgid "Publication List "
-#~ msgstr ""
-
-#~ msgid "Showing the"
-#~ msgstr ""
-
-#~ msgid "most recent documents:"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
-#~ msgid "Manage your profile"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
-
-#~ msgid "Choose your profile"
-#~ msgstr ""
-
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
-#~ msgid "Manage publication list"
-#~ msgstr ""
-
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
-#~ msgid "add external id"
-#~ msgstr ""
-
-#~ msgid "delete selected ids"
-#~ msgstr ""
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
-
-#~ msgid "suggest missing ids"
-#~ msgstr ""
-
-#~ msgid "Choose system"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr ""
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
-#~ msgid "Fatal: You are not allowed to access this functionality."
-#~ msgstr ""
-
-#~ msgid "Claim this paper"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The publication date of this book is %s."
-#~ msgstr ""
-
-#~ msgid "You can see your library account %(x_url_open)shere%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid "%i items found."
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
-#~ msgid "Unweighted %s keywords:"
-#~ msgstr ""
-
-#~ msgid "Weighted %s keywords:"
-#~ msgstr ""
-
-#~ msgid "Unknown type: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file named %s already exists. Please choose another name."
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Record #%i"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
-#~ msgid "Revision"
-#~ msgstr ""
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Could not find format element named %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s could not be found."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
-
-#~ msgid "Output format with code %s could not be found."
-#~ msgstr ""
-
-#~ msgid "Could not find output format named %s."
-#~ msgstr ""
-
-#~ msgid "Could not find a fresh name for output format %s."
-#~ msgstr ""
-
-#~ msgid "Modify Template Attributes"
-#~ msgstr ""
-
-#~ msgid "Template Editor"
-#~ msgstr ""
-
-#~ msgid "Check Dependencies"
-#~ msgstr ""
-
-#~ msgid "Update Format Attributes"
-#~ msgstr ""
-
-#~ msgid "Show Documentation"
-#~ msgstr ""
-
-#~ msgid "Hide Documentation"
-#~ msgstr ""
-
-#~ msgid "Last Modification Date"
-#~ msgstr ""
-
-#~ msgid "Manage Output Formats"
-#~ msgstr ""
-
-#~ msgid "Manage Format Templates"
-#~ msgstr ""
-
-#~ msgid "Format Elements Documentation"
-#~ msgstr ""
-
-#~ msgid "Add New Format Template"
-#~ msgstr ""
-
-#~ msgid "Check Format Templates Extensively"
-#~ msgstr ""
-
-#~ msgid "Code"
-#~ msgstr ""
-
-#~ msgid "Add New Output Format"
-#~ msgstr ""
-
-#~ msgid "menu"
-#~ msgstr ""
-
-#~ msgid "Close Output Format"
-#~ msgstr ""
-
-#~ msgid "Rules"
-#~ msgstr ""
-
-#~ msgid "Modify Output Format Attributes"
-#~ msgstr ""
-
-#~ msgid "Remove Rule"
-#~ msgstr ""
-
-#~ msgid "Add New Rule"
-#~ msgstr ""
-
-#~ msgid "No problem found with format"
-#~ msgstr ""
-
-#~ msgid "An error has been found"
-#~ msgstr ""
-
-#~ msgid "The following errors have been found"
-#~ msgstr ""
-
-#~ msgid "BibFormat Admin"
-#~ msgstr ""
-
-#~ msgid "Test with record:"
-#~ msgstr ""
-
-#~ msgid "Enter a search query here."
-#~ msgstr ""
-
-#~ msgid "No Record Found for %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
-#~ msgid "Template \"%s\" does not exist at line %s."
-#~ msgstr ""
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
-
-#~ msgid "Output format %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
-#~ msgid "Format template %s calls undefined element \"%s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
-
-#~ msgid "Error in format element %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Show all %i authors"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
-
-#~ msgid "Restricted Output Format"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Rules"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Output Format"
-#~ msgstr ""
-
-#~ msgid "Cannot create output format"
-#~ msgstr ""
-
-#~ msgid "Format template %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Element %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Test Format Element %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Output Format %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Element"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Element %s"
-#~ msgstr ""
-
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
-#~ msgid "Format Validation"
-#~ msgstr ""
-
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Download history:"
-#~ msgstr ""
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid "Cannot send error request, %s parameter missing."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Not Set"
-#~ msgstr ""
-
-#~ msgid "never"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Your account on '%s' has been activated"
-#~ msgstr ""
-
-#~ msgid "Your account earlier created on '%s' has been activated:"
-#~ msgstr ""
-
-#~ msgid "Account created on '%s'"
-#~ msgstr ""
-
-#~ msgid "An account has been created for you on '%s':"
-#~ msgstr ""
-
-#~ msgid "Account rejected on '%s'"
-#~ msgstr ""
-
-#~ msgid "Your request for an account has been rejected on '%s':"
-#~ msgstr ""
-
-#~ msgid "Username/Email: %s"
-#~ msgstr ""
-
-#~ msgid "Account deleted on '%s'"
-#~ msgstr ""
-
-#~ msgid "Your account on '%s' has been deleted:"
-#~ msgstr ""
-
-#~ msgid "You already have an alert named %s."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been added to your profile."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been successfully updated."
-#~ msgstr ""
-
-#~ msgid "You have defined %s alerts."
-#~ msgstr ""
-
-#~ msgid "Here are the %s most popular searches."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display searches"
-#~ msgstr ""
-
-#~ msgid "%s, personalize"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Set a new alert"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Modify alert settings"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display alerts"
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
-
-#~ msgid "times"
-#~ msgstr ""
-
-#~ msgid "Papers"
-#~ msgstr ""
-
-#~ msgid "No Keywords"
-#~ msgstr ""
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
-
-#~ msgid "No Subject categories"
-#~ msgstr ""
-
-#~ msgid "Subject categories"
-#~ msgstr ""
-
-#~ msgid "No Collaborations"
-#~ msgstr ""
-
-#~ msgid "Collaborations"
-#~ msgstr ""
-
-#~ msgid "unknown affiliation"
-#~ msgstr ""
-
-#~ msgid "No Affiliations"
-#~ msgstr ""
-
-#~ msgid "Affiliations"
-#~ msgstr ""
-
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
-#~ msgid "Citations%s"
-#~ msgstr ""
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
-
-#~ msgid "No Publication Graph"
-#~ msgstr ""
-
-#~ msgid "<strong> Publications list </strong>"
-#~ msgstr ""
-
-#~ msgid "No publications available"
-#~ msgstr ""
-
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "Sorry, you do not have sufficient rights to add record #%i."
-#~ msgstr ""
-
-#~ msgid "%i matching items"
-#~ msgstr ""
-
-#~ msgid "%i items have been successfully added to your basket"
-#~ msgstr ""
-
-#~ msgid "%i users are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "%i user groups are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "You have set %i alerts on this basket."
-#~ msgstr ""
-
-#~ msgid "%i items"
-#~ msgstr ""
-
-#~ msgid "%i notes"
-#~ msgstr ""
-
-#~ msgid "%i subscribers"
-#~ msgstr ""
-
-#~ msgid "Record %i"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s does not exist in the database."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is an invalid ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "Showing the latest %i comments:"
-#~ msgstr ""
-
-#~ msgid "Sorry, the record %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "Sorry, %s is not a valid ID value."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s"
-#~ msgstr ""
-
-#~ msgid "Readers found the following %s reviews to be most helpful."
-#~ msgstr ""
-
-#~ msgid "View all %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s comments"
-#~ msgstr ""
-
-#~ msgid "Note: Your nickname, %s, will be displayed as author of this comment."
-#~ msgstr ""
-
-#~ msgid "Max %i files"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Note: Your nickname, %s, will be "
-#~ "displayed as the author of this "
-#~ "review."
-#~ msgstr ""
-
-#~ msgid "View all %s reported comments"
-#~ msgstr ""
-
-#~ msgid "View all %s reported reviews"
-#~ msgstr ""
-
-#~ msgid "This review has been reported %i times"
-#~ msgstr ""
-
-#~ msgid "This comment has been reported %i times"
-#~ msgstr ""
-
-#~ msgid "Here are the reported reviews of user %s"
-#~ msgstr ""
-
-#~ msgid "Here are the reported comments of user %s"
-#~ msgstr ""
-
-#~ msgid "Here is review %s"
-#~ msgstr ""
-
-#~ msgid "Here is comment %s"
-#~ msgstr ""
-
-#~ msgid "Here are all reviews for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "Here are all comments for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "%s items"
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid "%i items found in total"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "%s View your previously submitted comments"
-#~ msgstr ""
-
-#~ msgid "Comment ID %s does not exist."
-#~ msgstr ""
-
-#~ msgid "Record ID %s does not exist."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your message is too long, please "
-#~ "shorten it. Maximum size allowed is "
-#~ "%i characters."
-#~ msgstr ""
-
-#~ msgid "Group %s does not exist."
-#~ msgstr ""
-
-#~ msgid "User %s does not exist."
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
-#~ msgid "There are no records referring to %s."
-#~ msgstr ""
-
-#~ msgid "There are no records modified by %s."
-#~ msgstr ""
-
-#~ msgid "There are no records cited by %s."
-#~ msgstr ""
-
-#~ msgid "No word index is available for %s."
-#~ msgstr ""
-
-#~ msgid "No phrase index is available for %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Search term %s did not match any"
-#~ " record. Nearest terms in any "
-#~ "collection are:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, %s does not seem to be "
-#~ "a valid sort option. The records "
-#~ "will not be sorted."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, sorting is allowed on sets "
-#~ "of up to %d records only. Using"
-#~ " default sort order."
-#~ msgstr ""
-
-#~ msgid "The record %d replaces it."
-#~ msgstr ""
-
-#~ msgid "%s results found"
-#~ msgstr ""
-
-#~ msgid "%s seconds"
-#~ msgstr ""
-
-#~ msgid "Search %s records for"
-#~ msgstr ""
-
-#~ msgid "Cited by %i records"
-#~ msgstr ""
-
-#~ msgid "%s records found"
-#~ msgstr ""
-
-#~ msgid "Search took %s seconds."
-#~ msgstr ""
-
-#~ msgid "Cited by 1 record"
-#~ msgstr ""
-
-#~ msgid "%i comments"
-#~ msgstr ""
-
-#~ msgid "%i reviews"
-#~ msgstr ""
-
-#~ msgid "Collection %s Not Found"
-#~ msgstr ""
-
-#~ msgid "Sorry, collection %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s."
-#~ msgstr ""
-
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid "Cited by: %s records"
-#~ msgstr ""
-
-#~ msgid "Co-cited with: %s records"
-#~ msgstr ""
-
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
-#~ msgid "No Papers"
-#~ msgstr ""
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
-
-#~ msgid "Citations:"
-#~ msgstr ""
-
-#~ msgid "No Citation Information available"
-#~ msgstr ""
-
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Sorry, DOI %s could not be resolved."
-#~ msgstr ""
-
-#~ msgid "DOI \"%s\" Not Found"
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
-#~ msgid "Discussion"
-#~ msgstr ""
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If you are using a lightweight CERN account you can\n"
-#~ "                %(x_url_open)sreset the password%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Alternatively, you can ask %s to "
-#~ "change your login system from external"
-#~ " to internal."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "%s offers you the possibility to "
-#~ "personalize the interface, to set up "
-#~ "your own personal library of documents,"
-#~ " or to set up an automatic "
-#~ "alert query that would run periodically"
-#~ " and would notify you of search "
-#~ "results by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid "Okay, a password reset link has been emailed to %s."
-#~ msgstr ""
-
-#~ msgid "If you don't own an account yet, please contact %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please do not use valuable passwords "
-#~ "such as your Unix, AFS or NICE "
-#~ "passwords with this service. Your email"
-#~ " address will stay strictly confidential"
-#~ " and will not be disclosed to "
-#~ "any third party. It will be used"
-#~ " to identify you for personal "
-#~ "services of %s. For example, you "
-#~ "may set up an automatic alert "
-#~ "search that will look for new "
-#~ "preprints and will notify you daily "
-#~ "of new arrivals by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "It is not possible to create an"
-#~ " account yourself. Contact %s if you"
-#~ " want an account."
-#~ msgstr ""
-
 #~ msgid "Your alerts"
 #~ msgstr "Emlékeztetők"
-
-#~ msgid "Your approvals"
-#~ msgstr ""
 
 #~ msgid "Your baskets"
 #~ msgstr "Kosarak"
 
 #~ msgid "Your loans"
 #~ msgstr "Emlékeztetők"
-
-#~ msgid "Your submissions"
-#~ msgstr ""
-
-#~ msgid "Administration"
-#~ msgstr ""
-
-#~ msgid "Statistics"
-#~ msgstr ""
-
-#~ msgid "Edit %s members"
-#~ msgstr ""
-
-#~ msgid "Edit group %s"
-#~ msgstr ""
-
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
-#~ msgid "Group: %s"
-#~ msgstr ""
-
-#~ msgid "Group %s: New membership request"
-#~ msgstr ""
-
-#~ msgid "A user wants to join the group %s."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been accepted"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been accepted."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been rejected"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been rejected."
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted"
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted by its administrator."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Your Settings"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown to the external login "
-#~ "system."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The external login method %s does "
-#~ "not support email address based logins."
-#~ "  Please contact the site administrators."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is already in use."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "Sorry, page %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
-#~ msgid "Page %s Not Found"
-#~ msgstr ""
-
-#~ msgid "Please contact %s quoting the following information:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
-
-#~ msgid "Unable to find the submission directory for the action: %s"
-#~ msgstr ""
-
-#~ msgid "Unable to find document type: %s"
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory."
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory. Please fill it in."
-#~ msgstr ""
-
-#~ msgid "Function %s does not exist."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s%s'"
-#~ msgstr ""
-

--- a/invenio/base/translations/invenio.pot
+++ b/invenio/base/translations/invenio.pot
@@ -1,21 +1,21 @@
-# Translations template for PROJECT.
-# Copyright (C) 2015 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
+# Translations template for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
+"Project-Id-Version: invenio 2.0.6.dev20150717\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -190,7 +190,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr ""
 
@@ -247,45 +247,49 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+msgid "Provided data is not valid"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 msgid "Authorization failure"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 msgid "Please sign in to continue."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 msgid "Authorization failure."
 msgstr ""
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
 "A newer version of Invenio is available for download. You may want to "
 "visit <a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -785,7 +789,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -827,8 +831,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr ""
@@ -843,8 +847,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr ""
 
@@ -1390,11 +1394,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1405,11 +1409,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1564,9 +1568,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr ""
 
@@ -2165,7 +2169,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr ""
 
@@ -2681,7 +2685,7 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr ""
 
@@ -3141,8 +3145,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr ""
 
@@ -4369,15 +4373,15 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr ""
@@ -4465,10 +4469,10 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -5037,7 +5041,7 @@ msgid "Total"
 msgstr ""
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr ""
 
@@ -5336,7 +5340,7 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5699,8 +5703,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr ""
 
@@ -5912,104 +5916,104 @@ msgid ""
 "this doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 msgid ""
 "No public collection matched your query. If you were looking for a hidden"
 " document, please type the correct URL for this record."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 msgid "No match found, please enter different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
 "Search term %(x_term)s inside index %(x_index)s did not match any record."
 " Nearest terms in any collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, python-format
 msgid ""
 "Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
 " default sort order."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, python-format
 msgid ""
 "Sorry, %(x_name)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6023,11 +6027,11 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
 
@@ -6329,7 +6333,7 @@ msgstr ""
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6393,7 +6397,7 @@ msgstr ""
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -7043,7 +7047,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr ""
 
@@ -7204,7 +7208,7 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7335,207 +7339,207 @@ msgstr ""
 msgid "Record ID %(x_rec)s does not exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, python-format
 msgid "%(x_nb)i Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, python-format
 msgid "View all %(x_name)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 msgid "Be the first to review this document.</div>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 msgid "Close"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7544,487 +7548,487 @@ msgstr ""
 msgid "Record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, python-format
 msgid ""
 "Note: Your nickname, %(nick)s, will be displayed as author of this "
 "comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, python-format
 msgid "Max %(maxfiles)i files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
 "Here is a list, sorted by total number of reports, of all users who have "
 "had a comment reported at least once."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, python-format
 msgid "Here is review %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, python-format
 msgid "Here is comment %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2257
+#: invenio/legacy/webcomment/templates.py:2256
 #, python-format
 msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
+#: invenio/legacy/webcomment/templates.py:2257
 #, python-format
 msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 msgid "Your comment will be lost."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 msgid "Oldest comment first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 msgid "Latest comment first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 msgid "Group by record, latest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 msgid "Records and comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 msgid "Records only"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 msgid "Comments only"
 msgstr ""
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, python-format
 msgid "%(x_i)s items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 msgid "All items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
+#: invenio/legacy/webcomment/templates.py:2425
 msgid "You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 msgid "Order by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 msgid "Per page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 msgid "Display options"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8032,98 +8036,98 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 msgid "(in reply to a comment)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, python-format
 msgid "%(x_num)i items found in total"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 msgid "You do not have access to the specified comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 msgid "You cannot report a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 msgid "You are not authorized to use comments."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 msgid "Your Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr ""
@@ -13260,7 +13264,7 @@ msgstr ""
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr ""
 
@@ -13455,11 +13459,11 @@ msgstr ""
 msgid "Members"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 msgid "Knowledge base name"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 msgid "-None-"
 msgstr ""
@@ -13468,11 +13472,11 @@ msgstr ""
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 msgid "Index fields"
 msgstr ""
 
@@ -13518,7 +13522,7 @@ msgid "Create new record \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
+msgid "Create KB \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
@@ -13664,19 +13668,19 @@ msgstr ""
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 

--- a/invenio/base/translations/it/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/it/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2012-02-17 11:55+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:57+0200\n"
 "Last-Translator: Flavio Costa <flavio.costa@cern.ch>\n"
 "Language-Team: IT <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -44,7 +44,8 @@ msgstr "Non hai il permesso di usare le funzioni ILL."
 #: invenio/base/templates/401.html:29
 #, fuzzy
 msgid "You do not have access to this page."
-msgstr "Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
+msgstr ""
+"Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
 
 #: invenio/base/templates/401.html:30 invenio/base/templates/404.html:30
 msgid "Click the following link to go to the main page:"
@@ -58,8 +59,8 @@ msgstr "Pagina principale"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -205,7 +206,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Benvenuto/a:"
 
@@ -226,17 +227,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -262,50 +263,55 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Questo record non esiste."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr "Richiesta di reimpostazione password per"
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Non hai il permesso di usare le funzioni di prestito."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Fallimento nella registrazione"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Per favore, seleziona uno o più:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Richiesta di autorizzazione ruolo"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, fuzzy, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 "Una versione piu' recente di Invenio e' disponibile. Si consiglia di "
 "valutare  "
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -504,7 +510,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -578,8 +585,8 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"Il tuo file e' aggiunto alla lista di attesa. Puoi controllare la "
-"tua%(x_url1_open)scronologia dei caricamenti%(x_url1_close)s or "
+"Il tuo file e' aggiunto alla lista di attesa. Puoi controllare la tua"
+"%(x_url1_open)scronologia dei caricamenti%(x_url1_close)s or "
 "%(x_url2_open)ssottomettere un altro file%(x_url2_close)s."
 
 #: invenio/legacy/batchuploader/templates.py:282
@@ -714,10 +721,11 @@ msgid "The following errors have occurred:"
 msgstr "Sono stati riscontrati i seguenti errori:"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
-"Non e' stato possibile spostare alcuni file nella cartella DONE. Per "
-"favore sopprimili manualmente"
+"Non e' stato possibile spostare alcuni file nella cartella DONE. Per favore "
+"sopprimili manualmente"
 
 #: invenio/legacy/batchuploader/templates.py:585
 msgid "All uploaded files were moved to DONE folder."
@@ -729,17 +737,17 @@ msgid ""
 "Using %(x_fmt_open)sweb interface upload%(x_fmt_close)s, actions are "
 "executed a single time."
 msgstr ""
-"Utilizzando %(x_fmt_open)sl'upload via interfaccia web%(x_fmt_close)s, le"
-" azioni sono eseguire una sola volta."
+"Utilizzando %(x_fmt_open)sl'upload via interfaccia web%(x_fmt_close)s, le "
+"azioni sono eseguire una sola volta."
 
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
-"Controlla la %(x_url_open)sguida al demone Batch Uploader%(x_url_close)s "
-"per eseguire queste azioni periodicamente."
+"Controlla la %(x_url_open)sguida al demone Batch Uploader%(x_url_close)s per "
+"eseguire queste azioni periodicamente."
 
 #: invenio/legacy/batchuploader/templates.py:602
 msgid "Metadata folders"
@@ -820,7 +828,7 @@ msgstr "ID"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -862,8 +870,8 @@ msgstr "Tuoi cestini"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Precedente"
@@ -878,8 +886,8 @@ msgstr "chiudi"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Successiva"
 
@@ -894,18 +902,6 @@ msgstr "Successiva"
 #: invenio/legacy/weblinkback/adminlib.py:55
 msgid "Admin Area"
 msgstr "Area di amministrazione"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "autore"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
@@ -925,11 +921,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
 msgid "Limit to knowledge bases containing string:"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "cancellato con successo"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -959,10 +950,6 @@ msgstr "cancellato con successo"
 msgid "Delete"
 msgstr "Cancella"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:140
-msgid "Verify syntax"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:145
 #: invenio/modules/communities/views.py:258
 #, fuzzy
@@ -974,31 +961,9 @@ msgstr "Crea un nuovo cestino"
 msgid "File %(x_name)s does not exist."
 msgstr "L'utente %s non esiste."
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:174
-msgid "Calling bibcheck -verify failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
-msgid "Verify BibCheck config file"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Problema nel database"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "file"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
 msgstr "Memorizza modifiche"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:240
-msgid "Edit BibCheck config file"
-msgstr ""
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:268
 #, python-format
@@ -1015,10 +980,6 @@ msgstr ""
 msgid "File %(x_name)s: write failed."
 msgstr ""
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:279
-msgid "Save BibCheck config file"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:312
 #, python-format
 msgid "File %(x_name)s deleted."
@@ -1027,10 +988,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:314
 #, python-format
 msgid "File %(x_name)s: delete failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:316
-msgid "Delete BibCheck config file"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:195
@@ -1097,7 +1054,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1148,8 +1106,8 @@ msgstr "Un nuovo account è stato creato presso"
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1163,25 +1121,23 @@ msgstr "Sfoglia"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "Un nuovo account è stato creato presso"
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "Un nuovo account è stato creato presso"
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1206,13 +1162,14 @@ msgstr "Crea nuovo"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "Un nuovo account è stato creato presso"
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1244,9 +1201,8 @@ msgstr "Periodo di prestito"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "Un nuovo account è stato creato presso"
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1313,8 +1269,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1322,8 +1278,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1345,9 +1301,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "Un nuovo account è stato creato presso"
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1389,8 +1344,8 @@ msgstr "%s record trovati"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1449,11 +1404,11 @@ msgstr "Un nuovo account è stato creato presso"
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1464,11 +1419,11 @@ msgstr "Sì"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1481,8 +1436,8 @@ msgstr "No"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1579,8 +1534,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1600,29 +1555,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1631,9 +1586,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr "Il record richiesto sembra inesistente."
 
@@ -1993,16 +1948,14 @@ msgstr "Il record è stato cancellato."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2023,8 +1976,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2184,8 +2137,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2292,7 +2245,7 @@ msgstr "Collocazione"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Descrizione"
 
@@ -2485,8 +2438,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2762,9 +2715,8 @@ msgstr "Conferma"
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "Se lo desideri, puoi %(x_url_open)sautenticarti qui%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2818,7 +2770,7 @@ msgstr "Reimposta"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "OK"
 
@@ -2826,8 +2778,8 @@ msgstr "OK"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "Un nuovo account è stato creato presso"
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3290,8 +3242,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "Email"
 
@@ -3795,8 +3747,8 @@ msgstr ""
 #, fuzzy, python-format
 msgid "A %(x_url_open)snew copy%(x_url_close)s has been added."
 msgstr ""
-"Per favore %(x_url_open)saccetta o rifiuta%(x_url_close)s la richiesta di"
-" questo utente."
+"Per favore %(x_url_open)saccetta o rifiuta%(x_url_close)s la richiesta di "
+"questo utente."
 
 #: invenio/legacy/bibcirculation/templates.py:7443
 #, fuzzy
@@ -4139,8 +4091,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4158,8 +4110,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4224,17 +4176,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4619,25 +4571,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "Il record è stato cancellato."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4697,15 +4649,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4716,10 +4668,10 @@ msgstr "Scegli un file"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4732,15 +4684,15 @@ msgstr "Accesso"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, fuzzy, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr "Il file caricato e' troppo piccolo (<%i o) ed e' quindi stato ignorato"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4751,7 +4703,8 @@ msgid ""
 msgstr "Il file caricato e' troppo grande (>%i o) ed e' quindi stato ignorato"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr "Il nome del file caricato e' troppo lungo ed e' quindi stato ignorato"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4767,26 +4720,26 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:749
 #, fuzzy, python-format
 msgid "A file named %(x_name)s already exists. Please choose another name."
-msgstr "Un file con il nome %s esiste già. Si prega di scegliere un altro nome."
+msgstr ""
+"Un file con il nome %s esiste già. Si prega di scegliere un altro nome."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
-msgstr "Un file con formato '%s' esiste gia'. Si prega caricare un altro formato."
+"A file with format '%(x_name)s' already exists. Please upload another format."
+msgstr ""
+"Un file con formato '%s' esiste gia'. Si prega caricare un altro formato."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
-"Non sono ammessi punti '.', sbarre '/' o barre inverse '\\\\' nei nomi di"
-" file. Scegli un nome diverso e ricarica il tuo file. In particolare, "
-"nota che non devi includere l'estensione nel campo del nome."
+"Non sono ammessi punti '.', sbarre '/' o barre inverse '\\\\' nei nomi di "
+"file. Scegli un nome diverso e ricarica il tuo file. In particolare, nota "
+"che non devi includere l'estensione nel campo del nome."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
 msgid "Choose how you want to restrict access to this file."
@@ -4799,14 +4752,14 @@ msgstr "Aggiungi un nuovo file"
 #: invenio/legacy/bibdocfile/managedocfiles.py:900
 msgid "You can decide to hide or not previous version(s) of this file."
 msgstr ""
-"Puoi scegliere se nascondere o no la(le) versione(i) precedente(i) di "
-"questo file."
+"Puoi scegliere se nascondere o no la(le) versione(i) precedente(i) di questo "
+"file."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 "Quando rivedi un file, vengono rimossi i formati aggiuntivi che potresti "
 "aver caricato precedentemente, dato che non sono aggiornati con il nuovo "
@@ -4814,11 +4767,10 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
-"Saranno rimossi i formati alternativi caricati per la versione attuale di"
-" questo file"
+"Saranno rimossi i formati alternativi caricati per la versione attuale di "
+"questo file"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
 msgid "Keep previous versions"
@@ -4849,7 +4801,8 @@ msgstr "Memorizza modifiche"
 #: invenio/legacy/bibdocfile/managedocfiles.py:925
 #, python-format
 msgid "Need help revising or adding files to record %(recid)s"
-msgstr "Necessita aiuto per la revisione o per aggiungere file al record %(recid)s"
+msgstr ""
+"Necessita aiuto per la revisione o per aggiungere file al record %(recid)s"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:927
 #, python-format
@@ -4877,8 +4830,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 "Problemi aggiungendo o con la revisione di un file? Manda la versione "
 "riveduta a %(mailto_link)s."
@@ -4931,8 +4884,8 @@ msgstr "Il record richiesto sembra non essere ancora integrato."
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 "Il sistema ha incontrato un errore nel ricuperare l'elenco dei file di "
 "questo documento."
@@ -4979,8 +4932,7 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:326
 msgid "Not enough information to retrieve the document"
 msgstr ""
-"Non sono state fornite sufficienti informazioni per recuperare il "
-"documento"
+"Non sono state fornite sufficienti informazioni per recuperare il documento"
 
 #: invenio/legacy/bibdocfile/webinterface.py:334
 msgid "An error has happened in trying to retrieving the requested file."
@@ -5049,13 +5001,13 @@ msgstr "1. Scegli i criteri di ricerca"
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 "Specifica i criteri che vorresti usare per filtrare i record che saranno "
-"modificati. Usa \"Cerca\" per vedere quali record sarebbero stati "
-"filtrati con questi criteri."
+"modificati. Usa \"Cerca\" per vedere quali record sarebbero stati filtrati "
+"con questi criteri."
 
 #: invenio/legacy/bibeditmulti/templates.py:361
 msgid "Preview results"
@@ -5067,11 +5019,11 @@ msgstr "2. definisci modifiche"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
-"Specifica campi e sottocampi che devono essere modificati in ogni record "
-"che soddisfa i criteri di ricerca."
+"Specifica campi e sottocampi che devono essere modificati in ogni record che "
+"soddisfa i criteri di ricerca."
 
 #: invenio/legacy/bibeditmulti/templates.py:615
 msgid "Define new field action"
@@ -5200,11 +5152,10 @@ msgstr "Torna ai risultati della ricerca"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5328,7 +5279,7 @@ msgid "Total"
 msgstr "Totale"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Seleziona"
 
@@ -5491,8 +5442,8 @@ msgstr "Cancella basi di conoscenza"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5551,56 +5502,56 @@ msgstr "Per favore, autentificati."
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5640,7 +5591,7 @@ msgstr "Dipendenze della base di conoscenza"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5694,15 +5645,15 @@ msgstr "I tuoi avvisi"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5925,8 +5876,7 @@ msgstr "Errore durante l'estrazione del record"
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -6001,8 +5951,8 @@ msgstr "Ritorna alla selezione principale"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6017,8 +5967,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Risultato della ricerca"
 
@@ -6178,8 +6128,8 @@ msgstr "Nessun valore trovato."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6188,8 +6138,8 @@ msgid ""
 "Warning: figure caption search is only available for a subset of papers "
 "mostly from %(x_range_from_year)s-%(x_range_to_year)s."
 msgstr ""
-"Attenzione: la ricerca nella didascalia delle figure e' disponibile per "
-"un numero limitato di articoli, essenzialmente dal 2008 al 2010."
+"Attenzione: la ricerca nella didascalia delle figure e' disponibile per un "
+"numero limitato di articoli, essenzialmente dal 2008 al 2010."
 
 #: invenio/legacy/search_engine/__init__.py:2151
 #, python-format
@@ -6207,8 +6157,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6219,11 +6169,10 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
-"Nessun indice sulla frase disponibile per il testo integrale, ricerca "
-"della combinazione di parole..."
+"Nessun indice sulla frase disponibile per il testo integrale, ricerca della "
+"combinazione di parole..."
 
 #: invenio/legacy/search_engine/__init__.py:2213
 #, python-format
@@ -6234,90 +6183,90 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 "Sintassi della ricerca incomprensibile. Tutte le parentesi vengono "
 "soppresse. Se necessario si prega controllare i criteri di ricerca e "
 "riprovare."
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
 "Nessun risultato trovato nella collezione %(x_collection)s. Le altre "
-"collezioni pubbliche hanno dato %(x_url_open)s%(x_nb_hits)d "
-"risultati%(x_url_close)s."
+"collezioni pubbliche hanno dato %(x_url_open)s%(x_nb_hits)d risultati"
+"%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
-"Nessuna collezione pubblica ha dato risultati. Se cercate un documento "
-"non pubblico, vi preghiamo di interrogare la collezione riservata di "
-"vostro interesse."
+"Nessuna collezione pubblica ha dato risultati. Se cercate un documento non "
+"pubblico, vi preghiamo di interrogare la collezione riservata di vostro "
+"interesse."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
-"Nessuna collezione pubblica ha dato risultati. Se cercate un documento "
-"non pubblico, vi preghiamo di interrogare la collezione riservata di "
-"vostro interesse."
+"Nessuna collezione pubblica ha dato risultati. Se cercate un documento non "
+"pubblico, vi preghiamo di interrogare la collezione riservata di vostro "
+"interesse."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
 "Il termine di ricerca %s non corrisponde ad alcun record. I termini più "
 "vicini in tutte le collezioni sono:"
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "Utilizza diversi termini di ricerca."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Non ci sono record che fanno riferimento a %s."
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Non ci sono record citati da %s."
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Non ci sono record citati da %s."
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Nessun indice per parola è disponibile per %s."
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Nessun indice per frase è disponibile per %s."
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 "Il termine di ricerca %(x_term)s all'interno dell'indice %(x_index)s non "
 "corrisponde ad alcun record. I termini più vicini in tutte le collezioni "
 "sono:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
@@ -6326,44 +6275,44 @@ msgstr ""
 "Il termine di ricerca %s non corrisponde ad alcun record. I termini più "
 "vicini in tutte le collezioni sono:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
-"Spiacente, %s non sembra essere un'opzione di ordinamento valida. "
-"Effettuato ordinamento in base al titolo."
+"Spiacente, %s non sembra essere un'opzione di ordinamento valida. Effettuato "
+"ordinamento in base al titolo."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 "Spiacente, è possibile ordinare solo insiemi che contengono fino a %d "
 "record. Utilizzato ordinamento predefinito."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
-"Spiacente, %s non sembra essere un'opzione di ordinamento valida. "
-"Effettuato ordinamento in base al titolo."
+"Spiacente, %s non sembra essere un'opzione di ordinamento valida. Effettuato "
+"ordinamento in base al titolo."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Questo record non esiste."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Utilizza diversi termini di ricerca."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6377,13 +6326,13 @@ msgstr "Utilizza diversi termini di ricerca."
 msgid "Browse"
 msgstr "Sfoglia"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 "Nessun risultato nell'arco di tempo specificato, il criterio viene "
 "ignorato..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
 "Nessun risultato trovato nei limiti specificati, i criteri vengono "
@@ -6428,15 +6377,14 @@ msgstr "L'avviso %s è stato aggiornato con successo."
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Hai effettuato %(x_nb)s ricerche. Una %(x_url_open)slista "
-"dettagliata%(x_url_close)s è disponibile con la possibilità di (a) "
-"visualizzare i risultati della ricerca e (b) iscriversi ad un servizio "
-"automatico di avvisi via email per gli stessi."
+"Hai effettuato %(x_nb)s ricerche. Una %(x_url_open)slista dettagliata"
+"%(x_url_close)s è disponibile con la possibilità di (a) visualizzare i "
+"risultati della ricerca e (b) iscriversi ad un servizio automatico di avvisi "
+"via email per gli stessi."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6510,8 +6458,8 @@ msgid ""
 "This alert will notify you each time/only if a new item satisfies the "
 "following query:"
 msgstr ""
-"Verrai notificato riguardo a questo avviso ogni volta che/solo se un "
-"nuovo elemento soddisfa la seguente richiesta:"
+"Verrai notificato riguardo a questo avviso ogni volta che/solo se un nuovo "
+"elemento soddisfa la seguente richiesta:"
 
 #: invenio/legacy/webalert/templates.py:173
 msgid "QUERY"
@@ -6577,9 +6525,9 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"Imposta un nuovo avviso a partire dalle %(x_url1_open)stue "
-"ricerche%(x_url1_close)s, dalle %(x_url2_open)sricerche "
-"comuni%(x_url2_close)s o dal modulo di inserimento."
+"Imposta un nuovo avviso a partire dalle %(x_url1_open)stue ricerche"
+"%(x_url1_close)s, dalle %(x_url2_open)sricerche comuni%(x_url2_close)s o dal "
+"modulo di inserimento."
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6630,8 +6578,8 @@ msgstr "Hai definito %s avvisi."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 "Non hai ancora eseguito alcuna ricerca. Per favore, entra prima "
 "nell'%(x_url_open)sinterfaccia di ricerca%(x_url_close)s."
@@ -6639,11 +6587,11 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
-"Hai eseguito %(x_nb1)s ricerche (%(x_nb2)s argomenti differenti) durante "
-"gli ultimi 30 giorni."
+"Hai eseguito %(x_nb1)s ricerche (%(x_nb2)s argomenti differenti) durante gli "
+"ultimi 30 giorni."
 
 #: invenio/legacy/webalert/templates.py:453
 #, fuzzy, python-format
@@ -6700,7 +6648,7 @@ msgstr "Tue ricerche"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6764,7 +6712,7 @@ msgstr "%s Personalizza, Imposta un nuovo avviso"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6824,7 +6772,8 @@ msgstr "%s Personalizza, Visualizza avvisi"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6845,10 +6794,12 @@ msgstr "Aggiungi ad un cestino pubblico "
 #: invenio/legacy/webbasket/api.py:1548 invenio/legacy/webbasket/api.py:1613
 #, fuzzy
 msgid "You do not have permission to write notes to this item."
-msgstr "Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
+msgstr ""
+"Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6873,16 +6824,19 @@ msgstr ""
 #: invenio/legacy/webbasket/api.py:1678
 #, fuzzy
 msgid "You do not have permission to delete this note."
-msgstr "Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
+msgstr ""
+"Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
 #, fuzzy, python-format
 msgid "Sorry, you do not have sufficient rights to add record #%(x_id)i."
-msgstr "Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
+msgstr ""
+"Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
 
 #: invenio/legacy/webbasket/api.py:1797
 msgid "Some of the items were not added due to lack of sufficient rights."
@@ -6907,8 +6861,8 @@ msgstr "Questo record non esiste."
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6921,7 +6875,8 @@ msgstr ""
 #: invenio/legacy/webbasket/api.py:2042 invenio/legacy/webbasket/api.py:2111
 #, fuzzy
 msgid "Sorry, you do not have sufficient rights on this basket."
-msgstr "Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
+msgstr ""
+"Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
 
 #: invenio/legacy/webbasket/api.py:1920
 #, fuzzy
@@ -6930,8 +6885,8 @@ msgstr "Copia record nel cestino"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6964,8 +6919,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7035,11 +6990,10 @@ msgstr "Cestini pubblici"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
-"Possiedi %(x_nb_perso)s cestini personali e sei iscritto a %(x_nb_group)s"
-" cestini di gruppo e a %(x_nb_public)s cestini pubblici di altri utenti."
+"Possiedi %(x_nb_perso)s cestini personali e sei iscritto a %(x_nb_group)s "
+"cestini di gruppo e a %(x_nb_public)s cestini pubblici di altri utenti."
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
 #, fuzzy
@@ -7061,17 +7015,14 @@ msgid ""
 "You have no personal or group baskets or are subscribed to any public "
 "baskets."
 msgstr ""
-"Non hai cestini personali o di gruppo ne' hai sottoscritto cestini "
-"pubblici."
+"Non hai cestini personali o di gruppo ne' hai sottoscritto cestini pubblici."
 
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
-"Potresti cominciare a %(x_url_open)screare un cestino "
-"nuovo%(x_url_close)s."
+"Potresti cominciare a %(x_url_open)screare un cestino nuovo%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
 #: invenio/legacy/webbasket/templates.py:198
@@ -7232,11 +7183,11 @@ msgstr "Elemento esterno"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
-"Inserisci l'url per l'elemento esterno che vuoi aggiungere, il titolo e "
-"la descrizione"
+"Inserisci l'url per l'elemento esterno che vuoi aggiungere, il titolo e la "
+"descrizione"
 
 #: invenio/legacy/webbasket/templates.py:1612
 #: invenio/modules/linkbacks/templates/linkbacks/index_base.html:44
@@ -7274,8 +7225,8 @@ msgid ""
 "Please choose a basket: %(x_basket_selection_box)s %(x_fmt_open)s(or "
 "%(x_url_open)screate a new one%(x_url_close)s first)%(x_fmt_close)s"
 msgstr ""
-"Per favore scegli un cestino: %(x_basket_selection_box)s %(x_fmt_open)s(o"
-" %(x_url_open)screane uno nuovo%(x_url_close)s prima)%(x_fmt_close)s"
+"Per favore scegli un cestino: %(x_basket_selection_box)s %(x_fmt_open)s(o "
+"%(x_url_open)screane uno nuovo%(x_url_close)s prima)%(x_fmt_close)s"
 
 #: invenio/legacy/webbasket/templates.py:1764
 msgid "Optionally, add a note to each one of these items"
@@ -7417,20 +7368,21 @@ msgstr "Condivisione cestino con un nuovo gruppo"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
-"Sei autenticato come utente ospite, perciò i tuoi cestini scompariranno "
-"al termine della sessione corrente."
+"Sei autenticato come utente ospite, perciò i tuoi cestini scompariranno al "
+"termine della sessione corrente."
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
-"Se lo desideri puoi %(x_url_open)sautenticarti o registrarti "
-"qui%(x_url_close)s."
+"Se lo desideri puoi %(x_url_open)sautenticarti o registrarti qui"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7439,7 +7391,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Questa funzionalità è vietata agli utenti ospiti."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Torna ai risultati della ricerca"
 
@@ -7498,7 +7450,8 @@ msgstr "Questa collezione non contiene ancora alcun documento."
 
 #: invenio/legacy/webbasket/templates.py:2519
 msgid "You do not have sufficient rights to view this basket's content."
-msgstr "Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
+msgstr ""
+"Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
 
 #: invenio/legacy/webbasket/templates.py:2562
 msgid "Move item up"
@@ -7603,7 +7556,7 @@ msgstr "Aggiungi commento"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7740,213 +7693,213 @@ msgstr "L'utente %s non esiste."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "L'utente %s non esiste."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Scrivi un commento"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i commenti per round \"%(x_name)s\""
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "%i commenti"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Visualizzazione degli ultimi %i commenti:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Discuti questo documento"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Inizia una discussione su un aspetto qualunque di questo documento."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Spiacente, il record %s non sembra esistere."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "Spiacente, %s non è un ID valido."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "Spiacente, non è stato fornito nessun ID di record."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Potresti voler navigare a cominciare da %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i commenti per round \"%(x_name)s\""
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Questa recensione ti è stata utile?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Scrivi una recensione"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 "Punteggio medio recensione: %(x_nb_score)s basato su %(x_nb_reviews)s "
 "recensioni"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "I lettori hanno trovato le seguenti %s recensioni tra le più utili."
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Visualizza tutte le %s recensioni"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Vota questo documento"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Sii il primo a recensire questo documento."
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "chiudi"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Notifica abuso"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr "Annulla soppressione commento"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Cancella commento"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr "Annulla il rapporto del commento"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr "File allegato"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr "File allegato"
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Recensito da %(x_nickname)s il %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
-"%(x_nb_people)i persone su %(x_nb_total)i hanno trovato questa recensione"
-" utile"
+"%(x_nb_people)i persone su %(x_nb_total)i hanno trovato questa recensione "
+"utile"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr "Annulla soppressione recensione"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr "Sopprimi recensione"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr "Annulla rapporto recensione"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Commenti"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Recensioni"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "%s recensioni in totale"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "%s commenti in totale"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Sii il primo a recensire questo documento."
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Iscriviti"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr "Annulla iscrizione"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7955,44 +7908,42 @@ msgstr "Annulla iscrizione"
 msgid "Record"
 msgstr "Record"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "recensione"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "commento"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Recensione"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Visualizzare"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Pagina:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr "Non sei autorizzato a commentare o recensire."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
-"Nota: il tuo soprannome, %s, sarà visualizzato come autore di questo "
-"commento"
+"Nota: il tuo soprannome, %s, sarà visualizzato come autore di questo commento"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
@@ -8001,48 +7952,47 @@ msgstr ""
 "Nota: non hai %(x_url_open)sdefinito il tuo soprannome%(x_url_close)s. "
 "%(x_nickname)sverrà visualizzato come autore di questo commento."
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
-"Dopo l'identificazione, gli utenti autorizzati potranno anche allegare "
-"file."
+"Dopo l'identificazione, gli utenti autorizzati potranno anche allegare file."
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr "Facoltativamente puoi allegare un file a questo commento"
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr "Facoltativamente puoi allegare file a questo commento"
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr "Non piu' di un file"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "Non piu'di %i file"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr "Non piu' di %(x_nb_bytes)s per file"
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr "Inviami un email all'affissione di un nuovo commento"
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Articolo"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "Aggiungi commento"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
@@ -8051,424 +8001,425 @@ msgstr ""
 "Nota: il tuo soprannome, %s, verrà visualizzato come autore di questa "
 "recensione."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Dai un voto a questo articolo"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Seleziona un punteggio"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Dai un titolo alla tua recensione"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Scrivi la tua recensione"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr "Aggiungi recensione"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Aggiungi recensione"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "La tua recensione è stata aggiunta con successo."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Il tuo commento è stato aggiunto con successo."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Torna al record"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr "Puoi consultare la lista dei %(x_url_open)stuoi ticket%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr "Visualizza record maggiormente commentati"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr "Visualizza gli ultimi record commentati"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr "Visualizza tutti i commenti segnalati come abusi"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr "Visualizza i record maggiormente recensiti"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr "Visualizza gli ultimi record recensiti"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr "Visualizza tutte le recensioni segnalate come abusi"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Visualizza tutti gli utenti segnalati"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Guida"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "I commenti e le recensioni sono stati disabilitati"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"Per favore, inserisci l'ID del commento/recensione per visualizzarlo "
-"prima di decidere se cancellarlo o meno"
+"Per favore, inserisci l'ID del commento/recensione per visualizzarlo prima "
+"di decidere se cancellarlo o meno"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "ID commento:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
-"O inserisci l'ID di un record per visualizzare commenti/recensioni "
-"associate"
+"O inserisci l'ID di un record per visualizzare commenti/recensioni associate"
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr "ID del record"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Visualizza commento"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Finora non c'è stato alcun commento."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Visualizza tutti i %s commenti riportati"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Visualizza tutte le %s recensioni riportate"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-"Ecco una lista, ordinata secondo il numero totale di commenti, di tutti "
-"gli utenti che hanno riportato un commento almeno una volta."
+"Ecco una lista, ordinata secondo il numero totale di commenti, di tutti gli "
+"utenti che hanno riportato un commento almeno una volta."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Soprannome"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "ID utente"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Numero di voti positivi"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Numero di voti negativi"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Numero totale di voti"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Numero totale di resoconti"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Visualizza tutti i commenti/recensioni dell'utente"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Questa recensione è stata valutata %i volte"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Questo commento è stato valutato %i volte"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Scritto da"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Informazioni generali"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Cancella le recensioni selezionate"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Sopprimi il rapporto d'abuso selezionato"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr "Annulla la soppressione delle recensioni selezionate"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr "Annulla la soppressione dei commenti selezionati"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Cancella i commenti selezionati"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Ecco le recensioni valutate dell'utente %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Ecco i commenti valutati dell'utente %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Ecco la recensione %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Ecco il commento %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Ecco la recensione %(x_cmtID)s scritta dall'utente %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Ecco il commento %(x_cmtID)s scritto dall'utente %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "Ecco tutte le recensioni valutate ordinate in base alle più valutate"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "Ecco tutti i commenti valutati ordinate in base ai più valutati"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
-"Ecco tutte le recensioni per il record %i, ordinate per numero di "
-"valutazioni"
+"Ecco tutte le recensioni per il record %i, ordinate per numero di valutazioni"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr "Visualizza commenti"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
-msgstr "Ecco tutti i commenti per il record %i, ordinate per numero di valutazioni"
+msgstr ""
+"Ecco tutti i commenti per il record %i, ordinate per numero di valutazioni"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr "Visualizza recensioni"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "ID commento"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "cancellato con successo"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr "Soppressione annullata"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "rapporto d'abuso soppresso con successo"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Non ancora recensito"
 
-#: invenio/legacy/webcomment/templates.py:2257
+#: invenio/legacy/webcomment/templates.py:2256
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 "La recensione seguente e' stata inviata a %(CFG_SITE_NAME)s da "
 "%(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2258
+#: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 "Il commento seguente e' stato inviato a %(CFG_SITE_NAME)s da "
 "%(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
-"Questo e' un messaggio automatico, si prega di non rispondere a questo "
-"email."
+"Questo e' un messaggio automatico, si prega di non rispondere a questo email."
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr "Per affiggere un altro commento, vai a <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr "Per ripondere a questo commento specifico, vai a <%(x_url)s>"
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr "Per annullare l'iscrizione a questa discussione, vai a <%(x_url)s>"
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr "Per assistenza, si prega usare <%(CFG_SITE_SUPPORT_EMAIL)s>"
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "I tuoi commenti sono stati registrati con successo"
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Cancella commenti"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "Le ultime all'inizio"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "Visualizza gli ultimi record commentati"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "Dettagli e commenti"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "record trovati"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Commenti"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "%i record"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Aggiungi elementi"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "Visualizza"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Data creazione"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Pagina successiva"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Visualizza avvisi"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8476,103 +8427,104 @@ msgstr "Visualizza avvisi"
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Annulla il rapporto del commento"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "%i elementi trovati."
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Record non trovato"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
-msgstr "Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
+msgstr ""
+"Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Aggiungi commento"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "Visualizza tutti i commenti riportati"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr "Pagina non trovata"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr "Il commento richiesto non e' reperibile"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr "Il file richiesto non e' reperibile"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Non hai il permesso di usare le funzioni di prestito."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Commenti"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "Visualizza tutti i commenti riportati"
@@ -8687,8 +8639,8 @@ msgstr "Spiacente, la pagina %s non sembra esistere."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
 "Potresti cominciare a consultare %(x_url_open)sl'indice delle pagine "
 "%(x_category)s%(x_url_close)s."
@@ -8754,11 +8706,11 @@ msgstr "Impossibile ricuperare alcun giornale"
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
-"Non sembrano esserci giornale definiti su questo server. Se pensi che "
-"questo non è corretto contatta il servizio di supporto."
+"Non sembrano esserci giornale definiti su questo server. Se pensi che questo "
+"non è corretto contatta il servizio di supporto."
 
 #: invenio/legacy/webjournal/config.py:239
 msgid "Select a journal on this server"
@@ -8773,8 +8725,8 @@ msgid ""
 "You did not provide an argument for a journal name. Please select the "
 "journal you want to read in the list below."
 msgstr ""
-"Non hai fornito un parametro per il nome del giornale. Per favore "
-"seleziona il giornale che desideri leggere dall'elenco sottostante."
+"Non hai fornito un parametro per il nome del giornale. Per favore seleziona "
+"il giornale che desideri leggere dall'elenco sottostante."
 
 #: invenio/legacy/webjournal/config.py:268
 msgid "No current issue"
@@ -8786,8 +8738,8 @@ msgstr "Impossibile trovare alcuna informazione sul numero corrente"
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 "La configurazione per il numero corrente sembra essere vuota. Prova a "
 "fornire il numero o fai riferimento al servizio di supporto."
@@ -8876,8 +8828,8 @@ msgid ""
 "The issue could not be correctly regenerated. Please contact your "
 "administrator."
 msgstr ""
-"Il numero non può essere rigenerato correttamente. Per favore contatta il"
-" tuo amministratore."
+"Il numero non può essere rigenerato correttamente. Per favore contatta il "
+"tuo amministratore."
 
 #: invenio/legacy/webjournal/templates.py:308
 #, python-format
@@ -8887,11 +8839,6 @@ msgstr ""
 #: invenio/legacy/webjournal/templates.py:699
 msgid "Apply"
 msgstr "Applica"
-
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "Soprannome"
 
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 msgid "WebJournal Admin"
@@ -8972,9 +8919,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8996,8 +8942,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9250,7 +9195,8 @@ msgstr "Sei sicuro di voler svuotare interamente la tua casella di posta?"
 #: invenio/legacy/webmessage/templates.py:582
 #, python-format
 msgid "Quota used: %(x_nb_used)i messages out of max. %(x_nb_total)i"
-msgstr "Quota utilizzata: %(x_nb_used)i messaggi su un massimo di %(x_nb_total)i"
+msgstr ""
+"Quota utilizzata: %(x_nb_used)i messaggi su un massimo di %(x_nb_total)i"
 
 #: invenio/legacy/webmessage/templates.py:599
 msgid "Please select one or more:"
@@ -9475,19 +9421,19 @@ msgstr "Cerca anche:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
-"Questa collezione è riservata.  Se pensi di avere i permessi necessari, "
-"per favore clicca il bottone Cerca."
+"Questa collezione è riservata.  Se pensi di avere i permessi necessari, per "
+"favore clicca il bottone Cerca."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
-"Questa e' una collezione esterna ospitata. Si prega di cliccare sul "
-"bottone Cerca per accedere ai contenuti."
+"Questa e' una collezione esterna ospitata. Si prega di cliccare sul bottone "
+"Cerca per accedere ai contenuti."
 
 #: invenio/legacy/websearch/templates.py:1619
 msgid "This collection does not contain any document yet."
@@ -9583,8 +9529,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found %(x_nb_records)s "
 "records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sRiassunto risultati:%(x_fmt_close)s Trovati "
-"%(x_nb_records)s record in %(x_nb_seconds)s secondi."
+"%(x_fmt_open)sRiassunto risultati:%(x_fmt_close)s Trovati %(x_nb_records)s "
+"record in %(x_nb_seconds)s secondi."
 
 #: invenio/legacy/websearch/templates.py:3132
 #, python-format
@@ -9625,8 +9571,7 @@ msgstr "Le tue sottomissioni"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 "La ricerca booleana non ha dato risultati. Vi preghiamo di combinare "
 "differentemente i termini."
@@ -9654,8 +9599,8 @@ msgstr "Potresti iniziare a sfogliare cominciando con %s."
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "Imposta un %(x_url1_open)savviso via mail%(x_url1_close)s personale\n"
 "o iscriviti al %(x_url2_open)sfeed RSS%(x_url2_close)s."
@@ -9667,7 +9612,8 @@ msgstr "Iscriviti al %(x_url2_open)sflusso RSS%(x_url2_close)s."
 
 #: invenio/legacy/websearch/templates.py:3841
 msgid "Interested in being notified about new results for this query?"
-msgstr "Sei interessato ad essere notificato su nuovi risultati di questa ricerca?"
+msgstr ""
+"Sei interessato ad essere notificato su nuovi risultati di questa ricerca?"
 
 #: invenio/legacy/websearch/templates.py:3907
 #: invenio/legacy/websearch/templates.py:3932
@@ -9847,7 +9793,8 @@ msgid "in"
 msgstr "in"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "Non hai trovato quello che cercavi? Prova la ricerca su altri server:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9943,8 +9890,8 @@ msgstr "obbligatorio"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9954,11 +9901,11 @@ msgstr "Crea un nuovo cestino"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
-"Se desideri modificare il tuo indirizzo email o impostare per la prima "
-"volta il tuo soprannome, per favore, inserisci i nuovi valori nei campi "
+"Se desideri modificare il tuo indirizzo email o impostare per la prima volta "
+"il tuo soprannome, per favore, inserisci i nuovi valori nei campi "
 "sottostanti."
 
 #: invenio/legacy/websession/templates.py:271
@@ -9975,19 +9922,19 @@ msgstr "Imposta nuovi valori"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
-"Dal momento che viene utilizzato come firma per i commenti e le "
-"recensioni, una volta impostato non può essere modificato."
+"Dal momento che viene utilizzato come firma per i commenti e le recensioni, "
+"una volta impostato non può essere modificato."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
-"Se desideri cambiare la tua password, per favore, inserisci la precedente"
-" e imposta il nuovo valore nei campi seguenti."
+"Se desideri cambiare la tua password, per favore, inserisci la precedente e "
+"imposta il nuovo valore nei campi seguenti."
 
 #: invenio/legacy/websession/templates.py:327
 msgid "Old password"
@@ -10024,8 +9971,8 @@ msgstr "Imposta nuova password"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 "Se stai utilizzando un account CERN lightweight puoi\n"
 "                %(x_url_open)sreimpostarne la password%(x_url_close)s."
@@ -10068,7 +10015,8 @@ msgstr "Modifica impostazioni relative alla lingua"
 
 #: invenio/legacy/websession/templates.py:401
 msgid "Select desired language of the web interface."
-msgstr "Seleziona la lingua che desideri veder utilizzata per l'interfaccia web."
+msgstr ""
+"Seleziona la lingua che desideri veder utilizzata per l'interfaccia web."
 
 #: invenio/legacy/websession/templates.py:417
 #, fuzzy
@@ -10108,8 +10056,8 @@ msgid ""
 "Please select which login method you would like to use to authenticate "
 "yourself"
 msgstr ""
-"Per favore, seleziona quale metodo di autenticazione desideri utilizzare "
-"per autenticarti"
+"Per favore, seleziona quale metodo di autenticazione desideri utilizzare per "
+"autenticarti"
 
 #: invenio/legacy/websession/templates.py:503
 #: invenio/legacy/websession/templates.py:518
@@ -10119,14 +10067,13 @@ msgstr "Seleziona metodo"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"Se hai dimenticato la password del tuo %(x_fmt_open)saccount "
-"interno%(x_fmt_close)s a %(sitename)s, allora inserisci, per favore, il "
-"tuo indirizzo email nel campo sottostante così da ricevere un link per "
+"Se hai dimenticato la password del tuo %(x_fmt_open)saccount interno"
+"%(x_fmt_close)s a %(sitename)s, allora inserisci, per favore, il tuo "
+"indirizzo email nel campo sottostante così da ricevere un link per "
 "reimpostarla."
 
 #: invenio/legacy/websession/templates.py:559
@@ -10143,22 +10090,21 @@ msgstr "Invia link per reimpostare la password"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
-"Se stai utilizzando il %(x_fmt_open)ssistema di login del "
-"CERN%(x_fmt_close)s, puoi ricuperare la tua password tramite il "
+"Se stai utilizzando il %(x_fmt_open)ssistema di login del CERN"
+"%(x_fmt_close)s, puoi ricuperare la tua password tramite il "
 "%(x_url_open)ssistema di autenticazione CERN%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
-"Nota che se stavi utilizzando un sistema di autenticazione esterno, "
-"allora non c'è nulla che possiamo fare e devi fare riferimento al sistema"
-" esterno."
+"Nota che se stavi utilizzando un sistema di autenticazione esterno, allora "
+"non c'è nulla che possiamo fare e devi fare riferimento al sistema esterno."
 
 #: invenio/legacy/websession/templates.py:573
 #, fuzzy, python-format
@@ -10172,15 +10118,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
-"%s ti offre la possibilità di personalizzare l'interfaccia, impostare la "
-"tua biblioteca di documenti personali o impostare una richiesta con "
-"avviso automatico che verrebbe eseguita periodicamente per notificarti i "
-"risultati della ricerca via email."
+"%s ti offre la possibilità di personalizzare l'interfaccia, impostare la tua "
+"biblioteca di documenti personali o impostare una richiesta con avviso "
+"automatico che verrebbe eseguita periodicamente per notificarti i risultati "
+"della ricerca via email."
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10197,16 +10143,17 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:620
 msgid "View all the searches you performed during the last 30 days."
-msgstr "Visualizza tutte le ricerche che hai effettuato negli ultimi 30 giorni."
+msgstr ""
+"Visualizza tutte le ricerche che hai effettuato negli ultimi 30 giorni."
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 "Con i cestini puoi definire le tue collezioni personali di elementi, "
-"memorizzare record interessanti che vuoi ricuperare in seguito o "
-"condividere con altre persone."
+"memorizzare record interessanti che vuoi ricuperare in seguito o condividere "
+"con altre persone."
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10218,35 +10165,35 @@ msgid ""
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
 "Iscriviti ad una ricerca che verrà effettuata periodicamente dal nostro "
-"servizio. I risultati potranno essere inviati via email o memorizzati i "
-"uno dei tuoi cestini."
+"servizio. I risultati potranno essere inviati via email o memorizzati i uno "
+"dei tuoi cestini."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
-"Controlla i libri che hai in prestito, sottoponi richieste di prestito, "
-"ecc. Richiede un ID CERN."
+"Controlla i libri che hai in prestito, sottoponi richieste di prestito, ecc. "
+"Richiede un ID CERN."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
-"Sei autenticato come utente ospite, perciò i tuoi avvisi scompariranno "
-"alla fine della sessione corrente."
+"Sei autenticato come utente ospite, perciò i tuoi avvisi scompariranno alla "
+"fine della sessione corrente."
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
-"Sei autenticato come %(x_user)s. Puoi a) "
-"%(x_url1_open)suscire%(x_url1_close)s; b) modificare le tue "
-"%(x_url2_open)simpostazioni dell'account%(x_url2_close)s."
+"Sei autenticato come %(x_user)s. Puoi a) %(x_url1_open)suscire"
+"%(x_url1_close)s; b) modificare le tue %(x_url2_open)simpostazioni "
+"dell'account%(x_url2_close)s."
 
 #: invenio/legacy/websession/templates.py:785
 #, fuzzy, python-format
@@ -10262,11 +10209,11 @@ msgstr "Tuoi avvisi di ricerche"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
-"Puoi consultare la lista dei %(x_url_open)stuoi gruppi%(x_url_close)s di "
-"cui sei amministratore o membro."
+"Puoi consultare la lista dei %(x_url_open)stuoi gruppi%(x_url_close)s di cui "
+"sei amministratore o membro."
 
 #: invenio/legacy/websession/templates.py:799
 #: invenio/legacy/websession/templates.py:2348
@@ -10277,11 +10224,11 @@ msgstr "Tuoi gruppi"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"Puoi consultare la lista delle %(x_url_open)stue "
-"sottomissioni%(x_url_close)s e controllarne lo stato."
+"Puoi consultare la lista delle %(x_url_open)stue sottomissioni"
+"%(x_url_close)s e controllarne lo stato."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -10291,12 +10238,11 @@ msgstr "Tue sottomissioni"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"Puoi consultare la lista delle %(x_url_open)stue "
-"approvazioni%(x_url_close)s con i documenti che hai approvato o di cui "
-"hai fatto da referee."
+"Puoi consultare la lista delle %(x_url_open)stue approvazioni%(x_url_close)s "
+"con i documenti che hai approvato o di cui hai fatto da referee."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10328,16 +10274,15 @@ msgid ""
 "for a password reset at %(x_sitename)s\n"
 "for the account \"%(x_email)s\".x_sitename"
 msgstr ""
-"Qualcuno (probabilmente tu) dall'indirizzo IP %(x_ip_address)s ha "
-"richiesto\n"
+"Qualcuno (probabilmente tu) dall'indirizzo IP %(x_ip_address)s ha richiesto\n"
 "di reimpostare la password di %(x_sitename)s\n"
 "per l'account \"%(x_email)s\"."
 
 #: invenio/legacy/websession/templates.py:877
 msgid "If you want to reset the password for this account, please go to:"
 msgstr ""
-"Se desideri reimpostare la password per questo account, per favore segui "
-"il link:"
+"Se desideri reimpostare la password per questo account, per favore segui il "
+"link:"
 
 #: invenio/legacy/websession/templates.py:883
 #: invenio/legacy/websession/templates.py:920
@@ -10347,7 +10292,8 @@ msgstr "per confermare la validità di questa richiesta."
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr "Nota che questa URL sarà valida solo per circa %(days)s giorni."
 
 #: invenio/legacy/websession/templates.py:909
@@ -10357,14 +10303,14 @@ msgid ""
 "to register a new account at %(x_sitename)s\n"
 "for the email address \"%(x_email)s\".x_sitename"
 msgstr ""
-"Qualcuno (probabilmente tu) dall'indirizzo IP %(x_ip_address)s ha "
-"richiesto\n"
+"Qualcuno (probabilmente tu) dall'indirizzo IP %(x_ip_address)s ha richiesto\n"
 "di registrare un nuovo account presso %(x_sitename)s\n"
 "con l'indirizzo email \"%(x_email)s\"."
 
 #: invenio/legacy/websession/templates.py:914
 msgid "If you want to complete this account registration, please go to:"
-msgstr "Se desideri completare la registrazione di questo account, segui il link:"
+msgstr ""
+"Se desideri completare la registrazione di questo account, segui il link:"
 
 #: invenio/legacy/websession/templates.py:940
 #, fuzzy, python-format
@@ -10398,14 +10344,14 @@ msgstr "Se lo desideri, puoi %(x_url_open)sautenticarti qui%(x_url_close)s."
 #: invenio/legacy/websession/templates.py:1011
 msgid "If you already have an account, please login using the form below."
 msgstr ""
-"Se possiedi già un account, per favore, autentificati utilizzando i campi"
-" seguenti."
+"Se possiedi già un account, per favore, autentificati utilizzando i campi "
+"seguenti."
 
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 "Se non possiedi ancora un account CERN, puoi registrare un "
 "%(x_url_open)snuovo CERN lightweight account%(x_url_close)s."
@@ -10413,11 +10359,11 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"Se non possiedi ancora un account, per favore "
-"%(x_url_open)sregistra%(x_url_close)s un account interno."
+"Se non possiedi ancora un account, per favore %(x_url_open)sregistra"
+"%(x_url_close)s un account interno."
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
@@ -10449,16 +10395,15 @@ msgstr "Password dimenticata?"
 #: invenio/legacy/websession/templates.py:1094
 msgid "You can use your nickname or your email address to login."
 msgstr ""
-"Puoi utilizzare il tuo soprannome o il tuo indirizzo email per "
-"autenticarti."
+"Puoi utilizzare il tuo soprannome o il tuo indirizzo email per autenticarti."
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
-"La tua richiesta è valida. Per favore, imposta la nuova password nei "
-"campi che seguono."
+"La tua richiesta è valida. Per favore, imposta la nuova password nei campi "
+"che seguono."
 
 #: invenio/legacy/websession/templates.py:1150
 msgid "Set a new password for"
@@ -10479,13 +10424,13 @@ msgstr "Imposta la nuova password"
 #: invenio/legacy/websession/templates.py:1175
 msgid "Please enter your email address and desired nickname and password:"
 msgstr ""
-"Per favore, inserisci il tuo indirizzo email, il soprannome desiderato e "
-"la password:"
+"Per favore, inserisci il tuo indirizzo email, il soprannome desiderato e la "
+"password:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
 "Non sarà possibile utilizzare l'account prima che venga verificato e "
 "attivato."
@@ -10504,36 +10449,34 @@ msgstr "registra"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
-"Per favore non utilizzare una password di valore quale la tua password "
-"Unix, AFS o NICE con questo servizio. Il tuo indirizzo email resterà "
-"strettamente confidenziale e non verrà esposto a terze parti. Verrà "
-"utilizzato per identificarti per i vari servizi personalizzati di %s. Per"
-" esempio, potresti impostare una ricerca con avviso automatico che "
-"cercherà nuove prestampe e ti notificherà giornalmente sui nuovi arrivi "
-"via email."
+"Per favore non utilizzare una password di valore quale la tua password Unix, "
+"AFS o NICE con questo servizio. Il tuo indirizzo email resterà strettamente "
+"confidenziale e non verrà esposto a terze parti. Verrà utilizzato per "
+"identificarti per i vari servizi personalizzati di %s. Per esempio, potresti "
+"impostare una ricerca con avviso automatico che cercherà nuove prestampe e "
+"ti notificherà giornalmente sui nuovi arrivi via email."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
-"Non è possibile creare da soli un account.Contatta %s se desideri un "
-"account."
+"Non è possibile creare da soli un account.Contatta %s se desideri un account."
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
-"Sembri essere un utente ospite. Devi prima "
-"%(x_url_open)sautenticarti%(x_url_close)s."
+"Sembri essere un utente ospite. Devi prima %(x_url_open)sautenticarti"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1267
 msgid "You are not authorized to access administrative functions."
@@ -10659,14 +10602,13 @@ msgstr "Esegui Document File Manager"
 #: invenio/legacy/websession/templates.py:1323
 msgid "Here are some interesting web admin links for you:"
 msgstr ""
-"Ecco per te alcuni interessanti collegamenti per l'amministrazione via "
-"web:"
+"Ecco per te alcuni interessanti collegamenti per l'amministrazione via web:"
 
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "Per ulteriori attività di amministrazione, vedi la completa "
 "%(x_url_open)sArea di amministrazione%(x_url_close)s."
@@ -10889,10 +10831,11 @@ msgstr "Un utente desidera unirsi al gruppo %s."
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
-"Per favore %(x_url_open)saccetta o rifiuta%(x_url_close)s la richiesta di"
-" questo utente."
+"Per favore %(x_url_open)saccetta o rifiuta%(x_url_close)s la richiesta di "
+"questo utente."
 
 #: invenio/legacy/websession/templates.py:2400
 #, fuzzy, python-format
@@ -10918,7 +10861,8 @@ msgstr "La tua richiesta di appartenenza al gruppo %s è stata rifiutata."
 #: invenio/legacy/websession/templates.py:2426
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour groups%(x_url_close)s."
-msgstr "Puoi consultare la lista dei  %(x_url_open)stuoi gruppi%(x_url_close)s."
+msgstr ""
+"Puoi consultare la lista dei  %(x_url_open)stuoi gruppi%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:2422
 #, fuzzy, python-format
@@ -10933,91 +10877,86 @@ msgstr "Il gruppo %s è stato cancellato dal suo amministratore."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"Puoi consultare la lista dei %(x_url_open)s%(x_nb_total)i "
-"gruppi%(x_url_close)s di cui sei membro (%(x_nb_member)i) o "
-"amministratore (%(x_nb_admin)i)."
+"Puoi consultare la lista dei %(x_url_open)s%(x_nb_total)i gruppi"
+"%(x_url_close)s di cui sei membro (%(x_nb_member)i) o amministratore "
+"(%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
-"Attenzione: La password impostata per l'utente root di MySQL e' la stessa"
-" della password di default d'Invenio. Per ragioni di sicurezza, si "
-"consiglia di cambiare la password."
+"Attenzione: La password impostata per l'utente root di MySQL e' la stessa "
+"della password di default d'Invenio. Per ragioni di sicurezza, si consiglia "
+"di cambiare la password."
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
-"Attenzione: La password impostata per l'utente Invenio di MySQL e' la "
-"stessa della password di default dell'istallazione. Per ragioni di "
-"sicurezza, si consiglia di cambiare la password."
+"Attenzione: La password impostata per l'utente Invenio di MySQL e' la stessa "
+"della password di default dell'istallazione. Per ragioni di sicurezza, si "
+"consiglia di cambiare la password."
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 "Attenzione: L'utente admin di Invenio attualmente non ha password. Per "
 "ragioni di sicurezza, si consiglia di definire una password."
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
-"\"Attenzione: L'email impostato per l'assistenza attualmente e' info"
-"@invenio-software.org. Per ragioni di sicurezza, si consiglia di "
-"sostituirlo con il vostro apposito email."
+"\"Attenzione: L'email impostato per l'assistenza attualmente e' info@invenio-"
+"software.org. Per ragioni di sicurezza, si consiglia di sostituirlo con il "
+"vostro apposito email."
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 "Una versione piu' recente di Invenio e' disponibile. Si consiglia di "
 "valutare  "
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
-"Non e' possibile scaricare o processare la documentazione sulla release "
-"da http://invenio-software.org/repo/invenio/tree/RELEASE-NOTES"
+"Non e' possibile scaricare o processare la documentazione sulla release da "
+"http://invenio-software.org/repo/invenio/tree/RELEASE-NOTES"
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
-"Sei autenticato come ospite. Puoi "
-"%(x_url_open)sautenticarti%(x_url_close)s come utente regolare."
+"Sei autenticato come ospite. Puoi %(x_url_open)sautenticarti%(x_url_close)s "
+"come utente regolare."
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 "Gli utenti %(x_fmt_open)sospiti%(x_fmt_close)s devono prima "
 "%(x_url_open)sregistrarsi%(x_url_close)s"
@@ -11028,16 +10967,16 @@ msgstr "Nessuna richiesta trovata"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 "Questa collezione è riservata.  Se pensi di avere diritto ad accedervi, "
 "autenticati."
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 "Questo file è riservato.  Se pensi di avere diritto ad accedervi, "
 "autenticati."
@@ -11048,8 +10987,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11061,8 +11000,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11129,7 +11068,8 @@ msgstr ""
 #: invenio/legacy/websession/webgroup.py:562
 #, fuzzy
 msgid "Sorry, you do not have sufficient rights on this group."
-msgstr "Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
+msgstr ""
+"Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
 
 #: invenio/legacy/websession/webgroup.py:499
 #, fuzzy
@@ -11142,8 +11082,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11199,8 +11138,7 @@ msgstr "Per favore, attendi che l'amministratore abiliti il tuo account."
 #, python-format
 msgid "You can now go to %(x_url_open)syour account page%(x_url_close)s."
 msgstr ""
-"Puoi ora accedere alla %(x_url_open)spagina del tuo "
-"account%(x_url_close)s."
+"Puoi ora accedere alla %(x_url_open)spagina del tuo account%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:136
 #: invenio/legacy/websession/webinterface.py:145
@@ -11213,11 +11151,9 @@ msgstr "Hai già confermato la validità del tuo indirizzo email!"
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
-"Questa richiesta di conferma di un indirizzo email non è valida od è "
-"scaduta."
+"Questa richiesta di conferma di un indirizzo email non è valida od è scaduta."
 
 #: invenio/legacy/websession/webinterface.py:153
 msgid "This request for an authorization is not valid or is expired."
@@ -11233,11 +11169,13 @@ msgstr "Questa richiesta per reimpostare la password è gia' stata usata."
 
 #: invenio/legacy/websession/webinterface.py:175
 msgid "This request for resetting a password is not valid or is expired."
-msgstr "Questa richiesta per reimpostare la password non è valida od è scaduta."
+msgstr ""
+"Questa richiesta per reimpostare la password non è valida od è scaduta."
 
 #: invenio/legacy/websession/webinterface.py:180
 msgid "This request for resetting the password is not valid or is expired."
-msgstr "Questa richiesta per reimpostare la password non è valida od è scaduta."
+msgstr ""
+"Questa richiesta per reimpostare la password non è valida od è scaduta."
 
 #: invenio/legacy/websession/webinterface.py:193
 msgid "The two provided passwords aren't equal."
@@ -11281,15 +11219,15 @@ msgstr "Impostata l'autenticazione tramite login interno."
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
-"Per favore, nota che se questa è la prima volta che stai utilizzando "
-"questo account con il metodo di autenticazione interno allora il sistema "
-"ha impostato per te una password generata in maniera casuale. Fai clic "
-"sul pulsante che segue perché ti venga inviato via email un link per "
+"Per favore, nota che se questa è la prima volta che stai utilizzando questo "
+"account con il metodo di autenticazione interno allora il sistema ha "
+"impostato per te una password generata in maniera casuale. Fai clic sul "
+"pulsante che segue perché ti venga inviato via email un link per "
 "reimpostarla:"
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -11302,8 +11240,8 @@ msgid ""
 "Unable to switch to external login method %(x_name)s, because your email "
 "address is unknown."
 msgstr ""
-"Impossibile passare al metodo di autenticazione interno %s, perché il tuo"
-" indirizzo email è sconosciuto."
+"Impossibile passare al metodo di autenticazione interno %s, perché il tuo "
+"indirizzo email è sconosciuto."
 
 #: invenio/legacy/websession/webinterface.py:445
 #, fuzzy, python-format
@@ -11311,8 +11249,8 @@ msgid ""
 "Unable to switch to external login method %(x_meth)s, because your email "
 "address is unknown to the external login system."
 msgstr ""
-"Impossibile passare al metodo di autenticazione esterno %s, perché il tuo"
-" indirizzo email è sconosciuto al sistema di autenticazione esterno."
+"Impossibile passare al metodo di autenticazione esterno %s, perché il tuo "
+"indirizzo email è sconosciuto al sistema di autenticazione esterno."
 
 #: invenio/legacy/websession/webinterface.py:449
 msgid "Login method successfully selected."
@@ -11321,11 +11259,11 @@ msgstr "Metodo di autenticazione selezionato con successo."
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
-"Il metodo di autenticazione esterno %s non supporta autenticazione basata"
-" su indirizzo email.  Per favore, contatta l'amministratore del sito."
+"Il metodo di autenticazione esterno %s non supporta autenticazione basata su "
+"indirizzo email.  Per favore, contatta l'amministratore del sito."
 
 #: invenio/legacy/websession/webinterface.py:464
 #, fuzzy
@@ -11500,23 +11438,23 @@ msgid ""
 "In order to confirm its validity, an email message containing an account "
 "activation key has been sent to the given email address."
 msgstr ""
-"Per confermarne la validità, è stato inviato all'indirizzo email fornito "
-"un messaggio contente una chiave di attivazione per l'account."
+"Per confermarne la validità, è stato inviato all'indirizzo email fornito un "
+"messaggio contente una chiave di attivazione per l'account."
 
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
-"Per favore, segui le istruzioni ivi contenute così da completare il "
-"processo di registrazione dell'account."
+"Per favore, segui le istruzioni ivi contenute così da completare il processo "
+"di registrazione dell'account."
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 "Una seconda email verrà inviata quando l'account sarà attivato e potrà "
 "essere utilizzato."
@@ -11569,8 +11507,8 @@ msgid ""
 "The site is having troubles in sending you an email for confirming your "
 "email address."
 msgstr ""
-"Il sito ha incontrato dei problemi nell'inviarti un email di conferma per"
-" il tuo indirizzo."
+"Il sito ha incontrato dei problemi nell'inviarti un email di conferma per il "
+"tuo indirizzo."
 
 #: invenio/legacy/websession/webinterface.py:1432
 msgid "Your tickets"
@@ -11636,14 +11574,16 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 "Record creato %(x_date_creation)s, modificato l'ultima volta il "
 "%(x_date_modification)s"
 
 #: invenio/legacy/webstyle/templates.py:707
 msgid "The server encountered an error while dealing with your request."
-msgstr "Il sistema ha riscontrato un errore nel trattamento della tua richiesta."
+msgstr ""
+"Il sistema ha riscontrato un errore nel trattamento della tua richiesta."
 
 #: invenio/legacy/webstyle/templates.py:709
 #, python-format
@@ -11661,37 +11601,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11699,15 +11639,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11773,18 +11713,18 @@ msgstr "Impossibile determinare il numero di pagine di sottomissione."
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
-"Impossibile creare una directory per questa sottomissione. "
-"L'amministratore e' stato avvisato."
+"Impossibile creare una directory per questa sottomissione. L'amministratore "
+"e' stato avvisato."
 
 #: invenio/legacy/websubmit/engine.py:440
 #: invenio/legacy/websubmit/engine.py:1058
 msgid "Cannot create submission directory. The administrator has been alerted."
 msgstr ""
-"Impossibile creare una directory di sottomissione. L'amministratore e' "
-"stato avvisato."
+"Impossibile creare una directory di sottomissione. L'amministratore e' stato "
+"avvisato."
 
 #: invenio/legacy/websubmit/engine.py:462
 #: invenio/legacy/websubmit/engine.py:1080
@@ -11813,11 +11753,11 @@ msgstr "Sottometti"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
-"Si e' verificato Un grave errore funzionale. Gli amminstratori sono stati"
-" avvisati. <br /><em>Si prega di notare che cio' puo' essere dovuto a "
+"Si e' verificato Un grave errore funzionale. Gli amminstratori sono stati "
+"avvisati. <br /><em>Si prega di notare che cio' puo' essere dovuto a "
 "caratteri incorretti inseriti nel modulo</em> (per esempio facendo copia-"
 "incolla di testo da un file PDF)."
 
@@ -11865,11 +11805,11 @@ msgstr "Seleziona una categoria e poi fai clic su un pulsante di azione."
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
-"Per continuare con una sottomissione precedentemente interrotta, "
-"inserisci un numero di accesso nella casella sottostante:"
+"Per continuare con una sottomissione precedentemente interrotta, inserisci "
+"un numero di accesso nella casella sottostante:"
 
 #: invenio/legacy/websubmit/templates.py:366
 msgid "GO"
@@ -11897,12 +11837,11 @@ msgstr "Torna al menu principale"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
-"Questo è il numero di accesso della tua sottomissione. Può essere "
-"utilizzato per continuare una sottomissione interrotta in caso di "
-"problemi."
+"Questo è il numero di accesso della tua sottomissione. Può essere utilizzato "
+"per continuare una sottomissione interrotta in caso di problemi."
 
 #: invenio/legacy/websubmit/templates.py:548
 msgid "Mandatory fields appear in red in the SUMMARY window."
@@ -11950,11 +11889,11 @@ msgstr "Sottomissione numero"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
-"Ecco la lista delle funzioni %(x_action)s per i documenti %(x_doctype)s "
-"al livello %(x_step)s"
+"Ecco la lista delle funzioni %(x_action)s per i documenti %(x_doctype)s al "
+"livello %(x_step)s"
 
 #: invenio/legacy/websubmit/templates.py:1041
 msgid "Function"
@@ -12035,8 +11974,7 @@ msgstr "Lista dei tipi di documento con referee"
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr "Seleziona uno dei seguenti tipi di documento per verificarne lo stato"
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -12173,10 +12111,11 @@ msgstr "Nota di approvazione:"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
-"Questo documento è ancora %(x_fmt_open)sin attesa di "
-"approvazione%(x_fmt_close)s."
+"Questo documento è ancora %(x_fmt_open)sin attesa di approvazione"
+"%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
 #: invenio/legacy/websubmit/templates.py:2163
@@ -12255,8 +12194,8 @@ msgstr "La richiesta di referee è stata fatta la prima volta il "
 #: invenio/legacy/websubmit/templates.py:2318
 msgid "Last request e-mail was sent to the publication committee chair on the "
 msgstr ""
-"L'ultima email di richiesta spedita alla rappresentanza della commissione"
-" per la pubblicazione è stata inviata il "
+"L'ultima email di richiesta spedita alla rappresentanza della commissione "
+"per la pubblicazione è stata inviata il "
 
 #: invenio/legacy/websubmit/templates.py:2268
 msgid "A referee has been selected by the publication committee on the "
@@ -12274,11 +12213,11 @@ msgstr "Seleziona un referee"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
-"Il referee ha inviato le sue raccomandazioni finali alla commissione "
-"della pubblicazione il "
+"Il referee ha inviato le sue raccomandazioni finali alla commissione della "
+"pubblicazione il "
 
 #: invenio/legacy/websubmit/templates.py:2281
 #: invenio/legacy/websubmit/templates.py:2342
@@ -12296,11 +12235,11 @@ msgstr "Spedisci una raccomandazione"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
-"La commissione per la pubblicazione ha spedito le proprie raccomandazioni"
-" finali al leader del progetto il "
+"La commissione per la pubblicazione ha spedito le proprie raccomandazioni "
+"finali al leader del progetto il "
 
 #: invenio/legacy/websubmit/templates.py:2291
 #: invenio/legacy/websubmit/templates.py:2358
@@ -12340,7 +12279,8 @@ msgid "Take a decision"
 msgstr "Prendi una decisione"
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 "Una editorial board è stata selezionata dalla commissione della "
 "pubblicazione il "
@@ -12363,19 +12303,17 @@ msgstr "L'editorial board ha selezionato un referee il "
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
-"Il referee ha inviato le sue raccomandazioni finali alla editorial board "
-"il "
+"Il referee ha inviato le sue raccomandazioni finali alla editorial board il "
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
-"L'editorial board ha inviato le sue raccomandazioni finali alla "
-"commissione della pubblicazione il "
+"L'editorial board ha inviato le sue raccomandazioni finali alla commissione "
+"della pubblicazione il "
 
 #: invenio/legacy/websubmit/templates.py:2350
 msgid "No recommendation from the editorial board yet."
@@ -12477,8 +12415,8 @@ msgid ""
 "Note that your submission has been inserted into the bibliographic task "
 "queue and is waiting for execution.\n"
 msgstr ""
-"Nota che la tua sottomissione e' stata inserita nella lista d'attesa "
-"delle operazioni bibliografiche per la sua esecuzione.\n"
+"Nota che la tua sottomissione e' stata inserita nella lista d'attesa delle "
+"operazioni bibliografiche per la sua esecuzione.\n"
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:206
 #, fuzzy, python-format
@@ -12490,21 +12428,20 @@ msgid ""
 msgstr ""
 "La lista d'attesa delle operazioni attualmente viene servita in modo "
 "automatico e attualmente ci sono %s operazioni in attesa. Il tuo record "
-"dovrebbe essere disponibile in pochi minuti e rintracciabile con la "
-"ricerca nel giro di circa un'ora.\n"
+"dovrebbe essere disponibile in pochi minuti e rintracciabile con la ricerca "
+"nel giro di circa un'ora.\n"
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
-"A causa di un intervento di manutenzione o un problema temporaneo, la "
-"lista d'attesa delle operazioni e' attualmente in modalita' manuale. La "
-"tua sottomissione e' stata memorizzata correttamente ma puo'richiedere un"
-" tempo piu' lungo del solito prima che il record sia processato e "
-"rintracciabile con la ricerca.\n"
+"A causa di un intervento di manutenzione o un problema temporaneo, la lista "
+"d'attesa delle operazioni e' attualmente in modalita' manuale. La tua "
+"sottomissione e' stata memorizzata correttamente ma puo'richiedere un tempo "
+"piu' lungo del solito prima che il record sia processato e rintracciabile "
+"con la ricerca.\n"
 
 #: invenio/legacy/websubmit/web/approve.py:53
 msgid "approve.py: cannot determine document reference"
@@ -12584,8 +12521,7 @@ msgstr "limite"
 #: invenio/legacy/websubmit/web/publiline.py:749
 msgid "users in brackets are already attached to the role, try another one..."
 msgstr ""
-"gli utenti tra parentesi sono già stati collegati al ruolo, provane "
-"altri..."
+"gli utenti tra parentesi sono già stati collegati al ruolo, provane altri..."
 
 #: invenio/legacy/websubmit/web/publiline.py:755
 msgid "Removing users from the editorial board"
@@ -12786,8 +12722,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12830,11 +12766,6 @@ msgstr "connesso"
 #, fuzzy
 msgid "Role details"
 msgstr "Articolo"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Nascondi"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12950,8 +12881,8 @@ msgstr "L'indirizzo email fornito %s esiste già nel database."
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -13016,9 +12947,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, fuzzy, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 "Sei tuttora riconosciuto dal sistema centralizzato\n"
 "                %(x_fmt_open)sSSO%(x_fmt_close)s. Puoi anche\n"
@@ -13035,8 +12965,8 @@ msgid ""
 "Please enter your email address. You will receive a link to create a new "
 "password via email."
 msgstr ""
-"Per favore, inserisci il tuo indirizzo email, il soprannome desiderato e "
-"la password:"
+"Per favore, inserisci il tuo indirizzo email, il soprannome desiderato e la "
+"password:"
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:33
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:33
@@ -13047,11 +12977,11 @@ msgstr "Imposta nuova password"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
-"Per favore, inserisci il tuo indirizzo email, il soprannome desiderato e "
-"la password:"
+"Per favore, inserisci il tuo indirizzo email, il soprannome desiderato e la "
+"password:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
 #, fuzzy
@@ -13080,7 +13010,7 @@ msgid "Problem with login."
 msgstr "Confronta con l'originale"
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "Puoi ora accedere al tuo %(x_url_open)saccount%(x_url_close)s."
 
@@ -13123,8 +13053,7 @@ msgstr "Modifica autorizzazione bibcatalog fallita"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13196,13 +13125,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13211,9 +13139,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13386,8 +13314,7 @@ msgstr "collezioni"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13477,8 +13404,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13570,10 +13497,10 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
 "Il tuo messaggio è troppo lungo, per favore, modificalo. La dimensione "
 "massima ammessa è di %i caratteri."
@@ -13619,12 +13546,12 @@ msgid "Review was sent"
 msgstr "Scrivi un commento"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Questo commento è stato valutato %i volte"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Questo commento è stato valutato %i volte"
 
@@ -13677,9 +13604,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13698,8 +13624,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13709,9 +13635,10 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
-msgstr "Un file con il nome %s esiste già. Si prega di scegliere un altro nome."
+msgstr ""
+"Un file con il nome %s esiste già. Si prega di scegliere un altro nome."
 
 #: invenio/modules/communities/views.py:135
 #: invenio/modules/communities/views.py:136
@@ -13765,8 +13692,7 @@ msgstr "recensione"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13806,8 +13732,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13854,7 +13779,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "La funzione %s non esiste."
 
@@ -13939,11 +13864,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "Stato della raccolta"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "I tuoi ticket"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -13978,8 +13898,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -14000,8 +13920,8 @@ msgstr "Nessun indice per parola è disponibile per %s."
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -14017,8 +13937,7 @@ msgstr "Validazione elemento di formato %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14138,7 +14057,7 @@ msgstr "Visualizza tutti i %i autori"
 msgid "Manage Files of This Record"
 msgstr "Gestione dei file di questo record"
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr "Modifica questo record"
 
@@ -14236,10 +14155,6 @@ msgstr "1 recensione"
 msgid "Authors"
 msgstr "autore"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14332,9 +14247,10 @@ msgstr "Gestisci permessi dei gruppi"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
-msgstr "Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
+msgstr ""
+"Non possiedi diritti sufficienti a visualizzare il contenuto del cestino."
 
 #: invenio/modules/groups/views.py:279
 #, fuzzy, python-format
@@ -14346,12 +14262,12 @@ msgstr "Non sei amministratore di alcun gruppo."
 msgid "Members"
 msgstr "No membri."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Mappature della base di conoscenza"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14361,11 +14277,11 @@ msgstr "Nessuno"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "qualsiasi campo"
@@ -14411,13 +14327,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "Non ci sono record citati da %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "Non ci sono record citati da %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14572,28 +14489,28 @@ msgstr "Tipo di documento sconosciuto"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14658,9 +14575,10 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
-msgstr "Se desideri completare la registrazione di questo account, segui il link:"
+"Fill in your details to complete your registration. You only have to do this "
+"once."
+msgstr ""
+"Se desideri completare la registrazione di questo account, segui il link:"
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
 msgid "Sign-up"
@@ -15031,7 +14949,7 @@ msgid "Tag name"
 msgstr "Soprannome"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "Il soprannome desiderato %s è già utilizzato."
 
@@ -15137,11 +15055,6 @@ msgstr ""
 msgid "Saving..."
 msgstr "Carica"
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "Nessuno"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15183,8 +15096,7 @@ msgstr "Opzioni di ricerca:"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15393,7 +15305,7 @@ msgid "just now"
 msgstr "Adesso devi"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s secondi"
 
@@ -15452,6 +15364,54 @@ msgstr "qualsiasi anno"
 msgid " years ago"
 msgstr "anno"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "Amministrazione di BibCheck"
+
+#~ msgid "Not authorized"
+#~ msgstr "Non autorizzato"
+
+#~ msgid "Really delete"
+#~ msgstr "Cancellare veramente"
+
+#~ msgid "Verify syntax"
+#~ msgstr "Controlla la sintassi"
+
+#~ msgid "Calling bibcheck -verify failed."
+#~ msgstr "Richiesto BibCheck - errori nella verifica."
+
+#~ msgid "Verify BibCheck config file"
+#~ msgstr "Controllare il file di configurazione di BibCheck"
+
+#~ msgid "Verify problem"
+#~ msgstr "Controlla problema"
+
+#~ msgid "File"
+#~ msgstr "File"
+
+#~ msgid "Edit BibCheck config file"
+#~ msgstr "Modifica il file di configurazione di BibCheck"
+
+#~ msgid "Save BibCheck config file"
+#~ msgstr "Memorizza il file di configurazione di BibCheck"
+
+#~ msgid "Delete BibCheck config file"
+#~ msgstr "Sopprimi il file di configurazione di BibCheck"
+
+#~ msgid "niceName"
+#~ msgstr "Nome"
+
+#~ msgid "Id"
+#~ msgstr "Id"
+
+#~ msgid "Tickets"
+#~ msgstr "volte"
+
+#~ msgid "by"
+#~ msgstr "di"
+
+#~ msgid "Done"
+#~ msgstr "Fatto"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Attenzion: Per favore seleziona un'ora corretta"
 
@@ -15469,9 +15429,6 @@ msgstr "anno"
 
 #~ msgid "*** basket name ***"
 #~ msgstr "*** Nome cestino ***"
-
-#~ msgid ""
-#~ msgstr ""
 
 #~ msgid "%(x_name)s"
 #~ msgstr "collegamento %(x_sitename)s"
@@ -15545,38 +15502,8 @@ msgstr "anno"
 #~ msgid "now"
 #~ msgstr "no"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "Amministrazione di BibCheck"
-
-#~ msgid "Not authorized"
-#~ msgstr "Non autorizzato"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "L'utente %s non esiste."
-
-#~ msgid "Limit to knowledge bases containing string:"
-#~ msgstr ""
-
-#~ msgid "Really delete"
-#~ msgstr "Cancellare veramente"
-
-#~ msgid "Verify syntax"
-#~ msgstr "Controlla la sintassi"
-
-#~ msgid "Calling bibcheck -verify failed."
-#~ msgstr "Richiesto BibCheck - errori nella verifica."
-
-#~ msgid "Verify BibCheck config file"
-#~ msgstr "Controllare il file di configurazione di BibCheck"
-
-#~ msgid "Verify problem"
-#~ msgstr "Controlla problema"
-
-#~ msgid "File"
-#~ msgstr "File"
-
-#~ msgid "Edit BibCheck config file"
-#~ msgstr "Modifica il file di configurazione di BibCheck"
 
 #~ msgid "File %s already exists."
 #~ msgstr "L'utente %s non esiste."
@@ -15587,17 +15514,11 @@ msgstr "anno"
 #~ msgid "File %s: write failed."
 #~ msgstr "Cancella cestino"
 
-#~ msgid "Save BibCheck config file"
-#~ msgstr "Memorizza il file di configurazione di BibCheck"
-
 #~ msgid "File %s deleted."
 #~ msgstr "L'utente %s non esiste."
 
 #~ msgid "File %s: delete failed."
 #~ msgstr "Cancella cestino"
-
-#~ msgid "Delete BibCheck config file"
-#~ msgstr "Sopprimi il file di configurazione di BibCheck"
 
 #~ msgid "Guests are not authorized to run batchuploader"
 #~ msgstr "Gli utenti Guest non sono autorizzati a eseguire il batchuploader"
@@ -15641,9 +15562,6 @@ msgstr "anno"
 #~ msgid "Not Mine!"
 #~ msgstr "Nota"
 
-#~ msgid "Tickets"
-#~ msgstr "volte"
-
 #~ msgid "Request Tickets"
 #~ msgstr "Regole"
 
@@ -15682,9 +15600,6 @@ msgstr "anno"
 
 #~ msgid "This book is sent to you ..."
 #~ msgstr "Questo libro ti viene spedito ..."
-
-#~ msgid "Id"
-#~ msgstr "Id"
 
 #~ msgid "0 borrower(s) found."
 #~ msgstr "Nessuna persona trovata"
@@ -15806,9 +15721,6 @@ msgstr "anno"
 #~ msgid "creating a new basket"
 #~ msgstr "Crea un nuovo cestino"
 
-#~ msgid "by"
-#~ msgstr "di"
-
 #~ msgid "on"
 #~ msgstr "su"
 
@@ -15827,9 +15739,6 @@ msgstr "anno"
 #~ msgid "Editing topic"
 #~ msgstr "Modifica cestino"
 
-#~ msgid "niceName"
-#~ msgstr "Nome"
-
 #~ msgid "Apply Changes"
 #~ msgstr "Memorizza modifiche"
 
@@ -15844,9 +15753,6 @@ msgstr "anno"
 
 #~ msgid "Edit record %(x_recid)s, field %(x_field)s"
 #~ msgstr "Modifica record %(x_recid)s, campo %(x_field)s"
-
-#~ msgid "Edit record %(x_recid)s, field %(x_field)s - Add a subfield"
-#~ msgstr ""
 
 #~ msgid "Submit and save record %s"
 #~ msgstr "Invia e memorizza record %s"
@@ -15920,20 +15826,11 @@ msgstr "anno"
 #~ msgid "Frequently publishes in:"
 #~ msgstr "Pubblica in"
 
-#~ msgid "The collection to which this file belong is restricted: "
-#~ msgstr ""
-
-#~ msgid "You will also lose any unsubmitted changes for this record!"
-#~ msgstr ""
-
 #~ msgid "This record does not exist. Please try another record ID."
 #~ msgstr "Per favore, prova un altro ID di record."
 
 #~ msgid "Cannot edit deleted record.\""
 #~ msgstr "Non è possibile modificare record cancellati."
-
-#~ msgid "The record will be deleted as soon as the task queue is empty."
-#~ msgstr ""
 
 #~ msgid "Please enter the ID of the record you want to edit"
 #~ msgstr "Per favore, inserisci l'ID del record che desideri modificare"
@@ -15955,9 +15852,6 @@ msgstr "anno"
 
 #~ msgid "Verbose"
 #~ msgstr "Prolisso"
-
-#~ msgid "Done"
-#~ msgstr "Fatto"
 
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "Le tue modifiche sono TEMPORANEE."
@@ -15998,9 +15892,6 @@ msgstr "anno"
 #~ msgid "from"
 #~ msgstr "Da:"
 
-#~ msgid "There are record revisions not yet synchronized with the database."
-#~ msgstr ""
-
 #~ msgid "Please try again in a few minutes."
 #~ msgstr "Per favore, riprova tra qualche minuto."
 
@@ -16028,23 +15919,11 @@ msgstr "anno"
 #~ msgid "approvals"
 #~ msgstr "approvazioni"
 
-#~ msgid "Unknown form field found on one of the submission pages."
-#~ msgstr ""
-
 #~ msgid "List of direct approval categories"
 #~ msgstr "Elenco delle categorie ad approvazione diretta"
 
 #~ msgid "Specific Approval and Refereeing Workflow"
 #~ msgstr "Processo specifico di approvazione e refereeing"
-
-#~ msgid "There is no format configured for this journals index page"
-#~ msgstr ""
-
-#~ msgid "There is no format configured for this journals search page"
-#~ msgstr ""
-
-#~ msgid "There is no format configured for this journals popup page"
-#~ msgstr ""
 
 #~ msgid "Export as"
 #~ msgstr "Esporta come"
@@ -16067,34 +15946,11 @@ msgstr "anno"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "Manuale di WebSubmit"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "Esegui ricerca"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Annullato"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "Sei un membro dei seguenti gruppi:"
@@ -16108,12 +15964,6 @@ msgstr "anno"
 #~ msgid "Invert Selection"
 #~ msgstr "Selezione referee"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Autore"
 
@@ -16125,12 +15975,6 @@ msgstr "anno"
 
 #~ msgid "No status information found."
 #~ msgstr "Ulteriori informazioni:"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "divisione"
@@ -16147,15 +15991,6 @@ msgstr "anno"
 #~ msgid "The author has an internal ID!"
 #~ msgstr "È avvenuto un errore interno"
 
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "commenti"
 
@@ -16165,87 +16000,20 @@ msgstr "anno"
 #~ msgid " Delete this ticket"
 #~ msgstr "Cancella cestino"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "Nessun giornale disponibile"
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Seleziona un punteggio"
 
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
 #~ msgid "Paper title: "
 #~ msgstr "Articoli:"
-
-#~ msgid "Ignore"
-#~ msgstr ""
 
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "Sono stati riscontrati i seguenti errori"
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "Seleziona un punteggio"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "Ulteriori informazioni:"
@@ -16253,35 +16021,11 @@ msgstr "anno"
 #~ msgid "Please provide your first name"
 #~ msgstr "Per favore, autentificati."
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "Tuoi prestiti"
 
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
 #~ msgid "Your eMail:"
 #~ msgstr "I tuoi avvisi"
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "Cancella le recensioni selezionate"
@@ -16289,186 +16033,35 @@ msgstr "anno"
 #~ msgid "Mark as your documents"
 #~ msgstr "tutti i tipi di documento"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "Torna al documento"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Torna al documento"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "o creane uno nuovo"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "Aggiungi agli utenti"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Articoli:"
-
-#~ msgid "Showing the"
-#~ msgstr ""
 
 #~ msgid "most recent documents:"
 #~ msgstr "Elenco dei documenti con referee"
 
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Gestioni file di documenti"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Scegli un file"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Data creazione"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "collegamento esterno"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "sottomissioni"
@@ -16476,175 +16069,20 @@ msgstr "anno"
 #~ msgid "Choose system"
 #~ msgstr "Scegli argomento"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "I seguenti file sono stati inseriti in lista d'attesa:"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Non sei autorizzato ad accedere alle funzioni amministrative."
 
 #~ msgid "Claim this paper"
 #~ msgstr "aggiungi questo utente"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The publication date of this book is %s."
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Citato da: %s articoli"
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
 
 #~ msgid "Revision"
 #~ msgstr "Revisione"
 
 #~ msgid "Failed to create a ticket"
 #~ msgstr "Errore nella creazione del ticket"
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Modifica gli attributi del modello"
@@ -16724,89 +16162,20 @@ msgstr "anno"
 #~ msgid "No Record Found for %s."
 #~ msgstr "Record non trovato"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Il file %s non esiste."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "Attributi formato di output %s"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "Dipendenze di modello di formato %s"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "Validazione elemento di formato %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "Dipendenze elemento di formato %s"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Formato di output con restrizioni"
@@ -16862,107 +16231,17 @@ msgstr "anno"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Validazione elemento di formato %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "Validazione formato"
 
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "Basi di conoscenza %s"
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "Non impostato"
 
 #~ msgid "never"
 #~ msgstr "mai"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "volte"
@@ -16991,17 +16270,11 @@ msgstr "anno"
 #~ msgid "Affiliations"
 #~ msgstr "Affiliazioni:"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
 #~ msgid "No Frequent Co-authors"
 #~ msgstr "Co-autori frequenti:"
 
 #~ msgid "Citations%s"
 #~ msgstr "Citazioni"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Data creazione"
@@ -17012,36 +16285,6 @@ msgstr "anno"
 #~ msgid "No publications available"
 #~ msgstr "Nessuna informazione disponibile"
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr "Citato da 1 record"
 
@@ -17051,17 +16294,11 @@ msgstr "anno"
 #~ msgid "%i reviews"
 #~ msgstr "%i recensione"
 
-#~ msgid "%s of"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "Articoli:"
 
 #~ msgid "Frequent co-authors"
 #~ msgstr "Co-autori frequenti:"
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "Citazioni:"
@@ -17069,23 +16306,8 @@ msgstr "anno"
 #~ msgid "No Citation Information available"
 #~ msgstr "Nessun giornale disponibile"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Discussioni"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "I tuoi avvisi"
@@ -17105,18 +16327,8 @@ msgstr "anno"
 #~ msgid "Statistics"
 #~ msgstr "Statistiche"
 
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
 #~ msgid "Group: %s"
 #~ msgstr "Gruppo: %s"
-
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
 
 #~ msgid "Page %s Not Found"
 #~ msgstr "Pagina %s non trovata"
@@ -17125,69 +16337,5 @@ msgstr "anno"
 #~ msgstr "Il campo %s è obbligatorio."
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "Impossibile determinare il numero di pagine di sottomissione."
-

--- a/invenio/base/translations/ja/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/ja/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2008-06-13 13:00+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:57+0200\n"
 "Last-Translator: Marko Niinimaki <man@cern.ch>\n"
 "Language-Team: JA <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -58,8 +58,8 @@ msgstr "管理者区域"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -205,7 +205,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 #, fuzzy
 msgid "Hello:"
 msgstr "ハロー"
@@ -227,17 +227,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -263,48 +263,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "この記録は存在しません。"
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "あなたはこのバスケットの所有者ではありません"
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "登録失敗"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "一つ以上選んでください"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "登録失敗"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -507,7 +512,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -565,7 +571,8 @@ msgstr "ログイン方法の編集"
 #: invenio/legacy/batchuploader/templates.py:475
 #, fuzzy, python-format
 msgid "All fields with %(x_fmt_open)s*%(x_fmt_close)s are mandatory"
-msgstr "もし %(x_fmt_open)sno%(x_fmt_close)s ならば、バスケットを指定してください。"
+msgstr ""
+"もし %(x_fmt_open)sno%(x_fmt_close)s ならば、バスケットを指定してください。"
 
 #: invenio/legacy/batchuploader/templates.py:245
 #: invenio/legacy/batchuploader/templates.py:466
@@ -584,8 +591,8 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"%(x_user)s　さん、つぎはa) %(x_url1_open)sログアウト または %(x_url1_close)s　b) "
-"%(x_url2_open)sアカウント設定の編集 %(x_url2_close)s　をしてください。"
+"%(x_user)s　さん、つぎはa) %(x_url1_open)sログアウト または %(x_url1_close)s"
+"　b) %(x_url2_open)sアカウント設定の編集 %(x_url2_close)s　をしてください。"
 
 #: invenio/legacy/batchuploader/templates.py:282
 #, fuzzy
@@ -729,7 +736,8 @@ msgid "The following errors have occurred:"
 msgstr "次のエラーが見つかりました。"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -746,8 +754,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -829,7 +837,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -872,8 +880,8 @@ msgstr "あなたのバスケット"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "前"
@@ -889,8 +897,8 @@ msgstr "評価"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "次"
 
@@ -910,14 +918,6 @@ msgstr "管理者区域"
 msgid "BibCheck Admin"
 msgstr ""
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "著者"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
 msgid "ERROR: %(x_name)s does not exist"
@@ -936,11 +936,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
 msgid "Limit to knowledge bases containing string:"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "消去しました"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -992,16 +987,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
 msgid "Verify BibCheck config file"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "データベースに問題があります"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "ファイル"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
@@ -1107,7 +1092,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1158,8 +1144,8 @@ msgstr "アカウントが作られました。"
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1173,25 +1159,23 @@ msgstr "ブラウズ"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "アカウントが作られました。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "アカウントが作られました。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1216,13 +1200,14 @@ msgstr "新しいトピックを作る。"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "アカウントが作られました。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1254,9 +1239,8 @@ msgstr "現在の状態"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "アカウントが作られました。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1323,8 +1307,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1332,8 +1316,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1355,9 +1339,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "アカウントが作られました。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1399,8 +1382,8 @@ msgstr "%s のレコードが見つかりました。"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1459,11 +1442,11 @@ msgstr "アカウントが作られました。"
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1474,11 +1457,11 @@ msgstr "はい"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1491,8 +1474,8 @@ msgstr "いいえ"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1589,8 +1572,8 @@ msgstr "<strong>%s</strong> の記録が見つかった。"
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1610,29 +1593,29 @@ msgstr "<strong>%s</strong> の記録が見つかった。"
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1641,9 +1624,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 #, fuzzy
 msgid "Requested record does not seem to exist."
 msgstr "レコード %s は存在しません。"
@@ -2005,16 +1988,14 @@ msgstr "このレコードは削除されました。"
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2035,8 +2016,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2198,8 +2179,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2308,7 +2289,7 @@ msgstr "アクション"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "説明"
 
@@ -2503,8 +2484,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2790,9 +2771,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "%(x_url_open)sここにログインしますか%(x_url_close)s？"
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2848,7 +2828,7 @@ msgstr "却下"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "ＯＫ"
 
@@ -2856,8 +2836,8 @@ msgstr "ＯＫ"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "アカウントが作られました。"
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3331,8 +3311,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "Ｅメイル"
 
@@ -3838,7 +3818,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:7419
 #, fuzzy, python-format
 msgid "A %(x_url_open)snew copy%(x_url_close)s has been added."
-msgstr "このユーザーの要求を%(x_url_open)s承諾または拒否%(x_url_close)sしてください"
+msgstr ""
+"このユーザーの要求を%(x_url_open)s承諾または拒否%(x_url_close)sしてください"
 
 #: invenio/legacy/bibcirculation/templates.py:7443
 #, fuzzy
@@ -4183,8 +4164,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4202,8 +4183,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4269,17 +4250,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4667,25 +4648,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "このレコードは削除されました。"
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4745,15 +4726,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4765,10 +4746,10 @@ msgstr "トピックを選ぶ"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4782,15 +4763,15 @@ msgstr "ルール"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4801,7 +4782,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4820,17 +4802,15 @@ msgstr "ニックネーム%sは存在します。"
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "ニックネーム%sは存在します。"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4849,14 +4829,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4910,8 +4889,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4966,8 +4945,8 @@ msgstr "レコード %s は存在しません。"
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -5088,9 +5067,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -5105,8 +5084,8 @@ msgstr "変更を保存"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -5250,11 +5229,10 @@ msgstr "検索結果に戻る"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5391,7 +5369,7 @@ msgid "Total"
 msgstr "オプション"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "選択"
 
@@ -5561,8 +5539,8 @@ msgstr "知識ベースの削除"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5621,56 +5599,56 @@ msgstr "ログインしてください。"
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5710,7 +5688,7 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5764,15 +5742,15 @@ msgstr "あなたの通知"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -6000,8 +5978,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -6080,8 +6057,8 @@ msgstr "参照（番号）がまだ与えられません。"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6096,8 +6073,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "検索結果"
 
@@ -6258,8 +6235,8 @@ msgstr "見つかりませんでした"
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6285,8 +6262,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6297,126 +6274,134 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
 #, python-format
 msgid "No exact match found for %(x_query1)s, using %(x_query2)s instead..."
-msgstr "%(x_query1)sに完全マッチするものはなかった。%(x_query2)s を試してください。"
+msgstr ""
+"%(x_query1)sに完全マッチするものはなかった。%(x_query2)s を試してください。"
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
-"コレクション %(x_collection)s ではマッチしませんでした。他の公共コレクションでは "
-"%(x_nb_hits)dの%(x_url_open)sヒット%(x_url_close)sがありました。"
+"コレクション %(x_collection)s ではマッチしませんでした。他の公共コレクション"
+"では %(x_nb_hits)dの%(x_url_open)sヒット%(x_url_close)sがありました。"
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
-msgstr "公共コレクションはあなたのクエリーにマッチしませんでした。非公開ドキュメントを探しているならば、まず、制限つきコレクションを選んでください。"
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
+msgstr ""
+"公共コレクションはあなたのクエリーにマッチしませんでした。非公開ドキュメント"
+"を探しているならば、まず、制限つきコレクションを選んでください。"
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
-msgstr "公共コレクションはあなたのクエリーにマッチしませんでした。非公開ドキュメントを探しているならば、まず、制限つきコレクションを選んでください。"
+msgstr ""
+"公共コレクションはあなたのクエリーにマッチしませんでした。非公開ドキュメント"
+"を探しているならば、まず、制限つきコレクションを選んでください。"
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
-msgstr "%s で検索したが、どのレコードにも合致しませんでした。すべてのコレクションで最も近いものは以下のとおりです："
+msgstr ""
+"%s で検索したが、どのレコードにも合致しませんでした。すべてのコレクションで最"
+"も近いものは以下のとおりです："
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "別の検索をします。"
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "バスケットは %i こあります。"
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "バスケットは %i こあります。"
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "バスケットは %i こあります。"
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "以下の単語インデックスは見つからなかった："
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "以下の句インデックスは見つからなかった："
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
-"%(x_index)s "
-"を　%(x_term)sで検索したが、どのレコードにも合致しませんでした。すべてのコレクションで最も近いものは以下のとおりです："
+"%(x_index)s を　%(x_term)sで検索したが、どのレコードにも合致しませんでした。"
+"すべてのコレクションで最も近いものは以下のとおりです："
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
-msgstr "%s で検索したが、どのレコードにも合致しませんでした。すべてのコレクションで最も近いものは以下のとおりです："
+msgstr ""
+"%s で検索したが、どのレコードにも合致しませんでした。すべてのコレクションで最"
+"も近いものは以下のとおりです："
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr "%s は正しいソートオプションではありません。タイトルでソートします。"
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr "レコード数が %d を越えているので、ソートできません。"
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr "%s は正しいソートオプションではありません。タイトルでソートします。"
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "この記録は存在しません。"
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "別の検索をします。"
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6430,11 +6415,11 @@ msgstr "別の検索をします。"
 msgid "Browse"
 msgstr "ブラウズ"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr "制限時間内に一致するものがみつかりませんでした。この条件を除きます。"
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr "制限条件内に一致するものがみつかりませんでした。この条件を除きます。"
 
@@ -6478,10 +6463,9 @@ msgstr "アラートは更新されました。 %s"
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
 
 #: invenio/legacy/webalert/htmlparser.py:186
@@ -6601,7 +6585,8 @@ msgstr "いいえ"
 #: invenio/legacy/webalert/templates.py:225
 #, python-format
 msgid "if %(x_fmt_open)sno%(x_fmt_close)s you must specify a basket"
-msgstr "もし %(x_fmt_open)sno%(x_fmt_close)s ならば、バスケットを指定してください。"
+msgstr ""
+"もし %(x_fmt_open)sno%(x_fmt_close)s ならば、バスケットを指定してください。"
 
 #: invenio/legacy/webalert/templates.py:227
 msgid "Store results in basket?"
@@ -6671,15 +6656,17 @@ msgstr "アラートの数 %s"
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
-msgstr "検索記録がありません。まず %(x_url_open)s検索%(x_url_close)s を実行してください。"
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
+msgstr ""
+"検索記録がありません。まず %(x_url_open)s検索%(x_url_close)s を実行してくださ"
+"い。"
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr "最近３０日間に%(x_nb1)s回（%(x_nb2)s回の異なる）検索をしました。"
 
 #: invenio/legacy/webalert/templates.py:453
@@ -6739,7 +6726,7 @@ msgstr "検索"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6803,7 +6790,7 @@ msgstr "新しいアラートの設定"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6863,7 +6850,8 @@ msgstr "アラートの表示"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6887,7 +6875,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "このバスケットの内容を編集する権限がありません。"
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6915,7 +6904,8 @@ msgid "You do not have permission to delete this note."
 msgstr "このバスケットの内容を編集する権限がありません。"
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6946,8 +6936,8 @@ msgstr "この記録は存在しません。"
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6969,8 +6959,8 @@ msgstr "レコードをバスケットにコピー"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -7003,8 +6993,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7077,11 +7067,10 @@ msgstr "公開バスケット"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
-"自分のバスケットの数：%(x_nb_perso)s、購読するバスケットの数：%(x_nb_group)s、他のユーザーのバスケットの数 "
-"%(x_nb_public)s"
+"自分のバスケットの数：%(x_nb_perso)s、購読するバスケットの数："
+"%(x_nb_group)s、他のユーザーのバスケットの数 %(x_nb_public)s"
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
 #, fuzzy
@@ -7108,9 +7097,9 @@ msgstr "このバスケットは %i グループが購読しています。"
 #: invenio/legacy/webbasket/templates.py:108
 #, fuzzy, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
-msgstr "いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
+msgstr ""
+"いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
 
 #: invenio/legacy/webbasket/templates.py:131
 #: invenio/legacy/webbasket/templates.py:198
@@ -7221,7 +7210,9 @@ msgstr "アクセスできる公開バスケットはありません。"
 msgid ""
 "Displaying public baskets %(x_from)i - %(x_to)i out of "
 "%(x_total_public_basket)i public baskets in total."
-msgstr "%(x_nb_total)i このバスケットのうち、%(x_nb_begin)i から %(x_nb_end)i　を表示しています。"
+msgstr ""
+"%(x_nb_total)i このバスケットのうち、%(x_nb_begin)i から %(x_nb_end)i　を表示"
+"しています。"
 
 #: invenio/legacy/webbasket/templates.py:1376
 #: invenio/legacy/webbasket/templates.py:1400
@@ -7280,8 +7271,8 @@ msgstr "外部レコード"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7302,7 +7293,8 @@ msgstr "%(x_url_open)sここにログインしますか%(x_url_close)s？"
 #: invenio/legacy/webbasket/templates.py:1649
 #, fuzzy, python-format
 msgid " or return to your %(x_url_open)sprevious basket%(x_url_close)s"
-msgstr "いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
+msgstr ""
+"いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
 
 #: invenio/legacy/webbasket/templates.py:1653
 #, fuzzy, python-format
@@ -7466,16 +7458,18 @@ msgstr "他のグループにバスケットを共有させる"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr "ゲストユーザが作ったバスケットはセッションが終わると消されます。"
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
-msgstr "ひつようなら %(x_url_open)sログインまたは登録%(x_url_close)s をしてください。"
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgstr ""
+"ひつようなら %(x_url_open)sログインまたは登録%(x_url_close)s をしてください。"
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7484,7 +7478,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "この機能はゲストユーザには使えません。"
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "検索結果に戻る"
 
@@ -7659,7 +7653,7 @@ msgstr "ユーザーに追加"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7806,215 +7800,215 @@ msgstr "ユーザ %sは存在しません。"
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "ユーザ %sは存在しません。"
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "コメントを核"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_name)s が %(x_date)s　に書いた。"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "コメント"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "最新の %i このコメントを表示"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "この文書のディスカッションをする"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "この文書についてのディスカッションを始める"
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "レコード %s は存在しません。"
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "%s　は有効なＩＤではありません。"
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "レコードＩＤはありません。"
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "%s を閲覧しますか？"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_name)s が %(x_date)s　に書いた。"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "このレビューは役に立ちましたか？"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "レビューを書く。"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr "レビュー数： %(x_nb_reviews)s 。平均レビュースコアー：　%(x_nb_score)s"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "読者には次の %s　のレビューが役に立った。"
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "全部で　%s のレビューを見る。"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "このドキュメントの評価"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "このドキュメントの最初のレビューです"
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "評価"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "不正使用の報告"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 #, fuzzy
 msgid "Undelete comment"
 msgstr "コメントを削除"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "コメントを削除"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 #, fuzzy
 msgid "Unreport comment"
 msgstr "コメントを削除"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "%(x_nickname)s が　%(x_date)s にレビューしました。"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr "このレビューは　%(x_nb_total)i 人中 %(x_nb_people)i 人に役立ちました。"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 #, fuzzy
 msgid "Undelete review"
 msgstr "選択したレビューを消す"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 #, fuzzy
 msgid "Delete review"
 msgstr "選択したレビューを消す"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 #, fuzzy
 msgid "Unreport review"
 msgstr "レビューを書いてください。"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "コメント"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "レビュー"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "全部で %s のレビューがあります"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "全部で %s のコメントがあります"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "このドキュメントの最初のレビューです"
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "購読"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 #, fuzzy
 msgid "Unsubscribe"
 msgstr "購読"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -8023,517 +8017,521 @@ msgstr "購読"
 msgid "Record"
 msgstr "レコード"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "レビュー"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "コメント"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "レビュー"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "読む"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "ページ"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 #, fuzzy
 msgid "You are not authorized to comment or review."
 msgstr "あなたはこのバスケットの所有者ではありません"
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr "注：このコメントの著者名はあなたのニックネーム %s になります。"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
-"注： %(x_url_open)sここ%(x_url_close)s でニックネームをとうろくしてください。このコメントの著者名は "
-"%(x_nickname)s になります。"
+"注： %(x_url_open)sここ%(x_url_close)s でニックネームをとうろくしてください。"
+"このコメントの著者名は %(x_nickname)s になります。"
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 #, fuzzy
 msgid "Max one file"
 msgstr "ルールを追加"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "ファイル"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "記事"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 #, fuzzy
 msgid "Add comment"
 msgstr "コメントを追加"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr "注：このレビューの著者名はあなたのニックネーム %s になります。"
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "この記事の評価"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "評価を選んでください"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "レビューにタイトルをつけてください。"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "レビューを書いてください。"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 #, fuzzy
 msgid "Add review"
 msgstr "レビューを追加"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "レビューを追加"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "あなたのレビューは追加されました。"
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "あなたのコメントは追加されました。"
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "レコードにもどる"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
-msgstr "いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
+msgstr ""
+"いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 #, fuzzy
 msgid "View most commented records"
 msgstr "コメントを見る"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 #, fuzzy
 msgid "View latest commented records"
 msgstr "コメントを見る"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all comments reported as abuse"
 msgstr "レポートした全ユーザを見る。"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 #, fuzzy
 msgid "View most reviewed records"
 msgstr "レコードを削除"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 #, fuzzy
 msgid "View latest reviewed records"
 msgstr "全部で　%s のレビューを見る。"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all reviews reported as abuse"
 msgstr "レポートした全ユーザを見る。"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "レポートをくれたすべてのユーザーを見る。"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "ガイド"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "コメントとレビューは受けられないようになっています。"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr "レビュー・コメントを読んでから消すかどうかを決める。ＩＤ＝"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "コメントＩＤ"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 #, fuzzy
 msgid "Record ID:"
 msgstr "記録的なID"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "コメントを読む"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "これまでにレポートはありません。"
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "全部で %s このコメントを読む。"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "全部で %s このレビューを読む。"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
-msgstr "これまでレポートをくれたことのあるユーザーの一覧（レポート数の順）です。"
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
+msgstr ""
+"これまでレポートをくれたことのあるユーザーの一覧（レポート数の順）です。"
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "ニックネーム"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "ユーザＩＤ"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "好意的な評価の数"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "批判的な評価の数"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "全評価数"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "全レポート数"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "すべてのユーザーのコメントとレビューを読む。"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "このレビューは%i回報告された。"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "このコメントは%i回報告された。"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "著者"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "一般情報"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "選択したレビューを消す"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "不正なレポートを抑制"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 #, fuzzy
 msgid "Undelete selected reviews"
 msgstr "選択したレビューを消す"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 #, fuzzy
 msgid "Undelete selected comments"
 msgstr "選択したコメントを消す"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "選択したコメントを消す"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "ユーサー %s のレポート"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "ユーサー %s のコメント"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "コメント・レビュー %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "コメント・レビュー %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, fuzzy, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "ユーザ %(x_user)s　によるコメント（ＩＤ＝%(x_cmtID)s）"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, fuzzy, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "ユーザ %(x_user)s　によるコメント（ＩＤ＝%(x_cmtID)s）"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "全レビュー（多い順）のリスト"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "全コメント（多い順）のリスト"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr "全レビュー（多い順）のリスト"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 #, fuzzy
 msgid "Show comments"
 msgstr "コメントを見る"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr "全コメント（多い順）のリスト"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 #, fuzzy
 msgid "Show reviews"
 msgstr "レビュー"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "コメントＩＤ"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "消去しました"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 #, fuzzy
 msgid "successfully undeleted"
 msgstr "消去しました"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "不正なレポートを抑制しました。"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 #, fuzzy
 msgid "Not yet reviewed"
 msgstr "レビューを書いてください。"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "コメントはポストされました"
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "コメント削除"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "新しいものから"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "コメントを見る"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "詳細とコメント"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "%s のレコードが見つかりました。"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "コメント"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "時間"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "ユーザーに追加"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "表示"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "生成日付"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "次のページ"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "アラートの表示"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8542,106 +8540,106 @@ msgstr "アラートの表示"
 msgid "Refresh"
 msgstr "参照："
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "コメントを削除"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "見つかりませんでした"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "レコードがみつからない"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "このバスケットの内容を編集する権限がありません。"
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "コメントを追加"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "すべてのコメントを読む。"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 #, fuzzy
 msgid "Page Not Found"
 msgstr "コレクション %s が見つかりません。"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 #, fuzzy
 msgid "The requested comment could not be found"
 msgstr "この記録は存在しません。"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 #, fuzzy
 msgid "The requested file could not be found"
 msgstr "この記録は存在しません。"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "あなたはこのバスケットの所有者ではありません"
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "コメント"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "すべてのコメントを読む。"
@@ -8763,9 +8761,10 @@ msgstr "レコード %s は存在しません。"
 #: invenio/legacy/webdoc/webinterface.py:200
 #, fuzzy, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
-msgstr "いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
+msgstr ""
+"いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
 #, fuzzy, python-format
@@ -8836,8 +8835,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8865,8 +8864,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -8970,11 +8969,6 @@ msgstr ""
 msgid "Apply"
 msgstr "4月"
 
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "ニックネーム"
-
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 msgid "WebJournal Admin"
 msgstr ""
@@ -9058,9 +9052,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -9082,8 +9075,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9568,14 +9560,14 @@ msgstr "検索対象の追加"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9713,9 +9705,10 @@ msgstr "参加希望"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
-msgstr "AND/OR/NOTを用いたクエリーがマッチしませんでした。他の組み合わせを試してください。"
+"Boolean query returned no hits. Please combine your search terms differently."
+msgstr ""
+"AND/OR/NOTを用いたクエリーがマッチしませんでした。他の組み合わせを試してくだ"
+"さい。"
 
 #: invenio/legacy/websearch/templates.py:3357
 msgid "See also: similar author names"
@@ -9740,8 +9733,8 @@ msgstr "%s の閲覧から始めてください。"
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3832
@@ -9935,7 +9928,8 @@ msgid "in"
 msgstr "中の"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "捜していたものを見つけなかったならば、他のサーバーもお試しください："
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -10028,8 +10022,8 @@ msgstr "必須"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -10039,8 +10033,8 @@ msgstr "新しいバスケットを作る"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:271
@@ -10057,15 +10051,17 @@ msgstr "新しい値を設定してください"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
-msgstr "パスワードを変更するには、現在のパスワードを入力し、新しいパスワードを次のフォームに入力してください"
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
+msgstr ""
+"パスワードを変更するには、現在のパスワードを入力し、新しいパスワードを次の"
+"フォームに入力してください"
 
 #: invenio/legacy/websession/templates.py:327
 msgid "Old password"
@@ -10102,16 +10098,18 @@ msgstr "新しいパスワード"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
-msgstr "ひつようなら %(x_url_open)sログインまたは登録%(x_url_close)s をしてください。"
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
+msgstr ""
+"ひつようなら %(x_url_open)sログインまたは登録%(x_url_close)s をしてください。"
 
 #: invenio/legacy/websession/templates.py:346
 #, fuzzy, python-format
 msgid ""
 "You can change or reset your CERN account password by means of the "
 "%(x_url_open)sCERN account system%(x_url_close)s."
-msgstr "いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
+msgstr ""
+"いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
 
 #: invenio/legacy/websession/templates.py:372
 #, fuzzy
@@ -10193,11 +10191,12 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:537
 #, fuzzy, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
-msgstr "CDS Indicoのパスワードをお忘れならば、以下にあなたのＥメイルアドレスを書いてお送りください。パスワードをお送りします。"
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
+msgstr ""
+"CDS Indicoのパスワードをお忘れならば、以下にあなたのＥメイルアドレスを書いて"
+"お送りください。パスワードをお送りします。"
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10214,17 +10213,18 @@ msgstr "パスワードを送る"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 #, fuzzy
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
-msgstr "もし外部ログインシステムをおつかいならば、所属機関に問い合わせてください。"
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
+msgstr ""
+"もし外部ログインシステムをおつかいならば、所属機関に問い合わせてください。"
 
 #: invenio/legacy/websession/templates.py:573
 #, fuzzy, python-format
@@ -10236,11 +10236,13 @@ msgstr "内部ログインシステムにアカウントを変更することも
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
-msgstr "%s のインターフェース設定：個人ライブラリの設定、定期的に検索をおこない結果をＥメイルで送るための自動通知の設定。"
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
+msgstr ""
+"%s のインターフェース設定：個人ライブラリの設定、定期的に検索をおこない結果を"
+"Ｅメイルで送るための自動通知の設定。"
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10251,7 +10253,8 @@ msgstr "あなたの設定"
 msgid ""
 "Set or change your account email address or password. Specify your "
 "preferences about the look and feel of the interface."
-msgstr "Ｅメイルアドレスやパスワードの設定・変更。インターフェースの外観の設定。"
+msgstr ""
+"Ｅメイルアドレスやパスワードの設定・変更。インターフェースの外観の設定。"
 
 #: invenio/legacy/websession/templates.py:620
 msgid "View all the searches you performed during the last 30 days."
@@ -10259,9 +10262,11 @@ msgstr "過去３０日間にあなたが行った検索を見る。"
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
-msgstr "バスケット：自分のコレクション・興味を持ったレコードを自分あるいは共有のために使えます。"
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
+msgstr ""
+"バスケット：自分のコレクション・興味を持ったレコードを自分あるいは共有のため"
+"に使えます。"
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10271,36 +10276,39 @@ msgstr ""
 msgid ""
 "Subscribe to a search which will be run periodically by our service. The "
 "result can be sent to you via Email or stored in one of your baskets."
-msgstr "定期的に行う検索を設定します。結果はＥメイルでおくったり、自分のバスケットに蓄積します。"
+msgstr ""
+"定期的に行う検索を設定します。結果はＥメイルでおくったり、自分のバスケットに"
+"蓄積します。"
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr "貸与品などのかんりをします。ＣＥＲＮＩＤが必要です"
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr "ゲストユーザはログアウトするとアラートが消失します。"
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
-"%(x_user)s　さん、つぎはa) %(x_url1_open)sログアウト または %(x_url1_close)s　b) "
-"%(x_url2_open)sアカウント設定の編集 %(x_url2_close)s　をしてください。"
+"%(x_user)s　さん、つぎはa) %(x_url1_open)sログアウト または %(x_url1_close)s"
+"　b) %(x_url2_open)sアカウント設定の編集 %(x_url2_close)s　をしてください。"
 
 #: invenio/legacy/websession/templates.py:785
 #, fuzzy, python-format
 msgid ""
 "You can consult the list of %(x_url_open)syour comments%(x_url_close)s "
 "submitted so far."
-msgstr "いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
+msgstr ""
+"いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
 
 #: invenio/legacy/websession/templates.py:790
 msgid "Your Alert Searches"
@@ -10309,8 +10317,8 @@ msgstr "アラートの検索"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:799
@@ -10322,8 +10330,8 @@ msgstr "あなたのグループ"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:805
@@ -10334,8 +10342,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:811
@@ -10346,7 +10354,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:815
 #, fuzzy, python-format
 msgid "You can consult the list of %(x_url_open)syour tickets%(x_url_close)s."
-msgstr "いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
+msgstr ""
+"いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
 
 #: invenio/legacy/websession/templates.py:818
 #, fuzzy
@@ -10382,7 +10391,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -10431,21 +10441,27 @@ msgstr "すでにアカウントをお持ちなら、以下のフォームをお
 #: invenio/legacy/websession/templates.py:1015
 #, fuzzy, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
-msgstr "アカウントを持っていないならば、%(x_url_open)s登録%(x_url_close)sをしてください。"
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
+msgstr ""
+"アカウントを持っていないならば、%(x_url_open)s登録%(x_url_close)sをしてくださ"
+"い。"
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
-msgstr "アカウントを持っていないならば、%(x_url_open)s登録%(x_url_close)sをしてください。"
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
+msgstr ""
+"アカウントを持っていないならば、%(x_url_open)s登録%(x_url_close)sをしてくださ"
+"い。"
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
 msgid "If you don't own an account yet, please contact %(x_name)s."
-msgstr "アカウントを持っていないならば、%(x_url_open)s登録%(x_url_close)sをしてください。"
+msgstr ""
+"アカウントを持っていないならば、%(x_url_open)s登録%(x_url_close)sをしてくださ"
+"い。"
 
 #: invenio/legacy/websession/templates.py:1051
 msgid "Login method:"
@@ -10475,8 +10491,8 @@ msgstr "ログインにはニックネームまたはＥメイルアドレスを
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -10504,8 +10520,8 @@ msgstr "自分のＥメイルアドレス、ニックネーム、パスワード
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr "アカウントは確認・有効化しないと使えません。"
 
 #: invenio/legacy/websession/templates.py:1228
@@ -10522,26 +10538,27 @@ msgstr "登録"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
-"簡単に分かるパスワードは使わないでください。Ｅメイルアドレスを第三者に譲渡することを禁じます。Ｅメイルアドレスがあなたを同定することにもちいられており"
-" %s、新しいプレプリントを検索し通知メイルを送る機能などに用いられます。"
+"簡単に分かるパスワードは使わないでください。Ｅメイルアドレスを第三者に譲渡す"
+"ることを禁じます。Ｅメイルアドレスがあなたを同定することにもちいられており "
+"%s、新しいプレプリントを検索し通知メイルを送る機能などに用いられます。"
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr "アカウントを作れません。%sに連絡をしてください。"
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr "最初に%(x_url_open)sログイン%(x_url_close)sしてください。"
 
 #: invenio/legacy/websession/templates.py:1267
@@ -10673,9 +10690,11 @@ msgstr "ここを見て下さい。"
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
-msgstr "%(x_url_open)sAdmin Area%(x_url_close)s には管理者レベルのページがさらにあります。"
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
+msgstr ""
+"%(x_url_open)sAdmin Area%(x_url_close)s には管理者レベルのページがさらにあり"
+"ます。"
 
 #: invenio/legacy/websession/templates.py:1378
 msgid "guest"
@@ -10850,7 +10869,9 @@ msgstr ""
 msgid ""
 "If you want to invite new members to join your group, please use the "
 "%(x_url_open)sweb message%(x_url_close)s system."
-msgstr "新しいメンバーを勧誘するために %(x_url_open)sweb message%(x_url_close)s システムを使ってください。"
+msgstr ""
+"新しいメンバーを勧誘するために %(x_url_open)sweb message%(x_url_close)s シス"
+"テムを使ってください。"
 
 #: invenio/legacy/websession/templates.py:2100
 #, fuzzy, python-format
@@ -10893,8 +10914,10 @@ msgstr "ユーザーがグループ %s に参加しようとしています"
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
-msgstr "このユーザーの要求を%(x_url_open)s承諾または拒否%(x_url_close)sしてください"
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgstr ""
+"このユーザーの要求を%(x_url_open)s承諾または拒否%(x_url_close)sしてください"
 
 #: invenio/legacy/websession/templates.py:2400
 #, fuzzy, python-format
@@ -10935,72 +10958,71 @@ msgstr "グループ %s は管理者により削除されました"
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
-msgstr "%(x_url_open)slogin%(x_url_close)sして、ユーザーとしてログインしてから作業をしてください。"
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
+msgstr ""
+"%(x_url_open)slogin%(x_url_close)sして、ユーザーとしてログインしてから作業を"
+"してください。"
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
-msgstr "%(x_fmt_open)sユーザー%(x_fmt_close)s %(x_url_open)s登録を%(x_url_close)s してください。"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
+msgstr ""
+"%(x_fmt_open)sユーザー%(x_fmt_close)s %(x_url_open)s登録を%(x_url_close)s し"
+"てください。"
 
 #: invenio/legacy/websession/webaccount.py:127
 msgid "No queries found"
@@ -11008,14 +11030,14 @@ msgstr "クエリーはありません。"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -11024,8 +11046,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11037,8 +11059,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11118,8 +11140,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11171,7 +11192,8 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:144
 #, fuzzy, python-format
 msgid "You can now go to %(x_url_open)syour account page%(x_url_close)s."
-msgstr "いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
+msgstr ""
+"いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
 
 #: invenio/legacy/websession/webinterface.py:136
 #: invenio/legacy/websession/webinterface.py:145
@@ -11185,8 +11207,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -11251,10 +11272,10 @@ msgstr "内部ログインに切り替え"
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -11266,14 +11287,17 @@ msgstr "パスワードを送信してください"
 msgid ""
 "Unable to switch to external login method %(x_name)s, because your email "
 "address is unknown."
-msgstr "あなたのＥメイルアドレスが未登録なため %s、内部ログインに切り替えできません"
+msgstr ""
+"あなたのＥメイルアドレスが未登録なため %s、内部ログインに切り替えできません"
 
 #: invenio/legacy/websession/webinterface.py:445
 #, fuzzy, python-format
 msgid ""
 "Unable to switch to external login method %(x_meth)s, because your email "
 "address is unknown to the external login system."
-msgstr "あなたのＥメイルアドレスが外部ログインシステムに未登録なため %s、外部ログインに切り替えられません"
+msgstr ""
+"あなたのＥメイルアドレスが外部ログインシステムに未登録なため %s、外部ログイン"
+"に切り替えられません"
 
 #: invenio/legacy/websession/webinterface.py:449
 msgid "Login method successfully selected."
@@ -11282,8 +11306,8 @@ msgstr "ログイン方法を変更しました"
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr "外部ログイン方法 %s がＥメイルアドレスを用いた ログインでは"
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -11463,21 +11487,22 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr "アカウントが確認できたら２番目のめいるをおくります。"
 
 #: invenio/legacy/websession/webinterface.py:989
 #, python-format
 msgid "You can now access your %(x_url_open)saccount%(x_url_close)s."
-msgstr "いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
+msgstr ""
+"いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
 
 #: invenio/legacy/websession/webinterface.py:996
 #: invenio/legacy/websession/webinterface.py:1001
@@ -11588,8 +11613,10 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
-msgstr "レコード　生成： %(x_date_creation)s, 最終変更： %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+"レコード　生成： %(x_date_creation)s, 最終変更： %(x_date_modification)s"
 
 #: invenio/legacy/webstyle/templates.py:707
 msgid "The server encountered an error while dealing with your request."
@@ -11611,37 +11638,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11649,15 +11676,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11725,8 +11752,8 @@ msgstr "ページ数が不明です。"
 #: invenio/legacy/websubmit/engine.py:931
 #, fuzzy
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr "ディレクトリーが作れません。"
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11762,8 +11789,8 @@ msgstr "アップロード"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11811,9 +11838,10 @@ msgstr "カテゴリーを選択してアクションボタンを押してくだ
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
-msgstr "中断したファイル提出を続行するには提出アクセス番号を下に入れてください。"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
+msgstr ""
+"中断したファイル提出を続行するには提出アクセス番号を下に入れてください。"
 
 #: invenio/legacy/websubmit/templates.py:366
 msgid "GO"
@@ -11841,8 +11869,8 @@ msgstr "メインメニューへ"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr "提出アクセス番号（提出に失敗したときなどに用います。）"
 
 #: invenio/legacy/websubmit/templates.py:548
@@ -11891,9 +11919,10 @@ msgstr "提出番号"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
-msgstr "ドキュメント %(x_doctype)s のレベル%(x_step)s の%(x_action)s の機能のリスト"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
+msgstr ""
+"ドキュメント %(x_doctype)s のレベル%(x_step)s の%(x_action)s の機能のリスト"
 
 #: invenio/legacy/websubmit/templates.py:1041
 msgid "Function"
@@ -11975,8 +12004,7 @@ msgstr "参照ドキュメントのリスト"
 #: invenio/legacy/websubmit/templates.py:1479
 #, fuzzy
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr "ドキュメント状態を調べたいものを選んでください。"
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -12118,7 +12146,8 @@ msgstr "承認"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr "ドキュメントは%(x_fmt_open)s承認待ちです%(x_fmt_close)s。"
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -12213,8 +12242,8 @@ msgstr "評価を選んでください"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -12234,8 +12263,8 @@ msgstr "コメントを核"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -12276,7 +12305,8 @@ msgid "Take a decision"
 msgstr "決定してください"
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12298,14 +12328,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -12428,10 +12457,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12723,8 +12751,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12767,11 +12795,6 @@ msgstr "バスケットを選択"
 #, fuzzy
 msgid "Role details"
 msgstr "記事"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "隠す"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12887,8 +12910,8 @@ msgstr "Ｅメイルアドレス %s は登録済みです。"
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -12953,9 +12976,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -12979,8 +13001,8 @@ msgstr "新しいパスワード"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr "自分のＥメイルアドレス、ニックネーム、パスワードを入力してください"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -13009,9 +13031,10 @@ msgid "Problem with login."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
-msgstr "いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
+msgstr ""
+"いまから%(x_url_open)sアカウントが%(x_url_close)sつかえるようになります。"
 
 #: invenio/modules/accounts/views/accounts.py:152
 #, fuzzy, python-format
@@ -13053,8 +13076,7 @@ msgstr "設定の編集の失敗"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13126,13 +13148,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13141,9 +13162,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13320,8 +13341,7 @@ msgstr "コレクション"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13411,8 +13431,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13504,10 +13524,10 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr "メッセージが長すぎます（%i字まで）"
 
 #: invenio/modules/comments/forms.py:55
@@ -13550,12 +13570,12 @@ msgid "Review was sent"
 msgstr "コメントを核"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "このコメントは%i回報告された。"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "このコメントは%i回報告された。"
 
@@ -13608,9 +13628,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13629,8 +13648,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13640,7 +13659,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "ニックネーム%sは存在します。"
 
@@ -13696,8 +13715,7 @@ msgstr "レビュー"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13737,8 +13755,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13784,7 +13801,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "機能%sはありません。"
 
@@ -13867,11 +13884,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "現在の状態"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "あなたのバスケット"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -13906,8 +13918,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13928,8 +13940,8 @@ msgstr "以下の単語インデックスは見つからなかった："
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13945,8 +13957,7 @@ msgstr "正当性の確認：フォーマット要素 %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14066,7 +14077,7 @@ msgstr "%i 人のオーサーを表示"
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 #, fuzzy
 msgid "Edit This Record"
 msgstr "別なＩＤを試してください。"
@@ -14170,10 +14181,6 @@ msgstr "レビュー"
 msgid "Authors"
 msgstr "著者"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14266,8 +14273,8 @@ msgstr "グループ権限の管理"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "このバスケットの内容を編集する権限がありません。"
 
 #: invenio/modules/groups/views.py:279
@@ -14280,12 +14287,12 @@ msgstr "あなたはどのグループの管理者でもありません"
 msgid "Members"
 msgstr "メンバーなし"
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "知識ベースのマッピング"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14295,11 +14302,11 @@ msgstr "終了"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "すべての分野"
@@ -14345,13 +14352,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "バスケットは %i こあります。"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "バスケットは %i こあります。"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14507,28 +14515,28 @@ msgstr "ドキュメントタイプが不明です。"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14592,8 +14600,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -14965,7 +14973,7 @@ msgid "Tag name"
 msgstr "ニックネーム"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "ニックネーム %s は登録済みです。"
 
@@ -15070,11 +15078,6 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "終了"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15116,8 +15119,7 @@ msgstr "検索オプション:"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15326,7 +15328,7 @@ msgid "just now"
 msgstr "次にすること："
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr " %s 秒"
 
@@ -15385,6 +15387,33 @@ msgstr "すべての年"
 msgid " years ago"
 msgstr "年"
 
+#~ msgid "Not authorized"
+#~ msgstr "著者"
+
+#~ msgid "Really delete"
+#~ msgstr "消去しました"
+
+#~ msgid "Verify problem"
+#~ msgstr "データベースに問題があります"
+
+#~ msgid "File"
+#~ msgstr "タイトル"
+
+#~ msgid "niceName"
+#~ msgstr "名前"
+
+#~ msgid "Id"
+#~ msgstr "ＩＤ"
+
+#~ msgid "Tickets"
+#~ msgstr "時間"
+
+#~ msgid "by"
+#~ msgstr ":"
+
+#~ msgid "Done"
+#~ msgstr "終了"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "カテゴリーを選択して下さい。"
 
@@ -15394,14 +15423,8 @@ msgstr "年"
 #~ msgid "Warning: Please, select a valid date"
 #~ msgstr "カテゴリーを選択して下さい。"
 
-#~ msgid " or return to your %(x_url_open)ssearch%(x_url_close)s"
-#~ msgstr ""
-
 #~ msgid "*** basket name ***"
 #~ msgstr "バスケット名"
-
-#~ msgid ""
-#~ msgstr ""
 
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "追加ファイル"
@@ -15465,20 +15488,8 @@ msgstr "年"
 #~ msgid "now"
 #~ msgstr "いいえ"
 
-#~ msgid "Not authorized"
-#~ msgstr "著者"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "ユーザ %sは存在しません。"
-
-#~ msgid "Really delete"
-#~ msgstr "消去しました"
-
-#~ msgid "Verify problem"
-#~ msgstr "データベースに問題があります"
-
-#~ msgid "File"
-#~ msgstr "タイトル"
 
 #~ msgid "File %s already exists."
 #~ msgstr "ユーザ %sは存在しません。"
@@ -15537,9 +15548,6 @@ msgstr "年"
 #~ msgid "Not Mine!"
 #~ msgstr "注意"
 
-#~ msgid "Tickets"
-#~ msgstr "時間"
-
 #~ msgid "Request Tickets"
 #~ msgstr "ルール"
 
@@ -15575,9 +15583,6 @@ msgstr "年"
 
 #~ msgid "Create a new Person for your search"
 #~ msgstr "結果はありませんでした。"
-
-#~ msgid "Id"
-#~ msgstr "ＩＤ"
 
 #~ msgid "A %s has been added."
 #~ msgstr "グループ %s は削除されました"
@@ -15630,9 +15635,6 @@ msgstr "年"
 #~ msgid "creating a new basket"
 #~ msgstr "新しいバスケットを作る。"
 
-#~ msgid "by"
-#~ msgstr ":"
-
 # Tsuboyama: because of difference of the word order, this
 # may not make sense if I give a translation.
 #~ msgid "on"
@@ -15656,9 +15658,6 @@ msgstr "年"
 #~ msgid "Editing topic"
 #~ msgstr "バスケットの編集"
 
-#~ msgid "niceName"
-#~ msgstr "名前"
-
 #~ msgid "Apply Changes"
 #~ msgstr "変更の保存"
 
@@ -15673,9 +15672,6 @@ msgstr "年"
 
 #~ msgid "Edit record %(x_recid)s, field %(x_field)s"
 #~ msgstr "レコード　%(x_recid)s　・フィールド　　　の編集 %(x_field)s"
-
-#~ msgid "Edit record %(x_recid)s, field %(x_field)s - Add a subfield"
-#~ msgstr ""
 
 #~ msgid "Submit and save record %s"
 #~ msgstr "サブミットしレコード %s を保存"
@@ -15769,9 +15765,6 @@ msgstr "年"
 
 #~ msgid "Verbose"
 #~ msgstr "冗長"
-
-#~ msgid "Done"
-#~ msgstr "終了"
 
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "変更は保存されていません。"
@@ -15970,47 +15963,18 @@ msgstr "年"
 #~ msgid "Citation Metrics"
 #~ msgstr "参照された履歴:"
 
-#~ msgid "WebSearch Admin Guide"
-#~ msgstr ""
-
 #~ msgid "Submit Guide"
 #~ msgstr "堤出しなさい助け"
 
 #~ msgid "Add to personal basket"
 #~ msgstr "個人バスケットに追加"
 
-#~ msgid "WebSubmit Admin Guide"
-#~ msgstr ""
-
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "検索実行"
-
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
 
 # Probably context dependent
 #~ msgid "Cancel merging"
 #~ msgstr "キャンセル"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "あなたは以下のグループのメンバーです"
@@ -16024,12 +15988,6 @@ msgstr "年"
 #~ msgid "Invert Selection"
 #~ msgstr "参照（番号）がまだ与えられません。"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "著者"
 
@@ -16041,12 +15999,6 @@ msgstr "年"
 
 #~ msgid "No status information found."
 #~ msgstr "情報"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "部"
@@ -16063,15 +16015,6 @@ msgstr "年"
 #~ msgid "The author has an internal ID!"
 #~ msgstr "内部エラー"
 
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "コメント"
 
@@ -16081,88 +16024,21 @@ msgstr "年"
 #~ msgid " Delete this ticket"
 #~ msgstr "バスケットの削除"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "ドキュメントタイプがありません。"
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "評価を選んでください"
 
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
 #~ msgid "Paper title: "
 #~ msgstr "ページ"
-
-#~ msgid "Ignore"
-#~ msgstr ""
 
 # In japanese we do not distinguish error and errors.
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "次のエラーが見つかりました。"
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "評価を選んでください"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "情報"
@@ -16170,35 +16046,11 @@ msgstr "年"
 #~ msgid "Please provide your first name"
 #~ msgstr "ログインしてください。"
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "貸し出し"
 
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
 #~ msgid "Your eMail:"
 #~ msgstr "あなたの通知"
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "選択したレビューを消す"
@@ -16206,257 +16058,38 @@ msgstr "年"
 #~ msgid "Mark as your documents"
 #~ msgstr "すべてのタイプのドキュメント"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "このドキュメントの評価"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "このドキュメントの評価"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "または新しいトピックをつくる。"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "ユーザーに追加"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "ページ"
-
-#~ msgid "Showing the"
-#~ msgstr ""
 
 #~ msgid "most recent documents:"
 #~ msgstr "査読ドキュメントのリスト"
 
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "フォーマットテンプレートの操作"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "トピックを選ぶ"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "生成日付"
-
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
 
 #~ msgid "add external id"
 #~ msgstr "外部 %(link_or_links)s"
 
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
-
-#~ msgid "suggest missing ids"
-#~ msgstr ""
-
 #~ msgid "Choose system"
 #~ msgstr "トピックを選ぶ"
-
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-# In japanese we do not distinguish error and errors.
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "次のエラーが見つかりました。"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
 
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "あなたは管理機能を実行することはできません。"
@@ -16464,114 +16097,11 @@ msgstr "年"
 #~ msgid "Claim this paper"
 #~ msgstr "ユーザーに追加"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr " %s　レコードから引用"
 
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
 #~ msgid "Revision"
 #~ msgstr "部"
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "テンプレート属性の変更"
@@ -16646,9 +16176,6 @@ msgstr "年"
 #~ msgid "The following errors have been found"
 #~ msgstr "次のエラーが見つかりました。"
 
-#~ msgid "BibFormat Admin"
-#~ msgstr ""
-
 # I assume another string follows.
 #~ msgid "Enter a search query here."
 #~ msgstr "ここに検索クエリーを入力"
@@ -16656,89 +16183,20 @@ msgstr "年"
 #~ msgid "No Record Found for %s."
 #~ msgstr "レコードがみつからない"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "ユーザ %sは存在しません。"
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "出力フォーマット属性 %s"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "フォーマットテンプレート依存関係 %s"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "正当性の確認：フォーマット要素 %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "フォーマット要素依存関係 %s"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "制限された出力フォーマット:"
@@ -16794,113 +16252,17 @@ msgstr "年"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "正当性の確認：フォーマット要素 %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "正当性の確認：フォーマット %s"
 
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "知識ベース %s"
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "注意"
 
 #~ msgid "never"
 #~ msgstr "変換"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "時間"
@@ -16910,9 +16272,6 @@ msgstr "年"
 
 #~ msgid "No Keywords"
 #~ msgstr "キーワード"
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
 
 #~ msgid "No Subject categories"
 #~ msgstr "公開バスケットのリスト"
@@ -16929,17 +16288,8 @@ msgstr "年"
 #~ msgid "Affiliations"
 #~ msgstr "参照された履歴:"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
 #~ msgid "Citations%s"
 #~ msgstr "参照された履歴:"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "生成日付"
@@ -16950,42 +16300,6 @@ msgstr "年"
 #~ msgid "No publications available"
 #~ msgstr "ドキュメントタイプがありません。"
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr " %s　レコードから引用"
 
@@ -16995,20 +16309,8 @@ msgstr "年"
 #~ msgid "%i reviews"
 #~ msgstr "レビュー"
 
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "ページ"
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "参照された履歴:"
@@ -17016,35 +16318,8 @@ msgstr "年"
 #~ msgid "No Citation Information available"
 #~ msgstr "ドキュメントタイプがありません。"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "会議"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "あなたの通知"
@@ -17064,108 +16339,15 @@ msgstr "年"
 #~ msgid "Statistics"
 #~ msgstr "状態"
 
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
 #~ msgid "Group: %s"
 #~ msgstr "グループ：%s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "コレクション %s が見つかりません。"
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "フィールド %s は必須です。"
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "ページ数が不明です。"
-

--- a/invenio/base/translations/ka/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/ka/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2010, 2011 CERN.
+# # Copyright (C) 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2010-07-27 15:13+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:58+0200\n"
 "Last-Translator: Nino Jejelava <nino.jejelava@gmail.com>\n"
 "Language-Team: KA <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -58,8 +58,8 @@ msgstr "ძირითადი გვერდი"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -205,7 +205,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "გამარჯობა:"
 
@@ -226,17 +226,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -262,48 +262,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "ელემენტი რომელიც თქვნ აირჩიეთ არ არსებობს"
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr "პაროლის გადატვირთვის მოთხოვნა"
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "თქვენ არ გაქვთ სესხის გამოყენების ავტორიზაცია."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "რეგისტრაცია ვერ განხორციელდა"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "გთხოვთ აირჩიოთ ერთი ან რამოდენიმე:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "როლის ავტორიზაციაზე მოთხოვნა"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, fuzzy, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr "Invenio -ს ახალი ვერსია შეიძლება იყოს გადმოწერილი. გთხოვთ გვეახლეთ"
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -504,7 +509,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -581,9 +587,9 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"თქვენი ფაილი წარმატებით დაემატებულია რიგში. თქვენ შეგიძლიათ შეამოწმოთ "
-"თქვენი %(x_url1_open)sატვირთვის ისტორია%(x_url1_close)s ან "
-"%(x_url2_open)sდაამატოთ სხვა ფაილი%(x_url2_close)s"
+"თქვენი ფაილი წარმატებით დაემატებულია რიგში. თქვენ შეგიძლიათ შეამოწმოთ თქვენი "
+"%(x_url1_open)sატვირთვის ისტორია%(x_url1_close)s ან %(x_url2_open)sდაამატოთ "
+"სხვა ფაილი%(x_url2_close)s"
 
 #: invenio/legacy/batchuploader/templates.py:282
 msgid "No metadata files have been uploaded yet."
@@ -721,8 +727,10 @@ msgid "The following errors have occurred:"
 msgstr "შემდეგი შეცდომები წარმოიშვა:"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
-msgstr "ზოგიერთი ფაილი ვერ გადავიდა DONE საქაღალდეში. გთხოვთ წაშალოთ ისინი ხელით."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
+msgstr ""
+"ზოგიერთი ფაილი ვერ გადავიდა DONE საქაღალდეში. გთხოვთ წაშალოთ ისინი ხელით."
 
 #: invenio/legacy/batchuploader/templates.py:585
 msgid "All uploaded files were moved to DONE folder."
@@ -734,14 +742,14 @@ msgid ""
 "Using %(x_fmt_open)sweb interface upload%(x_fmt_close)s, actions are "
 "executed a single time."
 msgstr ""
-"<b>ვებ ინტერფეისით ატვირთვა</b>, -ის გამოყენებისას ქმედება განხორციელდება"
-" მხოლოდ ერთხელ."
+"<b>ვებ ინტერფეისით ატვირთვა</b>, -ის გამოყენებისას ქმედება განხორციელდება "
+"მხოლოდ ერთხელ."
 
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -823,7 +831,7 @@ msgstr "საიდენტიფიკაციო"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -867,8 +875,8 @@ msgstr "თქვენი ბილეთები"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "წინა"
@@ -883,8 +891,8 @@ msgstr "დახურვა"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "შემდგომი"
 
@@ -900,18 +908,6 @@ msgstr "შემდგომი"
 msgid "Admin Area"
 msgstr "ადმინისტრატორის არეა"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "ავტორი"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
 msgid "ERROR: %(x_name)s does not exist"
@@ -926,15 +922,6 @@ msgstr ""
 #, python-format
 msgid "ERROR: %(x_name)s is not writable"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
-msgid "Limit to knowledge bases containing string:"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "წარმატებით წაიშალა"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -964,10 +951,6 @@ msgstr "წარმატებით წაიშალა"
 msgid "Delete"
 msgstr "წაშლა"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:140
-msgid "Verify syntax"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:145
 #: invenio/modules/communities/views.py:258
 #, fuzzy
@@ -979,31 +962,9 @@ msgstr "ახალი კალათის შექმნა"
 msgid "File %(x_name)s does not exist."
 msgstr "მომხმარებელი %s არ არსებობს."
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:174
-msgid "Calling bibcheck -verify failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
-msgid "Verify BibCheck config file"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "მონაცემთა ბაზასთან დაკავშირებული პრობლემა"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "ფაილი(s)"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
 msgstr "ცვლილების შენახვა"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:240
-msgid "Edit BibCheck config file"
-msgstr ""
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:268
 #, fuzzy, python-format
@@ -1020,10 +981,6 @@ msgstr ""
 msgid "File %(x_name)s: write failed."
 msgstr ""
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:279
-msgid "Save BibCheck config file"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:312
 #, python-format
 msgid "File %(x_name)s deleted."
@@ -1032,10 +989,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:314
 #, python-format
 msgid "File %(x_name)s: delete failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:316
-msgid "Delete BibCheck config file"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:195
@@ -1103,7 +1056,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1158,8 +1112,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1175,9 +1129,8 @@ msgstr "ბარკოდი"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
 "ჩანაწერი <strong>%s</strong>, ბარკოდით <strong>%s</strong>, წარმატებით "
 "დაბრუნებულია."
@@ -1185,17 +1138,16 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
 "ჩანაწერი <strong>%s</strong>, ბარკოდით <strong>%s</strong>, წარმატებით "
 "დაბრუნებულია."
@@ -1222,15 +1174,16 @@ msgstr "ახლის შექმნა"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
 "ჩანაწერი <strong>%s</strong>, ბარკოდით <strong>%s</strong>, წარმატებით "
 "დაბრუნებულია."
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1262,9 +1215,8 @@ msgstr "სესხის ვადა"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
 "ჩანაწერი <strong>%s</strong>, ბარკოდით <strong>%s</strong>, წარმატებით "
 "დაბრუნებულია."
@@ -1333,8 +1285,8 @@ msgstr "ახალი მოთხოვნა"
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1342,8 +1294,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1365,9 +1317,8 @@ msgstr "ახალი სესხები"
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
 "ჩანაწერი <strong>%s</strong>, ბარკოდით <strong>%s</strong>, წარმატებით "
 "დაბრუნებულია."
@@ -1411,8 +1362,8 @@ msgstr "0 მსესხებელი(ები) მოიძებნენ.
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1471,11 +1422,11 @@ msgstr "ახალი მოთხოვნა წარმატებით 
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1486,11 +1437,11 @@ msgstr "დიახ"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1503,8 +1454,8 @@ msgstr "არა"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1599,8 +1550,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1620,29 +1571,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1651,9 +1602,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr "მოთხოვნილი ჩანაჭერი არ არსებობს."
 
@@ -2013,16 +1964,14 @@ msgstr "ამ ჩანაწერზე არ არის მოთხო�
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2043,8 +1992,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2206,8 +2155,8 @@ msgstr "ILL მოთხოვნა"
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2314,7 +2263,7 @@ msgstr "მდებარეობა"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "აღწერა"
 
@@ -2507,8 +2456,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2782,12 +2731,10 @@ msgstr "დაადასტურეთ"
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr ""
-"თუ თქვენ გნებავთ, თქვენ შეგიძლიათ %(x_url_open)sშემოხვიდეთ "
-"აქ%(x_url_close)s."
+"თუ თქვენ გნებავთ, თქვენ შეგიძლიათ %(x_url_open)sშემოხვიდეთ აქ%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
 #, fuzzy
@@ -2840,7 +2787,7 @@ msgstr "გადატვირთვა"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "დიახ"
 
@@ -2848,8 +2795,8 @@ msgstr "დიახ"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
 "ჩანაწერი <strong>%s</strong>, ბარკოდით <strong>%s</strong>, წარმატებით "
 "დაბრუნებულია."
@@ -3311,8 +3258,8 @@ msgstr "საფოსტო ყუთი"
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "ელფოსტა"
 
@@ -3788,8 +3735,7 @@ msgstr "ახალი ასლის შესახებ ვრცლად
 #, fuzzy, python-format
 msgid "A %(x_url_open)snew copy%(x_url_close)s has been added."
 msgstr ""
-"გთხოვთ %(x_url_open)sმიიღოთ ან უარყოთ%(x_url_close)s ამ მომხმარებლის "
-"თხოვნა."
+"გთხოვთ %(x_url_open)sმიიღოთ ან უარყოთ%(x_url_close)s ამ მომხმარებლის თხოვნა."
 
 #: invenio/legacy/bibcirculation/templates.py:7443
 #, fuzzy
@@ -4121,8 +4067,8 @@ msgstr "საინტერესო პერიოდი (მდე)"
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, fuzzy, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr "მსესხებელი ეთანხმება %s სერვისს, კერძოდ დააბრუნოს წიგნი დროულად"
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4140,11 +4086,10 @@ msgstr "მხოლოდ ეს რედაქცია"
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, fuzzy, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
-"შეამოწმეთ თუ წიგნი უკვე არსებობს Invenio -ზე, სანამ გააგზავნით ILL "
-"მოთხოვნას."
+"შეამოწმეთ თუ წიგნი უკვე არსებობს Invenio -ზე, სანამ გააგზავნით ILL მოთხოვნას."
 
 #: invenio/legacy/bibcirculation/templates.py:10332
 msgid "0 items found."
@@ -4202,17 +4147,17 @@ msgstr "ISSN"
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4590,25 +4535,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "ჩანაწერი წაშლილია."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4668,15 +4613,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4687,10 +4632,10 @@ msgstr "აირჩიეთ ფაილი"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4703,15 +4648,15 @@ msgstr "ხელმისაწვდომობა"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, fuzzy, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr "ატვირთული ფაილი მეტისმეტად პატარაა (<%i o) და ამიტომ არ იქნა განხილული"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4722,7 +4667,8 @@ msgid ""
 msgstr "ატვირთული ფაილი მეტისმეტად დიდია (<%i o) და ამიტომ არ იქნა განხილული"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr "ატვირთული ფაილის სახელი მეტისმეტად გრძელია და ამიტომ არ იქნა განხილული"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4730,8 +4676,7 @@ msgid ""
 "You have already reached the maximum number of files for this type of "
 "document"
 msgstr ""
-"ამ ტიპის დოკუმეტის კვალობაზე თქვენ უკვე მიაღწიეთ მაქსიმალურ რიცხვს "
-"ფაილებისა "
+"ამ ტიპის დოკუმეტის კვალობაზე თქვენ უკვე მიაღწიეთ მაქსიმალურ რიცხვს ფაილებისა "
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:627
 #: invenio/legacy/bibdocfile/managedocfiles.py:637
@@ -4743,21 +4688,20 @@ msgstr "ფაილი სახელწოდებით %s უკვე ა
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
-msgstr "ფაილი შემდეგი ფორმატით '%s' უკვე არსებობს. გთხოვთ ატვირთოთ სხვა ფორმატი"
+"A file with format '%(x_name)s' already exists. Please upload another format."
+msgstr ""
+"ფაილი შემდეგი ფორმატით '%s' უკვე არსებობს. გთხოვთ ატვირთოთ სხვა ფორმატი"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
-"თქვენ არ გაქვთ წერტილის გამოყენების უფლება '.', ირიბის '/', ან უკუირიბის "
-"'\\\\' ფაილის სახელებში. არჩიეთ სხვა სახელი და ხელმეორედ ატვირთეტ. კერძოდ"
-" თქვენ არუნდა მიუთითოთ ფალის გაფართოება ფაილის გადარქმევისას."
+"თქვენ არ გაქვთ წერტილის გამოყენების უფლება '.', ირიბის '/', ან უკუირიბის '\\"
+"\\' ფაილის სახელებში. არჩიეთ სხვა სახელი და ხელმეორედ ატვირთეტ. კერძოდ თქვენ "
+"არუნდა მიუთითოთ ფალის გაფართოება ფაილის გადარქმევისას."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
 msgid "Choose how you want to restrict access to this file."
@@ -4774,16 +4718,15 @@ msgstr "თქვენი შეგიძლიათ გადაწყვი�
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
-"როცა თქვენ გადახედავთ ფაილს, დამატებითი ფორმატები რომელიც შეიძლება "
-"ატვირთეთ წაშლილია, რადგან ისინი არ არიან ფაილთან ერთად განახლებულები."
+"როცა თქვენ გადახედავთ ფაილს, დამატებითი ფორმატები რომელიც შეიძლება ატვირთეთ "
+"წაშლილია, რადგან ისინი არ არიან ფაილთან ერთად განახლებულები."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr "ალტერნატიული ფორმატები აიტვირთა ამ ფაილის მიმდინარე ვერსიისათვის "
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4843,11 +4786,11 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
-"ფაილის დამატებისას ან შესწორებისას პრობლემა შეგექმნათ? გაგზავნეთ "
-"ახალი/შეცვლილი ვერსია შემდეგ მისამართზე %(mailto_link)s."
+"ფაილის დამატებისას ან შესწორებისას პრობლემა შეგექმნათ? გაგზავნეთ ახალი/"
+"შეცვლილი ვერსია შემდეგ მისამართზე %(mailto_link)s."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
 msgid "revise"
@@ -4897,8 +4840,8 @@ msgstr "მოთხოვნილი ჩანაწერილი არ ა
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr "სისტემამ შეამჩნია შეცდომა ამ დოკუმენტისათვის ფაილების სიის მოძიებისას."
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -4926,8 +4869,8 @@ msgstr "მოთხოვნილი ფაილის დამუშავ�
 #, fuzzy
 msgid "The requested file is hidden and can not be accessed."
 msgstr ""
-"მოთხოვნილი ფაილი დამალულია და თქვენ არ გაქვთ საკმარისი უფლებები რომ "
-"იხილოთ იგი."
+"მოთხოვნილი ფაილი დამალულია და თქვენ არ გაქვთ საკმარისი უფლებები რომ იხილოთ "
+"იგი."
 
 #: invenio/legacy/bibdocfile/webinterface.py:238
 msgid "Requested file does not seem to exist."
@@ -5014,9 +4957,9 @@ msgstr "1.აირჩიეთ ძებნის კრიტერიუმ�
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 "მიუთითეთ კრიტერია რომელიც გნებავთ გამოიყენოთ ჩანაწერის ფილტრაციისათვის. "
 "გამოიყენეთ \"ძიება\" რომ იხილოთ რომელი ჩანაჭერები იქნა გაფილტრული ამ "
@@ -5033,8 +4976,8 @@ msgstr "2.განსაზღვრეთ ცვლილებები"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 "მიუთითეთ მინდვრები და მათი ქვე-მინდვერები რომელიც უნდა შეიცვალოს ყოველ "
 "ჩანაწერში, რომელიც ემთხვევა ძიების კრიტერიას."
@@ -5172,11 +5115,10 @@ msgstr "უკან შედეგებთან"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5300,7 +5242,7 @@ msgid "Total"
 msgstr "სრული"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "არჩევა"
 
@@ -5459,8 +5401,8 @@ msgstr "ცოდნის ბაზის წაშლა"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, fuzzy, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr "შეზღუდეთ ნაჩვენები ცოდნის ბაზის შესატყვისები"
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5516,78 +5458,78 @@ msgstr "გთხოვთ დააკონფიგურიროთ"
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 "დინამიური ცოდნის ბაზა არის მნიშვნელობების სია                          "
-"მოცემული მინდვრის. ეს სია გენერირებულია დინამიურად"
-"                          ჩანაწერის ძებნით, ძიების გამოსახულების "
-"დახმარებით."
+"მოცემული მინდვრის. ეს სია გენერირებულია დინამიურად                          "
+"ჩანაწერის ძებნით, ძიების გამოსახულების დახმარებით."
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
-"მაგალითი: თქვენი ჩანაწერები შეიცავენ ველ 270__a -ს"
-"                          ავტორის ინსტიტუტის სახელი და მისამართისათვის."
-"                          თუ თქვენ დააყენბს ველს '270__a' და "
-"გამოსახულებას                          '270__a:*Paris*', პარიზის "
-"ინსტიტუტების სია                          შეიქმნება."
+"მაგალითი: თქვენი ჩანაწერები შეიცავენ ველ 270__a -ს                          "
+"ავტორის ინსტიტუტის სახელი და მისამართისათვის.                          თუ "
+"თქვენ დააყენბს ველს '270__a' და გამოსახულებას                          "
+"'270__a:*Paris*', პარიზის ინსტიტუტების სია                          "
+"შეიქმნება."
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
-"თუ გამოსახულება ცარიელია, ყველა მნიშვნელობათა სია"
-"                           იქნება 270__a -ით შექმნილი."
+"თუ გამოსახულება ცარიელია, ყველა მნიშვნელობათა სია                           "
+"იქნება 270__a -ით შექმნილი."
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, fuzzy, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
-"თუ გამოსახულება შეიცავს '%', სავით '270__a:*%*',"
-"                          ის იქნება შეცვლილი ძიების სიტყვებით"
-"                           ცოდნის ბაზაა გამოყენებული."
+"თუ გამოსახულება შეიცავს '%', სავით '270__a:*%*',                          ის "
+"იქნება შეცვლილი ძიების სიტყვებით                           ცოდნის ბაზაა "
+"გამოყენებული."
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
-"თქვენ შეგიძლიათ შეიყვანოთ კოლექციის სახელი თუ გამოსახულება"
-"                           უნდა იყოს შეფასებული სპეციფიურ კოლექციაში."
+"თქვენ შეგიძლიათ შეიყვანოთ კოლექციის სახელი თუ "
+"გამოსახულება                           უნდა იყოს შეფასებული სპეციფიურ "
+"კოლექციაში."
 
 #: invenio/legacy/bibknowledge/templates.py:253
 #, fuzzy
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
-"მაგალითი: თქვენი ჩანაწერები შეიცავენ ველ 270__a -ს"
-"                          ავტორის ინსტიტუტის სახელი და მისამართისათვის."
-"                          თუ თქვენ დააყენბს ველს '270__a' და "
-"გამოსახულებას                          '270__a:*Paris*', პარიზის "
-"ინსტიტუტების სია                          შეიქმნება."
+"მაგალითი: თქვენი ჩანაწერები შეიცავენ ველ 270__a -ს                          "
+"ავტორის ინსტიტუტის სახელი და მისამართისათვის.                          თუ "
+"თქვენ დააყენბს ველს '270__a' და გამოსახულებას                          "
+"'270__a:*Paris*', პარიზის ინსტიტუტების სია                          "
+"შეიქმნება."
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5626,7 +5568,7 @@ msgstr "ცოდნის ბაზის დამოკიდებულე�
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5639,8 +5581,8 @@ msgid ""
 "Here you can add new mappings to this base                         and "
 "change the base attributes."
 msgstr ""
-"აქ თქვენ შეგიძლიათ დაამატოთ დაჯგუფებები ამ ბაზაზე"
-"                         და შეცვალეთ ბაზის ატრიბუტები."
+"აქ თქვენ შეგიძლიათ დაამატოთ დაჯგუფებები ამ ბაზაზე                         და "
+"შეცვალეთ ბაზის ატრიბუტები."
 
 #: invenio/legacy/bibknowledge/templates.py:364
 msgid "Map From"
@@ -5681,15 +5623,15 @@ msgstr "თქვენი წესი"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, fuzzy, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr "უკვე ჩდება ამ ცოდნის ბაზებში"
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, fuzzy, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr "უკვე ჩდება ამ ცოდნის ბაზებში"
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5713,8 +5655,8 @@ msgid ""
 "It is not possible to have two rules with the same left side in the same "
 "knowledge base."
 msgstr ""
-"შეუძლებელია იყოს ორი წესი ერთი და იგივე მარცხენა წესით ერთი და იგივე "
-"ცოდნის ბაზაში."
+"შეუძლებელია იყოს ორი წესი ერთი და იგივე მარცხენა წესით ერთი და იგივე ცოდნის "
+"ბაზაში."
 
 #: invenio/legacy/bibrank/citation_grapher.py:207
 msgid "Citation history:"
@@ -5914,11 +5856,10 @@ msgstr "ჩანაწერის გამოტანისას აღმ�
 #: invenio/legacy/oaiharvest/admin.py:1321
 #, fuzzy
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
-"დაკავების კალამის ჩანაწერის ფორმატირებისას შეიქმნა შეცდომა. შესაძლოა მისი"
-" შემადგენლობა დაზიანებულია"
+"დაკავების კალამის ჩანაწერის ფორმატირებისას შეიქმნა შეცდომა. შესაძლოა მისი "
+"შემადგენლობა დაზიანებულია"
 
 #: invenio/legacy/oaiharvest/admin.py:1326
 msgid "Accept Holding Pen version"
@@ -5992,8 +5933,8 @@ msgstr "მთავარ არჩევანთან დაბრუნე�
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6008,8 +5949,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "ძიების შედეგები"
 
@@ -6168,8 +6109,8 @@ msgstr "მნიშვნელობა ვერ მოიძებნა."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6195,8 +6136,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6207,8 +6148,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -6220,29 +6160,29 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
-"დამთხვევა ვერ მოიძებნა %(x_collection)s კოლექციაში. სხვა საჯარო "
-"კოლექციებმა მოგვცეს %(x_url_open)s%(x_nb_hits)d შედეგი%(x_url_close)s."
+"დამთხვევა ვერ მოიძებნა %(x_collection)s კოლექციაში. სხვა საჯარო კოლექციებმა "
+"მოგვცეს %(x_url_open)s%(x_nb_hits)d შედეგი%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 "თქვენი მოთხოვნა არცერთ საჯარო კოლექციას არ დაემთხვა. თუ თქვენ აკრძალული "
 "კოლექციებში გნებავთ ძიება, გთხოვთ ჯერ მიუთითოთ კოლექცია."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
@@ -6250,53 +6190,53 @@ msgstr ""
 "თქვენი მოთხოვნა არცერთ საჯარო კოლექციას არ დაემთხვა. თუ თქვენ აკრძალული "
 "კოლექციებში გნებავთ ძიება, გთხოვთ ჯერ მიუთითოთ კოლექცია."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
 "ძიების სიტყვა %s არ დაემთხვა არცერთ ჩანაწერს. წყობილი სიტყვები ყველა "
 "კოლექციაში არიან:"
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "გამოიყენეთ სხვადასხვა ძიების სიტყვები."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "მოთხოვნები არ არის."
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "მოთხოვნები არ არის."
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "მოთხოვნები არ არის."
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "სიტყვის ინდეხი არ არის ხელმისაწვდომი %s -სათვის."
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "ფრაზის ინდექსი მიუწვდომელია %s -თვის."
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
-"ძიების სიტყვა%(x_term)s ინდექსში %(x_index)s არ დაემთხვა არცერთ "
-"პარამეტრს. წყობილი სიტყვები ყველა კოლექციაშ არიან:"
+"ძიების სიტყვა%(x_term)s ინდექსში %(x_index)s არ დაემთხვა არცერთ პარამეტრს. "
+"წყობილი სიტყვები ყველა კოლექციაშ არიან:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
@@ -6305,44 +6245,44 @@ msgstr ""
 "ძიების სიტყვა %s არ დაემთხვა არცერთ ჩანაწერს. წყობილი სიტყვები ყველა "
 "კოლექციაში არიან:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
-"უკაცრავად, %s არ არის ნებადართული დახარისხების კრიტერიუმი. "
-"დასახარისხებლად ვიყენებ სათაურს."
+"უკაცრავად, %s არ არის ნებადართული დახარისხების კრიტერიუმი. დასახარისხებლად "
+"ვიყენებ სათაურს."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 "უკაცრავად, დახარისხება ხელმისაწვდომია თუ გვაქვს %d მდე ჩანაწერი. ვიყენებ "
 "პირველად დახარისხებას."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
-"უკაცრავად, %s არ არის ნებადართული დახარისხების კრიტერიუმი. "
-"დასახარისხებლად ვიყენებ სათაურს."
+"უკაცრავად, %s არ არის ნებადართული დახარისხების კრიტერიუმი. დასახარისხებლად "
+"ვიყენებ სათაურს."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "მოთხოვნილი გვერდი არ არსებობს"
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "გამოიყენეთ სხვადასხვა ძიების სიტყვები."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6356,11 +6296,12 @@ msgstr "გამოიყენეთ სხვადასხვა ძიე�
 msgid "Browse"
 msgstr "დათვალიერება"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
-msgstr "დამთხვევა არ არის მითთებულ დროის ინტერვალშ, ვუგულებელყოფ ამ პირობას ..."
+msgstr ""
+"დამთხვევა არ არის მითთებულ დროის ინტერვალშ, ვუგულებელყოფ ამ პირობას ..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr "თქვენი ძიების ლიმიტში დამთხვევა არ მოიძებნა, ვუგულებელყოფ ამ პირობას"
 
@@ -6405,15 +6346,13 @@ msgstr "შეტყობინება %s წარმატებით გ�
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"თქენ განახორციელეთ %(x_nb)s ძებნა. %(x_url_open)sდეტალური "
-"ლისტი%(x_url_close)s ხელმისაწვდომია შესაძლებლობებით (ა) იხილოთ ძიების "
-"შედეგები და (ბ) ჩაეწეროთ ავტომატურ ე-მეილის შეტყობინება ამ "
-"მოთხოვნებისათვის."
+"თქენ განახორციელეთ %(x_nb)s ძებნა. %(x_url_open)sდეტალური ლისტი"
+"%(x_url_close)s ხელმისაწვდომია შესაძლებლობებით (ა) იხილოთ ძიების შედეგები და "
+"(ბ) ჩაეწეროთ ავტომატურ ე-მეილის შეტყობინება ამ მოთხოვნებისათვის."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6607,8 +6546,8 @@ msgstr "თქვენ გაქვთ განსაზღვრული %s 
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 "თქვენ ჯერ არ განგიხორციელებიათ ძებნა. გთხოვთ პირველად მიხვიდეთ "
 "%(x_url_open)sძიების ინტერფეისზე%(x_url_close)s."
@@ -6616,8 +6555,8 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
 "თქვენ განახორციელეთ %(x_nb1)s ძიება (%(x_nb2)s განსხვავებული კითხვა) "
 "დაახლოებით ბოლო 30 დღის განმავლობაში."
@@ -6677,7 +6616,7 @@ msgstr "თქვენი ძებნა"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6741,7 +6680,7 @@ msgstr "%s პერსონოლიზაცია, ახალი შეტ
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6801,7 +6740,8 @@ msgstr "%s პერსონოლიზაცია, მაჩვენე შ
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6825,7 +6765,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "თქვენ არ გაგაჩნიათ ულება ამ ელემენტის ნახვის."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6853,7 +6794,8 @@ msgid "You do not have permission to delete this note."
 msgstr "თქვენ არ გაგაჩნიათ ულება ამ ელემენტის ნახვის."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6884,8 +6826,8 @@ msgstr "ელემენტი რომელიც თქვნ აირჩ
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6907,8 +6849,8 @@ msgstr "ჩანაწერის კალათასი კოპირე�
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6941,8 +6883,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7012,8 +6954,7 @@ msgstr "საჯარო კალათები"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 "თქვენ გაქვთ %(x_nb_perso)s პირადი კალათა და ჩაწერილი ხართ %(x_nb_group)s "
 "ჯგუფურ კალათებში %(x_nb_public)s სხვა მომხმარებლების საჯარო კალათებიდან."
@@ -7045,11 +6986,10 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:108
 #, fuzzy, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
 #: invenio/legacy/webbasket/templates.py:198
@@ -7209,11 +7149,11 @@ msgstr "გარე ელემენტი"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
-"მიუთითეთ ბმული გარე ელემენტისათვის, რომელიც გნებავთ რომ დაამატოთ, ჩაწერეთ"
-" სათაური და აღწერა."
+"მიუთითეთ ბმული გარე ელემენტისათვის, რომელიც გნებავთ რომ დაამატოთ, ჩაწერეთ "
+"სათაური და აღწერა."
 
 #: invenio/legacy/webbasket/templates.py:1612
 #: invenio/modules/linkbacks/templates/linkbacks/index_base.html:44
@@ -7233,7 +7173,8 @@ msgstr "ჩაეწერეთ %(x_url2_open)sRSS ფიდზე%(x_url2_clos
 #: invenio/legacy/webbasket/templates.py:1649
 #, fuzzy, python-format
 msgid " or return to your %(x_url_open)sprevious basket%(x_url_close)s"
-msgstr "თქვენ შეგიძლიათ შეხვიდეთ თქვენს %(x_url_open)sანგარიშზე%(x_url_close)s."
+msgstr ""
+"თქვენ შეგიძლიათ შეხვიდეთ თქვენს %(x_url_open)sანგარიშზე%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:1653
 #, fuzzy, python-format
@@ -7393,20 +7334,21 @@ msgstr "კალათის გაზიარება ახალ ჯგუ
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
-"თქვენ შემოსული ხართ როგორც სტუმარი, ამიტომ თქვენი კალათები წაიშლება "
-"სესიის დამთავრების შემდგომ."
+"თქვენ შემოსული ხართ როგორც სტუმარი, ამიტომ თქვენი კალათები წაიშლება სესიის "
+"დამთავრების შემდგომ."
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
-"თუ გნებავთ, თქვენ შეგიძლიათ %(x_url_open)sშეხვიდეთ ან დარეგისტრირდეთ "
-"აქ%(x_url_close)s."
+"თუ გნებავთ, თქვენ შეგიძლიათ %(x_url_open)sშეხვიდეთ ან დარეგისტრირდეთ აქ"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7415,7 +7357,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "ეს ფუნქციები აკრძალულია უცხო მომხმარებლებისათვის."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "უკან ძიების შედეგებთან"
 
@@ -7580,7 +7522,7 @@ msgstr "შენიშვნის დამატება"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7717,213 +7659,212 @@ msgstr "მომხმარებელი %s არ არსებობს.
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "მომხმარებელი %s არ არსებობს."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "კომენტარის დაწერა"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_name)s დაწერეს %(x_date)s ზე:"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "%i კომენტარი"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "უკანასკნელი %i კომენარის ჩვენება:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "ამ დოკუმენტის განხილვა"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "დისკუსიის დაწყება ამ დოკუმენტის ნებისმიერ ასპექტზე"
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "უკაცრავად, ჩანაწერი %s არ არსებობს."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "უკაცრავად, %s არ არის სწორი საიდენტიფიკაციო მნიშვნელობა."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "უკაცრავად, ჩანაწერის იდენტიფიკატორი არ იქნა მითითებული."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "თქვენ შეიძლება გინდოდედ განხილვის დაწყება %s დან"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_name)s დაწერეს %(x_date)s ზე:"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "ეს განხილვა სასარგებლო იყო?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "განხილვის დაწერა"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 "საშუალო განხილვის შედეგი: %(x_nb_score)s დაფუძნებულია %(x_nb_reviews)s "
 "განხილვაზე"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "მკითხავებმა ჩათვალეს %s ეს განხილვები ყველაზე სასარგებლოდ."
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "იხილე ყვლა %s განხილვა"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "შეაფასე ეს დოკუმენტი"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "იყავი პირველი ვინც განიხილავს ამ დოკუმენტს"
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "დახურვა"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "შეგვატყობინე დარღვევა"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr "კომენტარის აღდგენა"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "კომენტარის წაშლა"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr "მოუხსენებელი კომენტარი"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "განხილულია %(x_nickname)s ის მიერ %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
-"%(x_nb_people)i ადამიანმა %(x_nb_total)i -დან ჩათვალა ეს განხილვა "
-"სასარგებლოდ"
+"%(x_nb_people)i ადამიანმა %(x_nb_total)i -დან ჩათვალა ეს განხილვა სასარგებლოდ"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr "წაუშლელი განხილვა"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr "განხილვის წაშლა"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr "მოუხსენებლი განხილვა"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "კომენტარები"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "განხილვები"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "სულ არის %s განხილვა"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "სულ არის %s კომენტარი"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "იყავი პირველი ვინც განიხილავს ამ დოკუმენტს"
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "ჩაწერა"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr "ამოწერა"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7932,94 +7873,93 @@ msgstr "ამოწერა"
 msgid "Record"
 msgstr "ჩანაწერი"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "განხილვა"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "კომენტარი"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "განხილვა"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "ყურება"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "გვერდი"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr "თქვენ არ ხარ ავტორიზებული კომენტირებისათვის ან განხილვისათვის."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr "თქვენი მეტსახელი, %s, იქნება გამოყენებული როგორც ამ ცომენტარის ავტორი."
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
-"შენიშვნა: თქვენ არ გაქვთ %(x_url_open)sგანსაზღვრული "
-"ზედმეტსახელი%(x_url_close)s. %(x_nickname)s იქნება გამოყენებული როგორც ამ"
-" კომენტარის ავტორი."
+"შენიშვნა: თქვენ არ გაქვთ %(x_url_open)sგანსაზღვრული ზედმეტსახელი"
+"%(x_url_close)s. %(x_nickname)s იქნება გამოყენებული როგორც ამ კომენტარის "
+"ავტორი."
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 #, fuzzy
 msgid "Optionally, attach a file to this comment"
 msgstr "ოპტიმალურად, დაამატეთ შენიშვნა ამ ელემენტს"
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 #, fuzzy
 msgid "Optionally, attach files to this comment"
 msgstr "ოპტიმალურად, დაამატეთ შენიშვნა ამ ელემენტს"
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 #, fuzzy
 msgid "Max one file"
 msgstr " ახალი ფაილის დამატება"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, python-format
 msgid "Max %(maxfiles)i files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr "გამომიგზავნე ელფოსტა როცა კომენტარი იქნება დამატებული"
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "არტიკლი"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "კომენტარის დამატება"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
@@ -8028,425 +7968,431 @@ msgstr ""
 "შენიშვნა: თქვენი მეტსახელი, %s, იქნება გამოყენებლი როგორც ამ განხილვის "
 "ავტორი."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "არტიკლის შეფასება"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "ქულის შერჩევა"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "დაურთეთ სათაური თქვენს განხილვას"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "დაწერეთ თქვენი განხილვა"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr "განხილვის დამატება"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "განხილვის დამატება"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "თქვენი განხილვა წარმატებითაა დამატებული."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "თქვენი კომენტარი წარმატებით იქნა დამატებული."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "უკან ჩანაწერთან"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
-msgstr "თქვენ შეგიძლიათ იხილოთ %(x_url_open)sთქვენი ბილეთების სია%(x_url_close)s."
+msgstr ""
+"თქვენ შეგიძლიათ იხილოთ %(x_url_open)sთქვენი ბილეთების სია%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr "იხილეთ ყველაზე მეტად კომენტარებადი ჩანაწერი"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr "იხილეთ ახალი დაკომენტირებული ჩანაწერები"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr "იხილეთ ყველა კომენტარი რომელიც დარღვევად იყო მოხსენებული"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr "იხილეთ ყველაზე მეტად ხილვადი ჩანაწერები"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr "იხილეთ ახალი განხილული ჩანაწერები"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr "იხილეთ ყველა ჩანაწერი დარღვევად მოხსენებული"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "იხილეთ ყველა დამრღვევად მოხსენიებული მომხმარებელი"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "ხელმძღვანელი"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "კომენტარები და განხილვები გაუქმებულია"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"გთხოვთ შეიყვანოთ კომენტარის/განხილვის საიდენტიფიკაციო რომ შეძლოთ მისი "
-"ნახვა სანამ წაშლით"
+"გთხოვთ შეიყვანოთ კომენტარის/განხილვის საიდენტიფიკაციო რომ შეძლოთ მისი ნახვა "
+"სანამ წაშლით"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "კომენტარის საიდენტიფიკაციო:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 "ან შეიყვანეთ ჩანაწერის საიდენტიფიკაციო რომ იხილოთ ყველა ასოცირებული "
 "კომენტარი/განხილვა:"
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr "ჩანაწერის საიდენტიფიკაციო:"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "კომენტარის ნახვა"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "რეპორტები ჯერ არ არის."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "იხილეთ ყველა %s მოხსენებული კომენტარი"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "იხილეთ ყველა %s მოხსენებული განხილვა"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-"აქ არის სია, სორტირებული რეპორტების საერთო რაოდენობით, ყველა "
-"მომხმარებელის ვისი კომენტარიც იყო მოხსენებული ერთხელ მაინც."
+"აქ არის სია, სორტირებული რეპორტების საერთო რაოდენობით, ყველა მომხმარებელის "
+"ვისი კომენტარიც იყო მოხსენებული ერთხელ მაინც."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "მეტსახელი"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "მომხმარებლის საიდენტიფიკაციო"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "დადებითი ხმების რაოდენობა"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "უარყოფითი ხმების რაოდენობა"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "ხმების საერთო რაოდენობა"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "რეპორტების საერთო რაოდენობა"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "იხილეთ ყველა მომხმარებლის მოხსენებული კომენტარი/განხილვა"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "ეს განხილვა მოხსენიებული იყო %i ჯერ"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "ეს კომენტარი მოხსენიებული იყო %i ჯერ"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "დაწერილია"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "ზოგადი ინფორმაცია"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "არჩეული განხილვების წაშლა"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "არჩეული რეპორტის დაკავება"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr "არჩეული განხილვების წაშლის გაუქმება"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr "არჩეული კომენტარების წაშლის გაუქმება"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "არჩეული კომენტარების წაშლა"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "აქ არის %s მომხმარებლის მოხსენებული განხილვები"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "აქ არის მოხსენებული კომენტარები %s -ის მიერ"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "აქ არის განხილვა %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "აქ არის კომენტარი %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "აქ არის განხილვა %(x_cmtID)s დაწერილი %(x_user)s -ის მიერ"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "აქ არის კომენტარი %(x_cmtID)s დაწერილი %(x_user)s -ის მიერ"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr ""
-"აქ არის ყველა მოხსენებული განხილვა, დალაგებული მოხსლენების სიხშირის "
-"მიხედვით"
+"აქ არის ყველა მოხსენებული განხილვა, დალაგებული მოხსლენების სიხშირის მიხედვით"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
-msgstr "აქ არის ყველა მოხსენებული კომენტარი, ყველაზე ხშირად მოხსენებული პირველია"
+msgstr ""
+"აქ არის ყველა მოხსენებული კომენტარი, ყველაზე ხშირად მოხსენებული პირველია"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
 "აქ არის ყველა განხილვა ჩანაწერი %i სათვის, ყველაზე ხშირად მოხსენებული "
 "პირველია"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr "კომენტარების ჩვენება"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
 "აქ არის ყველა კომენტარი ჩანაწერი %i სათვის, ყველაზე ხშირად მოხსენებული "
 "პირველია"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr "მაჩვენე განხილვები"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "კომენტარის საიდენტიფიკაციო"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "წარმატებით წაიშალა"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr "წაშლა წარმატებით გაუქმდა"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "წარმატებით აღკვეთილია დარღვევის მოხსენება"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "ჯერ არ არის განხილული"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+"შემდეგი განხილვა გაგზავნილია %(CFG_SITE_NAME)s სთან %(user_nickname)s -ის "
+"მიერ:"
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
-"შემდეგი განხილვა გაგზავნილია %(CFG_SITE_NAME)s სთან %(user_nickname)s -ის"
-" მიერ:"
+"კომენტარი გაგზავნილია %(CFG_SITE_NAME)s თან %(user_nickname)s -ის მიერ:"
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr "კომენტარი გაგზავნილია %(CFG_SITE_NAME)s თან %(user_nickname)s -ის მიერ:"
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr "ეს არის ავტომატური გაგზავნა, გთხოვთ არ გამოეხმაუროთ მას."
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr "სხვა კომენტარის დასამატებლად, მიბრძანდით <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
-msgstr "იმისათვის, რომ კონკრეტულად გამოეხმაუროდ ამ კომენტარს გადადით <%(x_url)s>"
+msgstr ""
+"იმისათვის, რომ კონკრეტულად გამოეხმაუროდ ამ კომენტარს გადადით <%(x_url)s>"
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr "ამ დისკუსიისგან ამოსაწერათ, გადადით <%(x_url)s>"
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr "ნებისმიერი კითხვისათვის გამოიყენეთ <%(CFG_SITE_SUPPORT_EMAIL)s>"
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "თქვენი კომენტარი წარმატებით იქნა დამატებული."
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "კომენტარების წაშლა "
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "უახლესი პირველი"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "იხილეთ ახალი დაკომენტირებული ჩანაწერები"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "კომენტარის დამატება"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "ჩანაწერები ნაპოვნია"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "კომენტარები"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "ელემენტები"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "ელემენტების დამატება"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 #, fuzzy
 msgid "Display"
 msgstr "მაჩვენე შეტყობინებები"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "განკარგულების თარიღი"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "შემდგომი გვერდი"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "მაჩვენე შეტყობინებები"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8454,105 +8400,105 @@ msgstr "მაჩვენე შეტყობინებები"
 msgid "Refresh"
 msgstr "განახლება"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "მოუხსენებელი კომენტარი"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "ელემენტია ნაპოვნი"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "ჩანაწერი არ მოიძებნა"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "თქვენ არ გაგაჩნიათ ულება ამ ელემენტის ნახვის."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "კომენტარის დამატება"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 msgid "You cannot report a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 #, fuzzy
 msgid "Page Not Found"
 msgstr "%s გვერდი არ არის ნაპოვნი"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 #, fuzzy
 msgid "The requested comment could not be found"
 msgstr "მოთხოვნილი გვერდი არ არსებობს"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 #, fuzzy
 msgid "The requested file could not be found"
 msgstr "მოთხოვნილი გვერდი არ არსებობს"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "თქვენ არ გაქვთ სესხის გამოყენების ავტორიზაცია."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "კომენტარები"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr ""
@@ -8667,11 +8613,11 @@ msgstr "უკაცრავად, მაგრამ გვერდი %s �
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
 #, fuzzy, python-format
@@ -8734,11 +8680,11 @@ msgstr "ჩვენ ვერ გაწოდებთ ვერცერთ �
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
-"როგორც ჩანს ამ სერვერზე არ არის განსაზღვრული ჟურნალები. გთხოვთ "
-"დაუკავშირდეთ მხარდამჭერებს თუ ეს მცდარია."
+"როგორც ჩანს ამ სერვერზე არ არის განსაზღვრული ჟურნალები. გთხოვთ დაუკავშირდეთ "
+"მხარდამჭერებს თუ ეს მცდარია."
 
 #: invenio/legacy/webjournal/config.py:239
 msgid "Select a journal on this server"
@@ -8753,8 +8699,8 @@ msgid ""
 "You did not provide an argument for a journal name. Please select the "
 "journal you want to read in the list below."
 msgstr ""
-"თქვენ არ მოგვაწოდეთ არგუმენტი ჟურნალის სახელისთვის. გთხოვთ ამოირჩოთ "
-"ჟურნალი რომლის წაკითხვაც გსურთ მითითებული სიიდან."
+"თქვენ არ მოგვაწოდეთ არგუმენტი ჟურნალის სახელისთვის. გთხოვთ ამოირჩოთ ჟურნალი "
+"რომლის წაკითხვაც გსურთ მითითებული სიიდან."
 
 #: invenio/legacy/webjournal/config.py:268
 msgid "No current issue"
@@ -8766,11 +8712,11 @@ msgstr "ვერ მოვიძიეთ ინფორმაცია მი
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
-"მიმდინარე პრობლემისათივის კონფიგურაცია ცარიელია. სცადეთ მიუთითოთ "
-"პრობლემის ნომერი მხარდაჭერი გუნდისთვის."
+"მიმდინარე პრობლემისათივის კონფიგურაცია ცარიელია. სცადეთ მიუთითოთ პრობლემის "
+"ნომერი მხარდაჭერი გუნდისთვის."
 
 #: invenio/legacy/webjournal/config.py:298
 msgid "Issue number badly formed"
@@ -8854,8 +8800,7 @@ msgid ""
 "The issue could not be correctly regenerated. Please contact your "
 "administrator."
 msgstr ""
-"საკითხის კორექტული აღდგენა ვერ ხერხდება. გთხოვთ დაუკავშირდეთ "
-"ადმინისტრატორს."
+"საკითხის კორექტული აღდგენა ვერ ხერხდება. გთხოვთ დაუკავშირდეთ ადმინისტრატორს."
 
 #: invenio/legacy/webjournal/templates.py:308
 #, python-format
@@ -8867,11 +8812,6 @@ msgstr ""
 #: invenio/legacy/webjournal/templates.py:699
 msgid "Apply"
 msgstr "გამოყენება"
-
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "მეტსახელი"
 
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 msgid "WebJournal Admin"
@@ -8952,9 +8892,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8976,8 +8915,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9454,19 +9392,18 @@ msgstr "ასევე ეძებე:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
-"ეს აკრძალული კოლექციაა. თუ თქვენ ავტორიზებული ხართ, გთხოვთ დააჭიროთ "
-"ძიების ღილაკს."
+"ეს აკრძალული კოლექციაა. თუ თქვენ ავტორიზებული ხართ, გთხოვთ დააჭიროთ ძიების "
+"ღილაკს."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
-"ეს არის გარე კოლექცია. გთხოვთ დააჭიროთ ძიების ღილაკს რომ იხილოთ "
-"შემადგენლობა."
+"ეს არის გარე კოლექცია. გთხოვთ დააჭიროთ ძიების ღილაკს რომ იხილოთ შემადგენლობა."
 
 #: invenio/legacy/websearch/templates.py:1619
 msgid "This collection does not contain any document yet."
@@ -9481,8 +9418,8 @@ msgstr "ციტირებულია %i ჩანაწერის მი�
 #, python-format
 msgid "Words nearest to %(x_word)s inside %(x_field)s in any collection are:"
 msgstr ""
-"ყველაზე ახლო სიტყვები %(x_word)s -თან %(x_field)s -ში ნებისმიერი "
-"კოლექციიდან არიან:"
+"ყველაზე ახლო სიტყვები %(x_word)s -თან %(x_field)s -ში ნებისმიერი კოლექციიდან "
+"არიან:"
 
 #: invenio/legacy/websearch/templates.py:1859
 #, python-format
@@ -9562,8 +9499,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found %(x_nb_records)s "
 "records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sშედეგების განხილვა:%(x_fmt_close)s ნაპოვნია "
-"%(x_nb_records)s ჩანაწერი, %(x_nb_seconds)s წამში."
+"%(x_fmt_open)sშედეგების განხილვა:%(x_fmt_close)s ნაპოვნია %(x_nb_records)s "
+"ჩანაწერი, %(x_nb_seconds)s წამში."
 
 #: invenio/legacy/websearch/templates.py:3132
 #, python-format
@@ -9604,8 +9541,7 @@ msgstr "დამატებითი ინფორმაცია"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 "ორობით შეკითხვაზე შედეგი არ არის. გთხოვთ შერწყოთ თქვენი ძიების სიტყვები "
 "სხვანაერად"
@@ -9633,12 +9569,12 @@ msgstr "იქნებ გნებავთ დაიწყოთ დათვ
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "დააყენეთ პირადი %(x_url1_open)sელფოსტის შეტყობინება%(x_url1_close)s\n"
-"                                  ან ჩაეწერეთ %(x_url2_open)sRSS "
-"ფიდზე%(x_url2_close)s."
+"                                  ან ჩაეწერეთ %(x_url2_open)sRSS ფიდზე"
+"%(x_url2_close)s."
 
 #: invenio/legacy/websearch/templates.py:3832
 #, python-format
@@ -9827,7 +9763,8 @@ msgid "in"
 msgstr "ში"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "ვერ იპოვნეთ რასაც ეძებდით? სცადეთ თქვენი ძებნა სხვა სერვერებზე:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9843,8 +9780,8 @@ msgid ""
 "The external search engine has not responded in time. You can check its "
 "results here:"
 msgstr ""
-"გარე საძიებო სისტემამ დროულად არ გვიპასუხა. თქვენ შეგიძლიათ შეამოწმოთ "
-"მისი სტატუსი აქ:"
+"გარე საძიებო სისტემამ დროულად არ გვიპასუხა. თქვენ შეგიძლიათ შეამოწმოთ მისი "
+"სტატუსი აქ:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:146
 #: invenio/legacy/websearch_external_collections/templates.py:154
@@ -9872,8 +9809,8 @@ msgid ""
 "You can consult the list of your external groups directly in the "
 "%(x_url_open)sgroups page%(x_url_close)s."
 msgstr ""
-"თქვენ შეგიძლიათ ნახოთ თქვენი გარე ჯგუფების სია %(x_url_open)sჯგუფების "
-"გვერდზე%(x_url_close)s."
+"თქვენ შეგიძლიათ ნახოთ თქვენი გარე ჯგუფების სია %(x_url_open)sჯგუფების გვერდზე"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:110
 msgid "External user groups"
@@ -9923,8 +9860,8 @@ msgstr "აუცილებელი"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9934,8 +9871,8 @@ msgstr "ახალი კალათის შექმნა"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 "თუ გნებავთ თქვენი ელფოსტის შეცვლა ან მეტსახელის პირველად არცჰევა, გთხოვთ "
 "შეიყვანოთ ახალი მნიშვნელობები ქვემოთ."
@@ -9954,16 +9891,16 @@ msgstr "ახალი მნიშვნელობების მინი�
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 "რადგან ეს წარმოადგენს კომენტარების და მიმოხილვების იდენტიფიკატორს, მისი "
 "შემდგომი შეცვლა შეუძლებელია."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
 "თუ გსურთ პაროლის შეცვლა, გთხოვთ ჩაწეროთ ძველი და მიუთითოთ ახალი "
 "მნიშვნელობები ფორმას ქვემოთ."
@@ -10003,8 +9940,8 @@ msgstr "ახალი პაროლის დაყენება"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 "თუ თქვენ იყენებთ ცერნის მსუბუქ ანგარიშს\n"
 "                %(x_url_open)sგადატვირთეთ პაროლი%(x_url_close)s."
@@ -10096,15 +10033,13 @@ msgstr "აირჩიეთ მეთოდი"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"თუ თქვენ დაკარგეთ პაროლი %(sitename)s "
-"%(x_fmt_open)sანგარიშისათვის%(x_fmt_close)s, მაშინ გთხოვთ შეიყვანოთ "
-"თქვენი ელფოსტის მისამართი ქვემოთ მოცემულ ფორმაში, რომ გამოგიგზავნოთ "
-"წერილი პაროლის გადასატვირთად."
+"თუ თქვენ დაკარგეთ პაროლი %(sitename)s %(x_fmt_open)sანგარიშისათვის"
+"%(x_fmt_close)s, მაშინ გთხოვთ შეიყვანოთ თქვენი ელფოსტის მისამართი ქვემოთ "
+"მოცემულ ფორმაში, რომ გამოგიგზავნოთ წერილი პაროლის გადასატვირთად."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10120,18 +10055,18 @@ msgstr "გაგზავნე პაროლის გადასატვ�
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
-"თუ თქვენ იყენებდით %(x_fmt_open)sცერნის ავტორიზაციის "
-"სისტემას%(x_fmt_close)s, თქვენ შეგიძლიათ აღადგინოთ თქვენი პაროლი "
+"თუ თქვენ იყენებდით %(x_fmt_open)sცერნის ავტორიზაციის სისტემას"
+"%(x_fmt_close)s, თქვენ შეგიძლიათ აღადგინოთ თქვენი პაროლი "
 "%(x_url_open)sცერნის ავტორიზაციის სისტემით%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 "გთხოვთ გაითვალისწინოთ რომ, თუ თქვენ იყენებდით გარე სისტემას, თქვენ უნდა "
 "მიმართოთ მის ადმინისტრატორს."
@@ -10148,14 +10083,14 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
-"%s გაძლევთ შესაძლებლობას მოირგოთ ინტერფეისი, დააყენოთ თქვენი ბიბლიოთეკა "
-"ან დოკუმენტები, ან დააყენოთ ავტომატური შეტყობინება რომელიც გაუწყებთ "
-"ძიების შედეგებში ცვლილებებს."
+"%s გაძლევთ შესაძლებლობას მოირგოთ ინტერფეისი, დააყენოთ თქვენი ბიბლიოთეკა ან "
+"დოკუმენტები, ან დააყენოთ ავტომატური შეტყობინება რომელიც გაუწყებთ ძიების "
+"შედეგებში ცვლილებებს."
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10167,8 +10102,8 @@ msgid ""
 "Set or change your account email address or password. Specify your "
 "preferences about the look and feel of the interface."
 msgstr ""
-"დააყენეთ ან შეცვალეთ თქვენი ანგარიშის ელფოსტის მისამართი ან პაროლი. "
-"მიუთითეთ თქვენი პარამეტრები ინტერფეისის შესაცვლელად."
+"დააყენეთ ან შეცვალეთ თქვენი ანგარიშის ელფოსტის მისამართი ან პაროლი. მიუთითეთ "
+"თქვენი პარამეტრები ინტერფეისის შესაცვლელად."
 
 #: invenio/legacy/websession/templates.py:620
 msgid "View all the searches you performed during the last 30 days."
@@ -10176,11 +10111,11 @@ msgstr "იხილეთ ყველა ძიება რომელიც
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
-"კალათების გამოყენებით თქვენ შეგიძლიათ განსაზღვროთ ელემენტების კოლექციები,"
-" შეინახოთ საინტერესო ჩანაწერები რომელიც გნებავთ რომ მომავალში იხილოთ ან "
+"კალათების გამოყენებით თქვენ შეგიძლიათ განსაზღვროთ ელემენტების კოლექციები, "
+"შეინახოთ საინტერესო ჩანაწერები რომელიც გნებავთ რომ მომავალში იხილოთ ან "
 "გაუზიაროთ მეგობარს."
 
 #: invenio/legacy/websession/templates.py:636
@@ -10192,32 +10127,32 @@ msgid ""
 "Subscribe to a search which will be run periodically by our service. The "
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
-"ჩაეწერეთ ძიებაში, რომელიც ავტომატურად იქნება გაშვებული ჩვენს მიერ. ძიების"
-" შედეგები შეიძლება გამოგზავნილი იყოს თქვენს ელფოსტაზე ან შენახული იყოს "
-"თქვენ კალათებში."
+"ჩაეწერეთ ძიებაში, რომელიც ავტომატურად იქნება გაშვებული ჩვენს მიერ. ძიების "
+"შედეგები შეიძლება გამოგზავნილი იყოს თქვენს ელფოსტაზე ან შენახული იყოს თქვენ "
+"კალათებში."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
 "შეამოწმეთ წიგნები რომელიც გამოტანილი გაქვთ, დაამატეთ წიგნის გამოტანის "
 "მოთხოვნა, და ა.შ. მოითხოვება თქვენი ცერნის საიდენტიფიკაციო."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
-"თქვენ შემოსული ხართ როგორც სტუმარი, ამიტომ თქვენი შეტყობინებები წაიშლება "
-"ამ სესიის დამთავრების შემდეგ."
+"თქვენ შემოსული ხართ როგორც სტუმარი, ამიტომ თქვენი შეტყობინებები წაიშლება ამ "
+"სესიის დამთავრების შემდეგ."
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 "თქვენ შემოსული ხართ როგორც %(x_user)s. თქვენ შეიძლება გინდოდეთ ა) "
 "%(x_url1_open)sგამოსვლა%(x_url1_close)s; ბ) შეასწოროთ თქვენი "
@@ -10228,7 +10163,8 @@ msgstr ""
 msgid ""
 "You can consult the list of %(x_url_open)syour comments%(x_url_close)s "
 "submitted so far."
-msgstr "თქვენ შეგიძლიათ იხილოთ %(x_url_open)sთქვენი ბილეთების სია%(x_url_close)s."
+msgstr ""
+"თქვენ შეგიძლიათ იხილოთ %(x_url_open)sთქვენი ბილეთების სია%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:790
 msgid "Your Alert Searches"
@@ -10237,8 +10173,8 @@ msgstr "თქვენი ძიების შეტყობინება�
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 "თქვენ შეგიძლიათ იხილოთ სია %(x_url_open)sთქვენი ჯგუფების%(x_url_close)s "
 "რომლებსაც თქვენ განაგებთ ან გაწევრიანებული ხართ."
@@ -10252,11 +10188,11 @@ msgstr "თქვენი ჯგუფი "
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"თქვენ შეგიძლიათ იხილოთ თქვენი%(x_url_open)sწარდგინებების "
-"სია%(x_url_close)s და შეამოწმოთ მათი სტატუსი."
+"თქვენ შეგიძლიათ იხილოთ თქვენი%(x_url_open)sწარდგინებების სია%(x_url_close)s "
+"და შეამოწმოთ მათი სტატუსი."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -10266,8 +10202,8 @@ msgstr "თქვენი  წარდგენები"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
 "თქვენ შეგიძლიათ იხილოთ%(x_url_open)sთქვენი დასტურების სია%(x_url_close)s "
 "დოკუმენტებზე რომლებიც დაადასტურეთ ან მიმართეთ."
@@ -10280,7 +10216,8 @@ msgstr "თქვენი დასტური"
 #: invenio/legacy/websession/templates.py:815
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour tickets%(x_url_close)s."
-msgstr "თქვენ შეგიძლიათ იხილოთ %(x_url_open)sთქვენი ბილეთების სია%(x_url_close)s."
+msgstr ""
+"თქვენ შეგიძლიათ იხილოთ %(x_url_open)sთქვენი ბილეთების სია%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:818
 msgid "Your Tickets"
@@ -10309,8 +10246,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:877
 msgid "If you want to reset the password for this account, please go to:"
 msgstr ""
-"თუ თქვენ გსურთ გადატვირთოთ ამ ანგარიშთან დაკავშირებული თქვენი პაროლი "
-"გთხოვთ მიმართოთ:"
+"თუ თქვენ გსურთ გადატვირთოთ ამ ანგარიშთან დაკავშირებული თქვენი პაროლი გთხოვთ "
+"მიმართოთ:"
 
 #: invenio/legacy/websession/templates.py:883
 #: invenio/legacy/websession/templates.py:920
@@ -10320,10 +10257,10 @@ msgstr "იმისათვის რომ დაადასტუროთ 
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
-"გთხოვთ გაითვალისწინოთ რომ ეს მისამართი ძალაში იქნება დაახლოებით %(days)s "
-"დღე."
+"გთხოვთ გაითვალისწინოთ რომ ეს მისამართი ძალაში იქნება დაახლოებით %(days)s დღე."
 
 #: invenio/legacy/websession/templates.py:909
 #, fuzzy, python-format
@@ -10338,7 +10275,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:914
 msgid "If you want to complete this account registration, please go to:"
-msgstr "თუ თქვენ გსურთ საბოლოო რეგისტრაცია თქვენი ანგარიშის, გთხოვთ გადახვიდეთ:"
+msgstr ""
+"თუ თქვენ გსურთ საბოლოო რეგისტრაცია თქვენი ანგარიშის, გთხოვთ გადახვიდეთ:"
 
 #: invenio/legacy/websession/templates.py:940
 #, fuzzy, python-format
@@ -10361,16 +10299,14 @@ msgid ""
 "                %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 "თქვენ ჯერ კიდევ ამოცნობილი ხართ როგორც ცენტრალიზებული\n"
-"                %(x_fmt_open)sSSO%(x_fmt_close)s სისტემბა. თქვენ "
-"შეგიძლიათ\n"
+"                %(x_fmt_open)sSSO%(x_fmt_close)s სისტემბა. თქვენ შეგიძლიათ\n"
 "                %(x_url_open)sგამოხვიდეთ SSO%(x_url_close)s -დან."
 
 #: invenio/legacy/websession/templates.py:978
 #, python-format
 msgid "If you wish you can %(x_url_open)slogin here%(x_url_close)s."
 msgstr ""
-"თუ თქვენ გნებავთ, თქვენ შეგიძლიათ %(x_url_open)sშემოხვიდეთ "
-"აქ%(x_url_close)s."
+"თუ თქვენ გნებავთ, თქვენ შეგიძლიათ %(x_url_open)sშემოხვიდეთ აქ%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1011
 msgid "If you already have an account, please login using the form below."
@@ -10381,8 +10317,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 "თუ თქვენ ჯერ არ გაქვთ ცერნის ანგარიში, თქვენ შეგიძლიათ დაარეგისტრიროთ "
 "%(x_url_open)sცერნის ახალი მსუბუქი ანგარიში%(x_url_close)s."
@@ -10390,11 +10326,11 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"თუ თქვენ ჯერ არ გაქვთ ანგარიში, გთხოვთ "
-"%(x_url_open)sდაარეგისტრიროთ%(x_url_close)s ინტერნეტ ანგარიში."
+"თუ თქვენ ჯერ არ გაქვთ ანგარიში, გთხოვთ %(x_url_open)sდაარეგისტრიროთ"
+"%(x_url_close)s ინტერნეტ ანგარიში."
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
@@ -10431,8 +10367,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 "თქვენი მოთხოვნა სწორია. გთხოვთ აირჩიოთ ახალი თქვენთვის სასურველი პაროლი "
 "აღნიშნულ ფორაში."
@@ -10456,13 +10392,12 @@ msgstr "ახალი პაროლის დაყენება"
 #: invenio/legacy/websession/templates.py:1175
 msgid "Please enter your email address and desired nickname and password:"
 msgstr ""
-"გთზოვთ შეიყვანოთ თქვენი ელ-ფოსტის მისამართი და სასურველი მეტსახელი და "
-"პაროლი:"
+"გთზოვთ შეიყვანოთ თქვენი ელ-ფოსტის მისამართი და სასურველი მეტსახელი და პაროლი:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
 "ანგარიშის გამოყენება არ იქნება შესაძლებელი , ვიდრე ის არ იქნება "
 "დადასტურებული და გააქტიურებული."
@@ -10481,35 +10416,33 @@ msgstr "რეგისტრაცია"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
 "გთხოვთ ნუ გამოიყენებთ მნიშვნელოვან პაროლებს როგორიცაა Unix, AFS ან NICE "
 "პაროლები. თქვენი ელფოსტის მისამართი იქნება მკაცრად გასაიდუმლოებული და "
 "არიქნება გაცემული მესამე პირისთვის. ის იქნება გამოყენებლი თქვენი "
-"იდენტიფიცირებისათვის %s -ზე. მაგალითად, თქვენ შეგეძლებათ დააყენოთ "
-"ავტომატური შეტყობინებები ძიების შედეგებზე და შეგატყობინოთ ელფოსტის "
-"მეშვეობით."
+"იდენტიფიცირებისათვის %s -ზე. მაგალითად, თქვენ შეგეძლებათ დააყენოთ ავტომატური "
+"შეტყობინებები ძიების შედეგებზე და შეგატყობინოთ ელფოსტის მეშვეობით."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
-"ანგარიშს თავად ვერ შექმნით. დაუკავშრდით %s თუ თქვენ გსურთ ანგარიშის "
-"შექმნა."
+"ანგარიშს თავად ვერ შექმნით. დაუკავშრდით %s თუ თქვენ გსურთ ანგარიშის შექმნა."
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
-"თქვენ ხართ შემოსული როგორც სტუმარი. გთხოვთ ჯერ "
-"%(x_url_open)sშემოხვიდეთ%(x_url_close)s სისტემაში."
+"თქვენ ხართ შემოსული როგორც სტუმარი. გთხოვთ ჯერ %(x_url_open)sშემოხვიდეთ"
+"%(x_url_close)s სისტემაში."
 
 #: invenio/legacy/websession/templates.py:1267
 msgid "You are not authorized to access administrative functions."
@@ -10639,8 +10572,8 @@ msgstr "იხილეთ რამდენიმე საინტერე�
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "მეტი ადმინისტრატორის ფუნქციებისათვის, იხილეთ სრული %(x_url_open)sადმინის "
 "სივრცე%(x_url_close)s."
@@ -10814,8 +10747,7 @@ msgid ""
 msgstr ""
 "გამარჯობა:\n"
 "\n"
-"ჩემი აზრით თქვენთვის შესაძლოა საინტერესო იყოს ჯგუფში გაწევრიანება \"%s\"."
-"\n"
+"ჩემი აზრით თქვენთვის შესაძლოა საინტერესო იყოს ჯგუფში გაწევრიანება \"%s\".\n"
 "თქვენ შეგიძლიათ გაწევრიანდეთ აქ მიჭერით: %s.\n"
 "\n"
 "საუკეთესო სურვილებით.\n"
@@ -10870,10 +10802,10 @@ msgstr "წევრს სურს ჯგუფში გაწევრია
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
-"გთხოვთ %(x_url_open)sმიიღოთ ან უარყოთ%(x_url_close)s ამ მომხმარებლის "
-"თხოვნა."
+"გთხოვთ %(x_url_open)sმიიღოთ ან უარყოთ%(x_url_close)s ამ მომხმარებლის თხოვნა."
 
 #: invenio/legacy/websession/templates.py:2400
 #, fuzzy, python-format
@@ -10899,7 +10831,8 @@ msgstr "თქვენი თხოვნა %s ჯგუფში გასა
 #: invenio/legacy/websession/templates.py:2426
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour groups%(x_url_close)s."
-msgstr "თქვენ შეგიძლიათ იხილოთ თქვენი %(x_url_open)sჯგუფების სია%(x_url_close)s."
+msgstr ""
+"თქვენ შეგიძლიათ იხილოთ თქვენი %(x_url_open)sჯგუფების სია%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:2422
 #, fuzzy, python-format
@@ -10914,20 +10847,19 @@ msgstr "ჯგუფი %s წაშლილია ადმინისტრ�
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"თქვენ შეგიძლიათ იხილოთ %(x_url_open)s%(x_nb_total)i ჯგუფების "
-"სია%(x_url_close)s რომელზეც ჩაწერილი ხართ (%(x_nb_member)i) ან მართავთ "
+"თქვენ შეგიძლიათ იხილოთ %(x_url_open)s%(x_nb_total)i ჯგუფების სია"
+"%(x_url_close)s რომელზეც ჩაწერილი ხართ (%(x_nb_member)i) ან მართავთ "
 "(%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 #, fuzzy
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 "გაფრთხილება :  პაროლი რომელიც დააყენეთ MySQL -ზე იგივეა რაც სტანდარტული "
 "Invenio -ს პაროლი. თქვენი უსაფრთხოებისათივს, თქვენ უნდა შეცვალოთ პაროლი."
@@ -10936,8 +10868,7 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 "გაფრთხილება : დაყენებული პაროლი Invenio -ს მონაცემთა ბაზაზე იგივეა რაც  "
 "სტანდარტული პაროლი Invenio -ს პაროლი. უსაფრთხოებისათვის გირჩევთ შეცვალოთ "
@@ -10946,9 +10877,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2472
 #, fuzzy
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 "გაფრთხილება : პაროლი Invenio admin მომხმარებლისათვის ამჟამად ცარიელია. "
 "უსაფრთხოებისათვის რეკომენდირებულია რომ დაადოთ პაროლი."
@@ -10956,9 +10886,9 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2478
 #, fuzzy
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 "გაფრთხილება: მხარდაჭერის პაროლი ამჟამად არის info@invenio-software.org . "
 "რეკომენდირებულია რომ თქვენ შეცვალოთ ის თქვენს ელფოსტის მისამართზე."
@@ -10966,39 +10896,36 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2484
 #, fuzzy
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr "Invenio -ს ახალი ვერსია შეიძლება იყოს გადმოწერილი. გთხოვთ გვეახლეთ"
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
 "თქვენ შემოსული ხართ, როგორც სტუმარი. თქვენ შეიძლება გინდათ "
-"%(x_url_open)sშემოხვიდეთ%(x_url_close)s როგორც დარეგისტრირებული "
-"მომხმარებელი."
+"%(x_url_open)sშემოხვიდეთ%(x_url_close)s როგორც დარეგისტრირებული მომხმარებელი."
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 "%(x_fmt_open)sსტუმარ%(x_fmt_close)s მომხმარებლებს სჭირდება "
 "%(x_url_open)sრეგისტრაცია%(x_url_close)s"
@@ -11009,19 +10936,19 @@ msgstr "მოთხოვნები ვერ მოიძებნა"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 "ეს აკრძალული კოლექციაა. თუ თვლით რომ გაქვთ უფლებები მისი ნახვის გთხოვთ "
 "გაიაროთ ავტორიზაცია."
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
-"ფაილთან წვდომა შეზღუდულია. თუ თვლით რომ გაქვთ უფლებები მისი ნახვის გთხოვთ"
-" გაიაროთ ავტორიზაცია."
+"ფაილთან წვდომა შეზღუდულია. თუ თვლით რომ გაქვთ უფლებები მისი ნახვის გთხოვთ "
+"გაიაროთ ავტორიზაცია."
 
 #: invenio/legacy/websession/webaccount.py:400
 msgid "The OpenID identifier is invalid"
@@ -11029,8 +10956,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11042,8 +10969,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11121,8 +11048,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11161,8 +11087,8 @@ msgid ""
 "browser if you are a guest user."
 msgstr ""
 "თქვენ წარმატებით მოიპოვეთ ავტორიზაცია როგორც %(x_role)s! ეს ავტორიზაცია "
-"გაგრძელდება  %(x_expiration)s -მდე და სანამ დახურავთ ბრაუზერს თუ შემოსული"
-" ხართ როგორც სტუმარი."
+"გაგრძელდება  %(x_expiration)s -მდე და სანამ დახურავთ ბრაუზერს თუ შემოსული "
+"ხართ როგორც სტუმარი."
 
 #: invenio/legacy/websession/webinterface.py:128
 msgid "You have confirmed the validity of your email address!"
@@ -11178,8 +11104,8 @@ msgstr "თქვენი ანგარიშის ჩასართავ�
 #, python-format
 msgid "You can now go to %(x_url_open)syour account page%(x_url_close)s."
 msgstr ""
-"თქვენ უკვე შეგიძლიათ გადახვიდეთ %(x_url_open)sთქვენ ანგარისის "
-"გვერდზე%(x_url_close)s."
+"თქვენ უკვე შეგიძლიათ გადახვიდეთ %(x_url_open)sთქვენ ანგარისის გვერდზე"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:136
 #: invenio/legacy/websession/webinterface.py:145
@@ -11192,8 +11118,7 @@ msgstr "თქვენ უკვე დაადასტურეთ თქვ
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 "ეს მოთხოვნა ელ-ფოსტის მისამართის დასადასტურებლად არ არის სწორი ან უკვე "
 "ამოიწურა."
@@ -11212,11 +11137,13 @@ msgstr "ეს მოთხოვნა პაროლის გადასა
 
 #: invenio/legacy/websession/webinterface.py:175
 msgid "This request for resetting a password is not valid or is expired."
-msgstr "ეს მოთხოვნა პაროლის გადათვირთვის თაობაზე არ არის ძალაში ან უკვე ამოიწურა."
+msgstr ""
+"ეს მოთხოვნა პაროლის გადათვირთვის თაობაზე არ არის ძალაში ან უკვე ამოიწურა."
 
 #: invenio/legacy/websession/webinterface.py:180
 msgid "This request for resetting the password is not valid or is expired."
-msgstr "ეს მოთხოვნა პაროლის გადათვირთვის თაობაზე არ არის ძალაში ან უკვე ამოიწურა."
+msgstr ""
+"ეს მოთხოვნა პაროლის გადათვირთვის თაობაზე არ არის ძალაში ან უკვე ამოიწურა."
 
 #: invenio/legacy/websession/webinterface.py:193
 msgid "The two provided passwords aren't equal."
@@ -11260,15 +11187,14 @@ msgstr "გადავერთე შიდა შესვლის მეთ
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 "გთხოვთ შენიშნოთ რომ, თუ თქვენ პირველად იყენებთ ამ ანგარიშს შიდა შესვლის "
-"მეთოდით, სისტემამ დააყენა შემთხვევით დაგენერირებული პაროლი. გთხოვთ "
-"დააჭიროთ შემდეგ ღილაკს, პაროლის გადასატვირთი ლინკის გამოსაგზავნად "
-"ელფოსტაზე:"
+"მეთოდით, სისტემამ დააყენა შემთხვევით დაგენერირებული პაროლი. გთხოვთ დააჭიროთ "
+"შემდეგ ღილაკს, პაროლის გადასატვირთი ლინკის გამოსაგზავნად ელფოსტაზე:"
 
 #: invenio/legacy/websession/webinterface.py:431
 msgid "Send Password"
@@ -11299,11 +11225,11 @@ msgstr "შესვლის მეთოდი წარმატებულ�
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
-"გარე შესვლის მეთოდს %s არ აქვს ელფოსტაზე დაფუძვნებული შესვლის მხარდაჭერა."
-" გთხოვთ დაუკავშირდეთ საიტის ადმინისტრატორს."
+"გარე შესვლის მეთოდს %s არ აქვს ელფოსტაზე დაფუძვნებული შესვლის მხარდაჭერა. "
+"გთხოვთ დაუკავშირდეთ საიტის ადმინისტრატორს."
 
 #: invenio/legacy/websession/webinterface.py:464
 #, fuzzy
@@ -11443,8 +11369,8 @@ msgid ""
 "The entered email address is incorrect, please check that it is written "
 "correctly (e.g. johndoe@example.com)."
 msgstr ""
-"შეყვანილი ელ-ფოსტის მისამართი არ არის სწორი, გთხოვთ შეამოწმოთ რომ ის "
-"სწორედ ჩაჭერეთ  (მაგალიტად:  johndoe@example.com)."
+"შეყვანილი ელ-ფოსტის მისამართი არ არის სწორი, გთხოვთ შეამოწმოთ რომ ის სწორედ "
+"ჩაჭერეთ  (მაგალიტად:  johndoe@example.com)."
 
 #: invenio/legacy/websession/webinterface.py:684
 msgid "Incorrect email address"
@@ -11480,21 +11406,21 @@ msgid ""
 "In order to confirm its validity, an email message containing an account "
 "activation key has been sent to the given email address."
 msgstr ""
-"ელფოსტის დასადასტურებლად, წერილია გამოგზავნილი თქვენს მისამართზე "
-"აქტივაციის გასაღებით შემდეგ ელფოსტის მისამართზე."
+"ელფოსტის დასადასტურებლად, წერილია გამოგზავნილი თქვენს მისამართზე აქტივაციის "
+"გასაღებით შემდეგ ელფოსტის მისამართზე."
 
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr "გთხოვთ მიყვეთ ინსტრუქციას ანგარიშის რეგისტრაციის დასამთავრებლად."
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 "მეორე ელ-ფოსტა გამოგზავნილი იქნება მაშინ, როდესაც თქვენი ანგარიშ იქნება "
 "გააქტიურებული და შესაძლებელი იქნება მისის გამოყენება."
@@ -11502,7 +11428,8 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:989
 #, python-format
 msgid "You can now access your %(x_url_open)saccount%(x_url_close)s."
-msgstr "თქვენ შეგიძლიათ შეხვიდეთ თქვენს %(x_url_open)sანგარიშზე%(x_url_close)s."
+msgstr ""
+"თქვენ შეგიძლიათ შეხვიდეთ თქვენს %(x_url_open)sანგარიშზე%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:996
 #: invenio/legacy/websession/webinterface.py:1001
@@ -11547,8 +11474,7 @@ msgid ""
 "The site is having troubles in sending you an email for confirming your "
 "email address."
 msgstr ""
-"სისტემა ვერ ახერხებს თქვნთან ელფოსტის გაგზავნას, მისამართის "
-"დასადასტურებლად."
+"სისტემა ვერ ახერხებს თქვნთან ელფოსტის გაგზავნას, მისამართის დასადასტურებლად."
 
 #: invenio/legacy/websession/webinterface.py:1432
 msgid "Your tickets"
@@ -11614,7 +11540,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 "ჩანაწერი შექმნილია %(x_date_creation)s, ბოლოს შესწორებულია "
 "%(x_date_modification)s"
@@ -11639,37 +11566,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11677,15 +11604,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11749,8 +11676,8 @@ msgstr "ვერ ხერხდება წარდგენილი გვ
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
 "ვერ ხერხდება დირექტორიის შექმნა ამ დამატებისათვის. შეტყობინება გაეგზავა "
 "ადმინისტრატორს."
@@ -11789,12 +11716,12 @@ msgstr "დაყენება"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
-"ადგილი აქვს სერიოზულ ფუნქციუ შეცდომას. შეტყობინება გაეგზავნა "
-"ადმინისტრატორს. <br /><em>შეიძლება გამოწვეული იყოს არასწორი სიმბოლოების "
-"გამოყენების გამო</em> (მაგალითად PDF ფაილიდან დაკოპირებით)."
+"ადგილი აქვს სერიოზულ ფუნქციუ შეცდომას. შეტყობინება გაეგზავნა ადმინისტრატორს. "
+"<br /><em>შეიძლება გამოწვეული იყოს არასწორი სიმბოლოების გამოყენების გამო</"
+"em> (მაგალითად PDF ფაილიდან დაკოპირებით)."
 
 #: invenio/legacy/websubmit/engine.py:1501
 #, fuzzy, python-format
@@ -11840,11 +11767,11 @@ msgstr "გთხოვთ აირჩიოთ კატეგორია დ
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
-"იმისათვის რომ შეძლოთ გაგრძელება უწინ შეწყვეტილი წარდგენის, საჭიროა "
-"წვდომის ნომრის შეყვანა შემდგომ გრაფაში:  "
+"იმისათვის რომ შეძლოთ გაგრძელება უწინ შეწყვეტილი წარდგენის, საჭიროა წვდომის "
+"ნომრის შეყვანა შემდგომ გრაფაში:  "
 
 #: invenio/legacy/websubmit/templates.py:366
 msgid "GO"
@@ -11872,8 +11799,8 @@ msgstr "ძირითად მენიუში დაბრუნება"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 "ეს არის თქვენი წარგენის გამოსაყენებელი ნომერი.  ის შეიძლება გამოყენებულ "
 "იქნას პრობლემების შემთქვევაში შეწყვეტილი წარდგენის გასაგრძელებლად."
@@ -11924,11 +11851,11 @@ msgstr "დამატების ნომერი"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
-"აქ არის %(x_action)s ფუნქციების სია %(x_doctype)s დოკუმენტებისათვის "
-"შემდეგ დონეზე %(x_step)s"
+"აქ არის %(x_action)s ფუნქციების სია %(x_doctype)s დოკუმენტებისათვის შემდეგ "
+"დონეზე %(x_step)s"
 
 #: invenio/legacy/websubmit/templates.py:1041
 msgid "Function"
@@ -12009,11 +11936,10 @@ msgstr "მითითებული დოკუმენტების ტ�
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
-"აირჩიეთ ერთერთი მომდევნო დოკუმენტთაგანი  იმისათვის რომ შეამოძმოთ "
-"დოკუმენტის სტატუსი"
+"აირჩიეთ ერთერთი მომდევნო დოკუმენტთაგანი  იმისათვის რომ შეამოძმოთ დოკუმენტის "
+"სტატუსი"
 
 #: invenio/legacy/websubmit/templates.py:1447
 msgid "Go to specific approval workflow"
@@ -12149,8 +12075,10 @@ msgstr "დადასტურების შენიშვნა:"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
-msgstr "ეს დოკუმენტი ჯერ კიდევ %(x_fmt_open)sელოდება დადასტურებას%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgstr ""
+"ეს დოკუმენტი ჯერ კიდევ %(x_fmt_open)sელოდება დადასტურებას%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
 #: invenio/legacy/websubmit/templates.py:2163
@@ -12171,7 +12099,8 @@ msgstr "ბოლო დასტური ელ-ფოსტა გამო�
 msgid ""
 "You can send an approval request email again by clicking the following "
 "button:"
-msgstr "თქვენ შეგიძიათ კვლავ გააგზავნოთ დასტური ელ-ფოსტა აღნიშნულ რილაკზე მიჭერით:"
+msgstr ""
+"თქვენ შეგიძიათ კვლავ გააგზავნოთ დასტური ელ-ფოსტა აღნიშნულ რილაკზე მიჭერით:"
 
 #: invenio/legacy/websubmit/templates.py:2149
 #: invenio/legacy/websubmit/web/publiline.py:367
@@ -12226,7 +12155,8 @@ msgstr "ის ჯეერ შმოწმებული იყო რეფ�
 #: invenio/legacy/websubmit/templates.py:2264
 #: invenio/legacy/websubmit/templates.py:2318
 msgid "Last request e-mail was sent to the publication committee chair on the "
-msgstr "ბოლო მოთხოვნის ელფოსტა გაეგზავნა გამომცემლობის კომიტეტის თავჯდომარესთან"
+msgstr ""
+"ბოლო მოთხოვნის ელფოსტა გაეგზავნა გამომცემლობის კომიტეტის თავჯდომარესთან"
 
 #: invenio/legacy/websubmit/templates.py:2268
 msgid "A referee has been selected by the publication committee on the "
@@ -12244,8 +12174,8 @@ msgstr "რეფერის არჩევა"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr "რეფერიმ გაგზავნა მისი ბოლო რეკომენდაცია გამომცემლობის კომიტეტში"
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -12264,11 +12194,10 @@ msgstr "რეკომენდაციის გაგზავნა"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
-"პუბლიკაციის კომიტეტმა გაგზავნა მისი ბოლო რეკომენდაცია პროექტის "
-"ხელმძღვანელთან"
+"პუბლიკაციის კომიტეტმა გაგზავნა მისი ბოლო რეკომენდაცია პროექტის ხელმძღვანელთან"
 
 #: invenio/legacy/websubmit/templates.py:2291
 #: invenio/legacy/websubmit/templates.py:2358
@@ -12308,7 +12237,8 @@ msgid "Take a decision"
 msgstr "მიიღეთ გადაწყვეტილება"
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr "შემსწორებელთა გუნდი უკვე შეირჩა გამომცემლობის კომიტეტის მიერ"
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12329,15 +12259,15 @@ msgstr "რეფერი აირჩა შემსწორებელთ�
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr "რეფერიმ გაგზავნა მისი ბოლო რეკომენდაცია შემსტორებელთა გუნდთან"
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
-msgstr "შემსწორებელთა გუნდმა გაგზავნი ბოლო რეკომენდაცია გამომცემლობის კომიტეტში"
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
+msgstr ""
+"შემსწორებელთა გუნდმა გაგზავნი ბოლო რეკომენდაცია გამომცემლობის კომიტეტში"
 
 #: invenio/legacy/websubmit/templates.py:2350
 msgid "No recommendation from the editorial board yet."
@@ -12456,14 +12386,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 "ადამიანის ჩარევის გამო ან დრობითი პრობლემის, დავალებების რიგი გადავიდა "
-"ხელოვნურ რეჟიმზე. თქვენი დამატება წარმატებით დარეგისტრირდა, მაგრამ "
-"შეიძლება დაჭირდეს საჭიროზე მეტი დრო სრული ინტეგრაციისათვის.\n"
+"ხელოვნურ რეჟიმზე. თქვენი დამატება წარმატებით დარეგისტრირდა, მაგრამ შეიძლება "
+"დაჭირდეს საჭიროზე მეტი დრო სრული ინტეგრაციისათვის.\n"
 
 #: invenio/legacy/websubmit/web/approve.py:53
 msgid "approve.py: cannot determine document reference"
@@ -12745,8 +12674,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12789,11 +12718,6 @@ msgstr "დაკავშირებულია"
 #, fuzzy
 msgid "Role details"
 msgstr "დამატებითი ინფორმაცია"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "დამალვა"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12909,8 +12833,8 @@ msgstr "მოწოდებული ელფოსტის მისამ�
 #: invenio/modules/accounts/forms.py:94
 #, fuzzy, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 "გთხოვთ შენიშნოთ, რომ თუ თქვენ შეცვალეთ ელფოსტის მისამართი, თქვენ უნდა "
 "გადატვირთოთ %(x_url_open)sთქვენი პაროლი%(x_url_close)s ახალზე."
@@ -12977,21 +12901,18 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, fuzzy, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 "თქვენ ჯერ კიდევ ამოცნობილი ხართ როგორც ცენტრალიზებული\n"
-"                %(x_fmt_open)sSSO%(x_fmt_close)s სისტემბა. თქვენ "
-"შეგიძლიათ\n"
+"                %(x_fmt_open)sSSO%(x_fmt_close)s სისტემბა. თქვენ შეგიძლიათ\n"
 "                %(x_url_open)sგამოხვიდეთ SSO%(x_url_close)s -დან."
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
 #, fuzzy, python-format
 msgid "If you wish you can %(x_url_open)ssign in again%(x_url_close)s."
 msgstr ""
-"თუ თქვენ გნებავთ, თქვენ შეგიძლიათ %(x_url_open)sშემოხვიდეთ "
-"აქ%(x_url_close)s."
+"თუ თქვენ გნებავთ, თქვენ შეგიძლიათ %(x_url_open)sშემოხვიდეთ აქ%(x_url_close)s."
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:27
 #, fuzzy
@@ -12999,8 +12920,7 @@ msgid ""
 "Please enter your email address. You will receive a link to create a new "
 "password via email."
 msgstr ""
-"გთზოვთ შეიყვანოთ თქვენი ელ-ფოსტის მისამართი და სასურველი მეტსახელი და "
-"პაროლი:"
+"გთზოვთ შეიყვანოთ თქვენი ელ-ფოსტის მისამართი და სასურველი მეტსახელი და პაროლი:"
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:33
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:33
@@ -13011,11 +12931,10 @@ msgstr "ახალი პაროლის დაყენება"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
-"გთზოვთ შეიყვანოთ თქვენი ელ-ფოსტის მისამართი და სასურველი მეტსახელი და "
-"პაროლი:"
+"გთზოვთ შეიყვანოთ თქვენი ელ-ფოსტის მისამართი და სასურველი მეტსახელი და პაროლი:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
 #, fuzzy
@@ -13044,9 +12963,10 @@ msgid "Problem with login."
 msgstr "შეადარე ორიგინალს"
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
-msgstr "თქვენ შეგიძლიათ შეხვიდეთ თქვენს %(x_url_open)sანგარიშზე%(x_url_close)s."
+msgstr ""
+"თქვენ შეგიძლიათ შეხვიდეთ თქვენს %(x_url_open)sანგარიშზე%(x_url_close)s."
 
 #: invenio/modules/accounts/views/accounts.py:152
 #, fuzzy, python-format
@@ -13087,8 +13007,7 @@ msgstr "ბიბკატალოგის რედაქტირები�
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13160,13 +13079,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13175,9 +13093,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13350,8 +13268,7 @@ msgstr "კოლექციები"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13430,8 +13347,7 @@ msgstr ""
 #, fuzzy
 msgid "You have already reported an abuse for this comment."
 msgstr ""
-"ამ ტიპის დოკუმეტის კვალობაზე თქვენ უკვე მიაღწიეთ მაქსიმალურ რიცხვს "
-"ფაილებისა "
+"ამ ტიპის დოკუმეტის კვალობაზე თქვენ უკვე მიაღწიეთ მაქსიმალურ რიცხვს ფაილებისა "
 
 #: invenio/modules/comments/api.py:260
 #, fuzzy
@@ -13444,8 +13360,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13537,10 +13453,10 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
 "თქვენი გზავნილი მეტისმეტად გრძელია, გთხოვთ დაარედაქტიროთ ის. მინიმალური "
 "დასაშვები ზომა არის %i სიმბოლო."
@@ -13586,12 +13502,12 @@ msgid "Review was sent"
 msgstr "კომენტარის დაწერა"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "ეს კომენტარი მოხსენიებული იყო %i ჯერ"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "ეს კომენტარი მოხსენიებული იყო %i ჯერ"
 
@@ -13644,9 +13560,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13665,8 +13580,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13676,7 +13591,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "ფაილი სახელწოდებით %s უკვე არსებობს. გთხოვთ აირჩოთ სხვა სახელი."
 
@@ -13732,8 +13647,7 @@ msgstr "განხილვა"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13773,8 +13687,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13821,7 +13734,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "ფუნქცია %s არ არსებობს"
 
@@ -13907,11 +13820,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "შეგროვების სტატუსი"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "თქვენი ბილეთები"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -13946,8 +13854,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13968,8 +13876,8 @@ msgstr "სიტყვის ინდეხი არ არის ხელ�
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13985,8 +13893,7 @@ msgstr "ელემენტის ფორმატის დადასტ�
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14106,7 +14013,7 @@ msgstr "ყველა %i ავტორის ჩვენება "
 msgid "Manage Files of This Record"
 msgstr "ამ ჩანაწერის ფაილების მართვა"
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr "ჩანაწერის რედაქტირება "
 
@@ -14204,10 +14111,6 @@ msgstr "1 განხილვა"
 msgid "Authors"
 msgstr "ავტორი"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14300,8 +14203,8 @@ msgstr "ჯგუფის უფლებების მართვა"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "თქვენ არ გაგაჩნიათ ულება ამ ელემენტის ნახვის."
 
 #: invenio/modules/groups/views.py:279
@@ -14314,12 +14217,12 @@ msgstr "თქვენ არ ბრძანდებით არცერთ
 msgid "Members"
 msgstr "წევრები არ არიან."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "აკლია ცოდნის ბაზის სათაური "
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14329,11 +14232,11 @@ msgstr "არცერთი"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "ნებისმიერი ველი"
@@ -14379,13 +14282,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "მოთხოვნები არ არის."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "მოთხოვნები არ არის."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14540,28 +14444,28 @@ msgstr "დოკუმენტის ტიპი უცნობია"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14626,9 +14530,10 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
-msgstr "თუ თქვენ გსურთ საბოლოო რეგისტრაცია თქვენი ანგარიშის, გთხოვთ გადახვიდეთ:"
+"Fill in your details to complete your registration. You only have to do this "
+"once."
+msgstr ""
+"თუ თქვენ გსურთ საბოლოო რეგისტრაცია თქვენი ანგარიშის, გთხოვთ გადახვიდეთ:"
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
 msgid "Sign-up"
@@ -15000,7 +14905,7 @@ msgid "Tag name"
 msgstr "მეტსახელი"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "სასურველი მეტსახელი %s უკვე გამოყენებლია."
 
@@ -15152,8 +15057,7 @@ msgstr "სესხის პარამეტრები"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15215,7 +15119,7 @@ msgid "Identifiers"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/styles/harvesting_record.html:45
-#, fuzzy, python-format
+#, fuzzy
 msgid "Categories"
 msgstr "%(category)s გვერდები"
 
@@ -15362,7 +15266,7 @@ msgid "just now"
 msgstr "თქვენ უნდა იცოდეთ"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s წამი"
 
@@ -15421,6 +15325,54 @@ msgstr "ნებისმიერი წელი "
 msgid " years ago"
 msgstr "წელი"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "ბიბშემოწმების ადმინისტრატორი"
+
+#~ msgid "Not authorized"
+#~ msgstr "არაა აუტორიზირებული"
+
+#~ msgid "Limit to knowledge bases containing string:"
+#~ msgstr "შეზღუდეთ სტრიქონის ცოდნის ბაზაზე:"
+
+#~ msgid "Really delete"
+#~ msgstr "ნამდვილად წაშლა"
+
+#~ msgid "Verify syntax"
+#~ msgstr "შეამოწმე სინთაქსი"
+
+#~ msgid "Calling bibcheck -verify failed."
+#~ msgstr "ბიბშემოწმების გამოძახება - გადამოწმება ვერ მოხერხდა."
+
+#~ msgid "Verify BibCheck config file"
+#~ msgstr "ბიბგადამოწმების კონფიგურაციის ფაილის გადამოწმება"
+
+#~ msgid "Verify problem"
+#~ msgstr "დაადასტურეთ პრობლემა"
+
+#~ msgid "File"
+#~ msgstr "ფაილი"
+
+#~ msgid "Edit BibCheck config file"
+#~ msgstr "ბიბშემოწმების კონფიგურაციის ფაილის რედაქტირება"
+
+#~ msgid "Save BibCheck config file"
+#~ msgstr "ბიბშემოწმების კონფიგურაციის ფაილის შენახვა"
+
+#~ msgid "Delete BibCheck config file"
+#~ msgstr "ბიბშემოწმების კონფიგურაციის ფაილის წაშლა"
+
+#~ msgid "niceName"
+#~ msgstr "ლამაზისახელი"
+
+#~ msgid "Id"
+#~ msgstr "საიდენტიფიკაციო"
+
+#~ msgid "Tickets"
+#~ msgstr "ბილეთები"
+
+#~ msgid "by"
+#~ msgstr "ით"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "გაფრთხილება: გთხოვთ, ამოირჩიოთ სწორი დრო"
 
@@ -15433,23 +15385,14 @@ msgstr "წელი"
 #~ msgid "Warning: Please, select a valid date"
 #~ msgstr "გაფრთხილება: გთხოვთ, ამოირჩიოთ სწორი თარიღი"
 
-#~ msgid " or return to your %(x_url_open)ssearch%(x_url_close)s"
-#~ msgstr ""
-
 #~ msgid "*** basket name ***"
 #~ msgstr "*** კალათის სახელი ***"
-
-#~ msgid ""
-#~ msgstr ""
 
 #~ msgid "%(x_name)s"
 #~ msgstr "%(x_sitename)s ბმული"
 
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "დამათებითი ინფორმაცია"
-
-#~ msgid "Sorry, you must log in to perform this action."
-#~ msgstr ""
 
 #~ msgid "Please log in first."
 #~ msgstr "გთხოვთ ჯერ შეხვიდეთ. "
@@ -15538,12 +15481,6 @@ msgstr "წელი"
 #~ msgid "now"
 #~ msgstr "არა"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "ბიბშემოწმების ადმინისტრატორი"
-
-#~ msgid "Not authorized"
-#~ msgstr "არაა აუტორიზირებული"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "მომხმარებელი %s არ არსებობს."
 
@@ -15552,30 +15489,6 @@ msgstr "წელი"
 
 #~ msgid "ERROR: %s is not writable"
 #~ msgstr "არ არის ჩაწერადი"
-
-#~ msgid "Limit to knowledge bases containing string:"
-#~ msgstr "შეზღუდეთ სტრიქონის ცოდნის ბაზაზე:"
-
-#~ msgid "Really delete"
-#~ msgstr "ნამდვილად წაშლა"
-
-#~ msgid "Verify syntax"
-#~ msgstr "შეამოწმე სინთაქსი"
-
-#~ msgid "Calling bibcheck -verify failed."
-#~ msgstr "ბიბშემოწმების გამოძახება - გადამოწმება ვერ მოხერხდა."
-
-#~ msgid "Verify BibCheck config file"
-#~ msgstr "ბიბგადამოწმების კონფიგურაციის ფაილის გადამოწმება"
-
-#~ msgid "Verify problem"
-#~ msgstr "დაადასტურეთ პრობლემა"
-
-#~ msgid "File"
-#~ msgstr "ფაილი"
-
-#~ msgid "Edit BibCheck config file"
-#~ msgstr "ბიბშემოწმების კონფიგურაციის ფაილის რედაქტირება"
 
 #~ msgid "File %s already exists."
 #~ msgstr "უკვე არსებობს."
@@ -15586,17 +15499,11 @@ msgstr "წელი"
 #~ msgid "File %s: write failed."
 #~ msgstr "ჩაწერა ვერ მოხერხდა."
 
-#~ msgid "Save BibCheck config file"
-#~ msgstr "ბიბშემოწმების კონფიგურაციის ფაილის შენახვა"
-
 #~ msgid "File %s deleted."
 #~ msgstr "ფაილი %s არ არსებობს."
 
 #~ msgid "File %s: delete failed."
 #~ msgstr "წაშლა ვერ განხორციელდა"
-
-#~ msgid "Delete BibCheck config file"
-#~ msgstr "ბიბშემოწმების კონფიგურაციის ფაილის წაშლა"
 
 #~ msgid "Guests are not authorized to run batchuploader"
 #~ msgstr "თქვენ არ გაქვთ უფლება გამოიყენოთ შეტყობინებები."
@@ -15643,9 +15550,6 @@ msgstr "წელი"
 #~ msgid "Not Mine!"
 #~ msgstr "არ არის დაყენებული"
 
-#~ msgid "Tickets"
-#~ msgstr "ბილეთები"
-
 #~ msgid "Request Tickets"
 #~ msgstr "მოთხოვნები"
 
@@ -15681,9 +15585,6 @@ msgstr "წელი"
 
 #~ msgid "Create a new Person for your search"
 #~ msgstr "ვერაფერი იქნა ნაპოვნი"
-
-#~ msgid "Id"
-#~ msgstr "საიდენტიფიკაციო"
 
 #~ msgid "."
 #~ msgstr "."
@@ -15811,9 +15712,6 @@ msgstr "წელი"
 #~ msgid "In"
 #~ msgstr "ში"
 
-#~ msgid "by"
-#~ msgstr "ით"
-
 #~ msgid "on"
 #~ msgstr "ზე"
 
@@ -15843,9 +15741,6 @@ msgstr "წელი"
 
 #~ msgid " of "
 #~ msgstr "ის"
-
-#~ msgid "niceName"
-#~ msgstr "ლამაზისახელი"
 
 #~ msgid "Apply Changes"
 #~ msgstr "დაუმათეთ ცვლილებები"
@@ -15892,34 +15787,11 @@ msgstr "წელი"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "ვებწარდგენის ადმინისტრატორის ცნობარი"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "ძებნის განხორციელება"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "გაუქმებულია"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "თქვენ მომდებნო ჯგუფების წევრი ბრძანდებით:"
@@ -15933,12 +15805,6 @@ msgstr "წელი"
 #~ msgid "Invert Selection"
 #~ msgstr "რეფერის შერჩევა"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "ავტორი"
 
@@ -15950,12 +15816,6 @@ msgstr "წელი"
 
 #~ msgid "No status information found."
 #~ msgstr "ინფრომაცია სასხის თაობაზე"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "რევიზია"
@@ -15972,15 +15832,6 @@ msgstr "წელი"
 #~ msgid "The author has an internal ID!"
 #~ msgstr "შიდა შეცდომას ქონდა ადგილი"
 
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "კომენტარების ჩვენება"
 
@@ -15990,32 +15841,8 @@ msgstr "წელი"
 #~ msgid " Delete this ticket"
 #~ msgstr "კალათის წაშლა"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "არ არის ხელმისაწვდომი ჟურნალი"
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "ქულის შერჩევა"
@@ -16026,51 +15853,11 @@ msgstr "წელი"
 #~ msgid "Paper title: "
 #~ msgstr "პერიოდული სათაური"
 
-#~ msgid "Ignore"
-#~ msgstr ""
-
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "შემდეგი ფაილები წარმატებით დამატებულია რიგში:"
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "ქულის შერჩევა"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "იმფორმაცია ახალ გამყიდველზე"
@@ -16078,35 +15865,14 @@ msgstr "წელი"
 #~ msgid "Please provide your first name"
 #~ msgstr "გთხოვთ ჯერ შეხვიდეთ. "
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "თქვენი კრედითები"
-
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
 
 #~ msgid "Your eMail:"
 #~ msgstr "თქვენი ცვლილებები"
 
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
 #~ msgid "Continue claiming*"
 #~ msgstr "განაგრძე ყველა შემთხვევაში"
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "არჩეული განხილვების წაშლა"
@@ -16114,256 +15880,38 @@ msgstr "წელი"
 #~ msgid "Mark as your documents"
 #~ msgstr "ყველა ტიპის დოკუმეტი"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "დოკუმეტთან დაბრუნება"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "დოკუმეტთან დაბრუნება"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "შექმენით ახალი"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "მომხმარებლებთან დამატება"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "სტატიები:"
-
-#~ msgid "Showing the"
-#~ msgstr ""
 
 #~ msgid "most recent documents:"
 #~ msgstr "მიმთითებელი დოკუმენტების სია"
 
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "დოკუმენტის ფაილების მართვა"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "აირჩიეთ ფაილი"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "გამოქვეყნების თარიღი"
-
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
 
 #~ msgid "add external id"
 #~ msgstr "გარე ბმული"
 
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
-
-#~ msgid "suggest missing ids"
-#~ msgstr ""
-
 #~ msgid "Choose system"
 #~ msgstr "აირჩიეთ შაბლონი"
-
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "შემდეგი ფაილები წარმატებით დამატებულია რიგში:"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
 
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "თქვენ არ გაქვთ უფლებები რომ შეასწოროთ ადმინისტრაციული ფუნქციები."
@@ -16371,63 +15919,8 @@ msgstr "წელი"
 #~ msgid "Claim this paper"
 #~ msgstr "დაუმატეთ ეს მომხმარებელი"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The publication date of this book is %s."
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "ციტირებლია: %s ჩანაწერის მიერ"
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
 
 #~ msgid "Comparison of:"
 #~ msgstr "შედარება:"
@@ -16437,27 +15930,6 @@ msgstr "წელი"
 
 #~ msgid "Failed to create a ticket"
 #~ msgstr "ბილეთის შექმნა ვერ გახორციელდა "
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "თარგის ატრიბუტების შეცვლა"
@@ -16537,89 +16009,20 @@ msgstr "წელი"
 #~ msgid "No Record Found for %s."
 #~ msgstr "ჩანაწერი არ მოიძებნა"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "ფაილი %s არ არსებობს."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "გამავალი ფორმატის %s ატრიბუტები"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr " ფორმატის თარგის %s დამოკიდებულებანი"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "ელემენტის ფორმატის დადასტურება %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "ფორმატის ელემენტი  %s დამოკიდებულებანი"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "აკრძალული გამავალი ფორმატი"
@@ -16675,78 +16078,17 @@ msgstr "წელი"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "ელემენტის ფორმატის დადასტურება %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "ფორმატის დადასტურება"
 
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "ცოდნის ბაზა %s"
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "არ არის დაყენებული"
 
 #~ msgid "never"
 #~ msgstr "არასოდეს"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "ჯერ"
@@ -16760,12 +16102,6 @@ msgstr "წელი"
 #~ msgid "Frequent keywords"
 #~ msgstr "ხშირი საკვანძო სიტყვები:"
 
-#~ msgid "No Subject categories"
-#~ msgstr ""
-
-#~ msgid "Subject categories"
-#~ msgstr ""
-
 #~ msgid "No Collaborations"
 #~ msgstr "კოლექციები"
 
@@ -16778,17 +16114,11 @@ msgstr "წელი"
 #~ msgid "Affiliations"
 #~ msgstr "წევრობა:"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
 #~ msgid "No Frequent Co-authors"
 #~ msgstr "ხშირი თანა ავტორები:"
 
 #~ msgid "Citations%s"
 #~ msgstr "ციტირებები"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "გამოქვეყნების თარიღი"
@@ -16799,42 +16129,6 @@ msgstr "წელი"
 #~ msgid "No publications available"
 #~ msgstr "ინფორმაცია ხელმიუწვდომელია"
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "Max %i files"
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "%s View your previously submitted comments"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr "ციტირებულია 1 ჩანაწერის მიერ"
 
@@ -16844,17 +16138,11 @@ msgstr "წელი"
 #~ msgid "%i reviews"
 #~ msgstr "%i განხილვა"
 
-#~ msgid "%s of"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "სტატიები:"
 
 #~ msgid "Frequent co-authors"
 #~ msgstr "ხშირი თანა ავტორები:"
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "ციტირებები:"
@@ -16862,23 +16150,8 @@ msgstr "წელი"
 #~ msgid "No Citation Information available"
 #~ msgstr "ინფორმაცია ხელმიუწვდომელია"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "განხილვა"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "თქვენი ცვლილებები"
@@ -16901,13 +16174,6 @@ msgstr "წელი"
 #~ msgid "Group: %s"
 #~ msgstr "ჯგუფი: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "%s გვერდი არ არის ნაპოვნი"
 
@@ -16915,69 +16181,5 @@ msgstr "წელი"
 #~ msgstr "%s ველი სავალდებულოა"
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "ვერ ხერხდება წარდგენილი გვერდების რიცხვის დადგენა."
-

--- a/invenio/base/translations/lt/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/lt/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2011 CERN.
+# # Copyright (C) 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,16 +16,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2011-04-11 13:19+0200\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:58+0200\n"
 "Last-Translator: Jurga Girdzijauskaite <jurga.gird@gmail.com>\n"
 "Language-Team: LT <info@invenio-software.org>\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"(n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
+"%100<10 || n%100>=20) ? 1 : 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -59,8 +59,8 @@ msgstr "pagrindinis puslapis"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -206,7 +206,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Sveiki:"
 
@@ -227,17 +227,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -263,48 +263,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Pasirinktas elementas neegzistuoja"
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr "Slaptažodžio atnaujinimo prašymas"
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Neturite reikiamų teisių naudoti užsakymo sistemą"
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Registracija nepavyko"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Prašome pasirinkti vieną ar daugiau:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Vaidmens autorizacijos prašymas"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, fuzzy, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr "Jau galima atsisiųsti naują Invenio versiją. Galite apsilankyti  "
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -504,7 +509,8 @@ msgstr "Neturite reikiamų teisių įkelti į rinkinį '%s'"
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr "Vartotojas '%(x_user)s' neturi teisių modifikuoti rinkinį '%(x_coll)s'"
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -578,8 +584,8 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"Jūsų failas sėkmingai įterptas. Jus galite pažiūrėti %(x_url1_open)s "
-"įkėlimo istoriją%(x_url1_close)s ar %(x_url2_open)s įkelti kitą failą "
+"Jūsų failas sėkmingai įterptas. Jus galite pažiūrėti %(x_url1_open)s įkėlimo "
+"istoriją%(x_url1_close)s ar %(x_url2_open)s įkelti kitą failą "
 "%(x_url2_close)s."
 
 #: invenio/legacy/batchuploader/templates.py:282
@@ -713,7 +719,8 @@ msgid "The following errors have occurred:"
 msgstr "Rastos šios klaidos:"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 "Kai kurie failai nebuvo perkelti į DONE katalogą. Prašome juos pašalinti "
 "rankiniu būdu."
@@ -728,17 +735,17 @@ msgid ""
 "Using %(x_fmt_open)sweb interface upload%(x_fmt_close)s, actions are "
 "executed a single time."
 msgstr ""
-"Vykdoma naudojant %(x_fmt_open)stinklo sąsajos įkėlimą%(x_fmt_close)s tik"
-" vieną kartą."
+"Vykdoma naudojant %(x_fmt_open)stinklo sąsajos įkėlimą%(x_fmt_close)s tik "
+"vieną kartą."
 
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
-"Apsilankykite %(x_url_open)sPaketo įkelties \"daemon\" pagalbos "
-"puslapyje%(x_url_close)s, kad šie veiksmai būtų atliekami periodiškai."
+"Apsilankykite %(x_url_open)sPaketo įkelties \"daemon\" pagalbos puslapyje"
+"%(x_url_close)s, kad šie veiksmai būtų atliekami periodiškai."
 
 #: invenio/legacy/batchuploader/templates.py:602
 msgid "Metadata folders"
@@ -819,7 +826,7 @@ msgstr "ID"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -862,8 +869,8 @@ msgstr "Jūsų \"etiketės\" "
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Ankstesnis"
@@ -878,8 +885,8 @@ msgstr "uždaryti"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Kitas"
 
@@ -895,18 +902,6 @@ msgstr "Kitas"
 msgid "Admin Area"
 msgstr "Administratoriaus erdvė"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "autorius(-ė)"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
 msgid "ERROR: %(x_name)s does not exist"
@@ -921,15 +916,6 @@ msgstr ""
 #, python-format
 msgid "ERROR: %(x_name)s is not writable"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
-msgid "Limit to knowledge bases containing string:"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "sėkmingai ištrinta"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -959,10 +945,6 @@ msgstr "sėkmingai ištrinta"
 msgid "Delete"
 msgstr "Ištrinti"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:140
-msgid "Verify syntax"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:145
 #: invenio/modules/communities/views.py:258
 #, fuzzy
@@ -974,31 +956,9 @@ msgstr "Sukurkite naują krepšelį"
 msgid "File %(x_name)s does not exist."
 msgstr "Vartotojas %s neegzistuoja."
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:174
-msgid "Calling bibcheck -verify failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
-msgid "Verify BibCheck config file"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Duomenų bazės problema"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "failas(-ai)"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
 msgstr "Išsaugoti pakeitimus"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:240
-msgid "Edit BibCheck config file"
-msgstr ""
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:268
 #, fuzzy, python-format
@@ -1015,10 +975,6 @@ msgstr ""
 msgid "File %(x_name)s: write failed."
 msgstr ""
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:279
-msgid "Save BibCheck config file"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:312
 #, python-format
 msgid "File %(x_name)s deleted."
@@ -1027,10 +983,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:314
 #, python-format
 msgid "File %(x_name)s: delete failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:316
-msgid "Delete BibCheck config file"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:195
@@ -1098,7 +1050,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1136,8 +1089,7 @@ msgid ""
 "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s status is "
 "%(x_strong_tag_open)s%(x_status)s%(x_strong_tag_close)s"
 msgstr ""
-"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas "
-"sėkmingai."
+"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas sėkmingai."
 
 #: invenio/legacy/bibcirculation/adminlib.py:399
 #: invenio/legacy/bibcirculation/adminlib.py:896
@@ -1147,20 +1099,18 @@ msgid ""
 "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s location is "
 "%(x_strong_tag_open)s%(x_location)s%(x_strong_tag_close)s"
 msgstr ""
-"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas "
-"sėkmingai."
+"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas sėkmingai."
 
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
 msgstr ""
-"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas "
-"sėkmingai."
+"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas sėkmingai."
 
 #: invenio/legacy/bibcirculation/adminlib.py:411
 #, fuzzy
@@ -1170,30 +1120,26 @@ msgstr "Brūkšninis kodas"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
-"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas "
-"sėkmingai."
+"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas sėkmingai."
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
-"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas "
-"sėkmingai."
+"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas sėkmingai."
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
 msgid "You could enter the barcode for this user's next loan, if any."
@@ -1217,15 +1163,15 @@ msgstr "Sukurti naują"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
-"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas "
-"sėkmingai."
+"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas sėkmingai."
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1257,12 +1203,10 @@ msgstr "Išdavimo laikas"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
-"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas "
-"sėkmingai."
+"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas sėkmingai."
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
 msgid "Claim return"
@@ -1328,8 +1272,8 @@ msgstr "Naujas prašymas"
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1337,8 +1281,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1360,12 +1304,10 @@ msgstr "Naujas užsakymas"
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
-"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas "
-"sėkmingai."
+"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas sėkmingai."
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
 #: invenio/legacy/bibcirculation/adminlib.py:2332
@@ -1406,8 +1348,8 @@ msgstr "Rasta 0 skolininkų."
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1466,11 +1408,11 @@ msgstr "Naujas prašymas užregistruotas sėkmingai."
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1481,11 +1423,11 @@ msgstr "Taip"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1498,8 +1440,8 @@ msgstr "Ne"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1594,8 +1536,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1615,29 +1557,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1646,9 +1588,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr "Pageidaujamas įrašas neegzistuoja."
 
@@ -2008,16 +1950,14 @@ msgstr "Įrašas buvo ištrintas."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2038,8 +1978,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2201,8 +2141,8 @@ msgstr "ILL prašymas"
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2309,7 +2249,7 @@ msgstr "Vieta"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Aprašymas"
 
@@ -2502,8 +2442,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2777,9 +2717,8 @@ msgstr "Patvirtinti"
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "Jei norite galite %(x_url_open)sprisijungti čia%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2833,7 +2772,7 @@ msgstr "Atnaujinti"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "TAIP"
 
@@ -2841,11 +2780,10 @@ msgstr "TAIP"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
-"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas "
-"sėkmingai."
+"Elemento  %(x_title)s brūkšninis kodas %(x_barcode)s perskaitytas sėkmingai."
 
 #: invenio/legacy/bibcirculation/templates.py:1588
 msgid "The next(pending) request on the returned book is shown below."
@@ -3304,8 +3242,8 @@ msgstr "Pašto dėžutė"
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "Elektroninis paštas"
 
@@ -3779,7 +3717,8 @@ msgstr "Informacija apie naują kopiją"
 #: invenio/legacy/bibcirculation/templates.py:7419
 #, fuzzy, python-format
 msgid "A %(x_url_open)snew copy%(x_url_close)s has been added."
-msgstr "%(x_url_open)sPatvirtinkite ar atmeskite%(x_url_close)s vartotojo prašymą."
+msgstr ""
+"%(x_url_open)sPatvirtinkite ar atmeskite%(x_url_close)s vartotojo prašymą."
 
 #: invenio/legacy/bibcirculation/templates.py:7443
 #, fuzzy
@@ -4111,8 +4050,8 @@ msgstr "Dominantis laikotarpis (Iki)"
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, fuzzy, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr "Skolininkas priima serviso %s grąžinti knygą iki nustatyto laiko."
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4130,8 +4069,8 @@ msgstr "Tik šį leidimą"
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, fuzzy, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr "Patikrinti ar knyga yra Invenio, prieš siunčiant ILL prašymą."
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4190,17 +4129,17 @@ msgstr "ISSN"
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4575,25 +4514,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "Įrašas buvo ištrintas."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4653,15 +4592,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4672,10 +4611,10 @@ msgstr "Pasirinkite failą"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4688,15 +4627,15 @@ msgstr "Prieiga"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, fuzzy, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr "Patalpintas failas buvo per mažas (<%i o) ir todėl nebuvo panaudotas."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4707,7 +4646,8 @@ msgid ""
 msgstr "Patalpintas failas buvo per didelis (>%i o) ir todėl nebuvo panaudotas"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr "Patalpinto failo vardas per didelis ir todėl nebuvo patalpintas"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4726,17 +4666,15 @@ msgstr "Failo vardas %s jau egzistuoja. Pasirinkite kitą vardą."
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "'%s' tokio formato failas jau egzistuoja. Prašome įkelti kitu formatu."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 "Negalima naudoti specialiųjų simbolių '.',  '/' ar '\\\\' failo  varde. "
 "Pasirinkite failą ir bandykite įkleti dar sykį. Pervadinimo laukelyje "
@@ -4757,16 +4695,15 @@ msgstr "Jus galite pasirinkti paslėpti ar ne ankstesnes šio failo versijas."
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
-"Kai pertvarkote failą, papildomi formatai, kuriuos sukūrėte anksčiau, yra"
-" ištrinami, nes jie nėra atnaujinami pagal naują failą."
+"Kai pertvarkote failą, papildomi formatai, kuriuos sukūrėte anksčiau, yra "
+"ištrinami, nes jie nėra atnaujinami pagal naują failą."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr "Kiti įkelti formatai šiam failui bus ištrinti"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4798,7 +4735,8 @@ msgstr "Pritaikyti pakeitimus"
 #: invenio/legacy/bibdocfile/managedocfiles.py:925
 #, python-format
 msgid "Need help revising or adding files to record %(recid)s"
-msgstr "Reikia pagalbos peržiūrint ar pridedant naujus failus į įrašą %(recid)s"
+msgstr ""
+"Reikia pagalbos peržiūrint ar pridedant naujus failus į įrašą %(recid)s"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:927
 #, python-format
@@ -4819,16 +4757,17 @@ msgstr ""
 msgid ""
 "Having a problem revising a file? Send the revised version to "
 "%(mailto_link)s."
-msgstr "Problemos peržiūrint failą? Atsiųskite peržiūros versiją %(mailto_link)s."
+msgstr ""
+"Problemos peržiūrint failą? Atsiųskite peržiūros versiją %(mailto_link)s."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
-"Problemos peržiūrint ar pridedant failą? Atsiųskit naują/peržiūros "
-"versiją %(mailto_link)s."
+"Problemos peržiūrint ar pridedant failą? Atsiųskit naują/peržiūros versiją "
+"%(mailto_link)s."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
 msgid "revise"
@@ -4878,8 +4817,8 @@ msgstr "Pageidaujamas įrašas nėra integruotas. "
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr "Sistema surado klaidą ieškodama įrašą sudarančių failų."
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -4889,8 +4828,7 @@ msgid ""
 "The error has been logged and will be taken in consideration as soon as "
 "possible."
 msgstr ""
-"Išsaugojome klaidos pranešimą ir bandysime jį ištaisyti kaip galima "
-"greičiau."
+"Išsaugojome klaidos pranešimą ir bandysime jį ištaisyti kaip galima greičiau."
 
 #: invenio/legacy/bibdocfile/webinterface.py:202
 #, python-format
@@ -4992,12 +4930,12 @@ msgstr "1.Pasirinkite paieškos kriterijų"
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
-"Pasirinkite filtravimo kriterijų, pagal kurį bus atrinkti dokumentai, "
-"kurie bus keičiami. Naudokite \"Ieškoti\" pažiūrėti atrinktus dokumentus."
+"Pasirinkite filtravimo kriterijų, pagal kurį bus atrinkti dokumentai, kurie "
+"bus keičiami. Naudokite \"Ieškoti\" pažiūrėti atrinktus dokumentus."
 
 #: invenio/legacy/bibeditmulti/templates.py:361
 msgid "Preview results"
@@ -5009,11 +4947,11 @@ msgstr "2. Nustatykite pakeitimus"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
-"Pasirinkite laukelius ir polaukius, kurie bus pakeisti kiekviename įraše,"
-" atitinkančiame paieškos kriterijų."
+"Pasirinkite laukelius ir polaukius, kurie bus pakeisti kiekviename įraše, "
+"atitinkančiame paieškos kriterijų."
 
 #: invenio/legacy/bibeditmulti/templates.py:615
 msgid "Define new field action"
@@ -5142,11 +5080,10 @@ msgstr "Atgal į rezultatus"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5270,7 +5207,7 @@ msgid "Total"
 msgstr "Viso"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Pasirinkti"
 
@@ -5429,8 +5366,8 @@ msgstr "Ištrinti žinių bazę"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, fuzzy, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr "Apriboti rodymą žinių bazės sutapimų"
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5486,79 +5423,79 @@ msgstr "Prašome sukonfiguruoti"
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
-"Dinaminė žinių bazė yra sąrašas reikšmių iš"
-"                                 duotų laukelių. Sąrašas generuojamas "
-"dinamiškai                             ieškant įrašų užklausų pagalba."
+"Dinaminė žinių bazė yra sąrašas reikšmių iš                                 "
+"duotų laukelių. Sąrašas generuojamas dinamiškai                             "
+"ieškant įrašų užklausų pagalba."
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
-"Pavyzdys: Jūsų įrašas turi laukelį field 270__a atsakinga"
-"                         už pavadinimą ir adresą autoriaus instituto."
-"                                        Jei nustatysite laukelį į "
-"'270__a' ir užklausą                                         į "
-"'270__a:*Paris*', bus sukurtas sąrašas"
-"                                               institutų Paryžiuje."
+"Pavyzdys: Jūsų įrašas turi laukelį field 270__a "
+"atsakinga                         už pavadinimą ir adresą autoriaus "
+"instituto.                                        Jei nustatysite laukelį į "
+"'270__a' ir užklausą                                         į '270__a:"
+"*Paris*', bus sukurtas sąrašas                                               "
+"institutų Paryžiuje."
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
-"Jei užklausa tuščia, reikšmių sąrašas                           270__a "
-"bus sukurtas."
+"Jei užklausa tuščia, reikšmių sąrašas                           270__a bus "
+"sukurtas."
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, fuzzy, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
-"Jei užklausoje yra '%', kaip '270__a:*%*',"
-"                                  jis bus pakeistas fraze, kai naudojama"
-"                                   žinių bazė."
+"Jei užklausoje yra '%', kaip '270__a:*%*',                                  "
+"jis bus pakeistas fraze, kai naudojama                                   "
+"žinių bazė."
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
-"Galite įvesti rinkinio vardą, jei norite užklausą įvykdyti"
-"                 pasirinktame rinkinyje."
+"Galite įvesti rinkinio vardą, jei norite užklausą įvykdyti                 "
+"pasirinktame rinkinyje."
 
 #: invenio/legacy/bibknowledge/templates.py:253
 #, fuzzy
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
-"Pavyzdys: Jūsų įrašas turi laukelį field 270__a atsakinga"
-"                         už pavadinimą ir adresą autoriaus instituto."
-"                                        Jei nustatysite laukelį į "
-"'270__a' ir užklausą                                         į "
-"'270__a:*Paris*', bus sukurtas sąrašas"
-"                                               institutų Paryžiuje."
+"Pavyzdys: Jūsų įrašas turi laukelį field 270__a "
+"atsakinga                         už pavadinimą ir adresą autoriaus "
+"instituto.                                        Jei nustatysite laukelį į "
+"'270__a' ir užklausą                                         į '270__a:"
+"*Paris*', bus sukurtas sąrašas                                               "
+"institutų Paryžiuje."
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5597,7 +5534,7 @@ msgstr "Žinių bazės prieklausos"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5610,8 +5547,8 @@ msgid ""
 "Here you can add new mappings to this base                         and "
 "change the base attributes."
 msgstr ""
-"Čia galite keisti atvaizdavimą ar keisti atributus                      "
-"šiai bazei."
+"Čia galite keisti atvaizdavimą ar keisti atributus                      šiai "
+"bazei."
 
 #: invenio/legacy/bibknowledge/templates.py:364
 msgid "Map From"
@@ -5652,15 +5589,15 @@ msgstr "Jūsų taisyklė"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, fuzzy, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr "jau rasta šioje žinių bazėje"
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, fuzzy, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr "jau rasta šioje žinių bazėje"
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5683,7 +5620,8 @@ msgstr "Atšaukta: nepridėti šios taisyklės"
 msgid ""
 "It is not possible to have two rules with the same left side in the same "
 "knowledge base."
-msgstr "Negalima turėti dviejų kairės pusės taisyklių toje pačioje žinių bazėje."
+msgstr ""
+"Negalima turėti dviejų kairės pusės taisyklių toje pačioje žinių bazėje."
 
 #: invenio/legacy/bibrank/citation_grapher.py:207
 msgid "Citation history:"
@@ -5755,7 +5693,8 @@ msgstr "Esame labai dėkingi už pagalbą gerinant aptarnavimą."
 
 #: invenio/legacy/errorlib/webinterface.py:155
 msgid "Use the back button of your browser to return to the previous page."
-msgstr "Pasinaudokite BACK mygtuku, kad galėtumėte sugrįžti į ankstesnį puslapį."
+msgstr ""
+"Pasinaudokite BACK mygtuku, kad galėtumėte sugrįžti į ankstesnį puslapį."
 
 #: invenio/legacy/errorlib/webinterface.py:158
 msgid "Thank you!"
@@ -5880,9 +5819,9 @@ msgstr "Klaida bandant pasiekti įrašą"
 #: invenio/legacy/oaiharvest/admin.py:1321
 #, fuzzy
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
-msgstr "Klaida formatuojant Holding Pen įvestį. Tikėtina, kad sugadintas turinys."
+"Error when formatting the Holding Pen entry. Probably its content is broken"
+msgstr ""
+"Klaida formatuojant Holding Pen įvestį. Tikėtina, kad sugadintas turinys."
 
 #: invenio/legacy/oaiharvest/admin.py:1326
 msgid "Accept Holding Pen version"
@@ -5956,8 +5895,8 @@ msgstr "Grįžti į pagrindinį pasirinkimą"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -5972,8 +5911,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Paieškos rezultatai"
 
@@ -6132,8 +6071,8 @@ msgstr "reikšmių nerasta."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6142,8 +6081,8 @@ msgid ""
 "Warning: figure caption search is only available for a subset of papers "
 "mostly from %(x_range_from_year)s-%(x_range_to_year)s."
 msgstr ""
-"Įspėjimas: figūrų atpažinimo paieška galima 2008-2010 metais publikuotose"
-" dokumentuose."
+"Įspėjimas: figūrų atpažinimo paieška galima 2008-2010 metais publikuotose "
+"dokumentuose."
 
 #: invenio/legacy/search_engine/__init__.py:2151
 #, python-format
@@ -6161,8 +6100,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6173,8 +6112,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr "Dar nėra frazinio indekso pilnam tekstui, ieško žodžių derinio..."
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -6184,85 +6122,85 @@ msgstr "Atitikimų su %(x_query1)s nerasta, todėl naudojama %(x_query2)s ..."
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
-"Paieškos eilutės skiryba nesuprasta. Praleisti visi skliausteliai esantys"
-" užklausoje. Jei tai nepadės pakeiskite užklausą."
+"Paieškos eilutės skiryba nesuprasta. Praleisti visi skliausteliai esantys "
+"užklausoje. Jei tai nepadės pakeiskite užklausą."
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
-"Rinkinyje %(x_collection)s atitikmenų nerasta. Kituose viešuose "
-"rinkiniuose rasti(-as)%(x_url_open)s%(x_nb_hits)d%(x_url_close)s."
+"Rinkinyje %(x_collection)s atitikmenų nerasta. Kituose viešuose rinkiniuose "
+"rasti(-as)%(x_url_open)s%(x_nb_hits)d%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
-"Viešuose rinkiniuose niekas neatitiko jūsų užklausos. Jei ieškote "
-"dokumento ne iš viešo rinkinio - pasirinkite pageidaujamą ribotą rinkinį."
+"Viešuose rinkiniuose niekas neatitiko jūsų užklausos. Jei ieškote dokumento "
+"ne iš viešo rinkinio - pasirinkite pageidaujamą ribotą rinkinį."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
-"Viešuose rinkiniuose niekas neatitiko jūsų užklausos. Jei ieškote "
-"dokumento ne iš viešo rinkinio - pasirinkite pageidaujamą ribotą rinkinį."
+"Viešuose rinkiniuose niekas neatitiko jūsų užklausos. Jei ieškote dokumento "
+"ne iš viešo rinkinio - pasirinkite pageidaujamą ribotą rinkinį."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
 "Paieškos terminas %s neatitiko jokių įrašų. Panašiausias terminas "
 "rinkiniuose yra:"
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "Naudokite kitokius paieškos terminus."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Nėra įrašu susijusių su %s."
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Nėra įrašų paminėtų %s."
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Nėra įrašų paminėtų %s."
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Nėra žodžio indekso %s. "
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Nėra frazės indekso %s."
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 "Paieškos terminas %(x_term)s indekso viduje %(x_index)s neatitiko jokių "
 "įrašų. Panašiausias terminas rinkiniuose yra:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
@@ -6271,7 +6209,7 @@ msgstr ""
 "Paieškos terminas %s neatitiko jokių įrašų. Panašiausias terminas "
 "rinkiniuose yra:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
@@ -6280,35 +6218,35 @@ msgstr ""
 "Atsiprašome, %s nėra tinkama rūšiavimo parinktis. Pasirinktas rūšiavimas "
 "pagal pavadinimą."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
-"Atsiprašome, rūšiavimas leidžiamas tik %d įrašams. Rūšiuojama pagal "
-"numatytą tvarką."
+"Atsiprašome, rūšiavimas leidžiamas tik %d įrašams. Rūšiuojama pagal numatytą "
+"tvarką."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 "Atsiprašome, %s nėra tinkama rūšiavimo parinktis. Pasirinktas rūšiavimas "
 "pagal pavadinimą."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Puslapis neegzistuoja"
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Naudokite kitokius paieškos terminus."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6322,11 +6260,11 @@ msgstr "Naudokite kitokius paieškos terminus."
 msgid "Browse"
 msgstr "Naršyti"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr "Per nustatyta laiką nerasta jokių rezultatų, šį sąlyga atšaukiama..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr "Nustatyta paieškai nerasta rezultatų, šį sąlyga atšaukiama..."
 
@@ -6369,15 +6307,14 @@ msgstr "Įspėjimas %s buvo sėkmingai atnaujintas"
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Jūsų sukūrtos užklausos: %(x_nb)s. %(x_url_open)sDetalus "
-"sąrašas%(x_url_close)s yra prieinamas su galimybe (a) pamatyti paieškos "
-"rezultatus ir  (b) užsiprenumeruoti automatinį el.laišką su žiniomis apie"
-" šias užklausas ir pasikeitimus jose."
+"Jūsų sukūrtos užklausos: %(x_nb)s. %(x_url_open)sDetalus sąrašas"
+"%(x_url_close)s yra prieinamas su galimybe (a) pamatyti paieškos rezultatus "
+"ir  (b) užsiprenumeruoti automatinį el.laišką su žiniomis apie šias "
+"užklausas ir pasikeitimus jose."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6518,9 +6455,8 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"Nustatyti naują įspėjimą iš %(x_url1_open)sjūsų paieškos "
-"%(x_url1_close)s, %(x_url2_open)spopuliariausios paieškos%(x_url2_close)s"
-" ar įvėdimo formos."
+"Nustatyti naują įspėjimą iš %(x_url1_open)sjūsų paieškos %(x_url1_close)s, "
+"%(x_url2_open)spopuliariausios paieškos%(x_url2_close)s ar įvėdimo formos."
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6571,17 +6507,17 @@ msgstr "Jus sukūrėte %s įspėjimus(-ų)."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
-"Dar nevykdėte paieškų. Pradėkite atdarydami %(x_url_open)spaieškos "
-"sąsają%(x_url_close)s."
+"Dar nevykdėte paieškų. Pradėkite atdarydami %(x_url_open)spaieškos sąsają"
+"%(x_url_close)s."
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
 "Jūsų atliktos %(x_nb1)s paieška(-os) (%(x_nb2)s skirtingų(-os)) per "
 "paskutines 30 dienų."
@@ -6641,7 +6577,7 @@ msgstr "Jūsų paieškos"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6705,7 +6641,7 @@ msgstr "%s Personalizuoti, Nustatyti naują įspėjimą"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6765,7 +6701,8 @@ msgstr "%s Personalizuoti, Parodyti įspėjimus"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6789,7 +6726,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "Neturite reikiamų teisių šiam elementui peržiūrėti."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6817,7 +6755,8 @@ msgid "You do not have permission to delete this note."
 msgstr "Neturite reikiamų teisių šiam elementui peržiūrėti."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6848,8 +6787,8 @@ msgstr "Pasirinktas elementas neegzistuoja"
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6871,8 +6810,8 @@ msgstr "Perkelti įrašo kopiją į krepšelį"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6905,8 +6844,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -6976,12 +6915,11 @@ msgstr "Viešas krepšelis"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 "Jus turite %(x_nb_perso)s asmeninių krepšelių ir esate priskirtas prie "
-"%(x_nb_group)s grupių krepšelių ir %(x_nb_public)s kitų vartotojų viešųjų"
-" krepšelių."
+"%(x_nb_group)s grupių krepšelių ir %(x_nb_public)s kitų vartotojų viešųjų "
+"krepšelių."
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
 #, fuzzy
@@ -7003,14 +6941,13 @@ msgid ""
 "You have no personal or group baskets or are subscribed to any public "
 "baskets."
 msgstr ""
-"Jus neturite asmeninių ar grupės krepšelių, nesate priskirtas prie jokios"
-" grupės ar jokio viešojo krepšelių."
+"Jus neturite asmeninių ar grupės krepšelių, nesate priskirtas prie jokios "
+"grupės ar jokio viešojo krepšelių."
 
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr "Galite pradėti %(x_url_open)ssukurdami naują krepšelį%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -7114,8 +7051,8 @@ msgid ""
 "Displaying public baskets %(x_from)i - %(x_to)i out of "
 "%(x_total_public_basket)i public baskets in total."
 msgstr ""
-"Rodomi vieši krepšeliai %(x_from)i - %(x_to)i iš "
-"%(x_total_public_basket)i visų viešų krepšelių."
+"Rodomi vieši krepšeliai %(x_from)i - %(x_to)i iš %(x_total_public_basket)i "
+"visų viešų krepšelių."
 
 #: invenio/legacy/webbasket/templates.py:1376
 #: invenio/legacy/webbasket/templates.py:1400
@@ -7172,11 +7109,11 @@ msgstr "Išorinis elementas"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
-"Pateikite URL išorinio elemento, kurį norite pridėti ir užpildykite "
-"laukus, pridėkite pavadinimą iraprašymą"
+"Pateikite URL išorinio elemento, kurį norite pridėti ir užpildykite laukus, "
+"pridėkite pavadinimą iraprašymą"
 
 #: invenio/legacy/webbasket/templates.py:1612
 #: invenio/modules/linkbacks/templates/linkbacks/index_base.html:44
@@ -7214,8 +7151,8 @@ msgid ""
 "Please choose a basket: %(x_basket_selection_box)s %(x_fmt_open)s(or "
 "%(x_url_open)screate a new one%(x_url_close)s first)%(x_fmt_close)s"
 msgstr ""
-"Prašome pasirinkti krepšelį: %(x_basket_selection_box)s %(x_fmt_open)s(ar"
-" %(x_url_open)ssukurkite naują%(x_url_close)s)%(x_fmt_close)s"
+"Prašome pasirinkti krepšelį: %(x_basket_selection_box)s %(x_fmt_open)s(ar "
+"%(x_url_open)ssukurkite naują%(x_url_close)s)%(x_fmt_close)s"
 
 #: invenio/legacy/webbasket/templates.py:1764
 msgid "Optionally, add a note to each one of these items"
@@ -7357,8 +7294,8 @@ msgstr "Dalintis krepšeliu su nauja grupe"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 "Esate prisijungęs kaip svečias, todėl jūsų krepšelis išnyks šios sesijos "
 "pabaigoje."
@@ -7367,10 +7304,11 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
-"Jei pageidaujate, užsiregistruoti ar prisijungti galite "
-"%(x_url_open)sčia%(x_url_close)s."
+"Jei pageidaujate, užsiregistruoti ar prisijungti galite %(x_url_open)sčia"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7379,7 +7317,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Šita funkcija yra draudžiama neprisijungusiems vartotojams."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Atgal į paieškos rezultatus "
 
@@ -7543,7 +7481,7 @@ msgstr "Pridėti pastabą"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7680,213 +7618,213 @@ msgstr "Vartotojas %s neegzistuoja."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "Vartotojas %s neegzistuoja."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Rašyti komentarą"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i komentarai \"%(x_name)s\""
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "%i komentarai"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Rodomi %i kementaras(-ai):"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Aptarti šį dokumentą"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Pradėti diskusiją apie bet kokį šio dokumento aspektą. "
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Atsiprašome, bet nepanašu, kad %s įrašas egzistuotu."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "Atsiprašome, bet %s ID reikšmė netinkama."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "Atsiprašome, bet įrašo ID nebuvo numatytas."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Galite pradėti naršyti nuo %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_nb)i komentarai \"%(x_name)s\""
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Ar šis atsiliepimas buvo naudingas? "
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Rašyti atsiliepimą"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 "Vidutinis atsiliepimo įvertinimas:%(x_nb_score)s priklausantis nuo "
 "%(x_nb_reviews)s atsiliepimų "
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "Skaitytojai įvertino .%s atsiliepimus geriausiai"
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Peržiūrėti visus %s atsiliepimus"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Įvertinti šį dokumentą"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Tapkite pirmuojų parašę atsiliepimą šiam dokumentui."
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "uždaryti"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Pranešti apie piktnaudžiavimą"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr "Atkurti komentarą"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Ištrinti komentarą"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr "Nepranešti komentaro"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr "Pridėti failai"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr "Pridėti failai"
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Atsiliepimas %(x_nickname)s %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
-"%(x_nb_people)i iš %(x_nb_total)i vartotojų sakančių, kad šitas "
-"atsiliepimas buvo naudingas"
+"%(x_nb_people)i iš %(x_nb_total)i vartotojų sakančių, kad šitas atsiliepimas "
+"buvo naudingas"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr "Atkurti atsiliepimą"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr "Ištrinti atsiliepimą"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr "Nepraneštas atsiliepimas"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Komentarai"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Atsiliepimai"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Iš viso yra %s atsiliepimų"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Iš viso yra %s komentarų"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Tapkite pirmuojų parašę atsiliepimą šiam dokumentui."
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Prisijungti"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr "Pasišalinti"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7895,511 +7833,512 @@ msgstr "Pasišalinti"
 msgid "Record"
 msgstr "Įrašas"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "atsiliepimas"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "komentaras"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Atsiliepimas"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Peržiūri"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Puslapis:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr "Nesate įgaliotas komentuoti ar rašyti atsiliepimą."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
-"Atsiminkite: Jūsų vartotojo vardas, %s, bus naudojamas kaip autoriaus "
-"vardas šiam komentarui."
+"Atsiminkite: Jūsų vartotojo vardas, %s, bus naudojamas kaip autoriaus vardas "
+"šiam komentarui."
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr "Prisijungę vartotojai gali pridėti failų."
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr "Pasirinktinai, pridėkite failą prie šio komentaro"
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr "Pasirinktinai, pridėkite failą prie šio komentaro"
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr "Daugiausiai vienas failas"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "Daugiausiai %i failai"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr "Daugiausiai %(x_nb_bytes)s vienam failui "
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr "Atsiųsti el.pranešimą apie naują komentarą"
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Straipsnis"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "Pridėti komentarą"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr ""
-"Atsiminkite: Jūsų vartotojo vardas, %s, bus rodomas kaip autoriaus vardas"
-" prie šio atsiliepimo."
+"Atsiminkite: Jūsų vartotojo vardas, %s, bus rodomas kaip autoriaus vardas "
+"prie šio atsiliepimo."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Įvertinkite šį straipsnį"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Pasirinkite rezultatą"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Pridėkite pavadinimą "
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Parašykite atsiliepimą"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr "Pridėti atsiliepimą"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Pridėti atsiliepimą"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Jūsų atsiliepimas sėkmingai patalpintas."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Jūsų komentaras sėkmingai patalpintas."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Atgal į įrašą"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
-msgstr "Galite peržiūrėti savo %(x_url_open)s\"etikečių\"%(x_url_close)s sąrašą ."
+msgstr ""
+"Galite peržiūrėti savo %(x_url_open)s\"etikečių\"%(x_url_close)s sąrašą ."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr "Peržiūrėti daugiausiai komentarų turinčius įrašus"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr "Peržiūrėti vėliausiai pakomentuotus įrašus"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr "Peržiūrėti visus komentarus, apie kurių netinkamumą buvo pranešta"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr "Peržiūrėti įrašus, kurie turi daugiausiai atsiliepimų"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr "Peržiūrėti įrašus, kuriems atsiliepimai parašyti vėliausiai"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr "Peržiūrėti visus atsiliepimus, apie kurių netinkamumą buvo pranešta"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Peržiūrėti visus vartotojus, kurie atsiuntė pranešimus"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Vadovas"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Pašalinti komentarai ir atsiliepimai"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"Prašome, įveskite komentaro/atsiliepimo ID, kad galėtumėte peržiūrėti "
-"prieš nusprendžiant ištrinti ar palikti"
+"Prašome, įveskite komentaro/atsiliepimo ID, kad galėtumėte peržiūrėti prieš "
+"nusprendžiant ištrinti ar palikti"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "Komentaro ID:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr "Arba įveskite įrašo ID į sąrašą visų susijusių komentarų/pranešimų:"
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr "Įrašo ID:"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Peržiūrėti komentarą"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Pranešimų nėra"
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Peržiūrėti visus %s komentarus, apie kuriuos buvo pranešta "
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Peržiūrėti visus %s atsiliepimus, apie kuriuos buvo pranešta"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
 "Sąrašas, surušiuotas pagal pranešimų numerius, visų vartotojų, kurienors "
 "kartą pranešė apie komentarą.."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Vartotojo vardas"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "Vartotojo ID"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Teigiamų balsų skaičius"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Neigiamų balsų skaičius"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Išviso balsų"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Iš viso pranešimų"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Peržiūrėti visus vartotojus įkėlusius komentarus/atsiliepimus"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Apie šį pranešimą buvo %i kartą(-us) pranešta "
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Apie šį komentarą buvo pranešta %i kartą(-us)"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Parašyta"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Bendra informacija"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Ištrinti pasirinktus atsiliepimus"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Sustabdyti pasirinktą pranešimą apie piktnaudžiavimą "
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr "Atkurti pasirinktus atsiliepimus"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr "Atkurti pasirinktus komentarus"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Ištrinti pasirinktus komentarus"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Čia yra atsiliepimai, apie kuriuos buvo pranešta vartotojų %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Čia yra komentarai, apie kuriuos buvo pranešta vartotojų %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Čia yra atsiliepimas %s "
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Čia yra komentara %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Šis atsiliepimas %(x_cmtID)s parašytas vartotojo %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Šis komentaras %(x_cmtID)s parašytas vartotojo %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "Visi atsiliepimai surūšiuoti pagal pranešimų apie juos skaičių"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "Visi komentarai surūšiuoti pagal pranešimų apie juos skaičių"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
-"Visi atsiliepimai apie %i įrašą, surūšiuoti pagal pranešimų apie jį "
-"skaičių"
+"Visi atsiliepimai apie %i įrašą, surūšiuoti pagal pranešimų apie jį skaičių"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr "Rodyti komentarus"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
-"Visi komentaraiai apie %i įrašą, surūšiuoti pagal pranešimų apie jį "
-"skaičių "
+"Visi komentaraiai apie %i įrašą, surūšiuoti pagal pranešimų apie jį skaičių "
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr "Rodyti atsiliepimus"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "komentaro ID"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "sėkmingai ištrinta"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr "sėkmingai atkurta"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "sėkmingai sustabdytas piknaudžiavimo pranešimas"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Dar nėra atsiliepimų"
 
-#: invenio/legacy/webcomment/templates.py:2257
+#: invenio/legacy/webcomment/templates.py:2256
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr "Atsiliepimas sukurtas %(user_nickname)s nusiųstas %(CFG_SITE_NAME)s:"
 
-#: invenio/legacy/webcomment/templates.py:2258
+#: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr "Komentaras sukurtas %(user_nickname)s nusiųstas %(CFG_SITE_NAME)s:"
 
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr "Tai automatinis pranešimas, prašome į jį neatsakynėti."
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr "Norėdami parašyti dar vieną komentarą spauskite čia <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr "Norėdami atsakyti į šį komentarą spauskite čia <%(x_url)s>"
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr "Kad atsisakyti dalyvavimo diskusijoje spauskite čia <%(x_url)s>"
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr "Jei turite klausimų rašykite <%(CFG_SITE_SUPPORT_EMAIL)s>"
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "Jūsų komentaras sėkmingai patalpintas."
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Ištrinti komentarus"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "seniausias pirmas"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "Peržiūrėti vėliausiai pakomentuotus įrašus"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "pridėti komentarus"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "Rasta įrašų"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Komentarai"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "%i elementas(-ai)"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Pridėti elementus"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 #, fuzzy
 msgid "Display"
 msgstr "Parodyti įspėjimus"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Užsakymo data"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Kitas puslapis"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Parodyti įspėjimus"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8407,102 +8346,102 @@ msgstr "Parodyti įspėjimus"
 msgid "Refresh"
 msgstr "Atnaujinti"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Nepranešti komentaro"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "Rastas(-i) %i elemtas(-ai)"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Įrašas nerastas"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "Neturite reikiamų teisių šiam elementui peržiūrėti."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Pridėti komentarą"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 msgid "You cannot report a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr "Puslapis nerastas"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr "Pageidaujamas komentaras nerastas"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr "Pageidaujamas failas nerastas"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Neturite reikiamų teisių naudoti užsakymo sistemą"
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Komentarai"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr ""
@@ -8617,11 +8556,10 @@ msgstr "Atsiprašome, puslapis %s neegzistuoja."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
-"Jus galite peržiūrėti %(x_url_open)s%(x_category)s "
-"puslapius%(x_url_close)s."
+"Jus galite peržiūrėti %(x_url_open)s%(x_category)s puslapius%(x_url_close)s."
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
 #, fuzzy, python-format
@@ -8684,11 +8622,11 @@ msgstr "Mes negalime pateikti jums jokių žurnalų"
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
-"Panašu, kad šiame serveryje priskirtų žurnalų nėra. Jei tai ne ties, "
-"prašome susisiekti su sistemos palaikymo komanda."
+"Panašu, kad šiame serveryje priskirtų žurnalų nėra. Jei tai ne ties, prašome "
+"susisiekti su sistemos palaikymo komanda."
 
 #: invenio/legacy/webjournal/config.py:239
 msgid "Select a journal on this server"
@@ -8714,11 +8652,11 @@ msgstr "Mes negalėjome rasti informacijos apie šį leidimą"
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
-"Šio leidimo konfiguracija tuščia. Pateikite leidimo numerį ar "
-"pasitikrinkite su sistemos palaikymo komanda."
+"Šio leidimo konfiguracija tuščia. Pateikite leidimo numerį ar pasitikrinkite "
+"su sistemos palaikymo komanda."
 
 #: invenio/legacy/webjournal/config.py:298
 msgid "Issue number badly formed"
@@ -8781,7 +8719,8 @@ msgstr "Kategorija  \"%(category_name)s\" nerasta"
 
 #: invenio/legacy/webjournal/config.py:531
 msgid "Sorry, this category does not exist for this journal and issue."
-msgstr "Atsiprašome, ši kategorija neegzistuoja šiam žurnalui ir šiam leidimui."
+msgstr ""
+"Atsiprašome, ši kategorija neegzistuoja šiam žurnalui ir šiam leidimui."
 
 #: invenio/legacy/webjournal/templates.py:53
 msgid "Available Journals"
@@ -8898,9 +8837,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8922,8 +8860,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9399,19 +9336,19 @@ msgstr "Taip pat ieškoti:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 "Ribojamas rinkinys. Jei turite reikiamas teises peržiūrėti rinkinį, "
 "paspauskite paieškos mygtuką."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
-"Tai yra išorinis rinkinys. Paspauskite paieškos mygtuką, kad "
-"pažiūrėtumėte joturinį."
+"Tai yra išorinis rinkinys. Paspauskite paieškos mygtuką, kad pažiūrėtumėte "
+"joturinį."
 
 #: invenio/legacy/websearch/templates.py:1619
 msgid "This collection does not contain any document yet."
@@ -9425,7 +9362,8 @@ msgstr "Cituojama %i įrašų"
 #: invenio/legacy/websearch/templates.py:1856
 #, python-format
 msgid "Words nearest to %(x_word)s inside %(x_field)s in any collection are:"
-msgstr "Panašiausi žodžiai į %(x_word)s, esantys %(x_field)s, rinkiniuose yra: "
+msgstr ""
+"Panašiausi žodžiai į %(x_word)s, esantys %(x_field)s, rinkiniuose yra: "
 
 #: invenio/legacy/websearch/templates.py:1859
 #, python-format
@@ -9519,8 +9457,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found at least "
 "%(x_nb_records)s records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sRezultatų peržiūra:%(x_fmt_close)s Rasti bent "
-"%(x_nb_records)s įrašai per %(x_nb_seconds)s sekundes."
+"%(x_fmt_open)sRezultatų peržiūra:%(x_fmt_close)s Rasti bent %(x_nb_records)s "
+"įrašai per %(x_nb_seconds)s sekundes."
 
 #: invenio/legacy/websearch/templates.py:3184
 #, fuzzy
@@ -9547,9 +9485,9 @@ msgstr "Daugiau informacijos"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
-msgstr "Loginė užklausa nieko negrąžino. Prašome pakeisti savo paieškos užklausą."
+"Boolean query returned no hits. Please combine your search terms differently."
+msgstr ""
+"Loginė užklausa nieko negrąžino. Prašome pakeisti savo paieškos užklausą."
 
 #: invenio/legacy/websearch/templates.py:3357
 msgid "See also: similar author names"
@@ -9574,12 +9512,12 @@ msgstr "Jus galite pradėti naršyti nuo %s."
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "Nustatykite asmeninį %(x_url1_open)sįspėjimą el.paštu%(x_url1_close)s\n"
-"                                  ar užsiprenumeruokite "
-"%(x_url2_open)sRSS%(x_url2_close)s."
+"                                  ar užsiprenumeruokite %(x_url2_open)sRSS"
+"%(x_url2_close)s."
 
 #: invenio/legacy/websearch/templates.py:3832
 #, python-format
@@ -9768,7 +9706,8 @@ msgid "in"
 msgstr "viduje"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "Nepavyko surasti? Išbandykite paiešką kituose serveriuose:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9813,8 +9752,8 @@ msgid ""
 "You can consult the list of your external groups directly in the "
 "%(x_url_open)sgroups page%(x_url_close)s."
 msgstr ""
-"Galite peržiūrėti sąrašą savo išorinių grupių %(x_url_open)sgrupių "
-"puslapyje%(x_url_close)s."
+"Galite peržiūrėti sąrašą savo išorinių grupių %(x_url_open)sgrupių puslapyje"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:110
 msgid "External user groups"
@@ -9864,8 +9803,8 @@ msgstr "privalomas"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9875,11 +9814,11 @@ msgstr "Sukurkite naują krepšelį"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
-"Jei norite pakeisti savo el.paštą ar pirmą kartą nustatyti vartotojo "
-"vardą, tai atlikti galite žemiau."
+"Jei norite pakeisti savo el.paštą ar pirmą kartą nustatyti vartotojo vardą, "
+"tai atlikti galite žemiau."
 
 #: invenio/legacy/websession/templates.py:271
 msgid "Edit login credentials"
@@ -9895,19 +9834,19 @@ msgstr "Nustatyti naujus duomenis"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 "Kadangi tai bus jūsų parašas po parašytais komentarais ir atsiliepimais, "
 "vieną sykį nurodžius nebus neleidžiama pakeisti."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
-"Jei norite pakeisti slaptažodį, įveskite seną slaptažodį ir naują "
-"slaptažodį į atitinkamus laukelius."
+"Jei norite pakeisti slaptažodį, įveskite seną slaptažodį ir naują slaptažodį "
+"į atitinkamus laukelius."
 
 #: invenio/legacy/websession/templates.py:327
 msgid "Old password"
@@ -9944,12 +9883,11 @@ msgstr "Keisti slaptažodį"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 "Jei naudojate \"CERN  lightweight\" paskyrą, \n"
-"                %(x_url_open)spakeisti slaptažodį galite "
-"čia%(x_url_close)s."
+"                %(x_url_open)spakeisti slaptažodį galite čia%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:346
 #, python-format
@@ -10029,8 +9967,7 @@ msgid ""
 "Please select which login method you would like to use to authenticate "
 "yourself"
 msgstr ""
-"Pasirinkite prisijungimo metodą, kurį norite naudoti savęs "
-"autentifikavimui"
+"Pasirinkite prisijungimo metodą, kurį norite naudoti savęs autentifikavimui"
 
 #: invenio/legacy/websession/templates.py:503
 #: invenio/legacy/websession/templates.py:518
@@ -10040,14 +9977,13 @@ msgstr "Pasirinkite metodą"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
 "Jei pamiršote %(sitename)s %(x_fmt_open)s paskyros slaptažodį "
-"%(x_fmt_close)s, įveskite savo el.pašto adresą, kad galėtume atsiųsti "
-"laišką su nuoroda į puslapį, kur galėsite pasikeisti slaptažodį."
+"%(x_fmt_close)s, įveskite savo el.pašto adresą, kad galėtume atsiųsti laišką "
+"su nuoroda į puslapį, kur galėsite pasikeisti slaptažodį."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10063,18 +9999,18 @@ msgstr "Išsiųsti nuorodą"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
-"Jei naudojate %(x_fmt_open)sCERN prisijungimo sistemą%(x_fmt_close)s, "
-"tuomet atkurti slaptažodį galite %(x_url_open)sCERN autentifikavimo "
-"sistemoje%(x_url_close)s."
+"Jei naudojate %(x_fmt_open)sCERN prisijungimo sistemą%(x_fmt_close)s, tuomet "
+"atkurti slaptažodį galite %(x_url_open)sCERN autentifikavimo sistemoje"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 "Jei naudojate išorinę prisijungimo sistemą, mes negalime jums padėti. "
 "Pagalbos ieškokite išorinėje sistemoje."
@@ -10085,16 +10021,15 @@ msgid ""
 "Alternatively, you can ask %(x_name)s to change your login system from "
 "external to internal."
 msgstr ""
-"Arba, galite paprašyti %s pakeisti prisijungimo sistemą iš išorinės į "
-"vidinę."
+"Arba, galite paprašyti %s pakeisti prisijungimo sistemą iš išorinės į vidinę."
 
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 "%s suteikia galimybę keisti sąsają pagal jūsų pageidavimus, patalpinti "
 "asmeninius dokumentus ar nustatyti specifinę įspėjimų sistemą, kuri bus "
@@ -10110,8 +10045,8 @@ msgid ""
 "Set or change your account email address or password. Specify your "
 "preferences about the look and feel of the interface."
 msgstr ""
-"Nustatyti ar pakeisti paskyros el.paštą ar slaptažodį. Nustatykite "
-"sąsajos išvaizdą ir elgesį."
+"Nustatyti ar pakeisti paskyros el.paštą ar slaptažodį. Nustatykite sąsajos "
+"išvaizdą ir elgesį."
 
 #: invenio/legacy/websession/templates.py:620
 msgid "View all the searches you performed during the last 30 days."
@@ -10119,12 +10054,12 @@ msgstr "Peržiūrėti visas paieškas atliktas per 30 dienų."
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
-"Krepšelių pagalba galite susikurti įvairių elementų rinkinius, "
-"išsisaugoti dominančius įrašus, kuriuos norėsite peržiūrėti vėliau ar "
-"pasidalinti su kitais."
+"Krepšelių pagalba galite susikurti įvairių elementų rinkinius, išsisaugoti "
+"dominančius įrašus, kuriuos norėsite peržiūrėti vėliau ar pasidalinti su "
+"kitais."
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10135,31 +10070,31 @@ msgid ""
 "Subscribe to a search which will be run periodically by our service. The "
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
-"Užsiprenumeruoti naujienas apie periodiškai vykdomą paiešką. Rezultatai "
-"gali būti siunčiami el.paštu ar išsaugomi jūsų krepšelyje."
+"Užsiprenumeruoti naujienas apie periodiškai vykdomą paiešką. Rezultatai gali "
+"būti siunčiami el.paštu ar išsaugomi jūsų krepšelyje."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
-msgstr ""
-"Peržiūrėkite pasirinkta knygą, išsiųskite užsakymą, ir t.t. Reikalingas "
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
 "CERN ID."
+msgstr ""
+"Peržiūrėkite pasirinkta knygą, išsiųskite užsakymą, ir t.t. Reikalingas CERN "
+"ID."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
-"Esate prisijungęs svečio teisėmis, todėl jūsų įspėjimai išsitrins "
-"pasibaigus sesijai."
+"Esate prisijungęs svečio teisėmis, todėl jūsų įspėjimai išsitrins pasibaigus "
+"sesijai."
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 "Jus prisijungęs(-usi) kaip %(x_user)s. Jūsų pasirinkimai a) "
 "%(x_url1_open)satsijungti%(x_url1_close)s; b) redaguoti "
@@ -10170,7 +10105,8 @@ msgstr ""
 msgid ""
 "You can consult the list of %(x_url_open)syour comments%(x_url_close)s "
 "submitted so far."
-msgstr "Galite peržiūrėti savo %(x_url_open)s\"etikečių\"%(x_url_close)s sąrašą ."
+msgstr ""
+"Galite peržiūrėti savo %(x_url_open)s\"etikečių\"%(x_url_close)s sąrašą ."
 
 #: invenio/legacy/websession/templates.py:790
 msgid "Your Alert Searches"
@@ -10179,8 +10115,8 @@ msgstr "Jūsų įspėjimų paieškos"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 "Galite peržiūrėti sąrašą %(x_url_open)sgrupių%(x_url_close)s, kurias "
 "administruojate ar esate grupės narys."
@@ -10194,11 +10130,11 @@ msgstr "Jūsų grupės"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"Galite peržiūrėti sąrašą %(x_url_open)spatalpintų "
-"dokumentų%(x_url_close)s ir jų būsenų."
+"Galite peržiūrėti sąrašą %(x_url_open)spatalpintų dokumentų%(x_url_close)s "
+"ir jų būsenų."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -10208,8 +10144,8 @@ msgstr "Jūsų patalpinimai"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
 "Galite peržiūrėti sąrašą %(x_url_open)sdokumentų%(x_url_close)s, kuriuos "
 "patvirtinote."
@@ -10222,7 +10158,8 @@ msgstr "Jūsų patvirtinimai"
 #: invenio/legacy/websession/templates.py:815
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour tickets%(x_url_close)s."
-msgstr "Galite peržiūrėti savo %(x_url_open)s\"etikečių\"%(x_url_close)s sąrašą ."
+msgstr ""
+"Galite peržiūrėti savo %(x_url_open)s\"etikečių\"%(x_url_close)s sąrašą ."
 
 #: invenio/legacy/websession/templates.py:818
 msgid "Your Tickets"
@@ -10260,7 +10197,8 @@ msgstr "Paspauskite auksčiau esančią nuorodą, kad galėtume patvirtinti."
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr "Dėmesio, šis URL veiks tik %(days)s dieną(-as)."
 
 #: invenio/legacy/websession/templates.py:909
@@ -10314,20 +10252,20 @@ msgstr "Jei turite susikūrę paskyrą, galite prisijungti naudodamiesi forma."
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
-"Jei dar neturite CERN paskyros, galite užsiregistruoti "
-"%(x_url_open)snaują \"CERN lightweight\" paskyrą%(x_url_close)s."
+"Jei dar neturite CERN paskyros, galite užsiregistruoti %(x_url_open)snaują "
+"\"CERN lightweight\" paskyrą%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"Jei dar neturite paskyros, galite "
-"%(x_url_open)sužregistruoti%(x_url_close)s išorinę paskyrą."
+"Jei dar neturite paskyros, galite %(x_url_open)sužregistruoti%(x_url_close)s "
+"išorinę paskyrą."
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
@@ -10362,8 +10300,8 @@ msgstr "Prisijungdami galite naudoti vartotojo vardą ar slaptažodį."
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr "Jūsų prašymas patvirtintas. Prašome įrašyti naują slaptažodį įformą."
 
 #: invenio/legacy/websession/templates.py:1150
@@ -10388,9 +10326,10 @@ msgstr "Įrašykite savo el.paštą, vartotojo vardą ir slaptažodį:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
-msgstr "Paskyra galėsite naudotis tik po, kai ji bus patvirtinta ir  aktyvuota."
+"It will not be possible to use the account before it has been verified and "
+"activated."
+msgstr ""
+"Paskyra galėsite naudotis tik po, kai ji bus patvirtinta ir  aktyvuota."
 
 #: invenio/legacy/websession/templates.py:1228
 msgid "Retype Password"
@@ -10406,22 +10345,22 @@ msgstr "registracija"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
-"Slaptažodyje nenaudokite paprastų, jūsų aplinkoje paplitusių žodžių (kaip"
-" Unix, AFS, NICE). Jūsų el.pašto adresas nebus viešinamas ar perduotas "
-"trečioms šalims. Jis bus naudojamas identifikuoti jūsų servisus %s. Pvz.:"
-" jus galite užsiprenumeruoti automatinius įspėjimus apie naujus "
-"straipsnius, juodraščius ir pan., bei gauti juos el.paštu."
+"Slaptažodyje nenaudokite paprastų, jūsų aplinkoje paplitusių žodžių (kaip "
+"Unix, AFS, NICE). Jūsų el.pašto adresas nebus viešinamas ar perduotas "
+"trečioms šalims. Jis bus naudojamas identifikuoti jūsų servisus %s. Pvz.: "
+"jus galite užsiprenumeruoti automatinius įspėjimus apie naujus straipsnius, "
+"juodraščius ir pan., bei gauti juos el.paštu."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 "Negalima susikurti paskyros savarankiškai. Susisiekite su %s, jei "
 "pageidaujate turėti paskyrą."
@@ -10429,8 +10368,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
 "Esate neprisijungęs(-usi) vartotojas(-a). Prisijungti galite "
 "%(x_url_open)sčia%(x_url_close)s."
@@ -10558,13 +10497,14 @@ msgstr "Paleisti dokumentų failų tvarkyklę"
 
 #: invenio/legacy/websession/templates.py:1323
 msgid "Here are some interesting web admin links for you:"
-msgstr "Kelios nuorodos į įdomias interneto svetaines apie tinklo administravimą:"
+msgstr ""
+"Kelios nuorodos į įdomias interneto svetaines apie tinklo administravimą:"
 
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "Sužinoti daugiau apie administravimo lygmens galimybes galite "
 "%(x_url_open)sAdministratoriaus erdvėje%(x_url_close)s."
@@ -10749,8 +10689,8 @@ msgid ""
 "If you want to invite new members to join your group, please use the "
 "%(x_url_open)sweb message%(x_url_close)s system."
 msgstr ""
-"Jei norite pakviesti naujus narius prisijungti prie grupės, pasinaudokite"
-" %(x_url_open)stinklo žinučių%(x_url_close)s sistema."
+"Jei norite pakviesti naujus narius prisijungti prie grupės, pasinaudokite "
+"%(x_url_open)stinklo žinučių%(x_url_close)s sistema."
 
 #: invenio/legacy/websession/templates.py:2100
 #, fuzzy, python-format
@@ -10793,8 +10733,10 @@ msgstr "Vartotojas nori prisijungti prie grupės %s."
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
-msgstr "%(x_url_open)sPatvirtinkite ar atmeskite%(x_url_close)s vartotojo prašymą."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgstr ""
+"%(x_url_open)sPatvirtinkite ar atmeskite%(x_url_close)s vartotojo prašymą."
 
 #: invenio/legacy/websession/templates.py:2400
 #, fuzzy, python-format
@@ -10835,62 +10777,57 @@ msgstr "Grupė %s buvo ištrinta administratoriaus."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"Galite peržiūrėti sąrašą  %(x_url_open)s%(x_nb_total)i "
-"grupių%(x_url_close)s, kurių narys esate (%(x_nb_member)i) ar kurias "
+"Galite peržiūrėti sąrašą  %(x_url_open)s%(x_nb_total)i grupių"
+"%(x_url_close)s, kurių narys esate (%(x_nb_member)i) ar kurias "
 "administruojate (%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 "Įspėjimas:  MySQL slaptažodis \"root\" vartotojui toks pats kaip ir "
-"numatytas Invenio slaptažodis. Saugumo tikslais, jus turėtumėte "
-"pasikeisti slaptažodį."
+"numatytas Invenio slaptažodis. Saugumo tikslais, jus turėtumėte pasikeisti "
+"slaptažodį."
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
-"Įspėjimas: Invenio MySQL vartotojo slaptažodis yra toks pats kaip "
-"išsiuntimo pagal nutylėjimą.Saugumo tikslais, jus turėtumėte pasikeisti "
-"slaptažodį."
+"Įspėjimas: Invenio MySQL vartotojo slaptažodis yra toks pats kaip išsiuntimo "
+"pagal nutylėjimą.Saugumo tikslais, jus turėtumėte pasikeisti slaptažodį."
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 "Įspėjimas: Invenio administratoriaus slaptažodio nėra.Saugumo tikslais, "
 "rekomenduojame nustatyti slaptažodį."
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 "Įspėjimas: Aptarnaujantis el.pašto adresas nustatytas kaip info@invenio-"
 "software.org. Rekomenduojame pakeisti jį jūsų asmeniniu el.pašto adresu."
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr "Jau galima atsisiųsti naują Invenio versiją. Galite apsilankyti  "
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 "Negalima atsisiųsti ar peržiūrėti duomenų(pastabų) iš http://invenio-"
 "software.org/repo/invenio/tree/RELEASE-NOTES"
@@ -10898,25 +10835,24 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
-"Esate neprisijungęs vartotojas. Prisijunkti galite %(x_url_open)s  "
-"čia.%(x_url_close)s"
+"Esate neprisijungęs vartotojas. Prisijunkti galite %(x_url_open)s  čia."
+"%(x_url_close)s"
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 "%(x_fmt_open)s Neprisijungę vartotojai %(x_fmt_close)s pirmiausia turi "
 "%(x_url_open)s užsiregistruoti%(x_url_close)s"
@@ -10927,19 +10863,19 @@ msgstr "Užklausų nerasta"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 "Neturite reikiamų teisių naudotis šiuo rinkiniu. Jei manote, kad tokias "
 "teises turite - autentifikuokite save."
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
-"Neturite reikiamų teisių naudotis šiuo failu. Jei manote, kad tokias "
-"teises turite - autentifikuokite save."
+"Neturite reikiamų teisių naudotis šiuo failu. Jei manote, kad tokias teises "
+"turite - autentifikuokite save."
 
 #: invenio/legacy/websession/webaccount.py:400
 msgid "The OpenID identifier is invalid"
@@ -10947,8 +10883,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -10960,8 +10896,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11039,8 +10975,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11079,8 +11014,8 @@ msgid ""
 "browser if you are a guest user."
 msgstr ""
 "Jus buvote sėkmingai paskirtas %(x_role)s! Ši autorizacija tęsis iki "
-"%(x_expiration)s,o jei prisijungėte svečio teisėmis, autorizacija "
-"priskirta išlieka visą laiką, kol neišjungiama naršyklė."
+"%(x_expiration)s,o jei prisijungėte svečio teisėmis, autorizacija priskirta "
+"išlieka visą laiką, kol neišjungiama naršyklė."
 
 #: invenio/legacy/websession/webinterface.py:128
 msgid "You have confirmed the validity of your email address!"
@@ -11095,7 +11030,8 @@ msgstr "Prašome palaukti, administratorius turi įgalinti jūsų paskyrą. "
 #: invenio/legacy/websession/webinterface.py:144
 #, python-format
 msgid "You can now go to %(x_url_open)syour account page%(x_url_close)s."
-msgstr "Galite apsilankyti %(x_url_open)ssavo paskyros puslapyje%(x_url_close)s."
+msgstr ""
+"Galite apsilankyti %(x_url_open)ssavo paskyros puslapyje%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:136
 #: invenio/legacy/websession/webinterface.py:145
@@ -11108,15 +11044,15 @@ msgstr "Jus jau patvirtinote savo el.pašto adresą!"
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 "Šis prašymas patvirtinti el.pašto adresą yra netinkamas arba baigėsi jo "
 "galiojimo laikas."
 
 #: invenio/legacy/websession/webinterface.py:153
 msgid "This request for an authorization is not valid or is expired."
-msgstr "Šis autorizavimo prašymas yra netinkamas arba baigėsi jo galiojimo laikas."
+msgstr ""
+"Šis autorizavimo prašymas yra netinkamas arba baigėsi jo galiojimo laikas."
 
 #: invenio/legacy/websession/webinterface.py:166
 msgid "Reset password"
@@ -11129,14 +11065,14 @@ msgstr "Šis prašymas nustatyti slaptažodį iš naujo jau buvo panaudotas."
 #: invenio/legacy/websession/webinterface.py:175
 msgid "This request for resetting a password is not valid or is expired."
 msgstr ""
-"Šis prašymas nustatyti slaptažodį iš naujo yra netinkamas arba baigėsi jo"
-" galiojimo laikas."
+"Šis prašymas nustatyti slaptažodį iš naujo yra netinkamas arba baigėsi jo "
+"galiojimo laikas."
 
 #: invenio/legacy/websession/webinterface.py:180
 msgid "This request for resetting the password is not valid or is expired."
 msgstr ""
-"Šis prašymas nustatyti slaptažodį iš naujo yra netinkamas arba baigėsi jo"
-" galiojimo laikas."
+"Šis prašymas nustatyti slaptažodį iš naujo yra netinkamas arba baigėsi jo "
+"galiojimo laikas."
 
 #: invenio/legacy/websession/webinterface.py:193
 msgid "The two provided passwords aren't equal."
@@ -11178,15 +11114,15 @@ msgstr "Persijungė į išorinio prisijungimo metodą."
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 "Jei pirmą kartą jungiates prie paskyros naudodami išorinio prisijungimo "
 "metodą, sistema sugeneruos atsitiktinį  slaptažodį. Prašome paspausti "
-"mygtuką, kad galėtume į el.paštą atsiųsti laišką su nuoroda  kaip "
-"pasikeisti slaptažodį:"
+"mygtuką, kad galėtume į el.paštą atsiųsti laišką su nuoroda  kaip pasikeisti "
+"slaptažodį:"
 
 #: invenio/legacy/websession/webinterface.py:431
 msgid "Send Password"
@@ -11198,8 +11134,8 @@ msgid ""
 "Unable to switch to external login method %(x_name)s, because your email "
 "address is unknown."
 msgstr ""
-"Negalima prijungti išorinio prisijungimo metodo %s, nes nėra žinomas jūsų"
-" el.pašto adresas."
+"Negalima prijungti išorinio prisijungimo metodo %s, nes nėra žinomas jūsų el."
+"pašto adresas."
 
 #: invenio/legacy/websession/webinterface.py:445
 #, fuzzy, python-format
@@ -11207,8 +11143,8 @@ msgid ""
 "Unable to switch to external login method %(x_meth)s, because your email "
 "address is unknown to the external login system."
 msgstr ""
-"Negalima prijungti išorinio prisijungimo metodo %s, nes nėra žinomas jūsų"
-" el.pašto adresas išorinei prisijungimo sistemai."
+"Negalima prijungti išorinio prisijungimo metodo %s, nes nėra žinomas jūsų el."
+"pašto adresas išorinei prisijungimo sistemai."
 
 #: invenio/legacy/websession/webinterface.py:449
 msgid "Login method successfully selected."
@@ -11217,11 +11153,11 @@ msgstr "Prisijungimo metodas sėkmingai pasirinktas."
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
-"%s išorinis prisijungimo metodas nepalaiko prisijungimo, veikiančio "
-"el.pašto pagalba.  Prašome susisiekti su puslapio administratoriais."
+"%s išorinis prisijungimo metodas nepalaiko prisijungimo, veikiančio el.pašto "
+"pagalba.  Prašome susisiekti su puslapio administratoriais."
 
 #: invenio/legacy/websession/webinterface.py:464
 #, fuzzy
@@ -11238,8 +11174,8 @@ msgid ""
 "Note that if you have changed your email address, you will have to "
 "%(x_url_open)sreset your password%(x_url_close)s anew."
 msgstr ""
-"Jei pasikeis jūsų el.pašto adresas, jus turite %(x_url_open)snustatyti "
-"naują slaptažodį%(x_url_close)s."
+"Jei pasikeis jūsų el.pašto adresas, jus turite %(x_url_open)snustatyti naują "
+"slaptažodį%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:487
 #: invenio/legacy/websession/webinterface.py:1003
@@ -11349,8 +11285,8 @@ msgid ""
 "Cannot send password reset request since you are using external "
 "authentication system."
 msgstr ""
-"Negalime išsiųsti slaptažodžio atnaujinimo prašymo, nes naudojate išorinę"
-" autentifikavimo sistemą."
+"Negalime išsiųsti slaptažodžio atnaujinimo prašymo, nes naudojate išorinę "
+"autentifikavimo sistemą."
 
 #: invenio/legacy/websession/webinterface.py:665
 msgid "The entered email address does not exist in the database."
@@ -11397,20 +11333,21 @@ msgstr "Paskyra sukurta"
 msgid ""
 "In order to confirm its validity, an email message containing an account "
 "activation key has been sent to the given email address."
-msgstr "Laiškas su paskyros patvirtinimo nuoroda, buvo išsiųstas į jūsų el.paštą."
+msgstr ""
+"Laiškas su paskyros patvirtinimo nuoroda, buvo išsiųstas į jūsų el.paštą."
 
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr "Kad pabaigti registraciją, jums reikia atlikti nurodytus veiksmus."
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr "Apie aktyvuota paskyrą pranešime jums el.paštu."
 
 #: invenio/legacy/websession/webinterface.py:989
@@ -11526,7 +11463,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 "Įrašas sukurtas %(x_date_creation)s, paskutinį kartą modifikuotas "
 "%(x_date_modification)s"
@@ -11551,37 +11489,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11589,15 +11527,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11661,8 +11599,8 @@ msgstr "Negalima nustatyti patalpintų puslapių skaičiaus."
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr "Neleidžiama sukurti katalogo. Administratorius buvo įspėtas."
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11697,11 +11635,11 @@ msgstr "Patvirtinti"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
-"Rasta rimta funkcionavimo klaida. Adminstratorius buvo įspėtas. <br "
-"/><em>Patikrinkite ar ji iškilo ne dėl blogai įvestų simbolių į įvedimo "
+"Rasta rimta funkcionavimo klaida. Adminstratorius buvo įspėtas. <br /"
+"><em>Patikrinkite ar ji iškilo ne dėl blogai įvestų simbolių į įvedimo "
 "formą</em> (pvz.: kopijuojant tekstą iš PDF failo)."
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11748,8 +11686,8 @@ msgstr "Pasirinkite kategoriją ir paspauskite mygtuką."
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 "Kad pratęsti anksčiau sustabdytus įkėlimus, įveskite leidimo numerį į "
 "laukelį žemiau:"
@@ -11780,8 +11718,8 @@ msgstr "Grįžti į pagrindinį puslapį"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 "Tai įkėlimo leidimo numeris. Jis gali būti reikalingas nutraukto įkėlimo "
 "proceso atnaujinimo metu, iškylus nesklandumams."
@@ -11832,8 +11770,8 @@ msgstr "Vykdomas įkėlimas"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 " %(x_action)s funkcijų sąrašas %(x_doctype)s dokumentams, esantiems "
 "%(x_step)s"
@@ -11917,11 +11855,9 @@ msgstr "Sąrašas dokumentų, kurių tipai yra rekomenduojami"
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
-"Pasirinkite vieną dokumentų tipą, kad galėtumėte peržiūrėti dokumentų "
-"būseną"
+"Pasirinkite vieną dokumentų tipą, kad galėtumėte peržiūrėti dokumentų būseną"
 
 #: invenio/legacy/websubmit/templates.py:1447
 msgid "Go to specific approval workflow"
@@ -12057,7 +11993,8 @@ msgstr "Patvirtinimo pastaba:"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr "Šis dokumentas %(x_fmt_open)slaukia patvirtinimo%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -12079,7 +12016,8 @@ msgstr "Paskutinis patvirtinimo el.laiškas siųstas:"
 msgid ""
 "You can send an approval request email again by clicking the following "
 "button:"
-msgstr "Paspaudę mygtuką galite dar kartą išsiųsti patvirtinimo prašymą el.paštu:"
+msgstr ""
+"Paspaudę mygtuką galite dar kartą išsiųsti patvirtinimo prašymą el.paštu:"
 
 #: invenio/legacy/websubmit/templates.py:2149
 #: invenio/legacy/websubmit/web/publiline.py:367
@@ -12096,8 +12034,8 @@ msgid ""
 "As a referee for this document, you may approve or reject it from the "
 "submission interface"
 msgstr ""
-"Kaip šio dokumento vertintojas, jus galite patvirtinti ar atmesti "
-"dokumentą paspaudę mygtuką"
+"Kaip šio dokumento vertintojas, jus galite patvirtinti ar atmesti dokumentą "
+"paspaudę mygtuką"
 
 #: invenio/legacy/websubmit/templates.py:2155
 msgid "Approve/Reject"
@@ -12134,7 +12072,8 @@ msgstr "Pirmą kartą prašoma įvertinti pagal "
 #: invenio/legacy/websubmit/templates.py:2264
 #: invenio/legacy/websubmit/templates.py:2318
 msgid "Last request e-mail was sent to the publication committee chair on the "
-msgstr "paskutinis el.laiškas buvo išsiųstas publikacijų komiteto atstovui apie"
+msgstr ""
+"paskutinis el.laiškas buvo išsiųstas publikacijų komiteto atstovui apie"
 
 #: invenio/legacy/websubmit/templates.py:2268
 msgid "A referee has been selected by the publication committee on the "
@@ -12152,11 +12091,10 @@ msgstr "Pasirinkti įvertinimą"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
-"Vertintojas išsiuntė savo rekomendacijas publikacijų komiteto atstovui "
-"apie "
+"Vertintojas išsiuntė savo rekomendacijas publikacijų komiteto atstovui apie "
 
 #: invenio/legacy/websubmit/templates.py:2281
 #: invenio/legacy/websubmit/templates.py:2342
@@ -12174,8 +12112,8 @@ msgstr "Išsiųsti rekomendaciją."
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 "Publikacijų komiteto atstovas atsiuntė savo galutines rekomendacijas "
 "projekto vadovuiapie "
@@ -12218,7 +12156,8 @@ msgid "Take a decision"
 msgstr "Priimti sprendimą"
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr "Publikacijų komitetas išrinko redaktorių kolegiją atsižvelgiant į "
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12239,17 +12178,17 @@ msgstr "Redaktorių kolegija pasirinko vertintoją atsižvelgiant į"
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
-msgstr "Vertintojas išsiuntė galutines rekomendacijas redaktorių kolegijai apie "
+"The referee has sent his final recommendations to the editorial board on the "
+msgstr ""
+"Vertintojas išsiuntė galutines rekomendacijas redaktorių kolegijai apie "
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
-"Redaktorių kolegija išsiuntė galutines rekomendacijas publikacijų "
-"komitetui apie "
+"Redaktorių kolegija išsiuntė galutines rekomendacijas publikacijų komitetui "
+"apie "
 
 #: invenio/legacy/websubmit/templates.py:2350
 msgid "No recommendation from the editorial board yet."
@@ -12351,8 +12290,7 @@ msgid ""
 "Note that your submission has been inserted into the bibliographic task "
 "queue and is waiting for execution.\n"
 msgstr ""
-"Jūsų patalpinti dokumentai laukia eilėje  ir netrukus bus pradėti "
-"vykdyti.\n"
+"Jūsų patalpinti dokumentai laukia eilėje  ir netrukus bus pradėti vykdyti.\n"
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:206
 #, fuzzy, python-format
@@ -12368,14 +12306,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
-"Dėl žmogaus įsikišimo ar dėl iškilusių kitų problemų, užduočių eilė "
-"vykdoma rakiniu būdu. Jūsų patalpinti dokumentai sėkmingai užregistruoti,"
-" bet patalpinimo procesas gali užtrukti ilgiau nei įprasta.\n"
+"Dėl žmogaus įsikišimo ar dėl iškilusių kitų problemų, užduočių eilė vykdoma "
+"rakiniu būdu. Jūsų patalpinti dokumentai sėkmingai užregistruoti, bet "
+"patalpinimo procesas gali užtrukti ilgiau nei įprasta.\n"
 
 #: invenio/legacy/websubmit/web/approve.py:53
 msgid "approve.py: cannot determine document reference"
@@ -12658,8 +12595,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12702,11 +12639,6 @@ msgstr "prisijungę"
 #, fuzzy
 msgid "Role details"
 msgstr "Daugiau informacijos"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Paslėpti"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12822,11 +12754,11 @@ msgstr "Įvestas el.paštas %s jau yra duomenų bazėje."
 #: invenio/modules/accounts/forms.py:94
 #, fuzzy, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
-"Jei pasikeis jūsų el.pašto adresas, jus turite %(x_url_open)snustatyti "
-"naują slaptažodį%(x_url_close)s."
+"Jei pasikeis jūsų el.pašto adresas, jus turite %(x_url_open)snustatyti naują "
+"slaptažodį%(x_url_close)s."
 
 #: invenio/modules/accounts/forms.py:117
 #, fuzzy, python-format
@@ -12890,9 +12822,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, fuzzy, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 "Jus dar vis atskiriama(-s) centralizuotos sistemos\n"
 "                %(x_fmt_open)sSSO%(x_fmt_close)s. Jus taip pat galite\n"
@@ -12919,8 +12850,8 @@ msgstr "Keisti slaptažodį"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr "Įrašykite savo el.paštą, vartotojo vardą ir slaptažodį:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -12950,7 +12881,7 @@ msgid "Problem with login."
 msgstr "Palyginti su originalu"
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "Galite prisijungti prie  %(x_url_open)spaskyros%(x_url_close)s."
 
@@ -12993,8 +12924,7 @@ msgstr "Bibcatalog autorizavimo redaguoti nepavyko."
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13066,13 +12996,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13081,9 +13010,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13256,8 +13185,7 @@ msgstr "rinkiniai"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13348,8 +13276,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13441,10 +13369,10 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
 "Jūsų žintė viršija leistina simbolių skaičių. Prašome paredaguoti ją. "
 "Leistinas simbolių skaičius %i "
@@ -13490,12 +13418,12 @@ msgid "Review was sent"
 msgstr "Rašyti komentarą"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Apie šį komentarą buvo pranešta %i kartą(-us)"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Apie šį komentarą buvo pranešta %i kartą(-us)"
 
@@ -13548,9 +13476,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13569,8 +13496,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13580,7 +13507,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "Failo vardas %s jau egzistuoja. Pasirinkite kitą vardą."
 
@@ -13636,8 +13563,7 @@ msgstr "atsiliepimas"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13677,8 +13603,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13725,7 +13650,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "Funkcija %s neegzistuoja."
 
@@ -13811,11 +13736,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "Duomenų išgavimo būsena"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Jūsų \"etiketės\" "
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -13850,8 +13770,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13872,8 +13792,8 @@ msgstr "Nėra žodžio indekso %s. "
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13889,8 +13809,7 @@ msgstr "Formato elemnto %s patvirtinimas"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14010,7 +13929,7 @@ msgstr "Parodyti visus %i autorius"
 msgid "Manage Files of This Record"
 msgstr "Tvarkyti šio įrašo failus"
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr "Redaguoti šį įrašą"
 
@@ -14204,8 +14123,8 @@ msgstr "Tvarkyti grupės teises"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "Neturite reikiamų teisių šiam elementui peržiūrėti."
 
 #: invenio/modules/groups/views.py:279
@@ -14218,12 +14137,12 @@ msgstr "Jus neadministruojate grupių."
 msgid "Members"
 msgstr "Nėra narių."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Nežinomas žinių bazės vardas"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14233,11 +14152,11 @@ msgstr "Nieko"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "bet kuris laukelis"
@@ -14283,13 +14202,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "Nėra įrašų paminėtų %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "Nėra įrašų paminėtų %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14444,28 +14364,28 @@ msgstr "Nežinomas dokumento tipas"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14530,8 +14450,8 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr "Jei norite pabaigti naujos paskyros registraciją:"
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -14904,7 +14824,7 @@ msgid "Tag name"
 msgstr "Vartotojo vardas"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "Pageidaujamas vartotojo vardas %s jau egzistuoja."
 
@@ -15056,8 +14976,7 @@ msgstr "Užsakymo pasirinkimai"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15119,7 +15038,7 @@ msgid "Identifiers"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/styles/harvesting_record.html:45
-#, fuzzy, python-format
+#, fuzzy
 msgid "Categories"
 msgstr "%(category)s Puslapiai"
 
@@ -15266,7 +15185,7 @@ msgid "just now"
 msgstr "Dabar turite"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s sekundės"
 
@@ -15325,6 +15244,48 @@ msgstr "bet kurie metai"
 msgid " years ago"
 msgstr "metai"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "BibCheck modulio administratorius"
+
+#~ msgid "Not authorized"
+#~ msgstr "Nėra reikiamų teisių"
+
+#~ msgid "Limit to knowledge bases containing string:"
+#~ msgstr "Apriboti žinių bazės frazių rinkį:"
+
+#~ msgid "Really delete"
+#~ msgstr "Ištrinti"
+
+#~ msgid "Verify syntax"
+#~ msgstr "Patikrinti sintaksę"
+
+#~ msgid "Calling bibcheck -verify failed."
+#~ msgstr "Kviečiamas bibcheck - patikrinimas nepavyko."
+
+#~ msgid "Verify BibCheck config file"
+#~ msgstr "Patikrinti  BibCheck konfiguracinius failus"
+
+#~ msgid "Verify problem"
+#~ msgstr "Patikrinimo problemos"
+
+#~ msgid "File"
+#~ msgstr "Failas"
+
+#~ msgid "Edit BibCheck config file"
+#~ msgstr "Redaguoti BibCheck konfiguracinius failus"
+
+#~ msgid "Save BibCheck config file"
+#~ msgstr "Išsaugoti BibCheck konfiguracinį failą."
+
+#~ msgid "Delete BibCheck config file"
+#~ msgstr "Ištrinti BibCheck konfiguracinį failą"
+
+#~ msgid "Id"
+#~ msgstr "ID"
+
+#~ msgid "Tickets"
+#~ msgstr "\"etiketės\""
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Įspėjimas: Prašome pasirinkti tinkamą laiką"
 
@@ -15343,17 +15304,11 @@ msgstr "metai"
 #~ msgid "*** basket name ***"
 #~ msgstr "*** krepšelio vardas ***"
 
-#~ msgid ""
-#~ msgstr ""
-
 #~ msgid "%(x_name)s"
 #~ msgstr "%(x_sitename)s nuoroda"
 
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "Papildoma nurodomoji metrika"
-
-#~ msgid "Sorry, you must log in to perform this action."
-#~ msgstr ""
 
 #~ msgid "Please log in first."
 #~ msgstr "Prašome prisijungti."
@@ -15445,12 +15400,6 @@ msgstr "metai"
 #~ msgid "now"
 #~ msgstr "dabar"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "BibCheck modulio administratorius"
-
-#~ msgid "Not authorized"
-#~ msgstr "Nėra reikiamų teisių"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "Vartotojas %s neegzistuoja."
 
@@ -15459,30 +15408,6 @@ msgstr "metai"
 
 #~ msgid "ERROR: %s is not writable"
 #~ msgstr "negalima įrašyti"
-
-#~ msgid "Limit to knowledge bases containing string:"
-#~ msgstr "Apriboti žinių bazės frazių rinkį:"
-
-#~ msgid "Really delete"
-#~ msgstr "Ištrinti"
-
-#~ msgid "Verify syntax"
-#~ msgstr "Patikrinti sintaksę"
-
-#~ msgid "Calling bibcheck -verify failed."
-#~ msgstr "Kviečiamas bibcheck - patikrinimas nepavyko."
-
-#~ msgid "Verify BibCheck config file"
-#~ msgstr "Patikrinti  BibCheck konfiguracinius failus"
-
-#~ msgid "Verify problem"
-#~ msgstr "Patikrinimo problemos"
-
-#~ msgid "File"
-#~ msgstr "Failas"
-
-#~ msgid "Edit BibCheck config file"
-#~ msgstr "Redaguoti BibCheck konfiguracinius failus"
 
 #~ msgid "File %s already exists."
 #~ msgstr "Toks failas jau yra"
@@ -15493,17 +15418,11 @@ msgstr "metai"
 #~ msgid "File %s: write failed."
 #~ msgstr "nepavyko įrašyti."
 
-#~ msgid "Save BibCheck config file"
-#~ msgstr "Išsaugoti BibCheck konfiguracinį failą."
-
 #~ msgid "File %s deleted."
 #~ msgstr "Failai %s neegzistuoja."
 
 #~ msgid "File %s: delete failed."
 #~ msgstr "nepavyko ištrinti"
-
-#~ msgid "Delete BibCheck config file"
-#~ msgstr "Ištrinti BibCheck konfiguracinį failą"
 
 #~ msgid "Guests are not authorized to run batchuploader"
 #~ msgstr "Svečiai neturi teisių paleisti \"batchuploader\""
@@ -15550,9 +15469,6 @@ msgstr "metai"
 #~ msgid "Not Mine!"
 #~ msgstr "Nėra rinkinio"
 
-#~ msgid "Tickets"
-#~ msgstr "\"etiketės\""
-
 #~ msgid "Request Tickets"
 #~ msgstr "Prašymai"
 
@@ -15588,9 +15504,6 @@ msgstr "metai"
 
 #~ msgid "Create a new Person for your search"
 #~ msgstr "Nerasta rezultatų pagal jūsų paiešką."
-
-#~ msgid "Id"
-#~ msgstr "ID"
 
 #~ msgid "."
 #~ msgstr "."
@@ -15706,34 +15619,11 @@ msgstr "metai"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "WebSubmit modulio administravimo vadovas"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "Vykdyti paiešką"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Atšauktas"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "Jus esate narys šiose grupėse:"
@@ -15747,12 +15637,6 @@ msgstr "metai"
 #~ msgid "Invert Selection"
 #~ msgstr "Vertintojo pasirinkimas"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Autorius"
 
@@ -15764,12 +15648,6 @@ msgstr "metai"
 
 #~ msgid "No status information found."
 #~ msgstr "Užsakyti informaciją"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "Peržiūrėjimas"
@@ -15786,15 +15664,6 @@ msgstr "metai"
 #~ msgid "The author has an internal ID!"
 #~ msgstr "Vidinė klaida"
 
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "Rodyti komentarus"
 
@@ -15804,32 +15673,8 @@ msgstr "metai"
 #~ msgid " Delete this ticket"
 #~ msgstr "Ištrinti krepšelį"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "Nėra prieinamų žurnalų"
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Pasirinkite rezultatą"
@@ -15840,51 +15685,11 @@ msgstr "metai"
 #~ msgid "Paper title: "
 #~ msgstr "Periodinis pavadinimas"
 
-#~ msgid "Ignore"
-#~ msgstr ""
-
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "Šie failai buvo sėkmingai įkelti:"
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "Pasirinkite rezultatą"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "Naujo tiekėjo informacija"
@@ -15892,35 +15697,14 @@ msgstr "metai"
 #~ msgid "Please provide your first name"
 #~ msgstr "Prašome prisijungti."
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "Jūsų užsakymai"
-
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
 
 #~ msgid "Your eMail:"
 #~ msgstr "Jūsų įspėjimai"
 
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
 #~ msgid "Continue claiming*"
 #~ msgstr "Tęsti vis tiek"
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "Ištrinti pasirinktus atsiliepimus"
@@ -15928,256 +15712,38 @@ msgstr "metai"
 #~ msgid "Mark as your documents"
 #~ msgstr "visi dokumentų tipai"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "Atgal į dokumentą"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Atgal į dokumentą"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "Sukurti naują grupę"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "Pridėti prie vartotojų"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Popieriai:"
-
-#~ msgid "Showing the"
-#~ msgstr ""
 
 #~ msgid "most recent documents:"
 #~ msgstr "Sąrašas įvertintų dokumentų"
 
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Tvarkyti dokumento failus"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Pasirinkite failą"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Išleidimo data"
-
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
 
 #~ msgid "add external id"
 #~ msgstr "išorinė nuoroda"
 
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
-
-#~ msgid "suggest missing ids"
-#~ msgstr ""
-
 #~ msgid "Choose system"
 #~ msgstr "Pasirinkti šabloną"
-
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Šie failai buvo sėkmingai įkelti:"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
 
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Neturite tinkamų teisių naudotis administravimo funkcijomis."
@@ -16185,63 +15751,8 @@ msgstr "metai"
 #~ msgid "Claim this paper"
 #~ msgstr "pridėti šį vartotoją"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The publication date of this book is %s."
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Cituota: %s įrašuose"
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
 
 #~ msgid "Comparison of:"
 #~ msgstr "Palyginimas:"
@@ -16251,27 +15762,6 @@ msgstr "metai"
 
 #~ msgid "Failed to create a ticket"
 #~ msgstr "Nepavyko sukurti \"etiketės\""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Redaguoti šablonus"
@@ -16351,89 +15841,20 @@ msgstr "metai"
 #~ msgid "No Record Found for %s."
 #~ msgstr "Įrašas nerastas"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Failai %s neegzistuoja."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "Išeitinio formato %s atributai"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "Formato šablono %s prieklausos"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "Formato elemnto %s patvirtinimas"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "Formato elemento %s prieklausos"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Ribotas išeitinis formatas"
@@ -16489,75 +15910,17 @@ msgstr "metai"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Formato elemnto %s patvirtinimas"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "Formato patvirtinimas"
 
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "Žinių bazė %s"
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "Nėra rinkinio"
 
 #~ msgid "never"
 #~ msgstr "niekada"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "kartai"
@@ -16571,12 +15934,6 @@ msgstr "metai"
 #~ msgid "Frequent keywords"
 #~ msgstr "Dažniausiai naudojami raktažodžiai:"
 
-#~ msgid "No Subject categories"
-#~ msgstr ""
-
-#~ msgid "Subject categories"
-#~ msgstr ""
-
 #~ msgid "No Collaborations"
 #~ msgstr "Rinkiniai"
 
@@ -16589,17 +15946,11 @@ msgstr "metai"
 #~ msgid "Affiliations"
 #~ msgstr "Narystė:"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
 #~ msgid "No Frequent Co-authors"
 #~ msgstr "Dažniausi bendraautoriai"
 
 #~ msgid "Citations%s"
 #~ msgstr "Citatų šaltiniai"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Išleidimo data"
@@ -16610,39 +15961,6 @@ msgstr "metai"
 #~ msgid "No publications available"
 #~ msgstr "Nėra informacijos"
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "%s View your previously submitted comments"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr "Pacituota 1 įraše"
 
@@ -16652,17 +15970,11 @@ msgstr "metai"
 #~ msgid "%i reviews"
 #~ msgstr "%i atsiliepimų "
 
-#~ msgid "%s of"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "Popieriai:"
 
 #~ msgid "Frequent co-authors"
 #~ msgstr "Dažniausi bendraautoriai"
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "Citavimas:"
@@ -16670,26 +15982,8 @@ msgstr "metai"
 #~ msgid "No Citation Information available"
 #~ msgstr "Nėra informacijos"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Diskusijos"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid "If you don't own an account yet, please contact %s."
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Jūsų įspėjimai"
@@ -16712,13 +16006,6 @@ msgstr "metai"
 #~ msgid "Group: %s"
 #~ msgstr "Grupės: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "Puslapis %s nerastas "
 
@@ -16726,69 +16013,5 @@ msgstr "metai"
 #~ msgstr "Laukas %s yra privalomas."
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "Negalima nustatyti patalpintų puslapių skaičiaus."
-

--- a/invenio/base/translations/no/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/no/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2008-07-10 13:15+0200\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:58+0200\n"
 "Last-Translator: Lars Christian Raae <lars.christian.raae@cern.ch>\n"
 "Language-Team: NO <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -44,7 +44,8 @@ msgstr "Du har ikke tilgang til å se dette området."
 #: invenio/base/templates/401.html:29
 #, fuzzy
 msgid "You do not have access to this page."
-msgstr "Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
+msgstr ""
+"Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
 
 #: invenio/base/templates/401.html:30 invenio/base/templates/404.html:30
 msgid "Click the following link to go to the main page:"
@@ -58,8 +59,8 @@ msgstr "Administratorsider"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -205,7 +206,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Hallo:"
 
@@ -226,17 +227,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -262,48 +263,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Elementet finnes ikke."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr "Forespørsel om tilbakestilling av passord for"
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Du har ikke tilgang til å se dette området."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Registrering mislyktes"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Velg én eller flere:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Forespørsel om godkjenning av rolle"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -502,7 +508,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -579,9 +586,9 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"Du er logget inn som %(x_user)s. Du bør muligens a) %(x_url1_open)slogge "
-"ut%(x_url1_close)s; b) endre dine "
-"%(x_url2_open)skontoinnstillinger%(x_url2_close)s."
+"Du er logget inn som %(x_user)s. Du bør muligens a) %(x_url1_open)slogge ut"
+"%(x_url1_close)s; b) endre dine %(x_url2_open)skontoinnstillinger"
+"%(x_url2_close)s."
 
 #: invenio/legacy/batchuploader/templates.py:282
 #, fuzzy
@@ -725,7 +732,8 @@ msgid "The following errors have occurred:"
 msgstr "Følgende feil ble funnet"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -742,8 +750,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -825,7 +833,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -868,8 +876,8 @@ msgstr "Dine kurver"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Forrige"
@@ -885,8 +893,8 @@ msgstr "Rating"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Neste"
 
@@ -901,18 +909,6 @@ msgstr "Neste"
 #: invenio/legacy/weblinkback/adminlib.py:55
 msgid "Admin Area"
 msgstr "Administratorområde"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "forfatter"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
@@ -932,11 +928,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
 msgid "Limit to knowledge bases containing string:"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "ble slettet"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -988,16 +979,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
 msgid "Verify BibCheck config file"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Databaseproblem"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "fil(er)"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
@@ -1104,7 +1085,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1155,8 +1137,8 @@ msgstr "En ny konto er opprettet på"
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1170,25 +1152,23 @@ msgstr "Bla gjennom"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "En ny konto er opprettet på"
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "En ny konto er opprettet på"
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1213,13 +1193,14 @@ msgstr "Opprett nytt emne"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "En ny konto er opprettet på"
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1251,9 +1232,8 @@ msgstr "status:"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "En ny konto er opprettet på"
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1320,8 +1300,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1329,8 +1309,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1352,9 +1332,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "En ny konto er opprettet på"
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1396,8 +1375,8 @@ msgstr "%s elementer funnet"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1456,11 +1435,11 @@ msgstr "En ny konto er opprettet på"
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1471,11 +1450,11 @@ msgstr "Ja"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1488,8 +1467,8 @@ msgstr "Nei"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1586,8 +1565,8 @@ msgstr "<strong>%s</strong> poster funnet"
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1607,29 +1586,29 @@ msgstr "<strong>%s</strong> poster funnet"
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1638,9 +1617,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr "Element eksisterer ikke."
 
@@ -2001,16 +1980,14 @@ msgstr "Elementer har blitt slettet."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2031,8 +2008,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2194,8 +2171,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2305,7 +2282,7 @@ msgstr "Handling"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Beskrivelse"
 
@@ -2500,8 +2477,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2787,9 +2764,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "Hvis du ønsker kan du %(x_url_open)slogge inn her%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2845,7 +2821,7 @@ msgstr "Avslå"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "OK"
 
@@ -2853,8 +2829,8 @@ msgstr "OK"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "En ny konto er opprettet på"
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3327,8 +3303,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "E-post"
 
@@ -4181,8 +4157,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4200,8 +4176,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4267,17 +4243,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4665,25 +4641,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "Elementer har blitt slettet."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4744,15 +4720,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4764,10 +4740,10 @@ msgstr "Velg emne"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4781,15 +4757,15 @@ msgstr "mindre"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4800,7 +4776,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4819,17 +4796,15 @@ msgstr "Ønsket brukernavn %s finnes i databasen fra før."
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "Ønsket brukernavn %s finnes i databasen fra før."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4848,14 +4823,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4909,8 +4883,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4965,11 +4939,10 @@ msgstr "Element eksisterer ikke."
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
-"Det har oppstått en systemfeil under henting av dette dokumentets "
-"filliste."
+"Det har oppstått en systemfeil under henting av dette dokumentets filliste."
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
 #: invenio/legacy/websession/webinterface.py:1023
@@ -5086,9 +5059,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -5103,8 +5076,8 @@ msgstr "Lagre endringer"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -5248,11 +5221,10 @@ msgstr "Tilbake til søkeresultatene"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5389,7 +5361,7 @@ msgid "Total"
 msgstr "valgfritt"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Merk"
 
@@ -5560,8 +5532,8 @@ msgstr "Slett kunnskapsbase"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5620,56 +5592,56 @@ msgstr "Vennligst logg inn først."
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5709,7 +5681,7 @@ msgstr "Kunnskapsbase avhengigheter"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5763,15 +5735,15 @@ msgstr "Dine varsler"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5999,8 +5971,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -6079,8 +6050,8 @@ msgstr "Fagkonsulentvalg"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6095,8 +6066,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Søkeresultater"
 
@@ -6257,8 +6228,8 @@ msgstr "Fant ingen verdier."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6284,8 +6255,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6296,42 +6267,40 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
 #, python-format
 msgid "No exact match found for %(x_query1)s, using %(x_query2)s instead..."
 msgstr ""
-"Fikk ingen nøyaktige treff for %(x_query1)s, bruker %(x_query2)s i "
-"stedet..."
+"Fikk ingen nøyaktige treff for %(x_query1)s, bruker %(x_query2)s i stedet..."
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
-"Fikk ingen treff i samling %(x_collection)s. Andre offentlige samlinger "
-"gav %(x_url_open)s%(x_nb_hits)d treff%(x_url_close)s."
+"Fikk ingen treff i samling %(x_collection)s. Andre offentlige samlinger gav "
+"%(x_url_open)s%(x_nb_hits)d treff%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 "Ingen offentlige samlinger passet ditt søk. Dersom du så etter et ikke-"
 "offentlig dokument, velg den ønskede adgangsbegrensede samlingen først."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
@@ -6339,58 +6308,60 @@ msgstr ""
 "Ingen offentlige samlinger passet ditt søk. Dersom du så etter et ikke-"
 "offentlig dokument, velg den ønskede adgangsbegrensede samlingen først."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
-msgstr "Søkeuttrykk %s passet ingen elementer. Nærmeste uttrykk i noen samling er:"
+msgstr ""
+"Søkeuttrykk %s passet ingen elementer. Nærmeste uttrykk i noen samling er:"
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "Bruk et annet søkeuttrykk."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Det finnes %i kurver"
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Det finnes %i kurver"
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Det finnes %i kurver"
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Ingen ordindeks tilgjengelig for"
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Ingen uttrykksindeks tilgjengelig for"
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
-"Søkeuttrykk %(x_term)s i indeks %(x_index)s passet ingen elementer. "
-"Nærmeste uttrykk i noen samling er:"
+"Søkeuttrykk %(x_term)s i indeks %(x_index)s passet ingen elementer. Nærmeste "
+"uttrykk i noen samling er:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
-msgstr "Søkeuttrykk %s passet ingen elementer. Nærmeste uttrykk i noen samling er:"
+msgstr ""
+"Søkeuttrykk %s passet ingen elementer. Nærmeste uttrykk i noen samling er:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
@@ -6399,35 +6370,35 @@ msgstr ""
 "Beklager, %s er ikke et gyldig sorteringsvalg. Bruker tittelsortering i "
 "stedet."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
-"Beklager, sortering er kun tillatt på sett av opp til %d elementer. "
-"Bruker standard sorteringsorden."
+"Beklager, sortering er kun tillatt på sett av opp til %d elementer. Bruker "
+"standard sorteringsorden."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 "Beklager, %s er ikke et gyldig sorteringsvalg. Bruker tittelsortering i "
 "stedet."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Elementet finnes ikke."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Bruk et annet søkeuttrykk."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6441,13 +6412,14 @@ msgstr "Bruk et annet søkeuttrykk."
 msgid "Browse"
 msgstr "Bla gjennom"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr "Ingen treff innen angitt tidsbegrensning, forkaster dette kriteriet..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
-msgstr "Ingen treff innen angitte søkebegrensninger, forkaster dette kriteriet..."
+msgstr ""
+"Ingen treff innen angitte søkebegrensninger, forkaster dette kriteriet..."
 
 #: invenio/legacy/webalert/api.py:54
 #, fuzzy, python-format
@@ -6462,7 +6434,8 @@ msgstr "ukjent"
 #: invenio/legacy/webalert/api.py:303 invenio/legacy/webalert/api.py:341
 #, fuzzy
 msgid "You do not have rights for this operation."
-msgstr "Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
+msgstr ""
+"Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
 
 #: invenio/legacy/webalert/api.py:198
 msgid "You already have an alert defined for the specified query and basket."
@@ -6489,15 +6462,13 @@ msgstr "Varselet %s er oppdatert."
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Du har gjort %(x_nb)s spørringer. En %(x_url_open)sdetaljert "
-"liste%(x_url_close)s er tilgjengelig med mulighet for å (a) se "
-"søkeresultatene og (b) abonnere på en automatisk e-postvarsling for disse"
-" spørringene."
+"Du har gjort %(x_nb)s spørringer. En %(x_url_open)sdetaljert liste"
+"%(x_url_close)s er tilgjengelig med mulighet for å (a) se søkeresultatene og "
+"(b) abonnere på en automatisk e-postvarsling for disse spørringene."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6690,20 +6661,20 @@ msgstr "Du har angitt %s varsler."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
-"Du har ikke utført noe søk ennå. Gå til "
-"%(x_url_open)ssøkesiden%(x_url_close)s først."
+"Du har ikke utført noe søk ennå. Gå til %(x_url_open)ssøkesiden"
+"%(x_url_close)s først."
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
-"Du har utført %(x_nb1)s søk (%(x_nb2)s ulike spørsmål) i løpet av de "
-"siste 30 dagene eller så."
+"Du har utført %(x_nb1)s søk (%(x_nb2)s ulike spørsmål) i løpet av de siste "
+"30 dagene eller så."
 
 #: invenio/legacy/webalert/templates.py:453
 #, fuzzy, python-format
@@ -6761,7 +6732,7 @@ msgstr "Dine søk"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6825,7 +6796,7 @@ msgstr "%s Brukerinnstillinger, Sett nytt varsel"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6885,7 +6856,8 @@ msgstr "%s Brukerinnstillinger, Vis varsler"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6906,10 +6878,12 @@ msgstr "Legg i offentlig kurv"
 #: invenio/legacy/webbasket/api.py:1548 invenio/legacy/webbasket/api.py:1613
 #, fuzzy
 msgid "You do not have permission to write notes to this item."
-msgstr "Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
+msgstr ""
+"Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6934,16 +6908,19 @@ msgstr ""
 #: invenio/legacy/webbasket/api.py:1678
 #, fuzzy
 msgid "You do not have permission to delete this note."
-msgstr "Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
+msgstr ""
+"Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
 #, fuzzy, python-format
 msgid "Sorry, you do not have sufficient rights to add record #%(x_id)i."
-msgstr "Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
+msgstr ""
+"Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
 
 #: invenio/legacy/webbasket/api.py:1797
 msgid "Some of the items were not added due to lack of sufficient rights."
@@ -6968,8 +6945,8 @@ msgstr "Elementet finnes ikke."
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6982,7 +6959,8 @@ msgstr ""
 #: invenio/legacy/webbasket/api.py:2042 invenio/legacy/webbasket/api.py:2111
 #, fuzzy
 msgid "Sorry, you do not have sufficient rights on this basket."
-msgstr "Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
+msgstr ""
+"Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
 
 #: invenio/legacy/webbasket/api.py:1920
 #, fuzzy
@@ -6991,8 +6969,8 @@ msgstr "Kopier element til kurv"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -7025,8 +7003,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7099,8 +7077,7 @@ msgstr "Offentlig kurv"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 "Du har %(x_nb_perso)s egne kurver og abonnerer på %(x_nb_group)s "
 "gruppekurver og %(x_nb_public)s av andre brukeres offentlige kurver."
@@ -7130,11 +7107,10 @@ msgstr "%i brukergrupper abonnerer på denne kurven."
 #: invenio/legacy/webbasket/templates.py:108
 #, fuzzy, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
-"Du bør kanskje ta en kikk på "
-"%(x_url_open)s\"%(x_category)s\"-sidene%(x_url_close)s."
+"Du bør kanskje ta en kikk på %(x_url_open)s\"%(x_category)s\"-sidene"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
 #: invenio/legacy/webbasket/templates.py:198
@@ -7245,7 +7221,8 @@ msgstr "Det er for tiden ingen offentlig tilgjengelig kurv."
 msgid ""
 "Displaying public baskets %(x_from)i - %(x_to)i out of "
 "%(x_total_public_basket)i public baskets in total."
-msgstr "Viser kurv %(x_nb_begin)i-%(x_nb_end)i av totalt %(x_nb_total)i kurver."
+msgstr ""
+"Viser kurv %(x_nb_begin)i-%(x_nb_end)i av totalt %(x_nb_total)i kurver."
 
 #: invenio/legacy/webbasket/templates.py:1376
 #: invenio/legacy/webbasket/templates.py:1400
@@ -7304,8 +7281,8 @@ msgstr "Eksternt element"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7490,20 +7467,21 @@ msgstr "Deler kurv til ny gruppe."
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
-"Du er logget inn som gjestebruker, dine kurver vil forsvinne når sesjonen"
-" avsluttes."
+"Du er logget inn som gjestebruker, dine kurver vil forsvinne når sesjonen "
+"avsluttes."
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
-"Hvis du ønsker kan du %(x_url_open)slogge inn eller registrere deg "
-"her%(x_url_close)s."
+"Hvis du ønsker kan du %(x_url_open)slogge inn eller registrere deg her"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7512,7 +7490,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Denne funksjonaliteten er ikke tilgjengelig for gjestebrukere."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Tilbake til søkeresultatene"
 
@@ -7574,7 +7552,8 @@ msgstr "Denne samlingen inneholder ingen dokumenter ennå."
 
 #: invenio/legacy/webbasket/templates.py:2519
 msgid "You do not have sufficient rights to view this basket's content."
-msgstr "Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
+msgstr ""
+"Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
 
 #: invenio/legacy/webbasket/templates.py:2562
 msgid "Move item up"
@@ -7662,12 +7641,14 @@ msgstr "Elementet finnes ikke."
 #: invenio/legacy/webbasket/templates.py:3847
 #, fuzzy
 msgid "You do not have sufficient rights to view this item's notes."
-msgstr "Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
+msgstr ""
+"Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
 
 #: invenio/legacy/webbasket/templates.py:3066
 #, fuzzy
 msgid "You do not have sufficient rights to view this item."
-msgstr "Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
+msgstr ""
+"Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
 
 #: invenio/legacy/webbasket/templates.py:3173
 #: invenio/legacy/webbasket/templates.py:3184
@@ -7687,7 +7668,7 @@ msgstr "Legg til brukere"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7834,219 +7815,218 @@ msgstr "Brukeren %s finnes ikke."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "Brukeren %s finnes ikke."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Skriv en kommentar"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_name)s skrev den %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Viser siste %i kommentarer:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Diskuter dette dokumentet"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Start en diskusjon om dette dokumentet."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Beklager, elementet %s finnes ikke."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "Beklager, %s er ikke et gyldig ID-nummer."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "Beklager, ingen ID-nummer ble angitt."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Du bør muligens begynne å bla fra %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_name)s skrev den %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Var denne vurderingen nyttig?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Skriv en vurdering"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 "Gjennomsnittlig rangering: %(x_nb_score)s basert på %(x_nb_reviews)s "
 "vurderinger"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "Lesere syntes de følgende %s vurderingene var nyttigst."
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Vis alle %s vurderinger"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Ranger dette dokumentet"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Bli den første til å vurdere dette dokumentet."
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "Rating"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Rapporter misbruk"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 #, fuzzy
 msgid "Undelete comment"
 msgstr "slette kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Slett kommentar"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 #, fuzzy
 msgid "Unreport comment"
 msgstr "Slett kommentar"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Vurdert av %(x_nickname)s den %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
-"%(x_nb_people)i av %(x_nb_total)i lesere syntes denne vurderingen var "
-"nyttig"
+"%(x_nb_people)i av %(x_nb_total)i lesere syntes denne vurderingen var nyttig"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 #, fuzzy
 msgid "Undelete review"
 msgstr "Slett merkede vurderinger"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 #, fuzzy
 msgid "Delete review"
 msgstr "Slett merkede vurderinger"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 #, fuzzy
 msgid "Unreport review"
 msgstr "Skriv vurderingen din"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Vurderinger"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Det er totalt %s vurderinger"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Det er totalt %s kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Bli den første til å vurdere dette dokumentet."
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Abonner"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 #, fuzzy
 msgid "Unsubscribe"
 msgstr "Abonner"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -8055,43 +8035,43 @@ msgstr "Abonner"
 msgid "Record"
 msgstr "Element"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "vurdering"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "kommentar"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Vurdering"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Viser"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Side:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 #, fuzzy
 msgid "You are not authorized to comment or review."
 msgstr "Du har ikke tilgang til å se dette området."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
-msgstr "Merk: Ditt brukernavn, %s, vil vises som forfatter av denne kommentarer"
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
+msgstr ""
+"Merk: Ditt brukernavn, %s, vil vises som forfatter av denne kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
@@ -8100,473 +8080,477 @@ msgstr ""
 "Merk: Du har ikke %(x_url_open)sangitt et brukernavn%(x_url_close)s. "
 "%(x_nickname)s vil vises som forfatter av denne kommentaren."
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 #, fuzzy
 msgid "Max one file"
 msgstr "Ny regel"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "Hovedfil(er)"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Artikkel"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "Legg til kommentar"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
-msgstr "Merk: Ditt brukernavn, %s, vil vises som forfatter av denne vurderingen."
+msgstr ""
+"Merk: Ditt brukernavn, %s, vil vises som forfatter av denne vurderingen."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Ranger denne artikkelen"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Velg en rangering"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Gi vurderingen din en tittel"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Skriv vurderingen din"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr "Legg til vurdering"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Legg til vurdering"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Din vurdering er lagt til."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Din kommentar er lagt til."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Tilbake til element"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr "Se oversikten over %(x_url_open)sdine grupper%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 #, fuzzy
 msgid "View most commented records"
 msgstr "Se kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 #, fuzzy
 msgid "View latest commented records"
 msgstr "Se kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all comments reported as abuse"
 msgstr "Vis alle rapporterte brukere"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 #, fuzzy
 msgid "View most reviewed records"
 msgstr "fjerne elementer"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 #, fuzzy
 msgid "View latest reviewed records"
 msgstr "Vis alle %s vurderinger"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all reviews reported as abuse"
 msgstr "Vis alle rapporterte brukere"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Vis alle rapporterte brukere"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Guide"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Kommentarer og vurderinger er slått av"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"Oppgi kommentaren/vurderingens ID for å vise den, før du avgjør om den "
-"skal slettes eller ikke."
+"Oppgi kommentaren/vurderingens ID for å vise den, før du avgjør om den skal "
+"slettes eller ikke."
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "Kommentar-ID:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 #, fuzzy
 msgid "Record ID:"
 msgstr "element-ID"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Vis kommentar"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Ingen rapporteringer hittil."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Vis alle %s rapporterte kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Vis alle %s rapporterte vurderinger"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-"Viser brukere som har fått minst én kommentar rapportert, sortert på "
-"antall rapporteringer."
+"Viser brukere som har fått minst én kommentar rapportert, sortert på antall "
+"rapporteringer."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Brukernavn"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "Bruker-ID"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Antall positive stemmer"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Antall negative stemmer"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Totalt antall stemmer"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Totalt antall rapporteringer"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Se alle rapporterte kommentarer/vurderinger fra denne brukeren"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Denne vurderingen er rapportert %i ganger."
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Denne kommentaren er rapportert %i ganger."
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Skrevet av"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Generell informasjon"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Slett merkede vurderinger"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Ignorer merket misbruksrapport"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 #, fuzzy
 msgid "Undelete selected reviews"
 msgstr "Slett merkede vurderinger"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 #, fuzzy
 msgid "Undelete selected comments"
 msgstr "Slett merkede kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Slett merkede kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Rapporterte vurderinger fra bruker %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Rapporterte kommentarer fra bruker %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Kommentar/vurdering %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Kommentar/vurdering %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, fuzzy, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Kommentar/vurdering %(x_cmtID)s skrevet av bruker %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, fuzzy, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Kommentar/vurdering %(x_cmtID)s skrevet av bruker %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "Alle rapporterte vurderinger sortert på antall rapporteringer"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "Alle rapporterte kommentarer sortert på antall rapporteringer"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr "Alle rapporterte vurderinger sortert på antall rapporteringer"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 #, fuzzy
 msgid "Show comments"
 msgstr "Se kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr "Alle rapporterte kommentarer sortert på antall rapporteringer"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 #, fuzzy
 msgid "Show reviews"
 msgstr "vurdering"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "kommentar-ID"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "ble slettet"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 #, fuzzy
 msgid "successfully undeleted"
 msgstr "ble slettet"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "misbruksrapport ble ignorert"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Ingen vurderinger ennå"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "Kommentaren din ble postet"
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Slett kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "siste først"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "Se kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "Detaljer og kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "%s elementer funnet"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Kommentarer"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "ganger"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Legg til brukere"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "Vis"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Opprettet dato"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Neste side"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Vis varsler"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8574,106 +8558,107 @@ msgstr "Vis varsler"
 msgid "Refresh"
 msgstr "Oppdater"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Slett kommentar"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "Fant ingen verdier."
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Fant ikke element"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
-msgstr "Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
+msgstr ""
+"Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Legg til kommentar"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "Vis alle rapporterte kommentarer"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 #, fuzzy
 msgid "Page Not Found"
 msgstr "Fant ikke siden %s"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 #, fuzzy
 msgid "The requested comment could not be found"
 msgstr "Elementet finnes ikke."
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 #, fuzzy
 msgid "The requested file could not be found"
 msgstr "Elementet finnes ikke."
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Du har ikke tilgang til å se dette området."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Kommentarer"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "Vis alle rapporterte kommentarer"
@@ -8792,11 +8777,11 @@ msgstr "Beklager, siden %s finnes ikke."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
-"Du bør kanskje ta en kikk på "
-"%(x_url_open)s\"%(x_category)s\"-sidene%(x_url_close)s."
+"Du bør kanskje ta en kikk på %(x_url_open)s\"%(x_category)s\"-sidene"
+"%(x_url_close)s."
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
 #, fuzzy, python-format
@@ -8862,8 +8847,8 @@ msgstr "Vi kunne ikke tilveiebringe noen journaler"
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 "Det ser ikke ut til å finnes noen journaler på denne tjeneren. Vennligst "
 "kontakt brukerstøtte dersom du mener at dette er feil."
@@ -8881,8 +8866,8 @@ msgid ""
 "You did not provide an argument for a journal name. Please select the "
 "journal you want to read in the list below."
 msgstr ""
-"Du oppga ikke noe journalnavn. Velg journalen du ønsker å se på fra "
-"listen under."
+"Du oppga ikke noe journalnavn. Velg journalen du ønsker å se på fra listen "
+"under."
 
 #: invenio/legacy/webjournal/config.py:268
 msgid "No current issue"
@@ -8894,8 +8879,8 @@ msgstr "Klarte ikke å finne informasjon om aktuell utgave"
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 "Konfigurasjonen for aktuell utgave er tom. Forsøk å angi et utgavenummer "
 "eller sjekk med brukerstøtte."
@@ -8996,11 +8981,6 @@ msgstr ""
 msgid "Apply"
 msgstr "Bruk"
 
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "Brukernavn"
-
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 msgid "WebJournal Admin"
 msgstr "WebJournal Administrator"
@@ -9080,9 +9060,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -9104,8 +9083,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9217,8 +9195,8 @@ msgid ""
 "Your message is too long, please shorten it. Maximum size allowed is "
 "%(x_size)i characters."
 msgstr ""
-"Meldingen er for lang, vennligst rediger den. Maksimal tillatt størrelse "
-"er %i tegn."
+"Meldingen er for lang, vennligst rediger den. Maksimal tillatt størrelse er "
+"%i tegn."
 
 #: invenio/legacy/webmessage/api.py:402
 #, fuzzy, python-format
@@ -9242,7 +9220,8 @@ msgstr "Skriv melding"
 msgid ""
 "Your message could not be sent to the following recipients as it would "
 "exceed their quotas:"
-msgstr "Meldingen kunne ikke sendes til følgende mottakere grunnet deres kvote:"
+msgstr ""
+"Meldingen kunne ikke sendes til følgende mottakere grunnet deres kvote:"
 
 #: invenio/legacy/webmessage/api.py:457
 msgid "Your message has been sent."
@@ -9585,16 +9564,16 @@ msgstr "Søk også i:"
 #: invenio/legacy/websearch/templates.py:1589
 #, fuzzy
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
-"Denne samlingen er adgangsbegrenset. Vennligst autentiser deg hvis du "
-"mener at du har rettigheter til den."
+"Denne samlingen er adgangsbegrenset. Vennligst autentiser deg hvis du mener "
+"at du har rettigheter til den."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9732,8 +9711,7 @@ msgstr "Dine innsendinger"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 "Bolsk spørring ga ingen treff. Forsøk å kombinere søkeuttrykkene dine "
 "annerledes."
@@ -9761,12 +9739,12 @@ msgstr "Du bør muligens begynne å bla fra %s."
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "Sett opp ditt eget %(x_url1_open)se-postvarsel%(x_url1_close)s\n"
-"                                  eller abonner på "
-"%(x_url2_open)sRSS%(x_url2_close)s."
+"                                  eller abonner på %(x_url2_open)sRSS"
+"%(x_url2_close)s."
 
 #: invenio/legacy/websearch/templates.py:3832
 #, fuzzy, python-format
@@ -9956,7 +9934,8 @@ msgid "in"
 msgstr "i"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "Fant du ikke det du lette etter? Gjenta søket på andre tjenere:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9972,8 +9951,7 @@ msgid ""
 "The external search engine has not responded in time. You can check its "
 "results here:"
 msgstr ""
-"Den eksterne søkemotoren svarte ikke i tide. Du kan se dens resultater "
-"her:"
+"Den eksterne søkemotoren svarte ikke i tide. Du kan se dens resultater her:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:146
 #: invenio/legacy/websearch_external_collections/templates.py:154
@@ -10001,8 +9979,8 @@ msgid ""
 "You can consult the list of your external groups directly in the "
 "%(x_url_open)sgroups page%(x_url_close)s."
 msgstr ""
-"Du kan se dine eksterne grupper direkte på "
-"%(x_url_open)sgruppesiden%(x_url_close)s."
+"Du kan se dine eksterne grupper direkte på %(x_url_open)sgruppesiden"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:110
 msgid "External user groups"
@@ -10052,8 +10030,8 @@ msgstr "obligatorisk"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -10063,8 +10041,8 @@ msgstr "Opprett ny kurv"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 "Bruk skjemaet under hvis du ønsker å endre e-postadresse eller sette "
 "brukernavn for første gang."
@@ -10083,16 +10061,16 @@ msgstr "Lagre innstillinger"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
-"Dette er din signatur ved kommentarer eller vurderinger, den kan derfor "
-"ikke endres etter den er valgt."
+"Dette er din signatur ved kommentarer eller vurderinger, den kan derfor ikke "
+"endres etter den er valgt."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
 "Hvis du ønsker å endre passord, skriv inn det gamle og angi et nytt i "
 "skjemaet under."
@@ -10132,8 +10110,8 @@ msgstr "Sett nytt passord"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 "Hvis du bruker en lettvekts CERN-konto kan du\n"
 "                %(x_url_open)stilbakestille passordet%(x_url_close)s."
@@ -10144,8 +10122,8 @@ msgid ""
 "You can change or reset your CERN account password by means of the "
 "%(x_url_open)sCERN account system%(x_url_close)s."
 msgstr ""
-"Du kan endre eller tilbakestille passordet til din CERN-konto ved hjelp "
-"av %(x_url_open)sCERNs kontosystem%(x_url_close)s."
+"Du kan endre eller tilbakestille passordet til din CERN-konto ved hjelp av "
+"%(x_url_open)sCERNs kontosystem%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:372
 #, fuzzy
@@ -10226,15 +10204,13 @@ msgstr "Velg metode"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"Hvis du har mistet passordet til din interne %(sitename)s "
-"%(x_fmt_open)skonto%(x_fmt_close)s, oppgi din e-postadresse i det "
-"følgende skjemaet for å få tilsendt en lenke for å tilbakestille "
-"passordet."
+"Hvis du har mistet passordet til din interne %(sitename)s %(x_fmt_open)skonto"
+"%(x_fmt_close)s, oppgi din e-postadresse i det følgende skjemaet for å få "
+"tilsendt en lenke for å tilbakestille passordet."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10250,21 +10226,21 @@ msgstr "Send lenke for tilbakestilling av passord"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
-"Hvis du har brukt %(x_fmt_open)sCERNs innloggingssystem%(x_fmt_close)s "
-"kan du gjenopprette passordet ved hjelp av %(x_url_open)sCERNs "
+"Hvis du har brukt %(x_fmt_open)sCERNs innloggingssystem%(x_fmt_close)s kan "
+"du gjenopprette passordet ved hjelp av %(x_url_open)sCERNs "
 "autentiseringssystem%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
-"Merk at hvis du har bruk et eksternt innloggingssystem er det ikke noe vi"
-" kan gjøre, du må i stedet henvende deg dit."
+"Merk at hvis du har bruk et eksternt innloggingssystem er det ikke noe vi "
+"kan gjøre, du må i stedet henvende deg dit."
 
 #: invenio/legacy/websession/templates.py:573
 #, fuzzy, python-format
@@ -10272,20 +10248,20 @@ msgid ""
 "Alternatively, you can ask %(x_name)s to change your login system from "
 "external to internal."
 msgstr ""
-"Alternativt, kan du be %s om å bytte ditt innloggingssystem fra eksternt "
-"til internt."
+"Alternativt, kan du be %s om å bytte ditt innloggingssystem fra eksternt til "
+"internt."
 
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 "%s gir deg muligheten til å tilpasse grensesnittet, sette opp ditt eget "
-"personlige bibliotekt eller sette opp en automatisk varslingsspørring som"
-" kjører periodisk og varsler deg om søkeresultater per e-post."
+"personlige bibliotekt eller sette opp en automatisk varslingsspørring som "
+"kjører periodisk og varsler deg om søkeresultater per e-post."
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10306,12 +10282,11 @@ msgstr "Vis alle søk du har utført i løpet av de siste 30 dagene."
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 "Ved hjelp av kurver kan du spesifisere samlinger av elementer og lagre "
-"interessante elementer du ønsker å finne igjen senere eller dele med "
-"andre."
+"interessante elementer du ønsker å finne igjen senere eller dele med andre."
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10322,33 +10297,34 @@ msgid ""
 "Subscribe to a search which will be run periodically by our service. The "
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
-"Abonner på et søk som vil utføres periodisk av vår tjeneste. Resultatene "
-"kan du få tilsendt via e-post eller lagret i en av dine kurver."
+"Abonner på et søk som vil utføres periodisk av vår tjeneste. Resultatene kan "
+"du få tilsendt via e-post eller lagret i en av dine kurver."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
-msgstr "Sjekk ut bok du har lånt, legg inn lånereservasjoner, etc. Krever CERN-ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
+msgstr ""
+"Sjekk ut bok du har lånt, legg inn lånereservasjoner, etc. Krever CERN-ID."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
-"Du er logget inn som gjestebruker, dine varsler vil forsvinne når "
-"sesjonen avsluttes."
+"Du er logget inn som gjestebruker, dine varsler vil forsvinne når sesjonen "
+"avsluttes."
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
-"Du er logget inn som %(x_user)s. Du bør muligens a) %(x_url1_open)slogge "
-"ut%(x_url1_close)s; b) endre dine "
-"%(x_url2_open)skontoinnstillinger%(x_url2_close)s."
+"Du er logget inn som %(x_user)s. Du bør muligens a) %(x_url1_open)slogge ut"
+"%(x_url1_close)s; b) endre dine %(x_url2_open)skontoinnstillinger"
+"%(x_url2_close)s."
 
 #: invenio/legacy/websession/templates.py:785
 #, fuzzy, python-format
@@ -10364,8 +10340,8 @@ msgstr "Dine varslingssøk"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 "Du kan se oversikten over %(x_url_open)sgrupper%(x_url_close)s du "
 "administrerer eller er medlem av."
@@ -10379,11 +10355,11 @@ msgstr "Dine grupper"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"Du kan se oversikten over %(x_url_open)sdine innsendinger%(x_url_close)s "
-"og be om status på dem."
+"Du kan se oversikten over %(x_url_open)sdine innsendinger%(x_url_close)s og "
+"be om status på dem."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -10393,11 +10369,11 @@ msgstr "Dine innsendinger"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"Du kan se oversikten over %(x_url_open)sdine godkjenninger%(x_url_close)s"
-" med dokumenter du godkjente eller vurderte."
+"Du kan se oversikten over %(x_url_open)sdine godkjenninger%(x_url_close)s "
+"med dokumenter du godkjente eller vurderte."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10446,7 +10422,8 @@ msgstr "for å bekrefte ektheten av denne forespørselen."
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr "Merk at denne adressen kun vil være gyldig i omkring %(days)s dager."
 
 #: invenio/legacy/websession/templates.py:909
@@ -10467,7 +10444,8 @@ msgstr "Hvis du ønsker å fullføre registreringen av denne kontoen, gå til:"
 #: invenio/legacy/websession/templates.py:940
 #, fuzzy, python-format
 msgid "Okay, a password reset link has been emailed to %(x_email)s."
-msgstr "OK, en e-post med lenke for tilbakestilling av passord er sendt til %s."
+msgstr ""
+"OK, en e-post med lenke for tilbakestilling av passord er sendt til %s."
 
 #: invenio/legacy/websession/templates.py:955
 msgid "Deleting your account"
@@ -10500,27 +10478,27 @@ msgstr "Vennligst bruk skjemaet under dersom du allerede har en konto."
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
-"Hvis du ikke har en CERN-konto enda, kan du registrere en "
-"%(x_url_open)sny lettvekts CERN-konto%(x_url_close)s."
+"Hvis du ikke har en CERN-konto enda, kan du registrere en %(x_url_open)sny "
+"lettvekts CERN-konto%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"Hvis du ikke har en konto ennå, vennligst "
-"%(x_url_open)sregistrer%(x_url_close)s en intern konto."
+"Hvis du ikke har en konto ennå, vennligst %(x_url_open)sregistrer"
+"%(x_url_close)s en intern konto."
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
 msgid "If you don't own an account yet, please contact %(x_name)s."
 msgstr ""
-"Hvis du ikke har en konto ennå, vennligst "
-"%(x_url_open)sregistrer%(x_url_close)s en intern konto."
+"Hvis du ikke har en konto ennå, vennligst %(x_url_open)sregistrer"
+"%(x_url_close)s en intern konto."
 
 #: invenio/legacy/websession/templates.py:1051
 msgid "Login method:"
@@ -10550,11 +10528,11 @@ msgstr "Du kan logge inn med brukernavn eller e-postadresse."
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
-"Din forespørsel er godkjent. Vennligst angi ønsket nytt passord i "
-"følgende skjema."
+"Din forespørsel er godkjent. Vennligst angi ønsket nytt passord i følgende "
+"skjema."
 
 #: invenio/legacy/websession/templates.py:1150
 msgid "Set a new password for"
@@ -10578,8 +10556,8 @@ msgstr "Oppgi e-postadresse og ønsket brukernavn eller passord:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr "Kontoen kan ikke benyttes før den er verifisert og aktivert."
 
 #: invenio/legacy/websession/templates.py:1228
@@ -10596,33 +10574,33 @@ msgstr "registrer"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
-"Ikke bruk verdifulle passord som ditt Unix, AFS eller NICE-passord til "
-"denne tjenesten. E-postadressen din vil behandles strengt konfidensielt "
-"og vil ikke oppgies til noen tredjepart. Den vil brukes til å "
-"identifisere deg for personlige tjenester på %s. For eksempel kan du "
-"sette opp et automatisk søk etter nye førtrykk og få daglig e-postvarsel "
-"om nye ankomster."
+"Ikke bruk verdifulle passord som ditt Unix, AFS eller NICE-passord til denne "
+"tjenesten. E-postadressen din vil behandles strengt konfidensielt og vil "
+"ikke oppgies til noen tredjepart. Den vil brukes til å identifisere deg for "
+"personlige tjenester på %s. For eksempel kan du sette opp et automatisk søk "
+"etter nye førtrykk og få daglig e-postvarsel om nye ankomster."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
-msgstr "Du kan ikke opprette en konto selv. Kontakt %s dersom du ønsker en konto."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
+msgstr ""
+"Du kan ikke opprette en konto selv. Kontakt %s dersom du ønsker en konto."
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
-"Du ser ut til å være en gjestebruker. Du må %(x_url_open)slogge "
-"inn%(x_url_close)s først."
+"Du ser ut til å være en gjestebruker. Du må %(x_url_open)slogge inn"
+"%(x_url_close)s først."
 
 #: invenio/legacy/websession/templates.py:1267
 msgid "You are not authorized to access administrative functions."
@@ -10754,8 +10732,8 @@ msgstr "Her er noen interessante lenker for webadministratorer:"
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "For flere aktiviteter på administratornivå, se det fullstendige "
 "%(x_url_open)sadministratorområdet%(x_url_close)s."
@@ -10934,8 +10912,8 @@ msgid ""
 "If you want to invite new members to join your group, please use the "
 "%(x_url_open)sweb message%(x_url_close)s system."
 msgstr ""
-"Bruk %(x_url_open)smeldingssystemet%(x_url_close)s hvis du ønsker å "
-"invitere nye medlemmer til å bli med i gruppen."
+"Bruk %(x_url_open)smeldingssystemet%(x_url_close)s hvis du ønsker å invitere "
+"nye medlemmer til å bli med i gruppen."
 
 #: invenio/legacy/websession/templates.py:2100
 #, fuzzy, python-format
@@ -10978,7 +10956,8 @@ msgstr "En bruker ønsker å bli med i gruppen %s."
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 "Vennligst %(x_url_open)sgodkjenn eller avslå%(x_url_close)s brukerens "
 "forespørsel."
@@ -11022,78 +11001,73 @@ msgstr "Gruppen %s ble slettet av sin administrator."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"Se oversikten over %(x_url_open)s%(x_nb_total)i grupper%(x_url_close)s du"
-" abonnerer på (%(x_nb_member)i) eller administrerer (%(x_nb_admin)i)."
+"Se oversikten over %(x_url_open)s%(x_nb_total)i grupper%(x_url_close)s du "
+"abonnerer på (%(x_nb_member)i) eller administrerer (%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
-"Du er logget inn som gjest. Du bør muligens %(x_url_open)slogge "
-"inn%(x_url_close)s som vanlig bruker."
+"Du er logget inn som gjest. Du bør muligens %(x_url_open)slogge inn"
+"%(x_url_close)s som vanlig bruker."
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
-"%(x_fmt_open)sGjestebrukere%(x_fmt_close)s må "
-"%(x_url_open)sregistrere%(x_url_close)s seg først"
+"%(x_fmt_open)sGjestebrukere%(x_fmt_close)s må %(x_url_open)sregistrere"
+"%(x_url_close)s seg først"
 
 #: invenio/legacy/websession/webaccount.py:127
 msgid "No queries found"
@@ -11101,20 +11075,20 @@ msgstr "Fant ingen spørringer"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
-"Denne samlingen er adgangsbegrenset. Vennligst autentiser deg hvis du "
-"mener at du har rettigheter til den."
+"Denne samlingen er adgangsbegrenset. Vennligst autentiser deg hvis du mener "
+"at du har rettigheter til den."
 
 #: invenio/legacy/websession/webaccount.py:399
 #, fuzzy
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
-"Denne samlingen er adgangsbegrenset. Vennligst autentiser deg hvis du "
-"mener at du har rettigheter til den."
+"Denne samlingen er adgangsbegrenset. Vennligst autentiser deg hvis du mener "
+"at du har rettigheter til den."
 
 #: invenio/legacy/websession/webaccount.py:400
 msgid "The OpenID identifier is invalid"
@@ -11122,8 +11096,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11135,8 +11109,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11203,7 +11177,8 @@ msgstr ""
 #: invenio/legacy/websession/webgroup.py:562
 #, fuzzy
 msgid "Sorry, you do not have sufficient rights on this group."
-msgstr "Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
+msgstr ""
+"Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
 
 #: invenio/legacy/websession/webgroup.py:499
 #, fuzzy
@@ -11216,8 +11191,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11256,8 +11230,7 @@ msgid ""
 "browser if you are a guest user."
 msgstr ""
 "Du er godkjent som %(x_role)s! Denne godkjenningen varer inntil "
-"%(x_expiration)s og inntil du lukker nettleseren din hvis du er "
-"gjestebruker."
+"%(x_expiration)s og inntil du lukker nettleseren din hvis du er gjestebruker."
 
 #: invenio/legacy/websession/webinterface.py:128
 msgid "You have confirmed the validity of your email address!"
@@ -11285,8 +11258,7 @@ msgstr "Du har allerede bekreftet gyldigheten av e-postadressen din!"
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 "Denne forespørselen om bekreftelse av en e-postadresse er ugyldig eller "
 "utgått."
@@ -11303,21 +11275,18 @@ msgstr "Tilbakestill passord"
 #, fuzzy
 msgid "This request for resetting a password has already been used."
 msgstr ""
-"Denne forespørselen for tilbakestilling av passord er ugyldig eller "
-"utgått."
+"Denne forespørselen for tilbakestilling av passord er ugyldig eller utgått."
 
 #: invenio/legacy/websession/webinterface.py:175
 #, fuzzy
 msgid "This request for resetting a password is not valid or is expired."
 msgstr ""
-"Denne forespørselen for tilbakestilling av passord er ugyldig eller "
-"utgått."
+"Denne forespørselen for tilbakestilling av passord er ugyldig eller utgått."
 
 #: invenio/legacy/websession/webinterface.py:180
 msgid "This request for resetting the password is not valid or is expired."
 msgstr ""
-"Denne forespørselen for tilbakestilling av passord er ugyldig eller "
-"utgått."
+"Denne forespørselen for tilbakestilling av passord er ugyldig eller utgått."
 
 #: invenio/legacy/websession/webinterface.py:193
 msgid "The two provided passwords aren't equal."
@@ -11361,14 +11330,14 @@ msgstr "Byttet til intern innloggingsmetode."
 #: invenio/legacy/websession/webinterface.py:423
 #, fuzzy
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
-"Merk at hvis dette er første gang du bruker denne kontoen med den interne"
-" innloggingsmetoden, vil systemet ha satt et tilfeldig generert passord "
-"for deg. Klikk på denne knappen for å motta en e-post med lenke for "
+"Merk at hvis dette er første gang du bruker denne kontoen med den interne "
+"innloggingsmetoden, vil systemet ha satt et tilfeldig generert passord for "
+"deg. Klikk på denne knappen for å motta en e-post med lenke for "
 "tilbakestilling av passord:"
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -11381,8 +11350,8 @@ msgid ""
 "Unable to switch to external login method %(x_name)s, because your email "
 "address is unknown."
 msgstr ""
-"Klarte ikke å bytte til ekstern innloggingsmetode %s, fordi "
-"e-postadressen din er ukjent."
+"Klarte ikke å bytte til ekstern innloggingsmetode %s, fordi e-postadressen "
+"din er ukjent."
 
 #: invenio/legacy/websession/webinterface.py:445
 #, fuzzy, python-format
@@ -11390,8 +11359,8 @@ msgid ""
 "Unable to switch to external login method %(x_meth)s, because your email "
 "address is unknown to the external login system."
 msgstr ""
-"Klarte ikke å bytte til ekstern innloggingsmetode %s, fordi "
-"e-postadressen din er ukjent for det eksterne innloggingssystemet."
+"Klarte ikke å bytte til ekstern innloggingsmetode %s, fordi e-postadressen "
+"din er ukjent for det eksterne innloggingssystemet."
 
 #: invenio/legacy/websession/webinterface.py:449
 msgid "Login method successfully selected."
@@ -11400,11 +11369,11 @@ msgstr "Valg av innloggingsmetode var vellykket."
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
-"Den eksterne innloggingsmetoden %s støtter ikke e-postbaserte "
-"innlogginger. Kontakt tjenestens administratorer."
+"Den eksterne innloggingsmetoden %s støtter ikke e-postbaserte innlogginger. "
+"Kontakt tjenestens administratorer."
 
 #: invenio/legacy/websession/webinterface.py:464
 #, fuzzy
@@ -11532,8 +11501,8 @@ msgid ""
 "Cannot send password reset request since you are using external "
 "authentication system."
 msgstr ""
-"Kan ikke sende forespørsel om tilbakestilling av passord fordi du bruker "
-"et eksternt autentiseringssystem."
+"Kan ikke sende forespørsel om tilbakestilling av passord fordi du bruker et "
+"eksternt autentiseringssystem."
 
 #: invenio/legacy/websession/webinterface.py:665
 msgid "The entered email address does not exist in the database."
@@ -11581,21 +11550,21 @@ msgid ""
 "In order to confirm its validity, an email message containing an account "
 "activation key has been sent to the given email address."
 msgstr ""
-"En e-post med kontoaktiveringsnøkkel er sendt til oppgitt e-postadresse "
-"for å bekrefte dens gyldighet."
+"En e-post med kontoaktiveringsnøkkel er sendt til oppgitt e-postadresse for "
+"å bekrefte dens gyldighet."
 
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr "Følg instruksjonene i den for å fullføre kontoregistreringen."
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr "Det sendes en e-post til når kontoen er aktivert og klar til bruk."
 
 #: invenio/legacy/websession/webinterface.py:989
@@ -11637,8 +11606,8 @@ msgstr "Ønsket brukernavn %s finnes i databasen fra før."
 #: invenio/modules/accounts/views/accounts.py:143
 msgid "Users cannot register themselves, only admin can register them."
 msgstr ""
-"Brukere kan ikke registrere seg selv, kun en administrator kan registrere"
-" dem."
+"Brukere kan ikke registrere seg selv, kun en administrator kan registrere "
+"dem."
 
 #: invenio/legacy/websession/webinterface.py:1023
 #: invenio/modules/accounts/views/accounts.py:148
@@ -11646,8 +11615,8 @@ msgid ""
 "The site is having troubles in sending you an email for confirming your "
 "email address."
 msgstr ""
-"Denne tjenesten har problemer med å sende deg en e-post for å få "
-"bekreftet e-postadressen din."
+"Denne tjenesten har problemer med å sende deg en e-post for å få bekreftet e-"
+"postadressen din."
 
 #: invenio/legacy/websession/webinterface.py:1432
 #, fuzzy
@@ -11716,15 +11685,16 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
-msgstr "Element opprettet %(x_date_creation)s, sist endret %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+"Element opprettet %(x_date_creation)s, sist endret %(x_date_modification)s"
 
 #: invenio/legacy/webstyle/templates.py:707
 #, fuzzy
 msgid "The server encountered an error while dealing with your request."
 msgstr ""
-"Det har oppstått en systemfeil under henting av dette dokumentets "
-"filliste."
+"Det har oppstått en systemfeil under henting av dette dokumentets filliste."
 
 #: invenio/legacy/webstyle/templates.py:709
 #, python-format
@@ -11742,37 +11712,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11780,15 +11750,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11856,8 +11826,8 @@ msgstr "Klarte ikke å fastslå antall sider i innsendingen."
 #: invenio/legacy/websubmit/engine.py:931
 #, fuzzy
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr "Klarte ikke å opprette en mappe for denne innsendingen."
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11893,8 +11863,8 @@ msgstr "Send inn"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11941,11 +11911,11 @@ msgstr "Velg kategori og knapp for ønsket handling."
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
-"For å fortsette med en tidligere avbrutt innsending, angi et "
-"tilgangsnummer i boksen under:"
+"For å fortsette med en tidligere avbrutt innsending, angi et tilgangsnummer "
+"i boksen under:"
 
 #: invenio/legacy/websubmit/templates.py:366
 msgid "GO"
@@ -11973,8 +11943,8 @@ msgstr "Tilbake til hovedmeny"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 "Dette er tilgangsnummeret for denne innsendingen. Det kan brukes for å "
 "fortsette på en avbrutt innsending hvis det oppstår problemer."
@@ -12025,8 +11995,8 @@ msgstr "Innsendingsnummer"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 "Her er %(x_action)s funksjonslisten for %(x_doctype)sdokumenter på nivå "
 "%(x_step)s"
@@ -12110,8 +12080,7 @@ msgstr "Oversikt over vurderte dokumenttyper"
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr "Velg en av følgende dokumenttyper for å sjekke dokumentets status"
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -12249,10 +12218,10 @@ msgstr "Godkjenne"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
-"Dette dokumentet %(x_fmt_open)sventer fortsatt på "
-"godkjenning%(x_fmt_close)s."
+"Dette dokumentet %(x_fmt_open)sventer fortsatt på godkjenning%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
 #: invenio/legacy/websubmit/templates.py:2163
@@ -12292,8 +12261,8 @@ msgid ""
 "As a referee for this document, you may approve or reject it from the "
 "submission interface"
 msgstr ""
-"Som fagkonsulent for dette dokumentet, kan du klikke på denne knappen for"
-" å godkjenne eller avslå det"
+"Som fagkonsulent for dette dokumentet, kan du klikke på denne knappen for å "
+"godkjenne eller avslå det"
 
 #: invenio/legacy/websubmit/templates.py:2155
 msgid "Approve/Reject"
@@ -12348,8 +12317,8 @@ msgstr "Velg en fagkonsulent"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr "Fagkonsulenten sendte sin endelige anbefaling til pulikasjonskomitéen "
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -12368,9 +12337,10 @@ msgstr "Send en anbefaling"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
-msgstr "Publikasjonskomitéen har sendt sin endelige anbefaling til prosjektleder "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
+msgstr ""
+"Publikasjonskomitéen har sendt sin endelige anbefaling til prosjektleder "
 
 #: invenio/legacy/websubmit/templates.py:2291
 #: invenio/legacy/websubmit/templates.py:2358
@@ -12410,7 +12380,8 @@ msgid "Take a decision"
 msgstr "Ta en avgjørelse"
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr "Et redaksjonsutvalg board er valgt av publikasjonskomitéen "
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12431,14 +12402,13 @@ msgstr "En fagkonsulent er valgt av redaksjonsutvalget "
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr "Fagkonsulent har sendt sin endelige anbefaling til redaksjonsutvalget "
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 "Redaksjonsutvalget har sendt sin endelige anbefaling til "
 "publikasjonskomitéen "
@@ -12557,10 +12527,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12846,8 +12815,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12890,11 +12859,6 @@ msgstr "tilkoblet"
 #, fuzzy
 msgid "Role details"
 msgstr "Artikkel"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Skjul"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -13010,8 +12974,8 @@ msgstr "Oppgitt e-postadresse %s finnes i databasen fra før."
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -13076,9 +13040,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, fuzzy, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 "Du godtaes fortsatt av det sentrale\n"
 "                %(x_fmt_open)sSSO-systemet%(x_fmt_close)s. Du kan\n"
@@ -13105,8 +13068,8 @@ msgstr "Sett nytt passord"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr "Oppgi e-postadresse og ønsket brukernavn eller passord:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -13135,7 +13098,7 @@ msgid "Problem with login."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "Du kan nå bruke %(x_url_open)skontoen%(x_url_close)s din."
 
@@ -13170,7 +13133,8 @@ msgstr ""
 #: invenio/modules/accounts/views/settings.py:98
 #, fuzzy, python-format
 msgid "A password reset link has been sent to %(whom)s"
-msgstr "OK, en e-post med lenke for tilbakestilling av passord er sendt til %s."
+msgstr ""
+"OK, en e-post med lenke for tilbakestilling av passord er sendt til %s."
 
 #: invenio/modules/accounts/views/accounts.py:320
 #, fuzzy
@@ -13179,8 +13143,7 @@ msgstr "Endring av innstillinger mislyktes"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13252,13 +13215,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13267,9 +13229,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13446,8 +13408,7 @@ msgstr "samlinger"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13537,8 +13498,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13630,13 +13591,13 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
-"Meldingen er for lang, vennligst rediger den. Maksimal tillatt størrelse "
-"er %i tegn."
+"Meldingen er for lang, vennligst rediger den. Maksimal tillatt størrelse er "
+"%i tegn."
 
 #: invenio/modules/comments/forms.py:55
 #, fuzzy
@@ -13679,12 +13640,12 @@ msgid "Review was sent"
 msgstr "Skriv en kommentar"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Denne kommentaren er rapportert %i ganger."
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Denne kommentaren er rapportert %i ganger."
 
@@ -13737,9 +13698,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13758,8 +13718,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13769,7 +13729,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "Ønsket brukernavn %s finnes i databasen fra før."
 
@@ -13825,8 +13785,7 @@ msgstr "vurdering"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13866,8 +13825,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13913,7 +13871,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "Funksjon %s finnes ikke."
 
@@ -13996,11 +13954,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "status:"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Dine kurver"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -14035,8 +13988,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -14057,8 +14010,8 @@ msgstr "Ingen ordindeks tilgjengelig for"
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -14074,8 +14027,7 @@ msgstr "Validering av formatelement %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14195,7 +14147,7 @@ msgstr "Vis alle %i forfattere"
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 #, fuzzy
 msgid "Edit This Record"
 msgstr "Endre et annet element"
@@ -14296,10 +14248,6 @@ msgstr "vurdering"
 msgid "Authors"
 msgstr "forfatter"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14392,9 +14340,10 @@ msgstr "Administrer grupperettigheter"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
-msgstr "Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
+msgstr ""
+"Du har ikke tilstrekkelige rettigheter til å se innholdet i denne kurven."
 
 #: invenio/modules/groups/views.py:279
 #, fuzzy, python-format
@@ -14406,12 +14355,12 @@ msgstr "Du administrerer ingen grupper."
 msgid "Members"
 msgstr "Ingen medlemmer"
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Kunnskapsbase koblinger"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14421,11 +14370,11 @@ msgstr "Ferdig"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "alle felt"
@@ -14471,13 +14420,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "Det finnes %i kurver"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "Det finnes %i kurver"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14633,28 +14583,28 @@ msgstr "Ukjent dokumenttype"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14719,8 +14669,8 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr "Hvis du ønsker å fullføre registreringen av denne kontoen, gå til:"
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -15092,7 +15042,7 @@ msgid "Tag name"
 msgstr "Brukernavn"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "Ønsker brukernavn %s er i bruk fra før."
 
@@ -15197,11 +15147,6 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "Ferdig"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15243,8 +15188,7 @@ msgstr "Søkevalg:"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15453,7 +15397,7 @@ msgid "just now"
 msgstr "Du må nå"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s sekunder"
 
@@ -15512,6 +15456,36 @@ msgstr "alle år"
 msgid " years ago"
 msgstr "år"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "BibFormat Administrator"
+
+#~ msgid "Not authorized"
+#~ msgstr "forfatter"
+
+#~ msgid "Really delete"
+#~ msgstr "ble slettet"
+
+#~ msgid "Verify problem"
+#~ msgstr "Databaseproblem"
+
+#~ msgid "File"
+#~ msgstr "tittel"
+
+#~ msgid "niceName"
+#~ msgstr "Navn"
+
+#~ msgid "Id"
+#~ msgstr "ID"
+
+#~ msgid "Tickets"
+#~ msgstr "ganger"
+
+#~ msgid "by"
+#~ msgstr "av"
+
+#~ msgid "Done"
+#~ msgstr "Ferdig"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Velg en kategori."
 
@@ -15526,9 +15500,6 @@ msgstr "år"
 
 #~ msgid "*** basket name ***"
 #~ msgstr "Kurvens navn"
-
-#~ msgid ""
-#~ msgstr ""
 
 #~ msgid "%(x_name)s"
 #~ msgstr "%(x_sitename)s lenke"
@@ -15596,23 +15567,8 @@ msgstr "år"
 #~ msgid "now"
 #~ msgstr "nei"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "BibFormat Administrator"
-
-#~ msgid "Not authorized"
-#~ msgstr "forfatter"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "Brukeren %s finnes ikke."
-
-#~ msgid "Really delete"
-#~ msgstr "ble slettet"
-
-#~ msgid "Verify problem"
-#~ msgstr "Databaseproblem"
-
-#~ msgid "File"
-#~ msgstr "tittel"
 
 #~ msgid "File %s already exists."
 #~ msgstr "Brukeren %s finnes ikke."
@@ -15671,9 +15627,6 @@ msgstr "år"
 #~ msgid "Not Mine!"
 #~ msgstr "Kommentar"
 
-#~ msgid "Tickets"
-#~ msgstr "ganger"
-
 #~ msgid "Request Tickets"
 #~ msgstr "Regler"
 
@@ -15709,9 +15662,6 @@ msgstr "år"
 
 #~ msgid "Create a new Person for your search"
 #~ msgstr "Ingen resultater funnet."
-
-#~ msgid "Id"
-#~ msgstr "ID"
 
 #~ msgid "A %s has been added."
 #~ msgstr "Gruppen %s ble slettet."
@@ -15764,9 +15714,6 @@ msgstr "år"
 #~ msgid "creating a new basket"
 #~ msgstr "Opprett ny kurv"
 
-#~ msgid "by"
-#~ msgstr "av"
-
 #~ msgid "on"
 #~ msgstr "den"
 
@@ -15787,9 +15734,6 @@ msgstr "år"
 
 #~ msgid "Editing topic"
 #~ msgstr "Endrer kurv"
-
-#~ msgid "niceName"
-#~ msgstr "Navn"
 
 #~ msgid "Apply Changes"
 #~ msgstr "Lagre endringer"
@@ -15904,9 +15848,6 @@ msgstr "år"
 
 #~ msgid "Verbose"
 #~ msgstr "Tekst"
-
-#~ msgid "Done"
-#~ msgstr "Ferdig"
 
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "Endringene dine er MIDLERTIDIGE."
@@ -16148,34 +16089,11 @@ msgstr "år"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "WebSubmit Administrator Guide"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "Utfør søk"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Kansellert"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "Du er medlem av følgende grupper:"
@@ -16189,12 +16107,6 @@ msgstr "år"
 #~ msgid "Invert Selection"
 #~ msgstr "Fagkonsulentvalg"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Forfatter"
 
@@ -16206,12 +16118,6 @@ msgstr "år"
 
 #~ msgid "No status information found."
 #~ msgstr "Mer informasjon:"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "divisjon"
@@ -16228,15 +16134,6 @@ msgstr "år"
 #~ msgid "The author has an internal ID!"
 #~ msgstr "Det oppsto en intern feil"
 
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "kommentarer"
 
@@ -16246,87 +16143,20 @@ msgstr "år"
 #~ msgid " Delete this ticket"
 #~ msgstr "Slett kurv"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "Ingen tilgjengelige journaler"
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Velg en rangering"
 
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
 #~ msgid "Paper title: "
 #~ msgstr "Tekster:"
-
-#~ msgid "Ignore"
-#~ msgstr ""
 
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "Følgende feil ble funnet"
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "Velg en rangering"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "Mer informasjon:"
@@ -16334,35 +16164,11 @@ msgstr "år"
 #~ msgid "Please provide your first name"
 #~ msgstr "Vennligst logg inn først."
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "Dine lån"
 
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
 #~ msgid "Your eMail:"
 #~ msgstr "Dine varsler"
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "Slett merkede vurderinger"
@@ -16370,186 +16176,35 @@ msgstr "år"
 #~ msgid "Mark as your documents"
 #~ msgstr "alle typer dokumenter"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "Kom tilbake til dokumentet"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Kom tilbake til dokumentet"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "eller opprett nytt"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "Legg til brukere"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Tekster:"
-
-#~ msgid "Showing the"
-#~ msgstr ""
 
 #~ msgid "most recent documents:"
 #~ msgstr "Oversikt over vurderte dokumenter"
 
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Administrer visningsmaler"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Velg emne"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Opprettet dato"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "ekstern lenke"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "innsendinger"
@@ -16557,184 +16212,17 @@ msgstr "år"
 #~ msgid "Choose system"
 #~ msgstr "Velg emne"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Følgende feil ble funnet"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Du har ikke tilgang til å bruke administrative funksjoner."
 
 #~ msgid "Claim this paper"
 #~ msgstr "legg til denne brukeren"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Sitert av: %s elementer"
 
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
 #~ msgid "Revision"
 #~ msgstr "divisjon"
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Endre malattributter"
@@ -16814,89 +16302,20 @@ msgstr "år"
 #~ msgid "No Record Found for %s."
 #~ msgstr "Fant ikke element"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Brukeren %s finnes ikke."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "Visningsformat %s attributter"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "Visningsmal %s avhengigheter"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "Validering av formatelement %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "Formatelement %s avhengigheter"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Adgangsbegrenset visningsformat"
@@ -16952,110 +16371,17 @@ msgstr "år"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Validering av formatelement %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "Formatvalidering"
 
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "Kunnskapsbase %s"
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "Kommentar"
 
 #~ msgid "never"
 #~ msgstr "Eier"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "ganger"
@@ -17084,17 +16410,11 @@ msgstr "år"
 #~ msgid "Affiliations"
 #~ msgstr "Tilhørigheter:"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
 #~ msgid "No Frequent Co-authors"
 #~ msgstr "Vanlige medforfattere:"
 
 #~ msgid "Citations%s"
 #~ msgstr "Siteringer"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Opprettet dato"
@@ -17105,39 +16425,6 @@ msgstr "år"
 #~ msgid "No publications available"
 #~ msgstr "Ingen tilgjengelige journaler"
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr "Sitert i %i elementer"
 
@@ -17147,17 +16434,11 @@ msgstr "år"
 #~ msgid "%i reviews"
 #~ msgstr "vurdering"
 
-#~ msgid "%s of"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "Tekster:"
 
 #~ msgid "Frequent co-authors"
 #~ msgstr "Vanlige medforfattere:"
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "Siteringer:"
@@ -17165,23 +16446,8 @@ msgstr "år"
 #~ msgid "No Citation Information available"
 #~ msgstr "Ingen tilgjengelige journaler"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Diskusjoner"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Dine varsler"
@@ -17201,99 +16467,15 @@ msgstr "år"
 #~ msgid "Statistics"
 #~ msgstr "statistikk"
 
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
 #~ msgid "Group: %s"
 #~ msgstr "Gruppe: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "Fant ikke siden %s"
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "Feltet %s er obligatorisk."
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "Klarte ikke å fastslå antall sider i innsendingen."
-

--- a/invenio/base/translations/pl/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/pl/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,16 +16,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2008-09-24 15:55+0200\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:58+0200\n"
 "Last-Translator: Zbigniew Leonowicz <leonowicz@ieee.org>\n"
 "Language-Team: PL <info@invenio-software.org>\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
-"(n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -59,8 +59,8 @@ msgstr "Administracja"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -206,7 +206,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Witaj:"
 
@@ -227,17 +227,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -263,48 +263,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Ten rekord nie istnieje."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr "Prośba o zmianę hasła dla"
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Nie masz uprawnień aby tu wejść."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Rejestracja zakończona niepowodzeniem"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Proszę wybrać jeden lub więcej:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Prośba o uprawnienia"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -504,7 +509,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -581,9 +587,9 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"Jesteś zalogowany jako %(x_user)s. Możesz: a) %(x_url1_open)s wylogować "
-"się%(x_url1_close)s; b) edytować %(x_url2_open)s ustawienia "
-"konta%(x_url2_close)s."
+"Jesteś zalogowany jako %(x_user)s. Możesz: a) %(x_url1_open)s wylogować się"
+"%(x_url1_close)s; b) edytować %(x_url2_open)s ustawienia konta"
+"%(x_url2_close)s."
 
 #: invenio/legacy/batchuploader/templates.py:282
 #, fuzzy
@@ -727,7 +733,8 @@ msgid "The following errors have occurred:"
 msgstr "Znaleziono następujące błędy"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -744,8 +751,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -827,7 +834,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -870,8 +877,8 @@ msgstr "Twoje Koszyki"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Poprzedni"
@@ -887,8 +894,8 @@ msgstr "Wynik"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Następny"
 
@@ -903,18 +910,6 @@ msgstr "Następny"
 #: invenio/legacy/weblinkback/adminlib.py:55
 msgid "Admin Area"
 msgstr "Administracja"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "autor"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
@@ -934,11 +929,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
 msgid "Limit to knowledge bases containing string:"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "Usunięto"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -990,16 +980,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
 msgid "Verify BibCheck config file"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Błąd bazy danych"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "plik(i)"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
@@ -1106,7 +1086,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1157,8 +1138,8 @@ msgstr "Nowe konto zostało utworzone dnia"
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1172,25 +1153,23 @@ msgstr "Przeglądaj"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "Nowe konto zostało utworzone dnia"
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "Nowe konto zostało utworzone dnia"
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1215,13 +1194,14 @@ msgstr "Utwórz nowy temat"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "Nowe konto zostało utworzone dnia"
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1253,9 +1233,8 @@ msgstr "bieżący status:"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "Nowe konto zostało utworzone dnia"
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1322,8 +1301,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1331,8 +1310,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1354,9 +1333,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "Nowe konto zostało utworzone dnia"
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1398,8 +1376,8 @@ msgstr "Znaleziono %s rekordów"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1458,11 +1436,11 @@ msgstr "Nowe konto zostało utworzone dnia"
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1473,11 +1451,11 @@ msgstr "Tak"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1490,8 +1468,8 @@ msgstr "Nie"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1588,8 +1566,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1609,29 +1587,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1640,9 +1618,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr "Przepraszam, rekord %s prawdopodobnie nie istnieje."
 
@@ -2003,16 +1981,14 @@ msgstr "Rekord został usunięty."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2033,8 +2009,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2196,8 +2172,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2306,7 +2282,7 @@ msgstr "Działanie"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Opis"
 
@@ -2501,8 +2477,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2788,12 +2764,10 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr ""
-"Jeżeli sobie życzysz możesz %(x_url_open)szalogować się "
-"tutaj%(x_url_close)s."
+"Jeżeli sobie życzysz możesz %(x_url_open)szalogować się tutaj%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
 #, fuzzy
@@ -2848,7 +2822,7 @@ msgstr "Odrzuć"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "OK"
 
@@ -2856,8 +2830,8 @@ msgstr "OK"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "Nowe konto zostało utworzone dnia"
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3331,8 +3305,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "Email"
 
@@ -4184,8 +4158,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4203,8 +4177,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4270,17 +4244,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4668,25 +4642,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "Rekord został usunięty."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4747,15 +4721,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4767,10 +4741,10 @@ msgstr "Wybierz temat"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4784,15 +4758,15 @@ msgstr "mniej"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4803,7 +4777,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4822,17 +4797,15 @@ msgstr "Wybrana nazwa użytkownika %s już istnieje w bazie danych."
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "Wybrana nazwa użytkownika %s już istnieje w bazie danych."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4851,14 +4824,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4912,8 +4884,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4968,8 +4940,8 @@ msgstr "Przepraszam, rekord %s prawdopodobnie nie istnieje."
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 "System napotkał błąd przy próbie odnalezienia plików związanych z tym "
 "dokumentem."
@@ -4980,7 +4952,8 @@ msgstr ""
 msgid ""
 "The error has been logged and will be taken in consideration as soon as "
 "possible."
-msgstr "Ten błąd został zgłoszony i będzie sprawdzony tak szybko jak to możliwe."
+msgstr ""
+"Ten błąd został zgłoszony i będzie sprawdzony tak szybko jak to możliwe."
 
 #: invenio/legacy/bibdocfile/webinterface.py:202
 #, python-format
@@ -5090,9 +5063,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -5107,8 +5080,8 @@ msgstr "Zapisz zmiany"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -5252,11 +5225,10 @@ msgstr "Powrót do wyników wyszukiwania"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5393,7 +5365,7 @@ msgid "Total"
 msgstr "opcjonalny"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Wybierz"
 
@@ -5564,8 +5536,8 @@ msgstr "Usuń bazę wiedzy"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5624,56 +5596,56 @@ msgstr "Proszę się najpierw zalogować."
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5713,7 +5685,7 @@ msgstr "Zależności bazy wiedzy"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5767,15 +5739,15 @@ msgstr "Twoje Alerty"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -6004,8 +5976,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -6084,8 +6055,8 @@ msgstr "Wybór recenzentów"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6100,8 +6071,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Wyniki wyszukiwania"
 
@@ -6262,8 +6233,8 @@ msgstr "Nie znaleziono wartości."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6289,8 +6260,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6301,24 +6272,23 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
 #, python-format
 msgid "No exact match found for %(x_query1)s, using %(x_query2)s instead..."
 msgstr ""
-"Nie znaleziono dokładnego dopasowania dla %(x_query1)s, zastosowano w "
-"zamian %(x_query2)s ..."
+"Nie znaleziono dokładnego dopasowania dla %(x_query1)s, zastosowano w zamian "
+"%(x_query2)s ..."
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
@@ -6327,81 +6297,77 @@ msgstr ""
 "Nie znaleziono dopasowania w kolekcji %(x_collection)s. Inne publiczne "
 "kolekcje zwróciły %(x_url_open)s%(x_nb_hits)d wyników%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 "Nie znaleziono dopasowania w żadnej publicznej kolekcji. Jeśli szukałeś "
-"dokumentu zastrzeżonego, wybierz najpierw odpowiednią kolekcję "
-"zastrzeżoną."
+"dokumentu zastrzeżonego, wybierz najpierw odpowiednią kolekcję zastrzeżoną."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
 "Nie znaleziono dopasowania w żadnej publicznej kolekcji. Jeśli szukałeś "
-"dokumentu zastrzeżonego, wybierz najpierw odpowiednią kolekcję "
-"zastrzeżoną."
+"dokumentu zastrzeżonego, wybierz najpierw odpowiednią kolekcję zastrzeżoną."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
-"Szukane wyrażenie %s nie odpowiada żadnemu rekordowi. Najbliższe "
-"wyrażenia:"
+"Szukane wyrażenie %s nie odpowiada żadnemu rekordowi. Najbliższe wyrażenia:"
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "Użyj innych słów do wyszukiwania."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Jest %i koszyków"
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Jest %i koszyków"
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Jest %i koszyków"
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Brak indeksu słów dla"
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Brak indeksu fraz dla"
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 "Szukany termin %(x_term)s w indeksie %(x_index)s nie odpowiada żadnemu "
 "rekordowi. Najbliższe wyrażenia:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr ""
-"Szukane wyrażenie %s nie odpowiada żadnemu rekordowi. Najbliższe "
-"wyrażenia:"
+"Szukane wyrażenie %s nie odpowiada żadnemu rekordowi. Najbliższe wyrażenia:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
@@ -6410,35 +6376,35 @@ msgstr ""
 "Przepraszam, %s nie wydaje się dozwoloną opcją sortowania. Wybieram "
 "sortowanie według tytułów zamiast wybranego."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 "Przepraszamy, sortowanie dozwolone dla zbiorów o najwyżej %d rekordach. "
 "Używam sortowania domyślnego."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 "Przepraszam, %s nie wydaje się dozwoloną opcją sortowania. Wybieram "
 "sortowanie według tytułów zamiast wybranego."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Ten rekord nie istnieje."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Użyj innych słów do wyszukiwania."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6452,11 +6418,12 @@ msgstr "Użyj innych słów do wyszukiwania."
 msgid "Browse"
 msgstr "Przeglądaj"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
-msgstr "Brak wyniku podczas dozwolonego czasu wyszukiwania, usuwam ten warunek..."
+msgstr ""
+"Brak wyniku podczas dozwolonego czasu wyszukiwania, usuwam ten warunek..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr "Brak wyniku dla Twoich ograniczeń, usuwam ten warunek..."
 
@@ -6500,14 +6467,13 @@ msgstr "Alert %s został zmieniony."
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Wykonałeś %(x_nb)s kwerend. %(x_url_open)sSzczegółowa "
-"lista%(x_url_close)s jest dostępna z możliwością (a) przeglądania wyników"
-" (b) aktywacji automatycznego powiadamiania emailem dla tych kwerend."
+"Wykonałeś %(x_nb)s kwerend. %(x_url_open)sSzczegółowa lista%(x_url_close)s "
+"jest dostępna z możliwością (a) przeglądania wyników (b) aktywacji "
+"automatycznego powiadamiania emailem dla tych kwerend."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6649,8 +6615,7 @@ msgid ""
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
 "Ustaw nowy alert z %(x_url1_open)stwoich kwerend%(x_url1_close)s, "
-"%(x_url2_open)snajpopularniejszych kwerend%(x_url2_close)s, lub z "
-"formularza."
+"%(x_url2_open)snajpopularniejszych kwerend%(x_url2_close)s, lub z formularza."
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6701,8 +6666,8 @@ msgstr "Zdefiniowałeś %s alertów."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 "Jeszcze nie wykonałeś wyszukiwań. Proszę przejdź najpierw do "
 "%(x_url_open)sinterfejsu wyszukiwania%(x_url_close)s."
@@ -6710,11 +6675,11 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
-"Wykonałeś %(x_nb1)s wyszukiwań (%(x_nb2)s różnych pytań) podczas około 30"
-" ostatnich dni."
+"Wykonałeś %(x_nb1)s wyszukiwań (%(x_nb2)s różnych pytań) podczas około 30 "
+"ostatnich dni."
 
 #: invenio/legacy/webalert/templates.py:453
 #, fuzzy, python-format
@@ -6772,7 +6737,7 @@ msgstr "Twoje Wyszukiwania"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6836,7 +6801,7 @@ msgstr "%s Personalizuj, Ustaw nowy alert"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6896,7 +6861,8 @@ msgstr "%s Personalizuj, Wyświetl alerty"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6920,7 +6886,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "Nie masz uprawnień do przeglądania zawartości tego koszyka."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6948,7 +6915,8 @@ msgid "You do not have permission to delete this note."
 msgstr "Nie masz uprawnień do przeglądania zawartości tego koszyka."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6979,8 +6947,8 @@ msgstr "Ten rekord nie istnieje."
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -7002,8 +6970,8 @@ msgstr "Kopiuj rekord do koszyka"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -7036,8 +7004,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7110,12 +7078,10 @@ msgstr "Koszyk publiczny"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
-"Masz %(x_nb_perso)s osobistych koszyków i jesteś zapisany do "
-"%(x_nb_group)s koszyków grupy i %(x_nb_public)s innych koszyków "
-"publicznych."
+"Masz %(x_nb_perso)s osobistych koszyków i jesteś zapisany do %(x_nb_group)s "
+"koszyków grupy i %(x_nb_public)s innych koszyków publicznych."
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
 #, fuzzy
@@ -7142,8 +7108,7 @@ msgstr "%i grup użytkowników korzysta z tego koszyka."
 #: invenio/legacy/webbasket/templates.py:108
 #, fuzzy, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr "Możesz sprawdzić też %(x_url_open)s%(x_category)s pages%(x_url_close)s"
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -7316,8 +7281,8 @@ msgstr "Rekord zewnętrzny"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7334,8 +7299,7 @@ msgstr "Wybrane rekordy zostały dodane do %i koszyków."
 #, fuzzy, python-format
 msgid "Proceed to the %(x_url_open)sbasket%(x_url_close)s"
 msgstr ""
-"Jeżeli sobie życzysz możesz %(x_url_open)szalogować się "
-"tutaj%(x_url_close)s."
+"Jeżeli sobie życzysz możesz %(x_url_open)szalogować się tutaj%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:1649
 #, fuzzy, python-format
@@ -7346,8 +7310,7 @@ msgstr "Teraz masz dostęp %(x_url_open)s do konta%(x_url_close)s."
 #, fuzzy, python-format
 msgid " or go %(x_url_open)sback%(x_url_close)s"
 msgstr ""
-"Jeżeli sobie życzysz możesz %(x_url_open)szalogować się "
-"tutaj%(x_url_close)s."
+"Jeżeli sobie życzysz możesz %(x_url_open)szalogować się tutaj%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:1745
 #, fuzzy, python-format
@@ -7506,8 +7469,8 @@ msgstr "Udostępnienie koszyka innej grupie"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 "Jesteś zalogowany jako Gość, dlatego twój kosz zniknie po zakończeniu "
 "bieżącej sesji."
@@ -7516,10 +7479,11 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
-"Jeżeli chcesz, możesz się %(x_url_open)s zalogować lub zarejestrować "
-"tutaj%(x_url_close)s."
+"Jeżeli chcesz, możesz się %(x_url_open)s zalogować lub zarejestrować tutaj"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7528,7 +7492,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Jako Gość nie możesz korzystać z tej funkcji."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Powrót do wyników wyszukiwania"
 
@@ -7703,7 +7667,7 @@ msgstr "Dodaj do użytkowników"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7850,215 +7814,216 @@ msgstr "Użytkownik %s nie istnieje."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "Użytkownik %s nie istnieje."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Napisz komentarz"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_name)s napisał dnia %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "komentarze"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Pokaż ostatnich %i komentarzy:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Dyskusja nad tym dokumentem"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Rozpocznij dyskusję o tym dokumencie."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Przepraszam, rekord %s prawdopodobnie nie istnieje."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "Przepraszam, %s nie jest prawidłową wartością ID rekordu."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "Przepraszam, nie podano ID rekordu."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Może zechcesz rozpocząć przeszukiwanie od %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_name)s napisał dnia %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Czy ta recezja była dla Ciebie pomocna?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Napisz recenzję"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr "Średnia ocena: %(x_nb_score)s na podstawie %(x_nb_reviews)s recenzji"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "Czytelnicy uważają następujące %s recenzje za najlepsze."
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Zobacz wszystkie %s recenzji"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Oceń ten dokument"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Bądź pierwszy i oceń ten dokument."
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "Wynik"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Zgłoś nadużycie"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 #, fuzzy
 msgid "Undelete comment"
 msgstr "usuń komentarze"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Usuń komentarz"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 #, fuzzy
 msgid "Unreport comment"
 msgstr "Usuń komentarz"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Recenzowane przez %(x_nickname)s dnia %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
-msgstr "%(x_nb_people)i z %(x_nb_total)i czytelników dobrze oceniło tę recenzję"
+msgstr ""
+"%(x_nb_people)i z %(x_nb_total)i czytelników dobrze oceniło tę recenzję"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 #, fuzzy
 msgid "Undelete review"
 msgstr "Usuń zaznaczone recenzje"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 #, fuzzy
 msgid "Delete review"
 msgstr "Usuń zaznaczone recenzje"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 #, fuzzy
 msgid "Unreport review"
 msgstr "Napisz recenzję"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Komentarze"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Recenzje"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Jest w sumie %s recenzji"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Jest w sumie %s komentarzy"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Bądź pierwszy i oceń ten dokument."
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Zapisz się"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 #, fuzzy
 msgid "Unsubscribe"
 msgstr "Zapisz się"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -8067,191 +8032,190 @@ msgstr "Zapisz się"
 msgid "Record"
 msgstr "Rekord"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "recenzja"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "komentarz"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Recenzja"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Wyświetlam"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Strona:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 #, fuzzy
 msgid "You are not authorized to comment or review."
 msgstr "Nie masz uprawnień aby tu wejść."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr "Uwaga, Twój identyfikator, %s, będzie widoczny na stronie komentarza"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
-"Uwaga: Twój nickname %(x_url_open)s nie jest zdefiniowany%(x_url_close)s."
-" %(x_nickname)s będzie wyświetlony jako autor tego komentarza."
+"Uwaga: Twój nickname %(x_url_open)s nie jest zdefiniowany%(x_url_close)s. "
+"%(x_nickname)s będzie wyświetlony jako autor tego komentarza."
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 #, fuzzy
 msgid "Max one file"
 msgstr "Dodaj nową regułę"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "Plik(i) główne"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Artykuł"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "Dodaj komentarz"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr "Uwaga: Twój nickname, %s, będzie wyświetlony jako autor tej recenzji."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Oceń ten artykuł"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Wybierz ocenę"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Dodaj tytuł swojej recenzji"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Napisz recenzję"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr "Dodaj recenzję"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Dodaj recenzję"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Twoja recenzja została zapisana."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Twój komentarz został dodany."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Powrót do rekordu"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr "To jest lista %(x_url_open)sTwoich grup%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 #, fuzzy
 msgid "View most commented records"
 msgstr "Pokaż komentarze"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 #, fuzzy
 msgid "View latest commented records"
 msgstr "Pokaż komentarze"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all comments reported as abuse"
 msgstr "Zobacz wszystkich raportowanych użytkowników"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 #, fuzzy
 msgid "View most reviewed records"
 msgstr "usuń rekordy"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 #, fuzzy
 msgid "View latest reviewed records"
 msgstr "Zobacz wszystkie %s recenzji"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all reviews reported as abuse"
 msgstr "Zobacz wszystkich raportowanych użytkowników"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Zobacz wszystkich użytkowników, których zgłoszono"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Przewodnik"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Komentarze i recenzje zostały wyłączone"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
@@ -8259,330 +8223,333 @@ msgstr ""
 "Wprowadź ID komentarza/recenzji aby go zobaczyć zanim zdecydujesz czy go "
 "usunąć czy nie"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "ID Komentarza:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 #, fuzzy
 msgid "Record ID:"
 msgstr "ID rekordu"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Zobacz Komentarz"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Nie było dotychczas raportów."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Zobacz wszystkie %s raportowane komentarze"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Zobacz wszystkie %s raportowanych recenzji"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-"To jest lista, sortowana względem liczby raportów, wszystkich "
-"użytkowników, których komentarze były raportowane co najmniej raz."
+"To jest lista, sortowana względem liczby raportów, wszystkich użytkowników, "
+"których komentarze były raportowane co najmniej raz."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Identyfikator"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "ID użytkownika"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Liczba głosów pozytywnych"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Liczba negatywnych głosów"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Całkowita liczba głosów"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Całkowita liczba raportów"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Zobacz wszystkie raportowane komentarze/recenzje"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Ta recenzja była raportowana %i razy"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Ten komentarz był raportowany %i razy"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Napisane przez"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Informacje ogólne"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Usuń zaznaczone recenzje"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Usuń wybrane raporty nadużyć"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 #, fuzzy
 msgid "Undelete selected reviews"
 msgstr "Usuń zaznaczone recenzje"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 #, fuzzy
 msgid "Undelete selected comments"
 msgstr "Usuń wybrane komentarze"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Usuń wybrane komentarze"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Lista raportowanych recenzji użytkownika %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Lista raportowanych komentarzy użytkownika %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Komentarz/recenzja %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Komentarz/recenzja %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, fuzzy, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Komentarz/recenzja %(x_cmtID)s napisany przez %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, fuzzy, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Komentarz/recenzja %(x_cmtID)s napisany przez %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
-msgstr "Lista wszystkich raportowanych recenzji, sortowana według liczby raportów"
+msgstr ""
+"Lista wszystkich raportowanych recenzji, sortowana według liczby raportów"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr ""
-"Lista wszystkich raportowanych komentarzy, sortowana według liczby "
-"raportów"
+"Lista wszystkich raportowanych komentarzy, sortowana według liczby raportów"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
-msgstr "Lista wszystkich raportowanych recenzji, sortowana według liczby raportów"
+msgstr ""
+"Lista wszystkich raportowanych recenzji, sortowana według liczby raportów"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 #, fuzzy
 msgid "Show comments"
 msgstr "Pokaż komentarze"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
-"Lista wszystkich raportowanych komentarzy, sortowana według liczby "
-"raportów"
+"Lista wszystkich raportowanych komentarzy, sortowana według liczby raportów"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 #, fuzzy
 msgid "Show reviews"
 msgstr "recenzja"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "ID komentarza"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "Usunięto"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 #, fuzzy
 msgid "successfully undeleted"
 msgstr "Usunięto"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "usunięto raport nadużycia"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Jeszcze nie oceniony"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "Zapisano Twój komentarz"
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Usuń komentarze"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "najnowsze jako pierwsze"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "Pokaż komentarze"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "Szczegóły i komentarze"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "Znaleziono %s rekordów"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Komentarze"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "razy"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Dodaj do użytkowników"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "Pokaż"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Data utworzenia"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Następna strona"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Pokaż alerty"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8590,106 +8557,106 @@ msgstr "Pokaż alerty"
 msgid "Refresh"
 msgstr "Odświeżanie"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Usuń komentarz"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "Nie znaleziono wartości."
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Nie można odnaleźć rekordu"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "Nie masz uprawnień do przeglądania zawartości tego koszyka."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Dodaj komentarz"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "Zobacz wszystkie zgłoszone komentarze"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 #, fuzzy
 msgid "Page Not Found"
 msgstr "Kolekcja %s nie Odnaleziona"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 #, fuzzy
 msgid "The requested comment could not be found"
 msgstr "Ten rekord nie istnieje."
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 #, fuzzy
 msgid "The requested file could not be found"
 msgstr "Ten rekord nie istnieje."
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Nie masz uprawnień aby tu wejść."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Komentarze"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "Zobacz wszystkie zgłoszone komentarze"
@@ -8808,8 +8775,8 @@ msgstr "Przepraszamy, strona %s nie istnieje."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr "Możesz sprawdzić też %(x_url_open)s%(x_category)s pages%(x_url_close)s"
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8876,11 +8843,11 @@ msgstr "Nie możemy dostarczyć żadnych czasopism"
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
-"Na tym serwerze nie ma zdefiniowanych żadnych czasopism. Proszę napisz do"
-" administratora jeśli to błąd."
+"Na tym serwerze nie ma zdefiniowanych żadnych czasopism. Proszę napisz do "
+"administratora jeśli to błąd."
 
 #: invenio/legacy/webjournal/config.py:239
 msgid "Select a journal on this server"
@@ -8895,8 +8862,8 @@ msgid ""
 "You did not provide an argument for a journal name. Please select the "
 "journal you want to read in the list below."
 msgstr ""
-"Nie podano żadnych danych o tytule czasopisma. Wybierz czasopismo z listy"
-" poniżej."
+"Nie podano żadnych danych o tytule czasopisma. Wybierz czasopismo z listy "
+"poniżej."
 
 #: invenio/legacy/webjournal/config.py:268
 msgid "No current issue"
@@ -8908,11 +8875,11 @@ msgstr "Brak informacji o aktualnym wydaniu"
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
-"Konfiguracja bieżącego wydania jest pusta. Spróbuj podać numer wydania "
-"albo powiadom administratora"
+"Konfiguracja bieżącego wydania jest pusta. Spróbuj podać numer wydania albo "
+"powiadom administratora"
 
 #: invenio/legacy/webjournal/config.py:298
 msgid "Issue number badly formed"
@@ -9008,11 +8975,6 @@ msgstr ""
 msgid "Apply"
 msgstr "Zastosuj"
 
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "Identyfikator"
-
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 msgid "WebJournal Admin"
 msgstr "Administracja WebJournal"
@@ -9092,9 +9054,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -9116,8 +9077,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9229,8 +9189,8 @@ msgid ""
 "Your message is too long, please shorten it. Maximum size allowed is "
 "%(x_size)i characters."
 msgstr ""
-"Twoja wiadomość jest za długa, edytuj ją. Maksymalna dozwolona ilość "
-"znaków - %i."
+"Twoja wiadomość jest za długa, edytuj ją. Maksymalna dozwolona ilość znaków "
+"- %i."
 
 #: invenio/legacy/webmessage/api.py:402
 #, fuzzy, python-format
@@ -9255,8 +9215,8 @@ msgid ""
 "Your message could not be sent to the following recipients as it would "
 "exceed their quotas:"
 msgstr ""
-"Wiadomość nie mogła zostać wysłana do następujących użytkowników z powodu"
-" przekroczenia quot:"
+"Wiadomość nie mogła zostać wysłana do następujących użytkowników z powodu "
+"przekroczenia quot:"
 
 #: invenio/legacy/webmessage/api.py:457
 msgid "Your message has been sent."
@@ -9370,7 +9330,8 @@ msgstr "Czy jesteś pewna/y, że chcesz opóżnić całą skrzynkę?"
 #: invenio/legacy/webmessage/templates.py:582
 #, python-format
 msgid "Quota used: %(x_nb_used)i messages out of max. %(x_nb_total)i"
-msgstr "Wykorzystana pojemność: %(x_nb_used)i wiadomości z maks. %(x_nb_total)i"
+msgstr ""
+"Wykorzystana pojemność: %(x_nb_used)i wiadomości z maks. %(x_nb_total)i"
 
 #: invenio/legacy/webmessage/templates.py:599
 msgid "Please select one or more:"
@@ -9599,16 +9560,16 @@ msgstr "Szukaj również:"
 #: invenio/legacy/websearch/templates.py:1589
 #, fuzzy
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
-"Ta kolekcja jest zastrzeżona.   Jeśli masz prawo dostępu do tej kolekcji,"
-" zaloguj się."
+"Ta kolekcja jest zastrzeżona.   Jeśli masz prawo dostępu do tej kolekcji, "
+"zaloguj się."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9623,7 +9584,8 @@ msgstr "Cytowane przez %i rekordów"
 #: invenio/legacy/websearch/templates.py:1856
 #, python-format
 msgid "Words nearest to %(x_word)s inside %(x_field)s in any collection are:"
-msgstr "Najbliższe słowa %(x_word)s w polu %(x_field)s we wszystkich kolekcjach:"
+msgstr ""
+"Najbliższe słowa %(x_word)s w polu %(x_field)s we wszystkich kolekcjach:"
 
 #: invenio/legacy/websearch/templates.py:1859
 #, python-format
@@ -9703,8 +9665,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found %(x_nb_records)s "
 "records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sRezultaty:%(x_fmt_close)s Znaleziono %(x_nb_records)s "
-"rekordów w %(x_nb_seconds)s sekund."
+"%(x_fmt_open)sRezultaty:%(x_fmt_close)s Znaleziono %(x_nb_records)s rekordów "
+"w %(x_nb_seconds)s sekund."
 
 #: invenio/legacy/websearch/templates.py:3132
 #, fuzzy, python-format
@@ -9717,8 +9679,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found at least "
 "%(x_nb_records)s records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sRezultaty:%(x_fmt_close)s Znaleziono %(x_nb_records)s "
-"rekordów w %(x_nb_seconds)s sekund."
+"%(x_fmt_open)sRezultaty:%(x_fmt_close)s Znaleziono %(x_nb_records)s rekordów "
+"w %(x_nb_seconds)s sekund."
 
 #: invenio/legacy/websearch/templates.py:3184
 #, fuzzy
@@ -9746,8 +9708,7 @@ msgstr "Twoje dodane dokumenty"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 "Wyszukiwanie logiczne nie dało wyników. Powiąż wyrażenia wyszukiwania "
 "inaczej."
@@ -9775,19 +9736,18 @@ msgstr "Możesz zacząć przeglądanie od %s."
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "Ustaw własny %(x_url1_open)salert email%(x_url1_close)s\n"
-"                                  lub zaprenumeruj %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  lub zaprenumeruj %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 
 #: invenio/legacy/websearch/templates.py:3832
 #, fuzzy, python-format
 msgid "Subscribe to the %(x_url2_open)sRSS feed%(x_url2_close)s."
 msgstr ""
-"Jeżeli sobie życzysz możesz %(x_url_open)szalogować się "
-"tutaj%(x_url_close)s."
+"Jeżeli sobie życzysz możesz %(x_url_open)szalogować się tutaj%(x_url_close)s."
 
 #: invenio/legacy/websearch/templates.py:3841
 msgid "Interested in being notified about new results for this query?"
@@ -9972,10 +9932,10 @@ msgid "in"
 msgstr "w"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr ""
-"Jeżeli nie znaleziono tego czego szukasz, spróbuj szukać na innych "
-"serwerach:"
+"Jeżeli nie znaleziono tego czego szukasz, spróbuj szukać na innych serwerach:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
 msgid "External collections results overview:"
@@ -9990,8 +9950,8 @@ msgid ""
 "The external search engine has not responded in time. You can check its "
 "results here:"
 msgstr ""
-"Zewnętrzna wyszukiwarka nie odpowiedziała w określonym czasie. Sprawdź "
-"jej wyniki tutaj:"
+"Zewnętrzna wyszukiwarka nie odpowiedziała w określonym czasie. Sprawdź jej "
+"wyniki tutaj:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:146
 #: invenio/legacy/websearch_external_collections/templates.py:154
@@ -10019,8 +9979,8 @@ msgid ""
 "You can consult the list of your external groups directly in the "
 "%(x_url_open)sgroups page%(x_url_close)s."
 msgstr ""
-"Możesz sprawdzić listę Twoich grup zewnętrznych na %(x_url_open)sstronie "
-"grup%(x_url_close)s."
+"Możesz sprawdzić listę Twoich grup zewnętrznych na %(x_url_open)sstronie grup"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:110
 msgid "External user groups"
@@ -10070,8 +10030,8 @@ msgstr "wymagane"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -10081,11 +10041,11 @@ msgstr "Utwórz nowy koszyk"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
-"Jeżeli chcesz zmienić email lub ustawić po raz pierwszy nazwę "
-"użytkownika, wprowadź nowe dane w formularzu poniżej."
+"Jeżeli chcesz zmienić email lub ustawić po raz pierwszy nazwę użytkownika, "
+"wprowadź nowe dane w formularzu poniżej."
 
 #: invenio/legacy/websession/templates.py:271
 msgid "Edit login credentials"
@@ -10101,19 +10061,19 @@ msgstr "Ustaw nowe wartości"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 "Jest uznawany jako podpis pod komentarzami i ocenami, po pierwszym "
 "ustawieniu nie może być zmieniony."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
-"Jeżeli chcesz zmienić hasło, wprowadź poprzednie hasło i wpisz  nowe "
-"hasło poniżej."
+"Jeżeli chcesz zmienić hasło, wprowadź poprzednie hasło i wpisz  nowe hasło "
+"poniżej."
 
 #: invenio/legacy/websession/templates.py:327
 msgid "Old password"
@@ -10150,8 +10110,8 @@ msgstr "Wpisz nowe hasło"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 "Jeżeli używasz lightweight CERN account możesz\n"
 "                %(x_url_open)szmienić hasło%(x_url_close)s."
@@ -10162,8 +10122,8 @@ msgid ""
 "You can change or reset your CERN account password by means of the "
 "%(x_url_open)sCERN account system%(x_url_close)s."
 msgstr ""
-"Możesz zmienić hasło CERN poprzez %(x_url_open)ssystem obsługi "
-"kont%(x_url_close)s."
+"Możesz zmienić hasło CERN poprzez %(x_url_open)ssystem obsługi kont"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:372
 #, fuzzy
@@ -10244,14 +10204,13 @@ msgstr "Wybierz metodę"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"Jeżeli zapomnisz hasło %(sitename)s %(x_fmt_open)swewnętrznego "
-"konta%(x_fmt_close)s, wprowadź proszę Twój adres email w formularzu aby "
-"otrzymać emailem link do odzyskania hasła."
+"Jeżeli zapomnisz hasło %(sitename)s %(x_fmt_open)swewnętrznego konta"
+"%(x_fmt_close)s, wprowadź proszę Twój adres email w formularzu aby otrzymać "
+"emailem link do odzyskania hasła."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10267,18 +10226,17 @@ msgstr "Wyślij link odzyskania hasła"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 "Jeśli używasz %(x_fmt_open)sCERN login system%(x_fmt_close)s, mozesz "
-"odzyskać hasło poprzez %(x_url_open)sCERN system "
-"autentykacji%(x_url_close)s."
+"odzyskać hasło poprzez %(x_url_open)sCERN system autentykacji%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 "Jeśli używasz zewnętrznego systemu logowania, my nie możemy Ci pomóc , "
 "musisz zwrócić się do tego systemu."
@@ -10295,13 +10253,13 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
-"%s umożliwia zmianę ustawień osobistych interfejsu, ustawienie osobistych"
-" bibliotek dokumentów albo ustawienie automatycznych alertów, które będą "
+"%s umożliwia zmianę ustawień osobistych interfejsu, ustawienie osobistych "
+"bibliotek dokumentów albo ustawienie automatycznych alertów, które będą "
 "okresowo wysyłać powiadomienia emailem o nowych wynikach wyszukiwania."
 
 #: invenio/legacy/websession/templates.py:611
@@ -10321,8 +10279,8 @@ msgstr "Historia wyszukiwania w ciągu ostatnich 30 dni."
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 "W koszykach możesz zdefiniować określone kolekcje dokumentów, zachować "
 "interesujące wyniki, które chcesz zapamiętać lub udostępnić innym "
@@ -10338,35 +10296,35 @@ msgid ""
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
 "Zachowaj Twoje wyszukiwanie, które będzie wykonywane automatycznie przez "
-"system. Rezultaty mogą być wysyłane emailem lub zapisywane w jednym z "
-"Twoich koszyków."
+"system. Rezultaty mogą być wysyłane emailem lub zapisywane w jednym z Twoich "
+"koszyków."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
-"Sprawdź Twoje wypożyczenia, zarezerwuj książki, etc. Wymaga podania "
-"numeru CERN ID."
+"Sprawdź Twoje wypożyczenia, zarezerwuj książki, etc. Wymaga podania numeru "
+"CERN ID."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
-"Jesteś zalogowany jako Gość, więc Twoje alerty znikną po zamknięciu "
-"bieżącej sesji."
+"Jesteś zalogowany jako Gość, więc Twoje alerty znikną po zamknięciu bieżącej "
+"sesji."
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
-"Jesteś zalogowany jako %(x_user)s. Możesz: a) %(x_url1_open)s wylogować "
-"się%(x_url1_close)s; b) edytować %(x_url2_open)s ustawienia "
-"konta%(x_url2_close)s."
+"Jesteś zalogowany jako %(x_user)s. Możesz: a) %(x_url1_open)s wylogować się"
+"%(x_url1_close)s; b) edytować %(x_url2_open)s ustawienia konta"
+"%(x_url2_close)s."
 
 #: invenio/legacy/websession/templates.py:785
 #, fuzzy, python-format
@@ -10382,8 +10340,8 @@ msgstr "Twoje wyszukiwania zapisane w alertach"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 "To jest Twoja lista %(x_url_open)sgrup%(x_url_close)s, w których  jesteś "
 "administratorem lub członkiem."
@@ -10397,11 +10355,11 @@ msgstr "Twoje grupy"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"To jest lista twoich %(x_url_open)sdodanych dokumentów%(x_url_close)s "
-"możesz tu sprawdzić ich status."
+"To jest lista twoich %(x_url_open)sdodanych dokumentów%(x_url_close)s możesz "
+"tu sprawdzić ich status."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -10411,11 +10369,11 @@ msgstr "Twoje dodane dokumenty"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"To jest lista %(x_url_open)sTwoich akceptacji%(x_url_close)s dla "
-"dokumentów akceptowanych lub referowanych przez Ciebie."
+"To jest lista %(x_url_open)sTwoich akceptacji%(x_url_close)s dla dokumentów "
+"akceptowanych lub referowanych przez Ciebie."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10464,7 +10422,8 @@ msgstr "aby potwierdzić prawidłowość tego żądania."
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr "Uwaga, ten URL będzie ważny tylko przez około %(days)s dni."
 
 #: invenio/legacy/websession/templates.py:909
@@ -10510,8 +10469,7 @@ msgstr ""
 #, python-format
 msgid "If you wish you can %(x_url_open)slogin here%(x_url_close)s."
 msgstr ""
-"Jeżeli sobie życzysz możesz %(x_url_open)szalogować się "
-"tutaj%(x_url_close)s."
+"Jeżeli sobie życzysz możesz %(x_url_open)szalogować się tutaj%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1011
 msgid "If you already have an account, please login using the form below."
@@ -10520,27 +10478,27 @@ msgstr "Jeżeli masz już założone konto, zaloguj się poniżej."
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
-"Jeżeli nie posiadasz jeszcze konta CERN, proszę %(x_url_open)s "
-"zarejestrować się %(x_url_close)s."
+"Jeżeli nie posiadasz jeszcze konta CERN, proszę %(x_url_open)s zarejestrować "
+"się %(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"Jeżeli nie posiadasz jeszcze konta, proszę %(x_url_open)s zarejestrować "
-"się %(x_url_close)s."
+"Jeżeli nie posiadasz jeszcze konta, proszę %(x_url_open)s zarejestrować się "
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
 msgid "If you don't own an account yet, please contact %(x_name)s."
 msgstr ""
-"Jeżeli nie posiadasz jeszcze konta, proszę %(x_url_open)s zarejestrować "
-"się %(x_url_close)s."
+"Jeżeli nie posiadasz jeszcze konta, proszę %(x_url_open)s zarejestrować się "
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1051
 msgid "Login method:"
@@ -10566,13 +10524,15 @@ msgstr "Utraciłeś hasło?"
 
 #: invenio/legacy/websession/templates.py:1094
 msgid "You can use your nickname or your email address to login."
-msgstr "Możesz użyć Twojej nazwy użytkownika lub adresu email aby się zalogować."
+msgstr ""
+"Możesz użyć Twojej nazwy użytkownika lub adresu email aby się zalogować."
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
-msgstr "Twoje żądanie jest uprawnione. Ustaw nowe hasło w następującym formularzu."
+"Your request is valid. Please set the new desired password in the following "
+"form."
+msgstr ""
+"Twoje żądanie jest uprawnione. Ustaw nowe hasło w następującym formularzu."
 
 #: invenio/legacy/websession/templates.py:1150
 msgid "Set a new password for"
@@ -10596,11 +10556,11 @@ msgstr "Wpisz Twój adres email, wybraną nazwę użytkownika i hasło:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
-"Nie będzie można używać konta, zanim nie zostanie zweryfikowane i "
-"aktywowane przez administratora."
+"Nie będzie można używać konta, zanim nie zostanie zweryfikowane i aktywowane "
+"przez administratora."
 
 #: invenio/legacy/websession/templates.py:1228
 msgid "Retype Password"
@@ -10616,34 +10576,34 @@ msgstr "rejestracja"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
-"Nie używaj ważnych dla Ciebie haseł, takich jak hasła do systemu UNIX, "
-"banku w tym systemie. Twój adres email jest traktowany jako poufny i nie "
-"będzie nikomu przekazywany. Będzie używany wyłącznie do identyfikacji "
-"usług personalizowanych %s. Możesz np. ustawić automatyczne powiadomienia"
-" o nowych publikacjach, artykułach, książkach."
+"Nie używaj ważnych dla Ciebie haseł, takich jak hasła do systemu UNIX, banku "
+"w tym systemie. Twój adres email jest traktowany jako poufny i nie będzie "
+"nikomu przekazywany. Będzie używany wyłącznie do identyfikacji usług "
+"personalizowanych %s. Możesz np. ustawić automatyczne powiadomienia o nowych "
+"publikacjach, artykułach, książkach."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
-"Nie możesz sam utworzyć konta. Skontaktuj sie z %s jeżeli chcesz posiadać"
-" konto."
+"Nie możesz sam utworzyć konta. Skontaktuj sie z %s jeżeli chcesz posiadać "
+"konto."
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
-"Nie jesteś zalogowany. Musisz najpierw się "
-"%(x_url_open)szalogować%(x_url_close)s."
+"Nie jesteś zalogowany. Musisz najpierw się %(x_url_open)szalogować"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1267
 msgid "You are not authorized to access administrative functions."
@@ -10775,8 +10735,8 @@ msgstr "Kilka ciekawych linków administracyjnych dla Ciebie:"
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "Aby wykonać więcej czynności administracyjnych, przejdź do "
 "%(x_url_open)sAdministracji%(x_url_close)s."
@@ -10999,7 +10959,8 @@ msgstr "Użytkownik chce dołączyć do grupy %s."
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 "Proszę %(x_url_open)szaakceptuj lub odrzuć %(x_url_close)s wniosek "
 "użytkownika."
@@ -11043,9 +11004,9 @@ msgstr "Grupa %s została usunięta przez jej administratora."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
 "To jest lista %(x_url_open)s%(x_nb_total)i grup%(x_url_close)s których "
 "jesteś członkiem (%(x_nb_member)i) lub administratorem (%(x_nb_admin)i)."
@@ -11053,56 +11014,51 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
 "Jesteś zalogowany jako Gość. Możesz się %(x_url_open)szalogować "
 "%(x_url_close)s jako zarejestrowany użytkownik."
@@ -11110,11 +11066,11 @@ msgstr ""
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
-"%(x_fmt_open)sGoście%(x_fmt_close)s powinni się "
-"%(x_url_open)szarejestrować%(x_url_close)s najpierw"
+"%(x_fmt_open)sGoście%(x_fmt_close)s powinni się %(x_url_open)szarejestrować"
+"%(x_url_close)s najpierw"
 
 #: invenio/legacy/websession/webaccount.py:127
 msgid "No queries found"
@@ -11122,20 +11078,20 @@ msgstr "Nie znaleziono kwerend"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
-"Ta kolekcja jest zastrzeżona.   Jeśli masz prawo dostępu do tej kolekcji,"
-" zaloguj się."
+"Ta kolekcja jest zastrzeżona.   Jeśli masz prawo dostępu do tej kolekcji, "
+"zaloguj się."
 
 #: invenio/legacy/websession/webaccount.py:399
 #, fuzzy
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
-"Ta kolekcja jest zastrzeżona.   Jeśli masz prawo dostępu do tej kolekcji,"
-" zaloguj się."
+"Ta kolekcja jest zastrzeżona.   Jeśli masz prawo dostępu do tej kolekcji, "
+"zaloguj się."
 
 #: invenio/legacy/websession/webaccount.py:400
 msgid "The OpenID identifier is invalid"
@@ -11143,8 +11099,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11156,8 +11112,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11237,8 +11193,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11277,8 +11232,7 @@ msgid ""
 "browser if you are a guest user."
 msgstr ""
 "Otrzymałeś autoryzację jako %(x_role)s! Ta autoryzacja jest ważna do "
-"%(x_expiration)s lub do chwili zamknięcia przeglądarki jeśli jesteś "
-"gościem."
+"%(x_expiration)s lub do chwili zamknięcia przeglądarki jeśli jesteś gościem."
 
 #: invenio/legacy/websession/webinterface.py:128
 msgid "You have confirmed the validity of your email address!"
@@ -11306,8 +11260,7 @@ msgstr "Już wcześniej potwierdziłeś swój email!"
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr "Ta prośba o potwierdzenie adresu email jest nieważna lub spóźniona."
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -11374,14 +11327,14 @@ msgstr "Zmieniono tryb logowania na wewnętrzny."
 #: invenio/legacy/websession/webinterface.py:423
 #, fuzzy
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
-"Uwaga, jeśli po raz pierwszy używasz tego konta po zmianie trybu "
-"logowania wewnętrznego to system sam ustawił losowe hasło dla Ciebie, "
-"które zostanie wysłane emailem do Ciebie po kliknięciu tegoprzycisku:"
+"Uwaga, jeśli po raz pierwszy używasz tego konta po zmianie trybu logowania "
+"wewnętrznego to system sam ustawił losowe hasło dla Ciebie, które zostanie "
+"wysłane emailem do Ciebie po kliknięciu tegoprzycisku:"
 
 #: invenio/legacy/websession/webinterface.py:431
 msgid "Send Password"
@@ -11402,8 +11355,8 @@ msgid ""
 "Unable to switch to external login method %(x_meth)s, because your email "
 "address is unknown to the external login system."
 msgstr ""
-"Nie można przełączyć na zewnętrzny tryb logowania %s, ponieważ Twój email"
-" nie został rozpoznany przez zewnętrzny system."
+"Nie można przełączyć na zewnętrzny tryb logowania %s, ponieważ Twój email "
+"nie został rozpoznany przez zewnętrzny system."
 
 #: invenio/legacy/websession/webinterface.py:449
 msgid "Login method successfully selected."
@@ -11412,11 +11365,11 @@ msgstr "Wybrano poprawnie tryb logowania."
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
-"Metoda zewnętrznego systemu logowania %s nie używa adresu email jako "
-"login.  Skontaktuj się z administratorem."
+"Metoda zewnętrznego systemu logowania %s nie używa adresu email jako login.  "
+"Skontaktuj się z administratorem."
 
 #: invenio/legacy/websession/webinterface.py:464
 #, fuzzy
@@ -11543,7 +11496,8 @@ msgstr "Nie można zaktualizować ustawień."
 msgid ""
 "Cannot send password reset request since you are using external "
 "authentication system."
-msgstr "Nie można wysłać hasła, ponieważ używasz zewnętrznego systemu logowania."
+msgstr ""
+"Nie można wysłać hasła, ponieważ używasz zewnętrznego systemu logowania."
 
 #: invenio/legacy/websession/webinterface.py:665
 msgid "The entered email address does not exist in the database."
@@ -11591,14 +11545,14 @@ msgid ""
 "In order to confirm its validity, an email message containing an account "
 "activation key has been sent to the given email address."
 msgstr ""
-"Aby potwierdzić poprtawność, wysłano wiadomość zawierającą klucz "
-"aktywujący pod podany adres email."
+"Aby potwierdzić poprtawność, wysłano wiadomość zawierającą klucz aktywujący "
+"pod podany adres email."
 
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 "Proszę postępować zgodnie z instrukcajami aby zakończyć procedurę "
 "rejestracji konta."
@@ -11606,11 +11560,11 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
-"Email zostanie wysłany ponownie gdy konto zostanie aktywowane i gotowe do"
-" użytku."
+"Email zostanie wysłany ponownie gdy konto zostanie aktywowane i gotowe do "
+"użytku."
 
 #: invenio/legacy/websession/webinterface.py:989
 #, python-format
@@ -11660,8 +11614,7 @@ msgid ""
 "The site is having troubles in sending you an email for confirming your "
 "email address."
 msgstr ""
-"Mamy problemy z wysłaniem emaila w celu potwierdzenia Twojego adresu "
-"email."
+"Mamy problemy z wysłaniem emaila w celu potwierdzenia Twojego adresu email."
 
 #: invenio/legacy/websession/webinterface.py:1432
 #, fuzzy
@@ -11730,7 +11683,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 "Rekord stworzony %(x_date_creation)s, ostatnia modyfikacja "
 "%(x_date_modification)s"
@@ -11758,37 +11712,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11796,15 +11750,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11872,8 +11826,8 @@ msgstr "Nie mogę wykryć liczby stron dokumentu."
 #: invenio/legacy/websubmit/engine.py:931
 #, fuzzy
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr "Nie mogę utworzyć katalogu dla tego dokumentu."
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11909,8 +11863,8 @@ msgstr "Dodaj"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11957,11 +11911,10 @@ msgstr "Wybierz kategorię a następnie kliknij wybrany przycisk."
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
-"Aby kontynuować przerwane dodawanie, wprowadź numer dostępu w pole "
-"poniżej:"
+"Aby kontynuować przerwane dodawanie, wprowadź numer dostępu w pole poniżej:"
 
 #: invenio/legacy/websubmit/templates.py:366
 msgid "GO"
@@ -11989,11 +11942,11 @@ msgstr "Wróć do głównego menu"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
-"To jest numer dokumentu. Możesz go użyć do kontynuacji przerwanej "
-"operacji dodawania dokumentu."
+"To jest numer dokumentu. Możesz go użyć do kontynuacji przerwanej operacji "
+"dodawania dokumentu."
 
 #: invenio/legacy/websubmit/templates.py:548
 msgid "Mandatory fields appear in red in the SUMMARY window."
@@ -12041,11 +11994,11 @@ msgstr "Nr dodanego dokumentu"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
-"To jest %(x_action)s lista funkcji dla %(x_doctype)s dokumentów na "
-"poziomie %(x_step)s"
+"To jest %(x_action)s lista funkcji dla %(x_doctype)s dokumentów na poziomie "
+"%(x_step)s"
 
 #: invenio/legacy/websubmit/templates.py:1041
 msgid "Function"
@@ -12126,9 +12079,9 @@ msgstr "Lista recenzowanych typów dokumentów"
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
-msgstr "Wybierz jeden typ dokumentu z poniższych aby sprawdzić status dokumentu."
+"Select one of the following types of documents to check the documents status"
+msgstr ""
+"Wybierz jeden typ dokumentu z poniższych aby sprawdzić status dokumentu."
 
 #: invenio/legacy/websubmit/templates.py:1447
 msgid "Go to specific approval workflow"
@@ -12265,8 +12218,10 @@ msgstr "Zatwierdź"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
-msgstr "Ten dokument wciąż czeka %(x_fmt_open)sna zatwierdzenie %(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgstr ""
+"Ten dokument wciąż czeka %(x_fmt_open)sna zatwierdzenie %(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
 #: invenio/legacy/websubmit/templates.py:2163
@@ -12304,8 +12259,8 @@ msgid ""
 "As a referee for this document, you may approve or reject it from the "
 "submission interface"
 msgstr ""
-"Jako recenzent tego dokumentu, możesz go zatwierdzić lub odrzucić "
-"klikając ten przycisk."
+"Jako recenzent tego dokumentu, możesz go zatwierdzić lub odrzucić klikając "
+"ten przycisk."
 
 #: invenio/legacy/websubmit/templates.py:2155
 msgid "Approve/Reject"
@@ -12360,8 +12315,8 @@ msgstr "Wybierz recenzenta"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr "Recenzent wysłał swoją ostateczną ocenę do komitetu redakcyjnego dnia "
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -12380,9 +12335,10 @@ msgstr "Napisz komentarz"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
-msgstr "Komitet wydawniczy wysłał ostateczną ocenę do kierownika projektu dnia "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
+msgstr ""
+"Komitet wydawniczy wysłał ostateczną ocenę do kierownika projektu dnia "
 
 #: invenio/legacy/websubmit/templates.py:2291
 #: invenio/legacy/websubmit/templates.py:2358
@@ -12422,7 +12378,8 @@ msgid "Take a decision"
 msgstr "Podejmij decyzję"
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr "Wybrano komisję z komitetu wydawniczego dnia "
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12443,15 +12400,15 @@ msgstr "Komisja wybrała recenzenta dnia "
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr "Ten referent wysłał opinię do komisji dnia "
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
-msgstr "Komisja wysłała swoją ostateczną decyzji do komitetu wydawniczego dnia "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
+msgstr ""
+"Komisja wysłała swoją ostateczną decyzji do komitetu wydawniczego dnia "
 
 #: invenio/legacy/websubmit/templates.py:2350
 msgid "No recommendation from the editorial board yet."
@@ -12567,10 +12524,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12856,8 +12812,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12900,11 +12856,6 @@ msgstr "połączony"
 #, fuzzy
 msgid "Role details"
 msgstr "Artykuł"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Ukryj"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -13020,8 +12971,8 @@ msgstr "Podany adres email %s już istnieje w bazie danych."
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -13086,9 +13037,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, fuzzy, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 "Jesteś zalogowany nadal w systemie centralnym\n"
 "                %(x_fmt_open)sSSO%(x_fmt_close)s. Możesz\n"
@@ -13098,8 +13048,7 @@ msgstr ""
 #, fuzzy, python-format
 msgid "If you wish you can %(x_url_open)ssign in again%(x_url_close)s."
 msgstr ""
-"Jeżeli sobie życzysz możesz %(x_url_open)szalogować się "
-"tutaj%(x_url_close)s."
+"Jeżeli sobie życzysz możesz %(x_url_open)szalogować się tutaj%(x_url_close)s."
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:27
 #, fuzzy
@@ -13117,8 +13066,8 @@ msgstr "Wpisz nowe hasło"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr "Wpisz Twój adres email, wybraną nazwę użytkownika i hasło:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -13147,7 +13096,7 @@ msgid "Problem with login."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "Teraz masz dostęp %(x_url_open)s do konta%(x_url_close)s."
 
@@ -13191,8 +13140,7 @@ msgstr "Edycja ustawień zakończona niepowodzeniem"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13264,13 +13212,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13279,9 +13226,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13458,8 +13405,7 @@ msgstr "kolekcje"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13549,8 +13495,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13642,13 +13588,13 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
-"Twoja wiadomość jest za długa, edytuj ją. Maksymalna dozwolona ilość "
-"znaków - %i."
+"Twoja wiadomość jest za długa, edytuj ją. Maksymalna dozwolona ilość znaków "
+"- %i."
 
 #: invenio/modules/comments/forms.py:55
 #, fuzzy
@@ -13691,12 +13637,12 @@ msgid "Review was sent"
 msgstr "Napisz komentarz"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Ten komentarz był raportowany %i razy"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Ten komentarz był raportowany %i razy"
 
@@ -13749,9 +13695,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13770,8 +13715,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13781,7 +13726,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "Wybrana nazwa użytkownika %s już istnieje w bazie danych."
 
@@ -13837,8 +13782,7 @@ msgstr "recenzja"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13878,8 +13822,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13925,7 +13868,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "Funkcja %s nie istnieje."
 
@@ -14008,11 +13951,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "bieżący status:"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Twoje Koszyki"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -14047,8 +13985,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -14069,8 +14007,8 @@ msgstr "Brak indeksu słów dla"
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -14086,8 +14024,7 @@ msgstr "Sprawdzenie elementu formatowania %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14207,7 +14144,7 @@ msgstr "Pokaż wszystkich %i autorów"
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 #, fuzzy
 msgid "Edit This Record"
 msgstr "Edytuj kolejny rekord."
@@ -14308,10 +14245,6 @@ msgstr "recenzja"
 msgid "Authors"
 msgstr "autor"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14404,8 +14337,8 @@ msgstr "Ustaw uprawnienia grupy"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "Nie masz uprawnień do przeglądania zawartości tego koszyka."
 
 #: invenio/modules/groups/views.py:279
@@ -14418,12 +14351,12 @@ msgstr "Nie jesteś administratorem żadnej grupy."
 msgid "Members"
 msgstr "Brak członków."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Mapowanie bazy wiedzy"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14433,11 +14366,11 @@ msgstr "Wykonane"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "dowolne pole"
@@ -14483,13 +14416,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "Jest %i koszyków"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "Jest %i koszyków"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14645,28 +14579,28 @@ msgstr "Nieznany typ dokumentu"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14731,8 +14665,8 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr "Jeśli chcesz potwierdzić to utworzenie konta, proszę idź do:"
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -15104,7 +15038,7 @@ msgid "Tag name"
 msgstr "Identyfikator"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "Żądana nazwa użytkownika %s jest zajęta."
 
@@ -15209,11 +15143,6 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "Wykonane"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15255,8 +15184,7 @@ msgstr "Opcje wyszukiwania:"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15465,7 +15393,7 @@ msgid "just now"
 msgstr "Teraz musisz"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s sekund"
 
@@ -15524,6 +15452,36 @@ msgstr "dowolny rok"
 msgid " years ago"
 msgstr "rok"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "Administracja BibFormat"
+
+#~ msgid "Not authorized"
+#~ msgstr "autor"
+
+#~ msgid "Really delete"
+#~ msgstr "Usunięto"
+
+#~ msgid "Verify problem"
+#~ msgstr "Błąd bazy danych"
+
+#~ msgid "File"
+#~ msgstr "tytuł"
+
+#~ msgid "niceName"
+#~ msgstr "Nazwa"
+
+#~ msgid "Id"
+#~ msgstr "ID"
+
+#~ msgid "Tickets"
+#~ msgstr "razy"
+
+#~ msgid "by"
+#~ msgstr "przez"
+
+#~ msgid "Done"
+#~ msgstr "Wykonane"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Proszę wybrać kategorię"
 
@@ -15538,9 +15496,6 @@ msgstr "rok"
 
 #~ msgid "*** basket name ***"
 #~ msgstr "Nazwa koszyka"
-
-#~ msgid ""
-#~ msgstr "Wysłano email pod adres podany w ustawieniach konta."
 
 #~ msgid "%(x_name)s"
 #~ msgstr "link do %(x_sitename)s"
@@ -15608,23 +15563,8 @@ msgstr "rok"
 #~ msgid "now"
 #~ msgstr "nie"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "Administracja BibFormat"
-
-#~ msgid "Not authorized"
-#~ msgstr "autor"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "Użytkownik %s nie istnieje."
-
-#~ msgid "Really delete"
-#~ msgstr "Usunięto"
-
-#~ msgid "Verify problem"
-#~ msgstr "Błąd bazy danych"
-
-#~ msgid "File"
-#~ msgstr "tytuł"
 
 #~ msgid "File %s already exists."
 #~ msgstr "Użytkownik %s nie istnieje."
@@ -15683,9 +15623,6 @@ msgstr "rok"
 #~ msgid "Not Mine!"
 #~ msgstr "Notatka"
 
-#~ msgid "Tickets"
-#~ msgstr "razy"
-
 #~ msgid "Request Tickets"
 #~ msgstr "Reguły"
 
@@ -15721,9 +15658,6 @@ msgstr "rok"
 
 #~ msgid "Create a new Person for your search"
 #~ msgstr "Nie znaleziono wyników."
-
-#~ msgid "Id"
-#~ msgstr "ID"
 
 #~ msgid "A %s has been added."
 #~ msgstr "Grupa %s została usunięta."
@@ -15776,9 +15710,6 @@ msgstr "rok"
 #~ msgid "creating a new basket"
 #~ msgstr "Utwórz nowy koszyk"
 
-#~ msgid "by"
-#~ msgstr "przez"
-
 #~ msgid "on"
 #~ msgstr "w dniu"
 
@@ -15796,9 +15727,6 @@ msgstr "rok"
 
 #~ msgid "Editing topic"
 #~ msgstr "Edycja koszyka"
-
-#~ msgid "niceName"
-#~ msgstr "Nazwa"
 
 #~ msgid "Apply Changes"
 #~ msgstr "Zapisz Zmiany"
@@ -15914,9 +15842,6 @@ msgstr "rok"
 #~ msgid "Verbose"
 #~ msgstr "Rozwlekle"
 
-#~ msgid "Done"
-#~ msgstr "Wykonane"
-
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "Twoje zmiany są TYMCZASOWE."
 
@@ -15956,9 +15881,6 @@ msgstr "rok"
 #~ msgid "from"
 #~ msgstr "Od:"
 
-#~ msgid "There are record revisions not yet synchronized with the database."
-#~ msgstr ""
-
 #~ msgid "View all reported reviews"
 #~ msgstr "Zobacz wszystkie zgłoszone recenzje"
 
@@ -15982,9 +15904,6 @@ msgstr "rok"
 
 #~ msgid "approvals"
 #~ msgstr "akceptacje"
-
-#~ msgid "Unknown form field found on one of the submission pages."
-#~ msgstr ""
 
 #~ msgid "List of direct approval categories"
 #~ msgstr "Lista kategorii akceptacji bezpośredniej"
@@ -16133,34 +16052,11 @@ msgstr "rok"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "Przewodnik Admina WebSubmit"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "Wykonaj wyszukiwanie"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Anulowane"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "Jesteś członkiem następujących grup:"
@@ -16174,12 +16070,6 @@ msgstr "rok"
 #~ msgid "Invert Selection"
 #~ msgstr "Wybór recenzentów"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Autor"
 
@@ -16191,12 +16081,6 @@ msgstr "rok"
 
 #~ msgid "No status information found."
 #~ msgstr "Więcej informacji:"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "podział"
@@ -16213,15 +16097,6 @@ msgstr "rok"
 #~ msgid "The author has an internal ID!"
 #~ msgstr "Błąd wewnętrzny"
 
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "komentarze"
 
@@ -16231,87 +16106,20 @@ msgstr "rok"
 #~ msgid " Delete this ticket"
 #~ msgstr "Kasuj koszyk"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "Brak dostępnych czasopism"
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Wybierz ocenę"
 
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
 #~ msgid "Paper title: "
 #~ msgstr "Artykuły:"
-
-#~ msgid "Ignore"
-#~ msgstr ""
 
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "Znaleziono następujące błędy"
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "Wybierz ocenę"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "Więcej informacji:"
@@ -16319,35 +16127,11 @@ msgstr "rok"
 #~ msgid "Please provide your first name"
 #~ msgstr "Proszę się najpierw zalogować."
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "Twoje wypożyczenia"
 
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
 #~ msgid "Your eMail:"
 #~ msgstr "Twoje Alerty"
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "Usuń zaznaczone recenzje"
@@ -16355,186 +16139,35 @@ msgstr "rok"
 #~ msgid "Mark as your documents"
 #~ msgstr "wszystkie typy dokumentów"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "Powrót do dokumentu"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Powrót do dokumentu"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "albo utwórz inny"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "Dodaj do użytkowników"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Artykuły:"
-
-#~ msgid "Showing the"
-#~ msgstr ""
 
 #~ msgid "most recent documents:"
 #~ msgstr "Lista recenzowanych dokumentów"
 
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Zarządzanie szablonami formatowania"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Wybierz temat"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Data utworzenia"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "link zewnętrzny"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "dodane"
@@ -16542,190 +16175,17 @@ msgstr "rok"
 #~ msgid "Choose system"
 #~ msgstr "Wybierz temat"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Znaleziono następujące błędy"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Nie masz dostępu do czynności administracyjnych."
 
 #~ msgid "Claim this paper"
 #~ msgstr "Dodaj tego użytkownika"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Cytowane przez: %s rekordów"
 
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
 #~ msgid "Revision"
 #~ msgstr "podział"
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Zmień atrybuty szablonu"
@@ -16805,89 +16265,20 @@ msgstr "rok"
 #~ msgid "No Record Found for %s."
 #~ msgstr "Nie można odnaleźć rekordu"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Użytkownik %s nie istnieje."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "Atrybuty formatu wyjściowego %s"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "Zależności szablonu formatowania %s"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "Sprawdzenie elementu formatowania %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "Zależności elementu formatowania %s"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Format wyjściowy zastrzeżony"
@@ -16943,110 +16334,17 @@ msgstr "rok"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Sprawdzenie elementu formatowania %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "Sprawdzenie formatu"
 
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "Baza wiedzy %s"
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "Notatka"
 
 #~ msgid "never"
 #~ msgstr "Konwertuj"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "razy"
@@ -17075,17 +16373,11 @@ msgstr "rok"
 #~ msgid "Affiliations"
 #~ msgstr "Afiliacje:"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
 #~ msgid "No Frequent Co-authors"
 #~ msgstr "Często spotykani współautorzy:"
 
 #~ msgid "Citations%s"
 #~ msgstr "Cytowania"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Data utworzenia"
@@ -17096,39 +16388,6 @@ msgstr "rok"
 #~ msgid "No publications available"
 #~ msgstr "Brak dostępnych czasopism"
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr "Cytowane przez %i rekordów"
 
@@ -17138,17 +16397,11 @@ msgstr "rok"
 #~ msgid "%i reviews"
 #~ msgstr "recenzja"
 
-#~ msgid "%s of"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "Artykuły:"
 
 #~ msgid "Frequent co-authors"
 #~ msgstr "Często spotykani współautorzy:"
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "Cytowania:"
@@ -17156,23 +16409,8 @@ msgstr "rok"
 #~ msgid "No Citation Information available"
 #~ msgstr "Brak dostępnych czasopism"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Dyskusja"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Twoje Alerty"
@@ -17192,99 +16430,15 @@ msgstr "rok"
 #~ msgid "Statistics"
 #~ msgstr "statystyki"
 
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
 #~ msgid "Group: %s"
 #~ msgstr "Grupa: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "Kolekcja %s nie Odnaleziona"
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "Pole %s jest wymagane."
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "Nie mogę wykryć liczby stron dokumentu."
-

--- a/invenio/base/translations/pt/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/pt/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2008-03-26 15:56+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:58+0200\n"
 "Last-Translator: Joaquim Silvestre <joaquim.rodrigues.silvestre@cern.ch>\n"
 "Language-Team: PT <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -58,8 +58,8 @@ msgstr "Área do Administrador"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -208,7 +208,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 #, fuzzy
 msgid "Hello:"
 msgstr "Ola:"
@@ -230,17 +230,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -266,48 +266,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "O registo não existe."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr "Pedido de alteração de palavra-passe para"
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Não está autorizado a aceder a funções de administração."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Falhou registo"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Por favor seleccione um(a) ou mais"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Pedido de autorização de função"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -510,7 +515,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -587,9 +593,9 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"Está autenticado como %(x_user)s. Poderá querer a) "
-"%(x_url1_open)sterminar a sessão%(x_url1_close)s; b) editar as "
-"%(x_url2_open)sdefinições da sua conta%(x_url2_close)s."
+"Está autenticado como %(x_user)s. Poderá querer a) %(x_url1_open)sterminar a "
+"sessão%(x_url1_close)s; b) editar as %(x_url2_open)sdefinições da sua conta"
+"%(x_url2_close)s."
 
 #: invenio/legacy/batchuploader/templates.py:282
 #, fuzzy
@@ -733,7 +739,8 @@ msgid "The following errors have occurred:"
 msgstr "Foram encontrados os seguintes erros"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -750,8 +757,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -833,7 +840,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -876,8 +883,8 @@ msgstr "Os seus cestos"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Anterior"
@@ -893,8 +900,8 @@ msgstr "Contagem"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Próximo"
 
@@ -909,18 +916,6 @@ msgstr "Próximo"
 #: invenio/legacy/weblinkback/adminlib.py:55
 msgid "Admin Area"
 msgstr "Área do Administrador"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "autor"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
@@ -940,11 +935,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
 msgid "Limit to knowledge bases containing string:"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "apagado com sucesso"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -996,16 +986,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
 msgid "Verify BibCheck config file"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Problema na Base de Dados"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "ficheiro(s)"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
@@ -1112,7 +1092,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1163,8 +1144,8 @@ msgstr "Uma nova conta foi criada em"
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1178,25 +1159,23 @@ msgstr "Explorar"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "Uma nova conta foi criada em"
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "Uma nova conta foi criada em"
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1221,13 +1200,14 @@ msgstr "Criar um novo tópico"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "Uma nova conta foi criada em"
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1259,9 +1239,8 @@ msgstr "estado actual"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "Uma nova conta foi criada em"
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1328,8 +1307,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1337,8 +1316,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1360,9 +1339,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "Uma nova conta foi criada em"
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1404,8 +1382,8 @@ msgstr "%s registos encontrados"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1464,11 +1442,11 @@ msgstr "Uma nova conta foi criada em"
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1479,11 +1457,11 @@ msgstr "Sim"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1496,8 +1474,8 @@ msgstr "Não"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1594,8 +1572,8 @@ msgstr "<strong>%s</strong> registros encontrados"
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1615,29 +1593,29 @@ msgstr "<strong>%s</strong> registros encontrados"
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1646,9 +1624,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 #, fuzzy
 msgid "Requested record does not seem to exist."
 msgstr "O registro foi apagado."
@@ -2010,16 +1988,14 @@ msgstr "O registo foi apagado."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2040,8 +2016,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2203,8 +2179,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2315,7 +2291,7 @@ msgstr "Acção"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 #, fuzzy
 msgid "Description"
 msgstr "Descrição"
@@ -2511,8 +2487,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2798,9 +2774,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "Se desejar pode autenticar-se %(x_url_open)saqui%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2857,7 +2832,7 @@ msgstr "Rejeite"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "OK"
 
@@ -2865,8 +2840,8 @@ msgstr "OK"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "Uma nova conta foi criada em"
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3340,8 +3315,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 #, fuzzy
 msgid "Email"
 msgstr "Email"
@@ -4197,8 +4172,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4216,8 +4191,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4283,17 +4258,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4682,25 +4657,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "O registo foi apagado."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4760,15 +4735,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4780,10 +4755,10 @@ msgstr "Escolher tópico"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4797,15 +4772,15 @@ msgstr "Regras"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4816,7 +4791,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4835,17 +4811,15 @@ msgstr "O nome de utilizador pretendido %s já existe na base de dados."
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "O nome de utilizador pretendido %s já existe na base de dados."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4864,14 +4838,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4925,8 +4898,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4982,8 +4955,8 @@ msgstr "O registro foi apagado."
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 "O sistema encontrou um erro na recuperação da lista de ficheiros deste "
 "documento. "
@@ -5106,9 +5079,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -5123,8 +5096,8 @@ msgstr "Guardar alterações"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -5269,11 +5242,10 @@ msgstr "Regressar aos resultados da pesquisa"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5411,7 +5383,7 @@ msgid "Total"
 msgstr "opcional"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 #, fuzzy
 msgid "Select"
 msgstr "Seleccionar"
@@ -5584,8 +5556,8 @@ msgstr "Apagar Base de Conhecimento"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5645,56 +5617,56 @@ msgstr "É favor autenticar-se primeiro."
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5734,7 +5706,7 @@ msgstr "Dependências da Base de Conhecimento"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5788,15 +5760,15 @@ msgstr "Os seus avisos"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -6030,8 +6002,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -6111,8 +6082,8 @@ msgstr "ir para o registro:"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6127,8 +6098,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Resultados da pesquisa"
 
@@ -6289,8 +6260,8 @@ msgstr "Não foram encontrados valores"
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6316,8 +6287,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6328,99 +6299,98 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
 #, fuzzy, python-format
 msgid "No exact match found for %(x_query1)s, using %(x_query2)s instead..."
 msgstr ""
-"Nenhum resultado exacto foi encontrado para <em>%s</em>, usando "
-"<em>%s</em> em substituição..."
+"Nenhum resultado exacto foi encontrado para <em>%s</em>, usando <em>%s</em> "
+"em substituição..."
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
-"Nenhum resultado foi encontrado na colecção %s. Outras colecções públicas"
-" retornaram <a class=\"nearestterms\" href=\"%s/search.py?%s\">%d "
-"resultados</a>."
+"Nenhum resultado foi encontrado na colecção %s. Outras colecções públicas "
+"retornaram <a class=\"nearestterms\" href=\"%s/search.py?%s\">%d resultados</"
+"a>."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
-"Nenhuma coleção pública corresponde à sua pesquisa. Se você está "
-"procurando um documento que não é público, por favor escolha a colecção "
-"restrita desejada primeiro."
+"Nenhuma coleção pública corresponde à sua pesquisa. Se você está procurando "
+"um documento que não é público, por favor escolha a colecção restrita "
+"desejada primeiro."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
-"Nenhuma coleção pública corresponde à sua pesquisa. Se você está "
-"procurando um documento que não é público, por favor escolha a colecção "
-"restrita desejada primeiro."
+"Nenhuma coleção pública corresponde à sua pesquisa. Se você está procurando "
+"um documento que não é público, por favor escolha a colecção restrita "
+"desejada primeiro."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
 "A expressão procurada %s não está presente em nenhum registo. Os termos "
 "similares em todas as colecções são:"
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "Utilize diferentes termos de pesquisa."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Existem %i cestos"
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Existem %i cestos"
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Existem %i cestos"
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Nenhum índice de palavras está disponível para"
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Nenhum índice de frases está disponível para"
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, fuzzy, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
-"A expressão procura da %(x_term)s no indice %(x_index)s não corresponde a"
-" nenhum registo. Os termos similares em todas as colecções são:"
+"A expressão procura da %(x_term)s no indice %(x_index)s não corresponde a "
+"nenhum registo. Os termos similares em todas as colecções são:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
@@ -6429,7 +6399,7 @@ msgstr ""
 "A expressão procurada %s não está presente em nenhum registo. Os termos "
 "similares em todas as colecções são:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
@@ -6438,35 +6408,35 @@ msgstr ""
 "Desculpa, %s não parece ser uma opção de ordenação válida. Escolhendo "
 "ordenação por título."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 "Desculpe,mas a ordenação está disponivel em conjunto apenas acima dos %d "
 "registos. Usando definições por defeito."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 "Desculpa, %s não parece ser uma opção de ordenação válida. Escolhendo "
 "ordenação por título."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "O registo não existe."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Utilize diferentes termos de pesquisa."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6480,17 +6450,17 @@ msgstr "Utilize diferentes termos de pesquisa."
 msgid "Browse"
 msgstr "Explorar"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
-"Nenhum resultado dentro do período de tempo especificado, desconsiderando"
-" esta condição..."
+"Nenhum resultado dentro do período de tempo especificado, desconsiderando "
+"esta condição..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
-"Nenhum resultado dentro dos limites de pesquisa especificados, "
-"descartando esta condição..."
+"Nenhum resultado dentro dos limites de pesquisa especificados, descartando "
+"esta condição..."
 
 #: invenio/legacy/webalert/api.py:54
 #, fuzzy, python-format
@@ -6509,7 +6479,8 @@ msgstr "Voce não possui direitos suficientes para ver o conteudo deste cesto."
 
 #: invenio/legacy/webalert/api.py:198
 msgid "You already have an alert defined for the specified query and basket."
-msgstr "Já possui actualmente um aviso definido para um termo e cesto específicos"
+msgstr ""
+"Já possui actualmente um aviso definido para um termo e cesto específicos"
 
 #: invenio/legacy/webalert/api.py:221 invenio/legacy/webalert/api.py:345
 msgid "The alert name cannot be empty."
@@ -6532,15 +6503,14 @@ msgstr "O aviso %s foi actualizado com sucesso."
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Voce criou %(x_nb)s termos de pesquisa. A %(x_url_open)slista "
-"detalhada%(x_url_close)s esta disponivel com a possibilidade de (a) ver "
-"os resultados das pesquisas e (b) subscrever um aviso automatico via "
-"email para todos estes termos de pesquisa."
+"Voce criou %(x_nb)s termos de pesquisa. A %(x_url_open)slista detalhada"
+"%(x_url_close)s esta disponivel com a possibilidade de (a) ver os resultados "
+"das pesquisas e (b) subscrever um aviso automatico via email para todos "
+"estes termos de pesquisa."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6685,9 +6655,9 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"Defina um novo aviso para %(x_url1_open)sas suas "
-"pesquisas%(x_url1_close)s, as %(x_url2_open)spesquisas mais "
-"efectuadas%(x_url2_close)s, ou o formato de entrada."
+"Defina um novo aviso para %(x_url1_open)sas suas pesquisas%(x_url1_close)s, "
+"as %(x_url2_open)spesquisas mais efectuadas%(x_url2_close)s, ou o formato de "
+"entrada."
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6742,8 +6712,8 @@ msgstr "Você definiu %s avisos."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 "Você ainda não realizou qualquer pesquisa até agora. Por favor vá à "
 "%(x_url_open)s interface de pesquisa %(x_url_close)s primeiro."
@@ -6751,11 +6721,11 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
-"Você efectuou %(x_nb1)s pesquisas (%(x_nb2)s diferentes perguntas) "
-"durante os últimos 30 dias ou mais."
+"Você efectuou %(x_nb1)s pesquisas (%(x_nb2)s diferentes perguntas) durante "
+"os últimos 30 dias ou mais."
 
 #: invenio/legacy/webalert/templates.py:453
 #, fuzzy, python-format
@@ -6817,7 +6787,7 @@ msgstr "As suas pesquisas"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6882,7 +6852,7 @@ msgstr "%s Personalizar, definir novo aviso"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6944,7 +6914,8 @@ msgstr "%s Personalizar, Mostrat avisos"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6968,7 +6939,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "Voce não possui direitos suficientes para ver o conteudo deste cesto."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6996,7 +6968,8 @@ msgid "You do not have permission to delete this note."
 msgstr "Voce não possui direitos suficientes para ver o conteudo deste cesto."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -7027,8 +7000,8 @@ msgstr "O registo não existe."
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -7050,8 +7023,8 @@ msgstr "Copiar registo para o cesto"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -7084,8 +7057,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7163,12 +7136,10 @@ msgstr "Cesto Público"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
-"Você tem %(x_nb_perso)s cestos pessoais e está registada em "
-"%(x_nb_group)s grupos de cestos e noutros %(x_nb_public)s cestos "
-"públicos."
+"Você tem %(x_nb_perso)s cestos pessoais e está registada em %(x_nb_group)s "
+"grupos de cestos e noutros %(x_nb_public)s cestos públicos."
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
 #, fuzzy
@@ -7195,11 +7166,10 @@ msgstr "%i grupos de utilizadores subscreveram este cesto."
 #: invenio/legacy/webbasket/templates.py:108
 #, fuzzy, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
-"Podera querer ver tambem as %(x_url_open)s%(x_category)s "
-"paginas%(x_url_close)s."
+"Podera querer ver tambem as %(x_url_open)s%(x_category)s paginas"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
 #: invenio/legacy/webbasket/templates.py:198
@@ -7378,8 +7348,8 @@ msgstr "Registo Externo"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7570,20 +7540,21 @@ msgstr "Partilhar cesto a um novo grupo"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
-"Você está autênticado como visitante, os seus cestos irão desaparecer no "
-"fim da actual sessão."
+"Você está autênticado como visitante, os seus cestos irão desaparecer no fim "
+"da actual sessão."
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
-"Se desejar você pode %(x_url_open)sautênticar-se or registar-se "
-"aqui%(x_url_close)s."
+"Se desejar você pode %(x_url_open)sautênticar-se or registar-se aqui"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7592,7 +7563,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Esta funcionalidade é interdita a visitantes."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 #, fuzzy
 msgid "Back to search results"
 msgstr "Regressar aos resultados da pesquisa"
@@ -7774,7 +7745,7 @@ msgstr "Adicionar aos utilizadores"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7923,220 +7894,221 @@ msgstr "O utilizador %s não existe."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "O utilizador %s não existe."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Escrever um comentário"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_name)s escreveu em %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "comentários"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Mostrando os %i últimos comentários:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Discutir este comentário"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Iniciar discussão acerca de um aspecto deste document."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Desculpe, o registo %s parece não existir."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "Desculpe, %s não é um ID válido."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "Desculpe, nenhum Id foi fornecido."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Você poderá começar a explorar a partir de %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_name)s escreveu em %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Esta analise critica foi uma ajuda útil?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Escrever uma analise critica"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 "Media do resultado da analise critica: %(x_nb_score)s baseados em "
 "%(x_nb_reviews)s analises criticas"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
-msgstr "Leitores acharam que as seguintes %s analises criticas são uma boa ajuda"
+msgstr ""
+"Leitores acharam que as seguintes %s analises criticas são uma boa ajuda"
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Ver todas %s as analises criticas"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Classifique este documento"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Seja o primeiro a fazer a analise critica deste documento."
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "Contagem"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 #, fuzzy
 msgid "Report abuse"
 msgstr "Reportar abuso"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 #, fuzzy
 msgid "Undelete comment"
 msgstr "apagar comentários"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 #, fuzzy
 msgid "Delete comment"
 msgstr "Apagar comentário"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 #, fuzzy
 msgid "Unreport comment"
 msgstr "Apagar comentário"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, fuzzy, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Revisto por %(x_nickname)s em %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr "%(x_nb_people)i de %(x_nb_total)i pessoas acharam esta review útil"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 #, fuzzy
 msgid "Undelete review"
 msgstr "Apagar as análises criticas seleccionadas"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 #, fuzzy
 msgid "Delete review"
 msgstr "Apagar as análises criticas seleccionadas"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 #, fuzzy
 msgid "Unreport review"
 msgstr "Escreva a sua análise critica"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Comentários"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 #, fuzzy
 msgid "Reviews"
 msgstr "análises criticas"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Existem no total %s análises criticas"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Existem no total %s comentários"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Seja o primeiro a fazer a analise critica deste documento."
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Subscrever"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 #, fuzzy
 msgid "Unsubscribe"
 msgstr "Subscrever"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -8145,98 +8117,96 @@ msgstr "Subscrever"
 msgid "Record"
 msgstr "Registo"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "análise critica"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "comentaŕio"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 #, fuzzy
 msgid "Review"
 msgstr "análise critica"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Vendo"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Página:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 #, fuzzy
 msgid "You are not authorized to comment or review."
 msgstr "Não está autorizado a aceder a funções de administração."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 "Nota: O seu nome de utilizador, %s, será apresentado como autor deste "
 "comentário"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
-"Nota: Você não %(x_url_open)sdefiniu o seu nome de "
-"utilizador%(x_url_close)s. %(x_nickname)s será apresentado como autor "
-"deste comentário."
+"Nota: Você não %(x_url_open)sdefiniu o seu nome de utilizador"
+"%(x_url_close)s. %(x_nickname)s será apresentado como autor deste comentário."
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 #, fuzzy
 msgid "Max one file"
 msgstr "Adicionar Nova Regra"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "Ficheiro(s) principal/principais"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 #, fuzzy
 msgid "Article"
 msgstr "Artigo"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 #, fuzzy
 msgid "Add comment"
 msgstr "Adicionar comentario"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
@@ -8245,104 +8215,104 @@ msgstr ""
 "Nota: O seu nome de utilizador, %s, será apresentado como autor desta "
 "analise critica."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Classifique este artigo"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 #, fuzzy
 msgid "Select a score"
 msgstr "Seleccione um resultado"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Dê um título à sua análise critica"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Escreva a sua análise critica"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 #, fuzzy
 msgid "Add review"
 msgstr "Adicionar analise critica"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Adicionar análise critica"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "A sua análise critica foi adicionada com sucesso."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 #, fuzzy
 msgid "Your comment was successfully added."
 msgstr "O seu comentário foi adicionado com sucesso."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 #, fuzzy
 msgid "Back to record"
 msgstr "Voltar para o registo"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr "Pode consultar a lista dos %(x_url_open)sseus grupos%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 #, fuzzy
 msgid "View most commented records"
 msgstr "ver comentários"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 #, fuzzy
 msgid "View latest commented records"
 msgstr "ver comentários"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all comments reported as abuse"
 msgstr "Ver todos os utilizadores reportados"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 #, fuzzy
 msgid "View most reviewed records"
 msgstr "remover registos"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 #, fuzzy
 msgid "View latest reviewed records"
 msgstr "Ver todas %s as analises criticas"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all reviews reported as abuse"
 msgstr "Ver todos os utilizadores reportados"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 #, fuzzy
 msgid "View all users who have been reported"
 msgstr "Ver todos os utilizadores que foram reportados."
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Guia"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Comentários e análise critica estão indisponíveis"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
@@ -8350,334 +8320,340 @@ msgstr ""
 "Por favor indique o ID do(a) comentário/analise critica que viu "
 "anteriormente escolhendo se deseja ou não apagá-lo."
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "ID comentário:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 #, fuzzy
 msgid "Record ID:"
 msgstr "ID do registo"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Ver comentário"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Não houve nenhum relatório até agora."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Ver todos os %s comentários reportados"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Ver todas as %s análises criticas reportadas"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-"Aqui está uma lista, ordenada pelo numero total de relatórios, de todos "
-"os utilizadores que tenham um comentário reportado, pelo menos uma vez."
+"Aqui está uma lista, ordenada pelo numero total de relatórios, de todos os "
+"utilizadores que tenham um comentário reportado, pelo menos uma vez."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Nome de Utilizador"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "ID de Utilizador"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Número de votos positivos"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Número de votos negativos"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Número total de votos"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Número total de relatórios"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
-msgstr "Ver todos os comentários/análises criticas reportados pelos utilizadores"
+msgstr ""
+"Ver todos os comentários/análises criticas reportados pelos utilizadores"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Esta análise critica foi reportada %i vezes."
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Este comentário foi reportado %i vezes."
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 #, fuzzy
 msgid "Written by"
 msgstr "Escrito por"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Informações Gerais"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 #, fuzzy
 msgid "Delete selected reviews"
 msgstr "Apagar as análises criticas seleccionadas"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Suprimir relatorio de abuso seleccionado"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 #, fuzzy
 msgid "Undelete selected reviews"
 msgstr "Apagar as análises criticas seleccionadas"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 #, fuzzy
 msgid "Undelete selected comments"
 msgstr "Apagar comentários seleccionados"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 #, fuzzy
 msgid "Delete selected comments"
 msgstr "Apagar comentários seleccionados"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Aqui estão as análises criticas reportadas pelo utilizador %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Aqui estão os comentários reportados pelo utilizador %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Aqui está um(a) comentário/análise critica %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Aqui está um(a) comentário/análise critica %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, fuzzy, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 "Aqui está um(a) comentário/análise critica %(x_cmtID)s escrito(a) pelo "
 "utilizador %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, fuzzy, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 "Aqui está um(a) comentário/análise critica %(x_cmtID)s escrito(a) pelo "
 "utilizador %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
-msgstr "Aqui estão as análises criticas reportadas ordenadas pelo o maior número"
+msgstr ""
+"Aqui estão as análises criticas reportadas ordenadas pelo o maior número"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "Aqui estão comentários reportados ordenados pelo maior número"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
-msgstr "Aqui estão as análises criticas reportadas ordenadas pelo o maior número"
+msgstr ""
+"Aqui estão as análises criticas reportadas ordenadas pelo o maior número"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 #, fuzzy
 msgid "Show comments"
 msgstr "ver comentários"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr "Aqui estão comentários reportados ordenados pelo maior número"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 #, fuzzy
 msgid "Show reviews"
 msgstr "análise critica"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "ID do comentário"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "apagado com sucesso"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 #, fuzzy
 msgid "successfully undeleted"
 msgstr "apagado com sucesso"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "relatório de abuso suprimido com sucesso"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Not yet reviewed"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "O seu comentário foi colocado com sucesso"
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Apagar comentários"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "Último primeiro"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "ver comentários"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "Detalhes e comentários"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "%s registos encontrados"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Comentários"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "Tempo"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Adicionar aos utilizadores"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 #, fuzzy
 msgid "Display"
 msgstr "Mostrar"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Data de criação"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "próxima página"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Mostrar avisos"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8686,107 +8662,107 @@ msgstr "Mostrar avisos"
 msgid "Refresh"
 msgstr "Referência"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Apagar comentário"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "Não foram encontrados valores"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 #, fuzzy
 msgid "Record Not Found"
 msgstr "Registo não encontrado"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "Voce não possui direitos suficientes para ver o conteudo deste cesto."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Adicionar comentário"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "Ver todos os comentários reportados"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 #, fuzzy
 msgid "Page Not Found"
 msgstr "A pagina %s não foi encontrada"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 #, fuzzy
 msgid "The requested comment could not be found"
 msgstr "O registo não existe."
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 #, fuzzy
 msgid "The requested file could not be found"
 msgstr "O registo não existe."
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Não está autorizado a aceder a funções de administração."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Comentários"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "Ver todos os comentários reportados"
@@ -8910,11 +8886,11 @@ msgstr "Desculpe, a pagina %s parece não existir."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
-"Podera querer ver tambem as %(x_url_open)s%(x_category)s "
-"paginas%(x_url_close)s."
+"Podera querer ver tambem as %(x_url_open)s%(x_category)s paginas"
+"%(x_url_close)s."
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
 #, fuzzy, python-format
@@ -8985,8 +8961,8 @@ msgstr "não podemos fornecer qualquer jornal"
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -9013,8 +8989,8 @@ msgstr "não encontramos nenhuma informação na actual edição"
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -9118,11 +9094,6 @@ msgstr ""
 msgid "Apply"
 msgstr "Abril"
 
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "Nome de Utilizador"
-
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 #, fuzzy
 msgid "WebJournal Admin"
@@ -9206,9 +9177,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -9230,8 +9200,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9347,8 +9316,8 @@ msgid ""
 "Your message is too long, please shorten it. Maximum size allowed is "
 "%(x_size)i characters."
 msgstr ""
-"A sua mensagem é demasiado grande, por favor modifique-a. O tamanho "
-"maximo permitido é %i caracteres."
+"A sua mensagem é demasiado grande, por favor modifique-a. O tamanho maximo "
+"permitido é %i caracteres."
 
 #: invenio/legacy/webmessage/api.py:402
 #, fuzzy, python-format
@@ -9373,8 +9342,8 @@ msgid ""
 "Your message could not be sent to the following recipients as it would "
 "exceed their quotas:"
 msgstr ""
-"A sua mensagem não pode ser enviada para o seguinte endereço devido à sua"
-" quota:"
+"A sua mensagem não pode ser enviada para o seguinte endereço devido à sua "
+"quota:"
 
 #: invenio/legacy/webmessage/api.py:457
 msgid "Your message has been sent."
@@ -9491,12 +9460,14 @@ msgstr "APAGAR"
 #: invenio/legacy/webmessage/templates.py:506
 #: invenio/modules/messages/templates/messages/confirm_delete_base.html:25
 msgid "Are you sure you want to empty your whole mailbox?"
-msgstr "Tem a certeza que deseja esvaziar a sua caixa de correio na totalidade?"
+msgstr ""
+"Tem a certeza que deseja esvaziar a sua caixa de correio na totalidade?"
 
 #: invenio/legacy/webmessage/templates.py:582
 #, python-format
 msgid "Quota used: %(x_nb_used)i messages out of max. %(x_nb_total)i"
-msgstr "Quota utilizada: %(x_nb_used)i mensagens para alem do max. %(x_nb_total)i"
+msgstr ""
+"Quota utilizada: %(x_nb_used)i mensagens para alem do max. %(x_nb_total)i"
 
 #: invenio/legacy/webmessage/templates.py:599
 msgid "Please select one or more:"
@@ -9734,14 +9705,14 @@ msgstr "Procurar também:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9756,7 +9727,8 @@ msgstr "Citado por: %s registos"
 #: invenio/legacy/websearch/templates.py:1856
 #, fuzzy, python-format
 msgid "Words nearest to %(x_word)s inside %(x_field)s in any collection are:"
-msgstr "Palavras semelhantes a %(x_word)s em %(x_field)s em qualquer colecção são:"
+msgstr ""
+"Palavras semelhantes a %(x_word)s em %(x_field)s em qualquer colecção são:"
 
 #: invenio/legacy/websearch/templates.py:1859
 #, fuzzy, python-format
@@ -9881,11 +9853,10 @@ msgstr "As suas submissões"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
-"A consulta booleana não gerou resultados. Por favor combine seus termos "
-"de pesquisa de outra maneira."
+"A consulta booleana não gerou resultados. Por favor combine seus termos de "
+"pesquisa de outra maneira."
 
 #: invenio/legacy/websearch/templates.py:3357
 msgid "See also: similar author names"
@@ -9910,8 +9881,8 @@ msgstr "Você poderá começar a explorar a partir de %s"
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3832
@@ -10111,7 +10082,8 @@ msgstr "em"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
 #, fuzzy
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "Não encontrou o que estava procurando? Tentar a sua pesquisa em:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -10210,8 +10182,8 @@ msgstr "obrigatório"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -10221,11 +10193,11 @@ msgstr "Criar um novo cesto"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
-"Se deseja mudar o seu endereço de email ou definir pela primeira vez o "
-"seu nome de utilizador, defina os dados no formulario abaixo."
+"Se deseja mudar o seu endereço de email ou definir pela primeira vez o seu "
+"nome de utilizador, defina os dados no formulario abaixo."
 
 #: invenio/legacy/websession/templates.py:271
 msgid "Edit login credentials"
@@ -10241,16 +10213,16 @@ msgstr "Definir novos dados"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
-"Desde que isto é considerado a sua assinatura para comentarios e analises"
-" criticas, uma vez definida não pode ser alterada."
+"Desde que isto é considerado a sua assinatura para comentarios e analises "
+"criticas, uma vez definida não pode ser alterada."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
 "Se deseja mudar a sua palavra passe, indique a anteior e defina anova no "
 "formulario abaixo."
@@ -10290,8 +10262,8 @@ msgstr "Definir nova palavra-passe"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 "If you are using a lightweight CERN account you can\n"
 "                %(x_url_open)sreset the password%(x_url_close)s."
@@ -10389,10 +10361,9 @@ msgstr "Seleccione método"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
 "Se esqueceu a sua palavra-passe da sua%(sitename)s %(x_fmt_open)sconta "
 "interna%(x_fmt_close)s, indique o seu endereço de email no formulario "
@@ -10412,15 +10383,15 @@ msgstr "Enviar palavra-passe alternativa"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 "Note que se estiver usando um sistema de autenticação externo, nos não "
 "podemos fazer nada, tendo que perguntar onde se autenticou."
@@ -10437,15 +10408,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
-"%s permite-lhe a possibilidade de personalizar a interface, para definir "
-"a sua própria biblioteca de documentos, ou definir avisos de pesquisa "
-"automáticosque são executados periodicamente e o notificão por email "
-"acerca dos resultados obtidos."
+"%s permite-lhe a possibilidade de personalizar a interface, para definir a "
+"sua própria biblioteca de documentos, ou definir avisos de pesquisa "
+"automáticosque são executados periodicamente e o notificão por email acerca "
+"dos resultados obtidos."
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10467,12 +10438,11 @@ msgstr "Ver todas as pesquisas efectuadas durante os últimos 30 dias."
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 "Com os cestos, pode definir colecções especificas de items, guardar "
-"registodo seu interesse, aos quais queira aceder posteriormente ou "
-"partilhar."
+"registodo seu interesse, aos quais queira aceder posteriormente ou partilhar."
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10483,36 +10453,35 @@ msgid ""
 "Subscribe to a search which will be run periodically by our service. The "
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
-"Subscrever uma pesquisa que será executada periodicamente, ao seu "
-"serviço. Oresultado pode ser enviado por email ou guardado num dos seus "
-"cestos."
+"Subscrever uma pesquisa que será executada periodicamente, ao seu serviço. "
+"Oresultado pode ser enviado por email ou guardado num dos seus cestos."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
-"Para verificar livros requesitados, submeter pedidos de empréstimo, "
-"etc... é necessário o seu CERN ID."
+"Para verificar livros requesitados, submeter pedidos de empréstimo, etc... é "
+"necessário o seu CERN ID."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
-"Está autenticado como visitante, por isso os seus avisos irão desaparecer"
-" no fim da actual sessão."
+"Está autenticado como visitante, por isso os seus avisos irão desaparecer no "
+"fim da actual sessão."
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
-"Está autenticado como %(x_user)s. Poderá querer a) "
-"%(x_url1_open)sterminar a sessão%(x_url1_close)s; b) editar as "
-"%(x_url2_open)sdefinições da sua conta%(x_url2_close)s."
+"Está autenticado como %(x_user)s. Poderá querer a) %(x_url1_open)sterminar a "
+"sessão%(x_url1_close)s; b) editar as %(x_url2_open)sdefinições da sua conta"
+"%(x_url2_close)s."
 
 #: invenio/legacy/websession/templates.py:785
 #, fuzzy, python-format
@@ -10529,11 +10498,11 @@ msgstr "Os seus avisos de pesquisa"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
-"Pode consultar a lista dos %(x_url_open)sseus grupos%(x_url_close)s onde "
-"é administrador ou membro."
+"Pode consultar a lista dos %(x_url_open)sseus grupos%(x_url_close)s onde é "
+"administrador ou membro."
 
 #: invenio/legacy/websession/templates.py:799
 #: invenio/legacy/websession/templates.py:2348
@@ -10545,11 +10514,11 @@ msgstr "Os seus grupos"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"Pode consultar a lista das %(x_url_open)ssuas submissões%(x_url_close)s e"
-" informar-se acerca do seu estado."
+"Pode consultar a lista das %(x_url_open)ssuas submissões%(x_url_close)s e "
+"informar-se acerca do seu estado."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -10560,11 +10529,11 @@ msgstr "As suas submissões"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"Pode consultar a lista das %(x_url_open)ssuas aprovações%(x_url_close)s "
-"com com os documentos que aprovou ou referiu."
+"Pode consultar a lista das %(x_url_open)ssuas aprovações%(x_url_close)s com "
+"com os documentos que aprovou ou referiu."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10614,8 +10583,10 @@ msgstr "a fim de confirmar a validade deste pedido."
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
-msgstr "Note que este URL permanecera valido por um periodo de %(days)s apenas."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
+msgstr ""
+"Note que este URL permanecera valido por um periodo de %(days)s apenas."
 
 #: invenio/legacy/websession/templates.py:909
 #, fuzzy, python-format
@@ -10666,25 +10637,25 @@ msgstr "Se já possui uma conta, é favor autenticar-se usando o formulário."
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"Se ainda não possui uma conta, é favor %(x_url_open)sregistar-"
-"se%(x_url_close)s numa conta interna."
+"Se ainda não possui uma conta, é favor %(x_url_open)sregistar-se"
+"%(x_url_close)s numa conta interna."
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
 msgid "If you don't own an account yet, please contact %(x_name)s."
 msgstr ""
-"Se ainda não possui uma conta, é favor %(x_url_open)sregistar-"
-"se%(x_url_close)s numa conta interna."
+"Se ainda não possui uma conta, é favor %(x_url_open)sregistar-se"
+"%(x_url_close)s numa conta interna."
 
 #: invenio/legacy/websession/templates.py:1051
 #, fuzzy
@@ -10712,13 +10683,12 @@ msgstr "Esqueceu a sua palavra-passe?"
 #: invenio/legacy/websession/templates.py:1094
 msgid "You can use your nickname or your email address to login."
 msgstr ""
-"Pode usar o seu nome de utilizador ou endereço de email para se "
-"autenticar."
+"Pode usar o seu nome de utilizador ou endereço de email para se autenticar."
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 "O seu pedido é valido. Por favor defina a nova palavra-passe desejada "
 "noseguinte formulario."
@@ -10747,9 +10717,10 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
-msgstr "Não será possível utilizar a sua conta antes de ser verificada e activada."
+"It will not be possible to use the account before it has been verified and "
+"activated."
+msgstr ""
+"Não será possível utilizar a sua conta antes de ser verificada e activada."
 
 #: invenio/legacy/websession/templates.py:1228
 msgid "Retype Password"
@@ -10765,13 +10736,13 @@ msgstr "registar"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
-"É favor não usar palavras-passe de outros sistema, como Unix, AFS ou NICE"
-" como palavra-passe deste serviço. O seu endereço de email permanecerá "
+"É favor não usar palavras-passe de outros sistema, como Unix, AFS ou NICE "
+"como palavra-passe deste serviço. O seu endereço de email permanecerá "
 "confidencial e não será relevado a terceiros.  Este será utilizado para "
 "identifica-lo em funcionalidades deste serviço de %s. Por exemplo, pode "
 "definir avisos automáticos associados a pesquisas, que o informarão "
@@ -10780,20 +10751,20 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
-"Não é possível criar uma conta por si próprio. Contacte %s se deseja "
-"criar uma conta."
+"Não é possível criar uma conta por si próprio. Contacte %s se deseja criar "
+"uma conta."
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
-"Parece ser um visitante. Tem que se "
-"%(x_url_open)sautenticar%(x_url_close)s primeiro."
+"Parece ser um visitante. Tem que se %(x_url_open)sautenticar%(x_url_close)s "
+"primeiro."
 
 #: invenio/legacy/websession/templates.py:1267
 msgid "You are not authorized to access administrative functions."
@@ -10925,13 +10896,14 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1323
 msgid "Here are some interesting web admin links for you:"
-msgstr "Aqui estão alguns links interessantes para si, sobre administração web:"
+msgstr ""
+"Aqui estão alguns links interessantes para si, sobre administração web:"
 
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "Para mais actividades de administração, consulte a %(x_url_open)sÁrea "
 "deAdministração%(x_url_close)s."
@@ -11169,7 +11141,8 @@ msgstr "Um utilizador pretende juntar-se ao grupo %s."
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 "É favor %(x_url_open)saceitar ou rejeitar%(x_url_close)s o pedido deste "
 "utilizador."
@@ -11213,79 +11186,73 @@ msgstr "Grupo %s foi apagado pelo seu administrador."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"Pode consultar a list de %(x_url_open)s%(x_nb_total)i "
-"grupos%(x_url_close)s que suscreveu como (%(x_nb_member)i) ou como "
-"administrador (%(x_nb_admin)i)."
+"Pode consultar a list de %(x_url_open)s%(x_nb_total)i grupos%(x_url_close)s "
+"que suscreveu como (%(x_nb_member)i) ou como administrador (%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
-"Você está autenticado como visitante. Poderá desejar %(x_url_open"
-")sautenticar-se%(x_url_close)s como um utilizador normal."
+"Você está autenticado como visitante. Poderá desejar "
+"%(x_url_open)sautenticar-se%(x_url_close)s como um utilizador normal."
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
-"O %(x_fmt_open)svisitante%(x_fmt_close)s precisa de se "
-"%(x_url_open)sregistar%(x_url_close)s primeiro"
+"O %(x_fmt_open)svisitante%(x_fmt_close)s precisa de se %(x_url_open)sregistar"
+"%(x_url_close)s primeiro"
 
 #: invenio/legacy/websession/webaccount.py:127
 msgid "No queries found"
@@ -11293,14 +11260,14 @@ msgstr "Nenhuma termo de pesquisa encontrado"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -11309,8 +11276,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11322,8 +11289,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11403,8 +11370,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11443,8 +11409,8 @@ msgid ""
 "browser if you are a guest user."
 msgstr ""
 "Obtece com sucesso autorização para as funçoes de %(x_role)s! Esta "
-"autorização sera valida ate %(x_expiration)s e ate que encerre o "
-"seubrowser no caso de ser visitante."
+"autorização sera valida ate %(x_expiration)s e ate que encerre o seubrowser "
+"no caso de ser visitante."
 
 #: invenio/legacy/websession/webinterface.py:128
 msgid "You have confirmed the validity of your email address!"
@@ -11473,9 +11439,9 @@ msgstr "Voce ja confirmou a validade do seu endereço de email!"
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
-msgstr "Este pedido de confirmação de endereço de email não é valido ou expirou."
+"This request for confirmation of an email address is not valid or is expired."
+msgstr ""
+"Este pedido de confirmação de endereço de email não é valido ou expirou."
 
 #: invenio/legacy/websession/webinterface.py:153
 msgid "This request for an authorization is not valid or is expired."
@@ -11542,15 +11508,15 @@ msgstr "Mudar para metodo de autenticação interno."
 #: invenio/legacy/websession/webinterface.py:423
 #, fuzzy
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
-"Por favor note que se esta é a primeira vez que esta´ usando esta "
-"contacom um metodo de autenticação interno entao o sistema definiu uma "
-"palavra-passe aleatoria. Por favor clique no seguinte botao para que lhe "
-"seja enviado por emailum link, onde podera alterar a palavra-passe:"
+"Por favor note que se esta é a primeira vez que esta´ usando esta contacom "
+"um metodo de autenticação interno entao o sistema definiu uma palavra-passe "
+"aleatoria. Por favor clique no seguinte botao para que lhe seja enviado por "
+"emailum link, onde podera alterar a palavra-passe:"
 
 #: invenio/legacy/websession/webinterface.py:431
 msgid "Send Password"
@@ -11562,8 +11528,8 @@ msgid ""
 "Unable to switch to external login method %(x_name)s, because your email "
 "address is unknown."
 msgstr ""
-"Não é possivel mudar para metodo de autenticação externa %s, porque o seu"
-" endereço de email é desconhecido."
+"Não é possivel mudar para metodo de autenticação externa %s, porque o seu "
+"endereço de email é desconhecido."
 
 #: invenio/legacy/websession/webinterface.py:445
 #, fuzzy, python-format
@@ -11571,8 +11537,8 @@ msgid ""
 "Unable to switch to external login method %(x_meth)s, because your email "
 "address is unknown to the external login system."
 msgstr ""
-"Não é possivel mudar para metodo de aitenticação externa %s, porque o seu"
-" endereço de email é desconhecido para o sistema externo de autenticação."
+"Não é possivel mudar para metodo de aitenticação externa %s, porque o seu "
+"endereço de email é desconhecido para o sistema externo de autenticação."
 
 #: invenio/legacy/websession/webinterface.py:449
 msgid "Login method successfully selected."
@@ -11581,8 +11547,8 @@ msgstr "Método de autenticação escolhido com sucesso."
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 "O método de autenticação externa %s não suporta endereços de email como "
 "forma de autenticação.  É favor contactar os administradores do site."
@@ -11714,8 +11680,8 @@ msgid ""
 "Cannot send password reset request since you are using external "
 "authentication system."
 msgstr ""
-"não pode enviar pedido de alteração de palavra-passe pois esta´ usando um"
-" sistema de autenticação interno."
+"não pode enviar pedido de alteração de palavra-passe pois esta´ usando um "
+"sistema de autenticação interno."
 
 #: invenio/legacy/websession/webinterface.py:665
 msgid "The entered email address does not exist in the database."
@@ -11770,20 +11736,19 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
-"Siga as seguintes intruçoes apresentadas aqui a fim de completar o "
-"processo de registo da sua conta."
+"Siga as seguintes intruçoes apresentadas aqui a fim de completar o processo "
+"de registo da sua conta."
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
-"Um segundo email será enviado quando a conta for activada e poder ser "
-"usada."
+"Um segundo email será enviado quando a conta for activada e poder ser usada."
 
 #: invenio/legacy/websession/webinterface.py:989
 #, python-format
@@ -11824,8 +11789,8 @@ msgstr "O nome de utilizador pretendido %s já existe na base de dados."
 #: invenio/modules/accounts/views/accounts.py:143
 msgid "Users cannot register themselves, only admin can register them."
 msgstr ""
-"Utilizadores não se podem registar eles próprios, apenas o administrador "
-"os pode registar."
+"Utilizadores não se podem registar eles próprios, apenas o administrador os "
+"pode registar."
 
 #: invenio/legacy/websession/webinterface.py:1023
 #: invenio/modules/accounts/views/accounts.py:148
@@ -11833,8 +11798,8 @@ msgid ""
 "The site is having troubles in sending you an email for confirming your "
 "email address."
 msgstr ""
-"Este site esta´ com problemas em enviar-lhe um email com a confirmação do"
-" seu endereço de email."
+"Este site esta´ com problemas em enviar-lhe um email com a confirmação do "
+"seu endereço de email."
 
 #: invenio/legacy/websession/webinterface.py:1432
 #, fuzzy
@@ -11906,7 +11871,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, fuzzy, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 "Registo criado %(x_date_creation)s, modificado pela última vez em "
 "%(x_date_modification)s"
@@ -11934,37 +11900,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11972,15 +11938,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -12048,8 +12014,8 @@ msgstr "Não é possivel determinar o número de páginas da submissão."
 #: invenio/legacy/websubmit/engine.py:931
 #, fuzzy
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr "Não é possível criar um directório para esta submissão."
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -12085,8 +12051,8 @@ msgstr "Submeter"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -12136,8 +12102,8 @@ msgstr "Seleccione uma categoria e clique no botão"
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 "Para continuar com a submissão interrompida anteriormente, indique o seu "
 "número de acesso na caixa abaixo:"
@@ -12170,11 +12136,11 @@ msgstr "Voltar ao menu principal"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
-"Este é o seu número de submissão. Pode ser utilizado para continuar com "
-"uma submissão interrompida em caso de problemas."
+"Este é o seu número de submissão. Pode ser utilizado para continuar com uma "
+"submissão interrompida em caso de problemas."
 
 #: invenio/legacy/websubmit/templates.py:548
 msgid "Mandatory fields appear in red in the SUMMARY window."
@@ -12223,11 +12189,11 @@ msgstr "Submissão num"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
-"Aqui está a %(x_action)s lista de funções para %(x_doctype)s documentos "
-"no nível %(x_step)s"
+"Aqui está a %(x_action)s lista de funções para %(x_doctype)s documentos no "
+"nível %(x_step)s"
 
 #: invenio/legacy/websubmit/templates.py:1041
 #, fuzzy
@@ -12313,11 +12279,9 @@ msgstr "Lista de tipos de documentos sob moderação"
 #: invenio/legacy/websubmit/templates.py:1479
 #, fuzzy
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
-"Seleccione um dos seguintes tipos de documentos para verificar o seu "
-"estato."
+"Seleccione um dos seguintes tipos de documentos para verificar o seu estato."
 
 #: invenio/legacy/websubmit/templates.py:1447
 msgid "Go to specific approval workflow"
@@ -12460,10 +12424,10 @@ msgstr "Aprove"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
-"Este documento continua à %(x_fmt_open)sespera de "
-"aprovação%(x_fmt_close)s."
+"Este documento continua à %(x_fmt_open)sespera de aprovação%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
 #: invenio/legacy/websubmit/templates.py:2163
@@ -12496,7 +12460,8 @@ msgstr "Enviar novamente"
 
 #: invenio/legacy/websubmit/templates.py:2150
 msgid "WARNING! Upon confirmation, an email will be sent to the referee."
-msgstr "AVISO! Enquanto aguarda confirmação, um email será enviado ao moderador."
+msgstr ""
+"AVISO! Enquanto aguarda confirmação, um email será enviado ao moderador."
 
 #: invenio/legacy/websubmit/templates.py:2153
 #, fuzzy
@@ -12565,11 +12530,10 @@ msgstr "Seleccione um moderador"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
-"O moderador enviou as suas recomendaçoes finais ao comite de publicação "
-"em "
+"O moderador enviou as suas recomendaçoes finais ao comite de publicação em "
 
 #: invenio/legacy/websubmit/templates.py:2281
 #: invenio/legacy/websubmit/templates.py:2342
@@ -12587,11 +12551,11 @@ msgstr "Enviar recomendação"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
-"O comite de publicaçoes enviou as suas recomendaçoes finais para o gestor"
-" do projecto em "
+"O comite de publicaçoes enviou as suas recomendaçoes finais para o gestor do "
+"projecto em "
 
 #: invenio/legacy/websubmit/templates.py:2291
 #: invenio/legacy/websubmit/templates.py:2358
@@ -12631,7 +12595,8 @@ msgid "Take a decision"
 msgstr "Tomar uma decisao"
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr "Uma comissao editorial foi seleccionada pelo comite de publicaçoes em "
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12653,16 +12618,14 @@ msgstr "O moderador foi seleccionado pela comissao editorial em"
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
-"O moderador enviou as suas recomendaçoes finais para a comissao editorial"
-" em "
+"O moderador enviou as suas recomendaçoes finais para a comissao editorial em "
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 "A comissao editorial enviou as suas recomendaçoes finais para o comite "
 "depublicaçoes em "
@@ -12785,10 +12748,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12863,8 +12825,7 @@ msgstr ""
 #: invenio/legacy/websubmit/web/publiline.py:856
 msgid "too many qualified users, specify more narrow search."
 msgstr ""
-"demasiados utilizadores qualificados, seja mais espefico(a) na sua "
-"pesquisa."
+"demasiados utilizadores qualificados, seja mais espefico(a) na sua pesquisa."
 
 #: invenio/legacy/websubmit/web/publiline.py:733
 #: invenio/legacy/websubmit/web/publiline.py:856
@@ -13081,8 +13042,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -13125,11 +13086,6 @@ msgstr "conectado"
 #, fuzzy
 msgid "Role details"
 msgstr "Artigo"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Ocultar"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -13245,8 +13201,8 @@ msgstr "O endereço de email fornecido %s já existe na base de dados."
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -13311,9 +13267,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -13339,8 +13294,8 @@ msgstr "Definir nova palavra-passe"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
 "É favor indicar o seu endereço de email e o nome de utilizador e palavra-"
 "passe desejados."
@@ -13371,7 +13326,7 @@ msgid "Problem with login."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "Pode agora aceder à sua %(x_url_open)sconta%(x_url_close)s."
 
@@ -13415,8 +13370,7 @@ msgstr "Edição de definições falhou"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13488,13 +13442,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13503,9 +13456,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13682,8 +13635,7 @@ msgstr "colecções"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13773,8 +13725,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13866,13 +13818,13 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
-"A sua mensagem é demasiado grande, por favor modifique-a. O tamanho "
-"maximo permitido é %i caracteres."
+"A sua mensagem é demasiado grande, por favor modifique-a. O tamanho maximo "
+"permitido é %i caracteres."
 
 #: invenio/modules/comments/forms.py:55
 #, fuzzy
@@ -13915,12 +13867,12 @@ msgid "Review was sent"
 msgstr "Escrever um comentário"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Este comentário foi reportado %i vezes."
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Este comentário foi reportado %i vezes."
 
@@ -13973,9 +13925,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13994,8 +13945,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -14005,7 +13956,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "O nome de utilizador pretendido %s já existe na base de dados."
 
@@ -14061,8 +14012,7 @@ msgstr "análise critica"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -14102,8 +14052,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -14149,7 +14098,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "Função %s não existe."
 
@@ -14232,11 +14181,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "estado actual"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Os seus cestos"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -14271,8 +14215,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -14293,8 +14237,8 @@ msgstr "Nenhum índice de palavras está disponível para"
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -14310,8 +14254,7 @@ msgstr "Validação do Formato do Elemento %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14432,7 +14375,7 @@ msgstr "Mostrar todos os %i autores"
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 #, fuzzy
 msgid "Edit This Record"
 msgstr "Editar outro registo"
@@ -14536,10 +14479,6 @@ msgstr "análise critica"
 msgid "Authors"
 msgstr "autor"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14632,8 +14571,8 @@ msgstr "Gerir direitos do grupo"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "Voce não possui direitos suficientes para ver o conteudo deste cesto."
 
 #: invenio/modules/groups/views.py:279
@@ -14646,12 +14585,12 @@ msgstr "Não é administrador de nenhum grupo."
 msgid "Members"
 msgstr "Sem membros."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Mapeamento da Base de Conhecimento"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14661,11 +14600,11 @@ msgstr "Feito"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "qualquer campo"
@@ -14711,13 +14650,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "Existem %i cestos"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "Existem %i cestos"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14834,7 +14774,8 @@ msgstr "Escreva uma mensagem"
 #: invenio/modules/messages/views.py:254
 #, fuzzy
 msgid "Could not empty your mailbox."
-msgstr "Tem a certeza que deseja esvaziar a sua caixa de correio na totalidade?"
+msgstr ""
+"Tem a certeza que deseja esvaziar a sua caixa de correio na totalidade?"
 
 #: invenio/modules/messages/templates/messages/menu_base.html:23
 #, fuzzy
@@ -14873,28 +14814,28 @@ msgstr "Tipo de documento desconhecido"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14959,8 +14900,8 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr "Se pretende completar o registo da sua conta, va a:"
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -15332,7 +15273,7 @@ msgid "Tag name"
 msgstr "Nome de Utilizador"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "O nome de utilizador pretendido %s já existe."
 
@@ -15437,11 +15378,6 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "Feito"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15483,8 +15419,7 @@ msgstr "Opções de pesquisa:"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15709,7 +15644,7 @@ msgid "just now"
 msgstr "Você deve agora"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s segundos"
 
@@ -15768,6 +15703,38 @@ msgstr "qualquer ano"
 msgid " years ago"
 msgstr "ano"
 
+# msgstr "Registros similares"
+#~ msgid "BibCheck Admin"
+#~ msgstr "Administração BibFormat"
+
+#~ msgid "Not authorized"
+#~ msgstr "autor"
+
+#~ msgid "Really delete"
+#~ msgstr "apagado com sucesso"
+
+#~ msgid "Verify problem"
+#~ msgstr "Problema na Base de Dados"
+
+#~ msgid "File"
+#~ msgstr "título"
+
+#~ msgid "niceName"
+#~ msgstr "Nome"
+
+#~ msgid "Id"
+#~ msgstr "Id"
+
+#~ msgid "Tickets"
+#~ msgstr "Tempo"
+
+#~ msgid "by"
+#~ msgstr "por"
+
+# msgstr "Mostrar resultados:"
+#~ msgid "Done"
+#~ msgstr "Feito"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "É favor escolher uma categoria"
 
@@ -15782,9 +15749,6 @@ msgstr "ano"
 
 #~ msgid "*** basket name ***"
 #~ msgstr "Nome do Cesto"
-
-#~ msgid ""
-#~ msgstr ""
 
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "ficheiros adicionais"
@@ -15849,24 +15813,8 @@ msgstr "ano"
 #~ msgid "now"
 #~ msgstr "não"
 
-# msgstr "Registros similares"
-#~ msgid "BibCheck Admin"
-#~ msgstr "Administração BibFormat"
-
-#~ msgid "Not authorized"
-#~ msgstr "autor"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "O utilizador %s não existe."
-
-#~ msgid "Really delete"
-#~ msgstr "apagado com sucesso"
-
-#~ msgid "Verify problem"
-#~ msgstr "Problema na Base de Dados"
-
-#~ msgid "File"
-#~ msgstr "título"
 
 #~ msgid "File %s already exists."
 #~ msgstr "O utilizador %s não existe."
@@ -15925,9 +15873,6 @@ msgstr "ano"
 #~ msgid "Not Mine!"
 #~ msgstr "Nota"
 
-#~ msgid "Tickets"
-#~ msgstr "Tempo"
-
 # msgstr "Formato de saída:"
 #~ msgid "Request Tickets"
 #~ msgstr "Regras"
@@ -15966,9 +15911,6 @@ msgstr "ano"
 
 #~ msgid "Create a new Person for your search"
 #~ msgstr "Não foram encontrados resultados."
-
-#~ msgid "Id"
-#~ msgstr "Id"
 
 #~ msgid "A %s has been added."
 #~ msgstr "Grupo %s foi apagado"
@@ -16021,9 +15963,6 @@ msgstr "ano"
 #~ msgid "creating a new basket"
 #~ msgstr "Criar um novo cesto"
 
-#~ msgid "by"
-#~ msgstr "por"
-
 #~ msgid "on"
 #~ msgstr "em"
 
@@ -16044,9 +15983,6 @@ msgstr "ano"
 
 #~ msgid "Editing topic"
 #~ msgstr "Editar cesto"
-
-#~ msgid "niceName"
-#~ msgstr "Nome"
 
 #~ msgid "Apply Changes"
 #~ msgstr "Guardar Alterações"
@@ -16159,10 +16095,6 @@ msgstr "ano"
 
 #~ msgid "Verbose"
 #~ msgstr "Visionar"
-
-# msgstr "Mostrar resultados:"
-#~ msgid "Done"
-#~ msgstr "Feito"
 
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "As suas alterações são TEMPORÁRIAS"
@@ -16461,34 +16393,11 @@ msgstr "ano"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "Guia de Administração WebSubmit"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "Executar pesquisa"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Cancelado"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "É membro dos seguintes grupos:"
@@ -16502,12 +16411,6 @@ msgstr "ano"
 #~ msgid "Invert Selection"
 #~ msgstr "Selecção de moderador"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Autor:"
 
@@ -16519,12 +16422,6 @@ msgstr "ano"
 
 #~ msgid "No status information found."
 #~ msgstr "Mais informação:"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "divisão"
@@ -16541,15 +16438,6 @@ msgstr "ano"
 #~ msgid "The author has an internal ID!"
 #~ msgstr "Ocorreu um erro interno"
 
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "comentários"
 
@@ -16559,88 +16447,21 @@ msgstr "ano"
 #~ msgid " Delete this ticket"
 #~ msgstr "Apagar cesto"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "Nenhum índice de palavras está disponível para"
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Seleccione um resultado"
 
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
 #~ msgid "Paper title: "
 #~ msgstr "Página:"
-
-#~ msgid "Ignore"
-#~ msgstr ""
 
 # msgstr "O registro foi apagado."
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "Foram encontrados os seguintes erros"
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "Seleccione um resultado"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "Mais informação:"
@@ -16648,35 +16469,11 @@ msgstr "ano"
 #~ msgid "Please provide your first name"
 #~ msgstr "É favor autenticar-se primeiro."
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "Os seus empréstimos"
 
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
 #~ msgid "Your eMail:"
 #~ msgstr "Os seus avisos"
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "Apagar as análises criticas seleccionadas"
@@ -16684,187 +16481,36 @@ msgstr "ano"
 #~ msgid "Mark as your documents"
 #~ msgstr "todos od tipos de documento"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "Voltar ao documento"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Voltar ao documento"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "ou criar um novo"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "Adicionar aos utilizadores"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Página:"
 
-#~ msgid "Showing the"
-#~ msgstr ""
-
 #~ msgid "most recent documents:"
 #~ msgstr "Lista de documentos sob moderação"
-
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
 
 # msgstr "Formato de saída:"
 #~ msgid "Manage your profile"
 #~ msgstr "Gerir Formato dos Templates"
 
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Choose your profile"
 #~ msgstr "Escolher tópico"
-
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
 
 #~ msgid "Manage publication list"
 #~ msgstr "Data de criação"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "%(link_or_links)s externo(s)"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "submissões"
@@ -16872,185 +16518,17 @@ msgstr "ano"
 #~ msgid "Choose system"
 #~ msgstr "Escolher tópico"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-# msgstr "O registro foi apagado."
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Foram encontrados os seguintes erros"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Não está autorizado a aceder a funções de administração."
 
 #~ msgid "Claim this paper"
 #~ msgstr "adicionar este utilizador"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Citado por: %s registos"
 
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
 #~ msgid "Revision"
 #~ msgstr "divisão"
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Modificar Atributos do Template"
@@ -17140,78 +16618,15 @@ msgstr "ano"
 #~ msgid "No Record Found for %s."
 #~ msgstr "Registo não encontrado"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "O utilizador %s não existe."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 # msgstr "Formato de saída:"
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "Atributos %s do Formato de Saída"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "Dependências %s do Formato do Template"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "Validação do Formato do Elemento %s"
@@ -17219,12 +16634,6 @@ msgstr "ano"
 # msgstr "conta"
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "Dependências %s do Formato do Elemento"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Formato de Saída Restricto "
@@ -17284,88 +16693,11 @@ msgstr "ano"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Validação do Formato do Elemento %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "Validação do Formato"
 
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "Base de Conhecimento %s"
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "Nota"
@@ -17373,25 +16705,6 @@ msgstr "ano"
 # msgstr "Administração de Envios"
 #~ msgid "never"
 #~ msgstr "Converter"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "Tempo"
@@ -17401,9 +16714,6 @@ msgstr "ano"
 
 #~ msgid "No Keywords"
 #~ msgstr "palavra chave"
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
 
 #~ msgid "No Subject categories"
 #~ msgstr "Lista de categorias de publicaçoes"
@@ -17420,17 +16730,8 @@ msgstr "ano"
 #~ msgid "Affiliations"
 #~ msgstr "Histórico de citações:"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
 #~ msgid "Citations%s"
 #~ msgstr "Histórico de citações:"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Data de criação"
@@ -17441,42 +16742,6 @@ msgstr "ano"
 #~ msgid "No publications available"
 #~ msgstr "Nenhum índice de palavras está disponível para"
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr "Citado por: %s registos"
 
@@ -17486,20 +16751,8 @@ msgstr "ano"
 #~ msgid "%i reviews"
 #~ msgstr "análise critica"
 
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "Página:"
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "Histórico de citações:"
@@ -17507,29 +16760,8 @@ msgstr "ano"
 #~ msgid "No Citation Information available"
 #~ msgstr "Nenhum índice de palavras está disponível para"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "sessão"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Os seus avisos"
@@ -17549,99 +16781,15 @@ msgstr "ano"
 #~ msgid "Statistics"
 #~ msgstr "estatisticas"
 
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
 #~ msgid "Group: %s"
 #~ msgstr "Grupos: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "A pagina %s não foi encontrada"
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "O campo %s é obrigatório."
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "Não é possivel determinar o número de páginas da submissão."
-

--- a/invenio/base/translations/ro/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/ro/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2009, 2010, 2011 CERN.
+# # Copyright (C) 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,16 +16,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2010-12-07 10:51+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:58+0200\n"
 "Last-Translator: Ludmila Marian <ludmila.marian@gmail.com>\n"
 "Language-Team: RO <info@invenio-software.org>\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100"
-" < 20)) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -57,8 +57,8 @@ msgstr "Administrare"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -203,7 +203,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Bună ziua:"
 
@@ -224,17 +224,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -260,46 +260,51 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Ne pare rău, %s nu este o valoare validă pentru ID."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 msgid "Authorization failure"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Vă rugăm să selectaţi unul sau mai multe:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 msgid "Authorization failure."
 msgstr ""
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -498,7 +503,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -700,7 +706,8 @@ msgid "The following errors have occurred:"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -717,8 +724,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -800,7 +807,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -842,8 +849,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr ""
@@ -858,8 +865,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr ""
 
@@ -1073,7 +1080,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1124,8 +1132,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1138,25 +1146,23 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1180,13 +1186,14 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1215,9 +1222,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1283,8 +1289,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1292,8 +1298,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1315,9 +1321,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1359,8 +1364,8 @@ msgstr "%s documente găsite"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1416,11 +1421,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1431,11 +1436,11 @@ msgstr "Da"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1448,8 +1453,8 @@ msgstr "Nu"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1541,8 +1546,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1562,29 +1567,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1593,9 +1598,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr ""
 
@@ -1934,16 +1939,14 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -1963,8 +1966,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2114,8 +2117,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2222,7 +2225,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Descriere"
 
@@ -2414,8 +2417,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2687,12 +2690,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr ""
-"Înainte de a adăuga un comentariu, trebuie sa va "
-"%(x_url_open)sautentificaţi%(x_url_close)s."
+"Înainte de a adăuga un comentariu, trebuie sa va %(x_url_open)sautentificaţi"
+"%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
 #, fuzzy
@@ -2745,7 +2747,7 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "OK"
 
@@ -2753,8 +2755,8 @@ msgstr "OK"
 #, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3210,8 +3212,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "E-mail"
 
@@ -4006,8 +4008,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4025,8 +4027,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4085,17 +4087,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4452,25 +4454,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4529,15 +4531,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4548,10 +4550,10 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4564,15 +4566,15 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4583,7 +4585,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4602,17 +4605,15 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4630,14 +4631,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4688,8 +4688,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4739,8 +4739,8 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -4851,9 +4851,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -4866,8 +4866,8 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -4994,11 +4994,10 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5122,7 +5121,7 @@ msgid "Total"
 msgstr ""
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Selectaţi"
 
@@ -5279,8 +5278,8 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5336,56 +5335,56 @@ msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5424,7 +5423,7 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5476,15 +5475,15 @@ msgstr "Alertele tale"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5701,8 +5700,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -5776,8 +5774,8 @@ msgstr ""
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -5792,8 +5790,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Rezultatele căutării"
 
@@ -5951,8 +5949,8 @@ msgstr "Nicio valoare nu a fost gasită."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -5978,8 +5976,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -5990,8 +5988,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -6001,108 +5998,108 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 msgid "No match found, please enter different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Nu există raportări până în prezent."
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Nu există raportări până în prezent."
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Nu există raportări până în prezent."
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Utilizatorul %s nu există."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6116,11 +6113,11 @@ msgstr ""
 msgid "Browse"
 msgstr "Răsfoieşte "
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
 
@@ -6163,10 +6160,9 @@ msgstr "Mesajul a fost şters."
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
 
 #: invenio/legacy/webalert/htmlparser.py:186
@@ -6356,15 +6352,15 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:453
@@ -6422,7 +6418,7 @@ msgstr "Căutările tale"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6486,7 +6482,7 @@ msgstr ""
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6546,7 +6542,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6568,7 +6565,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6595,7 +6593,8 @@ msgid "You do not have permission to delete this note."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6625,8 +6624,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6647,8 +6646,8 @@ msgstr "%s documente găsite"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6680,8 +6679,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -6751,8 +6750,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
@@ -6778,8 +6776,7 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -6939,8 +6936,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -6967,8 +6964,8 @@ msgstr ""
 #, fuzzy, python-format
 msgid " or go %(x_url_open)sback%(x_url_close)s"
 msgstr ""
-"Înainte de a adăuga un comentariu, trebuie sa va "
-"%(x_url_open)sautentificaţi%(x_url_close)s."
+"Înainte de a adăuga un comentariu, trebuie sa va %(x_url_open)sautentificaţi"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:1745
 #, python-format
@@ -7122,15 +7119,16 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2131
@@ -7140,7 +7138,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Această funcţionalitate este interzisă utilizatorilor anonimi. "
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Înapoi la rezultatele căutării"
 
@@ -7304,7 +7302,7 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7439,207 +7437,207 @@ msgstr "Utilizatorul %s nu există."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "Utilizatorul %s nu există."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Scrie un comentariu"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_name)s a scris pe %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "Comentarii"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Cele mai recente %i comentarii:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Discutaţi despre acest document"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Începeţi o discuţie cu privire la orice aspect al acestui document."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Ne pare rău, dar colecţia %s nu există."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "Ne pare rău, %s nu este o valoare validă pentru ID."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Poate doriţi să începeţi de navigarea de la %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Vedeţi toate %s review-uri raportate"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 msgid "Be the first to review this document.</div>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 msgid "Close"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Şterge comentariu"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Comentarii"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Subscrie"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7648,498 +7646,500 @@ msgstr ""
 msgid "Record"
 msgstr "Document"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "comentariu"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Pagină:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, python-format
 msgid "Max %(maxfiles)i files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "Adaugă comentariu"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Review-ul dumneavoastră a fost adăugată cu succes."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Comentariul dumneavoastră a fost adăugat cu succes."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr ""
-"Înainte de a adăuga un comentariu, trebuie sa va "
-"%(x_url_open)sautentificaţi%(x_url_close)s."
+"Înainte de a adăuga un comentariu, trebuie sa va %(x_url_open)sautentificaţi"
+"%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Vedeţi toţi utilizatorii raportaţi"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Ghid"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Comentariile si review-urile sunt dezactivate"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr "Vă rugăm să introduceţi ID-ul comentariului/review-ului"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "ID-ul comentariului:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Vezi comentariu"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Nu există raportări până în prezent."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Vedeţi toate %s comentarii raportate"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Vedeţi toate %s review-uri raportate"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-" Lista sortată după numărul total de raportări, conţinând toţi "
-"utilizatorii care au avut un comentariu raportat cel puţin o dată."
+" Lista sortată după numărul total de raportări, conţinând toţi utilizatorii "
+"care au avut un comentariu raportat cel puţin o dată."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "ID Utilizator"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Numărul voturilor pozitive"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Numărul voturilor negative"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Numărul total de voturi"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Numărul total de raportări"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Vezi toate comentariile/review-rile raportate ale utilizatorului"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Acest review a fost raportat de %i ori"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Acest comentariu a fost raportat de %i ori"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Scris de"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Informaţii generale"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Ştergeţi comentariile selectate"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Suprimarea rapoartelor de abuz selectate"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Şterge comentariile selectate"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Review-urile raportate de utilizatorul %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Comentariile raportate de utilizatorul %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, python-format
 msgid "Here is review %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, python-format
 msgid "Here is comment %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "Toate review-urile raportate, sortate in funcţie de frecvenţa."
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "Toate comentariile raportate, sortate in funcţie de frecvenţa."
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr "Toate comentariile raportate, sortate in funcţie de frecvenţa."
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr "Toate comentariile raportate, sortate in funcţie de frecvenţa."
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "ID comentariu"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "şters cu succes"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "abuzul raportat a fost suprimat cu succes"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Nu a fost încă examinat"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "Comentariul dumneavoastră a fost adăugat cu succes."
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Şterge comentarii"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "ultimul comentariu:"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 msgid "Group by record, latest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "Detalii si comentarii"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "Document"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Comentarii"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "Nicio valoare nu a fost gasită."
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 msgid "All items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 msgid "Order by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Pagina următoare"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 msgid "Display options"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8147,101 +8147,101 @@ msgstr ""
 msgid "Refresh"
 msgstr "Reîncarca"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Scrie un comentariu"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "Nicio valoare nu a fost gasită."
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Documentul nu a fost găsit"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 msgid "You do not have access to the specified comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Adaugă comentariu"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "Vedeţi toate comentariile raportate"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 msgid "You are not authorized to use comments."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Comentarii"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "Vedeţi toate comentariile raportate"
@@ -8356,8 +8356,8 @@ msgstr "Ne pare rău, dar colecţia %s nu există."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8421,8 +8421,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8449,8 +8449,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -8628,9 +8628,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8651,8 +8650,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -8762,8 +8760,8 @@ msgid ""
 "Your message is too long, please shorten it. Maximum size allowed is "
 "%(x_size)i characters."
 msgstr ""
-"Mesajul este prea lung, vă rugăm să il editaţi. Dimensiunea maximă "
-"permisă este %i caractere."
+"Mesajul este prea lung, vă rugăm să il editaţi. Dimensiunea maximă permisă "
+"este %i caractere."
 
 #: invenio/legacy/webmessage/api.py:402
 #, fuzzy, python-format
@@ -9126,14 +9124,14 @@ msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9149,8 +9147,8 @@ msgstr "Citat de %i documente"
 #, python-format
 msgid "Words nearest to %(x_word)s inside %(x_field)s in any collection are:"
 msgstr ""
-"Cuvintele asemănătoare cu %(x_word)s, aparţinând câmpului  %(x_field)s, "
-"din orice colecţie, sunt:"
+"Cuvintele asemănătoare cu %(x_word)s, aparţinând câmpului  %(x_field)s, din "
+"orice colecţie, sunt:"
 
 #: invenio/legacy/websearch/templates.py:1859
 #, python-format
@@ -9270,8 +9268,7 @@ msgstr "versiuni mai vechi"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 "Căutarea booleană nu a returnat rezultate. Vă rugăm să combinaţi diferit "
 "termenii de căutare."
@@ -9299,8 +9296,8 @@ msgstr "Aţi putea să începeţi navigarea de la %s."
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3832
@@ -9488,7 +9485,8 @@ msgid "in"
 msgstr "în"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr ""
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9580,8 +9578,8 @@ msgstr "obligatoriu"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9591,8 +9589,8 @@ msgstr "Creează un subiect nou"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:271
@@ -9609,14 +9607,14 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:327
@@ -9654,11 +9652,11 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
-"Înainte de a adăuga un comentariu, trebuie sa va "
-"%(x_url_open)sautentificaţi%(x_url_close)s."
+"Înainte de a adăuga un comentariu, trebuie sa va %(x_url_open)sautentificaţi"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:346
 #, python-format
@@ -9745,10 +9743,9 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:559
@@ -9765,15 +9762,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:573
@@ -9786,10 +9783,10 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:611
@@ -9809,8 +9806,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:636
@@ -9825,22 +9822,22 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:785
@@ -9849,8 +9846,8 @@ msgid ""
 "You can consult the list of %(x_url_open)syour comments%(x_url_close)s "
 "submitted so far."
 msgstr ""
-"Înainte de a adăuga un comentariu, trebuie sa va "
-"%(x_url_open)sautentificaţi%(x_url_close)s."
+"Înainte de a adăuga un comentariu, trebuie sa va %(x_url_open)sautentificaţi"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:790
 msgid "Your Alert Searches"
@@ -9859,8 +9856,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:799
@@ -9872,8 +9869,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:805
@@ -9884,8 +9881,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:811
@@ -9931,7 +9928,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -9979,15 +9977,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1027
@@ -10023,8 +10021,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -10049,8 +10047,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1228
@@ -10067,24 +10065,24 @@ msgstr ""
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1235
 #, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1267
@@ -10213,8 +10211,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1378
@@ -10433,7 +10431,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2400
@@ -10475,71 +10474,66 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:127
@@ -10548,14 +10542,14 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -10564,8 +10558,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -10577,8 +10571,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -10654,8 +10648,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -10720,8 +10713,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -10784,10 +10776,10 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -10815,8 +10807,8 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:452
 #, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -10992,15 +10984,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:989
@@ -11114,7 +11106,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:707
@@ -11137,37 +11130,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11175,15 +11168,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11247,8 +11240,8 @@ msgstr ""
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11283,8 +11276,8 @@ msgstr ""
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11330,8 +11323,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:366
@@ -11360,8 +11353,8 @@ msgstr "Înapoi la meniul principal"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:548
@@ -11410,8 +11403,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1041
@@ -11493,8 +11486,7 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -11631,7 +11623,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -11723,8 +11716,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -11743,8 +11736,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -11785,7 +11778,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -11806,14 +11800,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -11926,10 +11919,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12208,8 +12200,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12249,11 +12241,6 @@ msgstr ""
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:50
 msgid "Role details"
 msgstr ""
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Ascunde"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12366,8 +12353,8 @@ msgstr ""
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -12431,17 +12418,16 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
 #, fuzzy, python-format
 msgid "If you wish you can %(x_url_open)ssign in again%(x_url_close)s."
 msgstr ""
-"Înainte de a adăuga un comentariu, trebuie sa va "
-"%(x_url_open)sautentificaţi%(x_url_close)s."
+"Înainte de a adăuga un comentariu, trebuie sa va %(x_url_open)sautentificaţi"
+"%(x_url_close)s."
 
 #: invenio/modules/accounts/templates/accounts/lost_base.html:27
 msgid ""
@@ -12457,8 +12443,8 @@ msgstr "Parola nouă"
 
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -12527,8 +12513,7 @@ msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -12599,13 +12584,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -12614,9 +12598,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -12782,8 +12766,7 @@ msgstr "colecţii"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -12870,8 +12853,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -12960,13 +12943,13 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
-"Mesajul este prea lung, vă rugăm să il editaţi. Dimensiunea maximă "
-"permisă este %i caractere."
+"Mesajul este prea lung, vă rugăm să il editaţi. Dimensiunea maximă permisă "
+"este %i caractere."
 
 #: invenio/modules/comments/forms.py:55
 #, fuzzy
@@ -13009,12 +12992,12 @@ msgid "Review was sent"
 msgstr "Scrie un comentariu"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Acest comentariu a fost raportat de %i ori"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Acest comentariu a fost raportat de %i ori"
 
@@ -13065,9 +13048,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13086,8 +13068,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13151,8 +13133,7 @@ msgstr "Nu a fost încă examinat"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13191,8 +13172,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13353,8 +13333,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13375,8 +13355,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13392,8 +13372,7 @@ msgstr ""
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -13510,7 +13489,7 @@ msgstr ""
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr ""
 
@@ -13607,10 +13586,6 @@ msgstr ""
 msgid "Authors"
 msgstr "autor"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 msgid "Download Video"
 msgstr ""
@@ -13700,8 +13675,8 @@ msgstr "Administrează drepturile de grup "
 #: invenio/modules/groups/views.py:223
 #, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr ""
 
 #: invenio/modules/groups/views.py:279
@@ -13714,12 +13689,12 @@ msgstr "Nu sunteţi administratorul nici unui grup."
 msgid "Members"
 msgstr "Noiembrie"
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Gestionează bazele de cunoştinţe"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 msgid "-None-"
 msgstr ""
@@ -13728,11 +13703,11 @@ msgstr ""
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "orice câmp"
@@ -13782,7 +13757,7 @@ msgid "Create new record \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
+msgid "Create KB \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
@@ -13937,28 +13912,28 @@ msgstr "document"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14021,8 +13996,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -14344,7 +14319,7 @@ msgid "Display as List"
 msgstr ""
 
 #: invenio/modules/tags/views.py:141
-#, fuzzy, python-format
+#, fuzzy
 msgid "Associated Records"
 msgstr "Co-citat cu: %s documente"
 
@@ -14517,8 +14492,7 @@ msgstr "Alertele tale"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -14720,7 +14694,7 @@ msgid "just now"
 msgstr ""
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s secunde"
 
@@ -14777,6 +14751,12 @@ msgstr "orice an"
 msgid " years ago"
 msgstr "an"
 
+#~ msgid "Id"
+#~ msgstr "Id"
+
+#~ msgid "by"
+#~ msgstr "de"
+
 #~ msgid "record"
 #~ msgstr "document"
 
@@ -14807,9 +14787,6 @@ msgstr "an"
 #~ msgid "Error:"
 #~ msgstr "Eroare"
 
-#~ msgid "Id"
-#~ msgstr "Id"
-
 #~ msgid "HTML brief"
 #~ msgstr "HTML scurt"
 
@@ -14833,9 +14810,6 @@ msgstr "an"
 
 #~ msgid "There is a total of %i comments"
 #~ msgstr "In total sunt %i comentarii"
-
-#~ msgid "by"
-#~ msgstr "de"
 
 #~ msgid "on"
 #~ msgstr "pe"
@@ -14867,67 +14841,14 @@ msgstr "an"
 #~ msgid "statistics"
 #~ msgstr "statistici"
 
-#~ msgid "There is no format configured for this journals index page"
-#~ msgstr ""
-
-#~ msgid "There is no format configured for this journals search page"
-#~ msgstr ""
-
-#~ msgid "There is no format configured for this journals popup page"
-#~ msgstr ""
-
 #~ msgid "We could not find a current issue in the Database"
 #~ msgstr "Ediţia curentă nu a fost gasită in baza de date"
-
-#~ msgid "Export as"
-#~ msgstr ""
 
 #~ msgid "Search Services"
 #~ msgstr "Indicii de căutare "
 
-#~ msgid "Citation Metrics"
-#~ msgstr ""
-
-#~ msgid "WebSearch Admin Guide"
-#~ msgstr ""
-
-#~ msgid "Submit Guide"
-#~ msgstr ""
-
-#~ msgid "Add to personal basket"
-#~ msgstr ""
-
-#~ msgid "WebSubmit Admin Guide"
-#~ msgstr ""
-
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
-#~ msgid "Quit searching."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Anulat"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "Sunteţi membru al următoarelor grupuri:"
@@ -14941,35 +14862,11 @@ msgstr "an"
 #~ msgid "Invert Selection"
 #~ msgstr "orice colecţie"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Autor:"
 
 #~ msgid "Experiment"
 #~ msgstr "experiment"
-
-#~ msgid "Not assigned"
-#~ msgstr ""
-
-#~ msgid "No status information found."
-#~ msgstr ""
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
-
-#~ msgid "Review Transaction"
-#~ msgstr ""
-
-#~ msgid "On all pages"
-#~ msgstr ""
 
 #~ msgid "With selected do"
 #~ msgstr "A fost respins pe:"
@@ -14980,15 +14877,6 @@ msgstr "an"
 #~ msgid "The author has an internal ID!"
 #~ msgstr "Eroare internă"
 
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "comentarii"
 
@@ -14998,528 +14886,35 @@ msgstr "an"
 #~ msgid " Delete this ticket"
 #~ msgstr "Şterge comentariu"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "Niciun jurnal nu este disponibil"
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
-
-#~ msgid "Select name for"
-#~ msgstr ""
-
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
-#~ msgid "Paper title: "
-#~ msgstr ""
-
-#~ msgid "Ignore"
-#~ msgstr ""
-
-#~ msgid "The following names have been automatically chosen:"
-#~ msgstr ""
-
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
-#~ msgid "Selected name on paper"
-#~ msgstr ""
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
-
-#~ msgid "Please provide your information"
-#~ msgstr ""
-
-#~ msgid "Please provide your first name"
-#~ msgstr ""
-
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
 
 #~ msgid "Your last name:"
 #~ msgstr "Numele grupului:"
 
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
-#~ msgid "Your eMail:"
-#~ msgstr ""
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
-
 #~ msgid "!Delete the entire request!"
 #~ msgstr "Ştergeţi comentariile selectate"
-
-#~ msgid "Mark as your documents"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
 
 #~ msgid "Mark as their documents"
 #~ msgstr "Discutaţi despre acest document"
 
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ their documents"
-#~ msgstr ""
-
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "Creaţi un nou grup"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "Adaugă la utilizatori"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
-#~ msgid "Recent Papers"
-#~ msgstr ""
-
-#~ msgid "Publication List "
-#~ msgstr ""
-
-#~ msgid "Showing the"
-#~ msgstr ""
-
-#~ msgid "most recent documents:"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Administrează drepturile de grup "
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Alege un subiect"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
-#~ msgid "Manage publication list"
-#~ msgstr ""
-
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
-#~ msgid "add external id"
-#~ msgstr ""
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
-
-#~ msgid "suggest missing ids"
-#~ msgstr ""
-
 #~ msgid "Choose system"
 #~ msgstr "Alege un subiect"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr ""
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
-#~ msgid "Fatal: You are not allowed to access this functionality."
-#~ msgstr ""
-
-#~ msgid "Claim this paper"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "You have %i tickets."
-#~ msgstr ""
-
-#~ msgid "The publication date of this book is %s."
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Citat de: %s documente"
-
-#~ msgid "Unknown type: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file named %s already exists. Please choose another name."
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Record #%i"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
-#~ msgid "Revision"
-#~ msgstr ""
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Could not find format element named %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
-
-#~ msgid "Output format with code %s could not be found."
-#~ msgstr ""
-
-#~ msgid "Could not find output format named %s."
-#~ msgstr ""
-
-#~ msgid "Could not find a fresh name for output format %s."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Modifică atributele formatului"
@@ -15578,332 +14973,14 @@ msgstr "an"
 #~ msgid "Add New Rule"
 #~ msgstr "Adaugă regulă nouă"
 
-#~ msgid "No problem found with format"
-#~ msgstr ""
-
-#~ msgid "An error has been found"
-#~ msgstr ""
-
-#~ msgid "The following errors have been found"
-#~ msgstr ""
-
-#~ msgid "BibFormat Admin"
-#~ msgstr ""
-
-#~ msgid "Test with record:"
-#~ msgstr ""
-
-#~ msgid "Enter a search query here."
-#~ msgstr ""
-
 #~ msgid "No Record Found for %s."
 #~ msgstr "Documentul nu a fost găsit"
-
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
 
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Utilizatorul %s nu există."
 
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
-
-#~ msgid "Output format %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
-#~ msgid "Format template %s calls undefined element \"%s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
-
-#~ msgid "Error in format element %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Show all %i authors"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
-
-#~ msgid "Restricted Output Format"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Rules"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Output Format"
-#~ msgstr ""
-
-#~ msgid "Cannot create output format"
-#~ msgstr ""
-
-#~ msgid "Format template %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Element %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Test Format Element %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Output Format %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Element"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Element %s"
-#~ msgstr ""
-
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
-#~ msgid "Format Validation"
-#~ msgstr ""
-
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Download history:"
-#~ msgstr ""
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid "Cannot send error request, %s parameter missing."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Not Set"
-#~ msgstr ""
-
-#~ msgid "never"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been added to your profile."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been successfully updated."
-#~ msgstr ""
-
-#~ msgid "You have defined %s alerts."
-#~ msgstr ""
-
-#~ msgid "Here are the %s most popular searches."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display searches"
-#~ msgstr ""
-
-#~ msgid "%s, personalize"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Set a new alert"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Modify alert settings"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display alerts"
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
-
-#~ msgid "times"
-#~ msgstr ""
-
-#~ msgid "Papers"
-#~ msgstr ""
-
 #~ msgid "No Keywords"
 #~ msgstr "cuvânt cheie"
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
-
-#~ msgid "No Subject categories"
-#~ msgstr ""
-
-#~ msgid "Subject categories"
-#~ msgstr ""
 
 #~ msgid "No Collaborations"
 #~ msgstr "Afilieri:"
@@ -15917,472 +14994,5 @@ msgstr "an"
 #~ msgid "Affiliations"
 #~ msgstr "Afilieri:"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
 #~ msgid "Citations%s"
 #~ msgstr "Citaţii:"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
-
-#~ msgid "No Publication Graph"
-#~ msgstr ""
-
-#~ msgid "<strong> Publications list </strong>"
-#~ msgstr ""
-
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "Sorry, you do not have sufficient rights to add record #%i."
-#~ msgstr ""
-
-#~ msgid "%i items have been successfully added to your basket"
-#~ msgstr ""
-
-#~ msgid "Adding %i items to your baskets"
-#~ msgstr ""
-
-#~ msgid "%i users are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "%i user groups are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "You have set %i alerts on this basket."
-#~ msgstr ""
-
-#~ msgid "%i items"
-#~ msgstr ""
-
-#~ msgid "%i notes"
-#~ msgstr ""
-
-#~ msgid "%i subscribers"
-#~ msgstr ""
-
-#~ msgid "Record %i"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "Sorry, the record %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "Readers found the following %s reviews to be most helpful."
-#~ msgstr ""
-
-#~ msgid "View all %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s comments"
-#~ msgstr ""
-
-#~ msgid "Note: Your nickname, %s, will be displayed as author of this comment."
-#~ msgstr ""
-
-#~ msgid "Max %i files"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Note: Your nickname, %s, will be "
-#~ "displayed as the author of this "
-#~ "review."
-#~ msgstr ""
-
-#~ msgid "Here is review %s"
-#~ msgstr ""
-
-#~ msgid "Here is comment %s"
-#~ msgstr ""
-
-#~ msgid "Here are all reviews for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "Here are all comments for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
-#~ msgid "There are no records referring to %s."
-#~ msgstr ""
-
-#~ msgid "There are no records cited by %s."
-#~ msgstr ""
-
-#~ msgid "No word index is available for %s."
-#~ msgstr ""
-
-#~ msgid "No phrase index is available for %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Search term %s did not match any"
-#~ " record. Nearest terms in any "
-#~ "collection are:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, %s does not seem to be "
-#~ "a valid sort option. The records "
-#~ "will not be sorted."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, sorting is allowed on sets "
-#~ "of up to %d records only. Using"
-#~ " default sort order."
-#~ msgstr ""
-
-#~ msgid "Search %s records for"
-#~ msgstr ""
-
-#~ msgid "Cited by 1 record"
-#~ msgstr ""
-
-#~ msgid "%i comments"
-#~ msgstr ""
-
-#~ msgid "%i reviews"
-#~ msgstr ""
-
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid "No Papers"
-#~ msgstr ""
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
-
-#~ msgid "No Citation Information available"
-#~ msgstr ""
-
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
-#~ msgid "Discussion"
-#~ msgstr ""
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If you are using a lightweight CERN account you can\n"
-#~ "                %(x_url_open)sreset the password%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Alternatively, you can ask %s to "
-#~ "change your login system from external"
-#~ " to internal."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "%s offers you the possibility to "
-#~ "personalize the interface, to set up "
-#~ "your own personal library of documents,"
-#~ " or to set up an automatic "
-#~ "alert query that would run periodically"
-#~ " and would notify you of search "
-#~ "results by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid "Okay, a password reset link has been emailed to %s."
-#~ msgstr ""
-
-#~ msgid "If you don't own an account yet, please contact %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please do not use valuable passwords "
-#~ "such as your Unix, AFS or NICE "
-#~ "passwords with this service. Your email"
-#~ " address will stay strictly confidential"
-#~ " and will not be disclosed to "
-#~ "any third party. It will be used"
-#~ " to identify you for personal "
-#~ "services of %s. For example, you "
-#~ "may set up an automatic alert "
-#~ "search that will look for new "
-#~ "preprints and will notify you daily "
-#~ "of new arrivals by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "It is not possible to create an"
-#~ " account yourself. Contact %s if you"
-#~ " want an account."
-#~ msgstr ""
-
-#~ msgid "Your alerts"
-#~ msgstr ""
-
-#~ msgid "Your approvals"
-#~ msgstr ""
-
-#~ msgid "Your baskets"
-#~ msgstr ""
-
-#~ msgid "Your groups"
-#~ msgstr ""
-
-#~ msgid "Your loans"
-#~ msgstr ""
-
-#~ msgid "Your submissions"
-#~ msgstr ""
-
-#~ msgid "Your searches"
-#~ msgstr ""
-
-#~ msgid "Administration"
-#~ msgstr ""
-
-#~ msgid "Statistics"
-#~ msgstr ""
-
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
-#~ msgid "Group: %s"
-#~ msgstr ""
-
-#~ msgid "Group %s: New membership request"
-#~ msgstr ""
-
-#~ msgid "A user wants to join the group %s."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been accepted"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been accepted."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been rejected"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been rejected."
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted"
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted by its administrator."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Your Settings"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown to the external login "
-#~ "system."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The external login method %s does "
-#~ "not support email address based logins."
-#~ "  Please contact the site administrators."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is already in use."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "Sorry, page %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
-#~ msgid "Page %s Not Found"
-#~ msgstr ""
-
-#~ msgid "Please contact %s quoting the following information:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
-
-#~ msgid "Unable to find the submission directory for the action: %s"
-#~ msgstr ""
-
-#~ msgid "Unable to find document type: %s"
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory."
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory. Please fill it in."
-#~ msgstr ""
-
-#~ msgid "Function %s does not exist."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s%s'"
-#~ msgstr ""
-

--- a/invenio/base/translations/ru/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/ru/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2011 CERN.
+# # Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,16 +16,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2011-06-15 10:47+0200\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:58+0200\n"
 "Last-Translator: Andrey Tremba <metandrey@gmail.com>\n"
 "Language-Team: RU <info@invenio-software.org>\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -59,8 +59,8 @@ msgstr "главная страница"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -206,7 +206,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Здравствуйте:"
 
@@ -227,17 +227,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -263,48 +263,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Выбранный Вами элемент не существует."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr "Запрос на смену пароля для"
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Вам не разрешено использовать прокат."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Регистрация не удалась"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Пожалуйста, выберите один или более:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Запрос на ролевую авторизацию"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, fuzzy, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr "Более новая версия Invenio доступна для загрузки. Подробнее "
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -504,7 +509,8 @@ msgstr "Нет прав для загрузки в коллекцию '%s'"
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr "Пользователю '%(x_user)s' не разрешено изменять коллекцию '%(x_coll)s'"
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -578,9 +584,9 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"Ваш файл был успешно поставлен в очередь. Вы можете проверить "
-"свою%(x_url1_open)sисторию загрузки%(x_url1_close)s или "
-"%(x_url2_open)sзагрузить другой файл%(x_url2_close)s"
+"Ваш файл был успешно поставлен в очередь. Вы можете проверить свою"
+"%(x_url1_open)sисторию загрузки%(x_url1_close)s или %(x_url2_open)sзагрузить "
+"другой файл%(x_url2_close)s"
 
 #: invenio/legacy/batchuploader/templates.py:282
 msgid "No metadata files have been uploaded yet."
@@ -715,10 +721,11 @@ msgid "The following errors have occurred:"
 msgstr "Произошли следующие ошибки:"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
-"Некоторые файлы не удалось переместить в папку DONE. Пожалуйста, удалите "
-"их вручную."
+"Некоторые файлы не удалось переместить в папку DONE. Пожалуйста, удалите их "
+"вручную."
 
 #: invenio/legacy/batchuploader/templates.py:585
 msgid "All uploaded files were moved to DONE folder."
@@ -734,8 +741,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -817,7 +824,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -860,8 +867,8 @@ msgstr "Ваши запросы"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Предыдущий"
@@ -876,8 +883,8 @@ msgstr "закрыть"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Следующий"
 
@@ -893,18 +900,6 @@ msgstr "Следующий"
 msgid "Admin Area"
 msgstr "Область Администратора"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "автор"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
 msgid "ERROR: %(x_name)s does not exist"
@@ -919,15 +914,6 @@ msgstr ""
 #, python-format
 msgid "ERROR: %(x_name)s is not writable"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
-msgid "Limit to knowledge bases containing string:"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "успешно удалено"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -957,10 +943,6 @@ msgstr "успешно удалено"
 msgid "Delete"
 msgstr "Удалить"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:140
-msgid "Verify syntax"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:145
 #: invenio/modules/communities/views.py:258
 #, fuzzy
@@ -972,31 +954,9 @@ msgstr "Создать новую книжную полку"
 msgid "File %(x_name)s does not exist."
 msgstr "Пользователь %s не существует."
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:174
-msgid "Calling bibcheck -verify failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
-msgid "Verify BibCheck config file"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Проблема базы данных"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "файл(ы)"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
 msgstr "Сохранить изменения"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:240
-msgid "Edit BibCheck config file"
-msgstr ""
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:268
 #, fuzzy, python-format
@@ -1013,10 +973,6 @@ msgstr ""
 msgid "File %(x_name)s: write failed."
 msgstr ""
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:279
-msgid "Save BibCheck config file"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:312
 #, python-format
 msgid "File %(x_name)s deleted."
@@ -1025,10 +981,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:314
 #, python-format
 msgid "File %(x_name)s: delete failed."
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:316
-msgid "Delete BibCheck config file"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:195
@@ -1096,7 +1048,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1147,8 +1100,8 @@ msgstr "Объект %(x_title)s со штрихкодом %(x_barcode)s был 
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1162,25 +1115,23 @@ msgstr "Штрих-код"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "Объект %(x_title)s со штрихкодом %(x_barcode)s был успешно возвращен. "
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "Объект %(x_title)s со штрихкодом %(x_barcode)s был успешно возвращен. "
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1205,13 +1156,14 @@ msgstr "Создать новую тему"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "Объект %(x_title)s со штрихкодом %(x_barcode)s был успешно возвращен. "
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1243,9 +1195,8 @@ msgstr "Срок проката"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "Объект %(x_title)s со штрихкодом %(x_barcode)s был успешно возвращен. "
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1312,8 +1263,8 @@ msgstr "Новый запрос"
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1321,8 +1272,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1344,9 +1295,8 @@ msgstr "Новый прокат"
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "Объект %(x_title)s со штрихкодом %(x_barcode)s был успешно возвращен. "
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1388,8 +1338,8 @@ msgstr "0 занявших найдено."
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1448,11 +1398,11 @@ msgstr "Новый запрос был успешно зарегистриров
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1463,11 +1413,11 @@ msgstr "Да"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1480,8 +1430,8 @@ msgstr "Нет"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1576,8 +1526,8 @@ msgstr "<strong>%s</strong> найденных записей"
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1597,29 +1547,29 @@ msgstr "<strong>%s</strong> найденных записей"
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1628,9 +1578,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr "Эта запись не существует"
 
@@ -1990,16 +1940,14 @@ msgstr "Этот элемент не задержан."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2020,8 +1968,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2183,8 +2131,8 @@ msgstr "запрос ILL"
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2291,7 +2239,7 @@ msgstr "Местонахождение"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Описание"
 
@@ -2484,8 +2432,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2760,9 +2708,8 @@ msgstr "Подтвердить"
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "Если Вы хотите, можете сделать %(x_url_open)slogin%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2816,7 +2763,7 @@ msgstr "Очистить"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "ОК"
 
@@ -2824,8 +2771,8 @@ msgstr "ОК"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "Объект %(x_title)s со штрихкодом %(x_barcode)s был успешно возвращен. "
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3284,8 +3231,8 @@ msgstr "Почтовый ящик"
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "Электронная почта"
 
@@ -4092,11 +4039,10 @@ msgstr "Интересуемый период (До)"
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, fuzzy, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
-"Занимающий соглашается с %s этого сервиса, в частности, вернуть книги "
-"вовремя"
+"Занимающий соглашается с %s этого сервиса, в частности, вернуть книги вовремя"
 
 #: invenio/legacy/bibcirculation/templates.py:9721
 msgid "Borrower wants this edition only."
@@ -4113,9 +4059,10 @@ msgstr "Именно эта редакция"
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, fuzzy, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
-msgstr "Проверить, существует ли уже эта книга в Invenio, до отправки ILL запроса."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
+msgstr ""
+"Проверить, существует ли уже эта книга в Invenio, до отправки ILL запроса."
 
 #: invenio/legacy/bibcirculation/templates.py:10332
 msgid "0 items found."
@@ -4173,17 +4120,17 @@ msgstr "ISSN"
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4558,25 +4505,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "Запись была удалена."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4636,15 +4583,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4655,10 +4602,10 @@ msgstr "Выбрать файл"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4671,15 +4618,15 @@ msgstr "Доступ"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, fuzzy, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr "Загруженный файл слишком мал (<%i o) и поэтому не подошел"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4690,7 +4637,8 @@ msgid ""
 msgstr "Загруженный файл слишком велик (>%i o) и поэтому не подошел"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr "Имя загруженного файл слишком длинное и поэтому файл не подошел"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4709,17 +4657,15 @@ msgstr "Файл с именем %s уже существует. Пожалуй�
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "Файл с именем %s уже существует. Пожалуйста, выберите другое имя."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4732,22 +4678,21 @@ msgstr "Добавить новый файл"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:900
 msgid "You can decide to hide or not previous version(s) of this file."
-msgstr "Вы можете решить, прятать или нет предыдущую версию (версии) этого файла."
+msgstr ""
+"Вы можете решить, прятать или нет предыдущую версию (версии) этого файла."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
-"При пересмотре файла дополнительные форматы, которые, возможно, были "
-"ранее  загружены, удаляются, поскольку они более не соответствуют новому "
-"файлу."
+"При пересмотре файла дополнительные форматы, которые, возможно, были ранее  "
+"загружены, удаляются, поскольку они более не соответствуют новому файлу."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 "Альтернативные форматы, загруженные для текущей версии этого файла будут "
 "удалены"
@@ -4792,8 +4737,7 @@ msgid ""
 "Best regards"
 msgstr ""
 "Уважаемая служба поддержки,\n"
-"Мне нужна ваша помощь в пересмотре или добавлении файла к записи "
-"%(recid)s.\n"
+"Мне нужна ваша помощь в пересмотре или добавлении файла к записи %(recid)s.\n"
 "Новая версия приложена к этому письму.\n"
 "С уважением"
 
@@ -4803,17 +4747,17 @@ msgid ""
 "Having a problem revising a file? Send the revised version to "
 "%(mailto_link)s."
 msgstr ""
-"Испытываете проблемы с пересмотром файла? Пошлите пересмотренную версию "
-"на %(mailto_link)s."
+"Испытываете проблемы с пересмотром файла? Пошлите пересмотренную версию на "
+"%(mailto_link)s."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
-"Испытываете проблемы с добавлением или пересмотром файла? Пошлите "
-"новую/пересмотренную версию на %(mailto_link)s."
+"Испытываете проблемы с добавлением или пересмотром файла? Пошлите новую/"
+"пересмотренную версию на %(mailto_link)s."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
 msgid "revise"
@@ -4864,8 +4808,8 @@ msgstr "Похоже, что запрошенная запись не была �
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr "Система обнаружила ошибку получения списка файлов для этого документа."
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -4977,13 +4921,13 @@ msgstr "1. Выбор критерия поиска"
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
-"Определите критерии, которые Вы бы хотели использовать для выбора "
-"записей, которые будут изменены. Используйте кнопку \"Искать\", чтобы "
-"увидеть, какие записи будут отобраны по этим критериям."
+"Определите критерии, которые Вы бы хотели использовать для выбора записей, "
+"которые будут изменены. Используйте кнопку \"Искать\", чтобы увидеть, какие "
+"записи будут отобраны по этим критериям."
 
 #: invenio/legacy/bibeditmulti/templates.py:361
 msgid "Preview results"
@@ -4995,11 +4939,11 @@ msgstr "2. Задание изменений"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
-"Задайте поля и подполя, которые должны быть изменены во всех подходящих "
-"под поисковые критерии записях."
+"Задайте поля и подполя, которые должны быть изменены во всех подходящих под "
+"поисковые критерии записях."
 
 #: invenio/legacy/bibeditmulti/templates.py:615
 msgid "Define new field action"
@@ -5128,11 +5072,10 @@ msgstr "Вернуться к результатам поиска"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5258,7 +5201,7 @@ msgid "Total"
 msgstr "Всего"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Выбор"
 
@@ -5417,8 +5360,8 @@ msgstr "Удалить базу знаний"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, fuzzy, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr "Ограничить вывод базами знаний, соответствующими"
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5474,10 +5417,9 @@ msgstr "Пожалуйста настройте"
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 "Динамическая база знаний это список значений данного поля. Этот список "
 "формируется динамически при поиске записей с использованием поискового "
@@ -5485,20 +5427,20 @@ msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
-"Пример: Ваши записи содержат поле 270__а для имени и адреса института "
-"автора Если вы установите поле как '270__a' и поисковое выражение как "
-"'270__a:*Paris*', то будет создан список институтов Парижа."
+"Пример: Ваши записи содержат поле 270__а для имени и адреса института автора "
+"Если вы установите поле как '270__a' и поисковое выражение как '270__a:"
+"*Paris*', то будет создан список институтов Парижа."
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 "Если поисковое выражение пусто, будет создан список всех значений поля "
 "'270__a'."
@@ -5506,17 +5448,17 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:248
 #, fuzzy, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
-"Если поисковое выражение содержит символ '%', например, '270__a:*%*', то "
-"при использовании базы знаний оно будет заменено на строку поиска."
+"Если поисковое выражение содержит символ '%', например, '270__a:*%*', то при "
+"использовании базы знаний оно будет заменено на строку поиска."
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 "Вы можете ввести имя коллекции если поисковое выражение должно быть "
 "применено к конкретной коллекции."
@@ -5524,22 +5466,23 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:253
 #, fuzzy
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
-"Пример: Ваши записи содержат поле 270__а для имени и адреса института "
-"автора Если вы установите поле как '270__a' и поисковое выражение как "
-"'270__a:*Paris*', то будет создан список институтов Парижа."
+"Пример: Ваши записи содержат поле 270__а для имени и адреса института автора "
+"Если вы установите поле как '270__a' и поисковое выражение как '270__a:"
+"*Paris*', то будет создан список институтов Парижа."
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5578,7 +5521,7 @@ msgstr "Зависимости базы знаний"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5591,8 +5534,8 @@ msgid ""
 "Here you can add new mappings to this base                         and "
 "change the base attributes."
 msgstr ""
-"Здесь Вы можете добавить новые отображения к этой базе знаний и изменить "
-"ее параметры."
+"Здесь Вы можете добавить новые отображения к этой базе знаний и изменить ее "
+"параметры."
 
 #: invenio/legacy/bibknowledge/templates.py:364
 msgid "Map From"
@@ -5633,15 +5576,15 @@ msgstr "Ваше правило"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, fuzzy, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr "уже есть в этих базах знаний"
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, fuzzy, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr "уже есть в этих базах знаний"
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5739,8 +5682,8 @@ msgstr "Большое спасибо за то, что помогаете на�
 #: invenio/legacy/errorlib/webinterface.py:155
 msgid "Use the back button of your browser to return to the previous page."
 msgstr ""
-"Используйте кнопку 'назад' в вашем браузере, чтобы вернуться на "
-"предыдущую страницу"
+"Используйте кнопку 'назад' в вашем браузере, чтобы вернуться на предыдущую "
+"страницу"
 
 #: invenio/legacy/errorlib/webinterface.py:158
 msgid "Thank you!"
@@ -5865,8 +5808,7 @@ msgstr "Ошибка при получении записи"
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -5940,8 +5882,8 @@ msgstr "Вернуться к основной выборке"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -5956,8 +5898,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Результаты поиска"
 
@@ -6116,8 +6058,8 @@ msgstr "не найдено."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6126,8 +6068,8 @@ msgid ""
 "Warning: figure caption search is only available for a subset of papers "
 "mostly from %(x_range_from_year)s-%(x_range_to_year)s."
 msgstr ""
-"Предупреждение: поиск по подписям графиков в основном доступен только для"
-" статей с 2008 по 2010 годы."
+"Предупреждение: поиск по подписям графиков в основном доступен только для "
+"статей с 2008 по 2010 годы."
 
 #: invenio/legacy/search_engine/__init__.py:2151
 #, python-format
@@ -6145,8 +6087,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6157,11 +6099,10 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
-"Фразовый индекс пока недоступен для полнотекстового поиска, ищем "
-"комбинацию слов"
+"Фразовый индекс пока недоступен для полнотекстового поиска, ищем комбинацию "
+"слов"
 
 #: invenio/legacy/search_engine/__init__.py:2213
 #, python-format
@@ -6172,14 +6113,14 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
-"Неверно распознан поисковый синтаксис. Будут проигнорированы все скобки в"
-" запросе. Если не работает, пожалуйста, проверьте поисковый запрос и "
+"Неверно распознан поисковый синтаксис. Будут проигнорированы все скобки в "
+"запросе. Если не работает, пожалуйста, проверьте поисковый запрос и "
 "попробуйте еще раз."
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
@@ -6188,75 +6129,75 @@ msgstr ""
 "не найдено соответствия в коллекции %(x_collection)s. В других публичных "
 "коллекциях %(x_url_open)s%(x_nb_hits)d результатов%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 "Ваш запрос не удовлетворён ни в одной доступной коллекции. Для поиска "
-"документа ограниченного доступа, выберете сначала коллекцию ограниченного"
-" доступа."
+"документа ограниченного доступа, выберете сначала коллекцию ограниченного "
+"доступа."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
 "Ваш запрос не удовлетворён ни в одной доступной коллекции. Для поиска "
-"документа ограниченного доступа, выберете сначала коллекцию ограниченного"
-" доступа."
+"документа ограниченного доступа, выберете сначала коллекцию ограниченного "
+"доступа."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr "%s не найден. Ближайшие термины:"
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "Используйте другие условия поиска."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Нет записей, ссылающихся на %s."
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Нет записей, цитируемых %s."
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Нет записей, цитируемых %s."
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Не найден словарный индекс для %s."
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Не найден фразовый индекс для %s."
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr "%(x_term)s внутри индекса %(x_index)s не найден. Ближайшие термины:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr "%s не найден. Ближайшие термины:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
@@ -6265,35 +6206,35 @@ msgstr ""
 "Извините, %s не является разрешенным параметром сортировки. Используйте "
 "сортировку по названиям"
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 "Извините, сортировка разрешена только на множестах до %d записей.  "
 "Используйте сортировку по умолчанию."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 "Извините, %s не является разрешенным параметром сортировки. Используйте "
 "сортировку по названиям"
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Эта запись не существует."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Используйте другие условия поиска."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6307,17 +6248,16 @@ msgstr "Используйте другие условия поиска."
 msgid "Browse"
 msgstr "Просмотреть"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
-"не найден ни один результат в пределах данного временного интервала, "
-"отмена условия..."
+"не найден ни один результат в пределах данного временного интервала, отмена "
+"условия..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
-"не найден ни один результат для вашего ограничения поиска, отмена "
-"условия..."
+"не найден ни один результат для вашего ограничения поиска, отмена условия..."
 
 #: invenio/legacy/webalert/api.py:54
 #, fuzzy, python-format
@@ -6360,15 +6300,14 @@ msgstr "Уведомление %s было успешно обновлено."
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Вы создали %(x_nb)s запросы. Для %(x_url_open)sподробного "
-"списка%(x_url_close)s имеется возможность (a) просмотреть результаты "
-"поиска и (b) подписаться на сервис автоматического уведомления через "
-"email для этих запросов."
+"Вы создали %(x_nb)s запросы. Для %(x_url_open)sподробного списка"
+"%(x_url_close)s имеется возможность (a) просмотреть результаты поиска и (b) "
+"подписаться на сервис автоматического уведомления через email для этих "
+"запросов."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6442,8 +6381,8 @@ msgid ""
 "This alert will notify you each time/only if a new item satisfies the "
 "following query:"
 msgstr ""
-"Это уведомление будет извещать Вас всякий раз, когда новые поступления "
-"будут удовлетворять следующему запросу:"
+"Это уведомление будет извещать Вас всякий раз, когда новые поступления будут "
+"удовлетворять следующему запросу:"
 
 #: invenio/legacy/webalert/templates.py:173
 msgid "QUERY"
@@ -6489,7 +6428,8 @@ msgstr "нет"
 #: invenio/legacy/webalert/templates.py:225
 #, python-format
 msgid "if %(x_fmt_open)sno%(x_fmt_close)s you must specify a basket"
-msgstr "Если %(x_fmt_open)sнет%(x_fmt_close)s, Вы должны определить книжную полку"
+msgstr ""
+"Если %(x_fmt_open)sнет%(x_fmt_close)s, Вы должны определить книжную полку"
 
 #: invenio/legacy/webalert/templates.py:227
 msgid "Store results in basket?"
@@ -6509,9 +6449,8 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"Установите новое уведомление из %(x_url1_open)sваши "
-"запросы%(x_url1_close)s, %(x_url2_open)sпопулярные "
-"запросы%(x_url2_close)s или форму ввода"
+"Установите новое уведомление из %(x_url1_open)sваши запросы%(x_url1_close)s, "
+"%(x_url2_open)sпопулярные запросы%(x_url2_close)s или форму ввода"
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6562,8 +6501,8 @@ msgstr "Вы установили %s уведомлений"
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 "Вы пока не произвели ни одного поиска. Пожалуйста перейдите сначала на "
 "%(x_url_open)sинтерфейс поиска%(x_url_close)s."
@@ -6571,8 +6510,8 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
 "Вы выполнили %(x_nb1)s поисков (%(x_nb2)s различных запросов) в течение "
 "последних 30 дней."
@@ -6632,7 +6571,7 @@ msgstr "Ваши запросы"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6696,7 +6635,7 @@ msgstr "%s Персонализовать, Установить новое ув�
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6756,7 +6695,8 @@ msgstr "%s Персонализовать, Показать уведомлени
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6780,7 +6720,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "У Вас недостаточно прав для просмотра этого элемента."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6808,7 +6749,8 @@ msgid "You do not have permission to delete this note."
 msgstr "У Вас недостаточно прав для просмотра этого элемента."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6839,8 +6781,8 @@ msgstr "Выбранный Вами элемент не существует."
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6862,8 +6804,8 @@ msgstr "Скопировать запись на книжную полку"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6896,8 +6838,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -6967,12 +6909,11 @@ msgstr "Общая полка"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
-"У вас %(x_nb_perso)s личные книжные полки, и вы подписаны на "
-"%(x_nb_group)s групповые книжные полки и на %(x_nb_public)s общие книжные"
-" полки других пользователей"
+"У вас %(x_nb_perso)s личные книжные полки, и вы подписаны на %(x_nb_group)s "
+"групповые книжные полки и на %(x_nb_public)s общие книжные полки других "
+"пользователей"
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
 #, fuzzy
@@ -6994,17 +6935,16 @@ msgid ""
 "You have no personal or group baskets or are subscribed to any public "
 "baskets."
 msgstr ""
-"У Вас нет ни личных, ни групповых книжных полок, и Вы не подписаны ни на"
-"  какую общую книжную полку."
+"У Вас нет ни личных, ни групповых книжных полок, и Вы не подписаны ни на  "
+"какую общую книжную полку."
 
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
-"Вы можете захотеть начать %(x_url_open)sс создания новой книжной "
-"полки%(x_url_close)s."
+"Вы можете захотеть начать %(x_url_open)sс создания новой книжной полки"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
 #: invenio/legacy/webbasket/templates.py:198
@@ -7107,8 +7047,8 @@ msgid ""
 "Displaying public baskets %(x_from)i - %(x_to)i out of "
 "%(x_total_public_basket)i public baskets in total."
 msgstr ""
-"Показаны общие полки %(x_from)i - %(x_to)i из всех "
-"%(x_total_public_basket)i общих полок."
+"Показаны общие полки %(x_from)i - %(x_to)i из всех %(x_total_public_basket)i "
+"общих полок."
 
 #: invenio/legacy/webbasket/templates.py:1376
 #: invenio/legacy/webbasket/templates.py:1400
@@ -7165,11 +7105,11 @@ msgstr "Внешний элемент"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
-"Введите адрес (URL) для внешнего элемента, который Вы хотели бы добавить;"
-" заполните его название и описание"
+"Введите адрес (URL) для внешнего элемента, который Вы хотели бы добавить; "
+"заполните его название и описание"
 
 #: invenio/legacy/webbasket/templates.py:1612
 #: invenio/modules/linkbacks/templates/linkbacks/index_base.html:44
@@ -7348,18 +7288,20 @@ msgstr "  Разделяемая книжная полка для новой г�
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
-"Вы зарегистрированы как 'Гость', поэтому Ваши книжные полки исчезнут в "
-"конце текущего сеанса."
+"Вы зарегистрированы как 'Гость', поэтому Ваши книжные полки исчезнут в конце "
+"текущего сеанса."
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
-msgstr "Вы можете %(x_url_open)slogin или зарегистрироваться здесь%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgstr ""
+"Вы можете %(x_url_open)slogin или зарегистрироваться здесь%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7368,7 +7310,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Эта функция запрещена для пользователей-гостей."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Назад к результатам поиска"
 
@@ -7532,7 +7474,7 @@ msgstr "Добавить примечание"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7669,211 +7611,211 @@ msgstr "Пользователь %s не существует."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "Пользователь %s не существует."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Написать комментарий"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "Рассмотрел %(nickname)s на %(date)s"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "%i комментариев"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Показаны последний(е) %i комментарий(ев):"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Обсудить этот документ"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Начинаем обсуждение этого документа."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Извините, запись %s, кажется, не существует."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "Извините, %s не является допустимым значение ID."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "Извините,не предоставлен ID записи."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Вы можете начать просмотр с %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "Рассмотрел %(nickname)s на %(date)s"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Была ли эта рецензия полезна?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Напишите рецензию"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 "Средняя оценка рецензии: %(x_nb_score)s, основанные на %(x_nb_reviews)s "
 "рецензиях"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "Читатели находят следующие %s рецензии наиболее полезными."
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Просмотреть все %s рецензии"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Оценить этот документ"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Будьте первым, рецензирующим этот документ"
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "закрыть"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Оскорбительное сообщение"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr "Восстановить комментарий"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Удалить комментарий"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr "Отменить оповещение о комментарии"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr "Присоединенный файл"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr "Присоединенные файлы"
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Рецензировал %(x_nickname)s %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr "%(x_nb_people)i из %(x_nb_total)i людей находит эту рецензию полезной"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr "Отменить удаление обзора"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr "Удалить обзор"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr "Отменить оповещение об обзоре"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Комментарии"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Рецензии"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Существует в общей сложности %s рецензий"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Существует в общей сложности %s комментариев"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Будьте первым, рецензирующим этот документ"
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Подписаться"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr "Отписаться"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7882,44 +7824,43 @@ msgstr "Отписаться"
 msgid "Record"
 msgstr "Запись"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "рецензия"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "комментарий"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Рецензия"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Просмотр"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Страница: "
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr "Вам не разрешено ни комментировать, ни делать обзоры."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 "Примечание: Ваш псевдоним %s будет отображаться в качестве автора этого "
 "комментария"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
@@ -7928,473 +7869,478 @@ msgstr ""
 "У Вас не %(x_url_open)sопределен nickname%(x_url_close)s. %(x_nickname)s "
 "будет отображаться в качестве автора комментария"
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr "После входа авторизированные пользователи могут также добавлять файлы"
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr "Приложить файл к этому комментарию (необязательно)"
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr "Приложить файл к этому комментарию (необязательно)"
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr "Не более одного файла"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "Не более %i файлов"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr "Файл размером не более %(x_nb_bytes)s"
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr "Посылать мне email при появлении новых комментариев"
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Статья"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr "Добавить комментарий"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr "Ваш nickname, %s,будет отображаться в качестве автора этой рецензии"
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Оценить эту статью"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Выберите оценку"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Дайте название вашей рецензии"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Напишите Вашу рецензию"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr "Добавьте рецензию"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Добавьте рецензию"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Ваша рецензия была добавлена."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Ваш комментарий был добавлен."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Назад к записи"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
-msgstr "Вы можете просмотреть список %(x_url_open)sВаших запросов%(x_url_close)s."
+msgstr ""
+"Вы можете просмотреть список %(x_url_open)sВаших запросов%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr "Просмотреть наиболее комментируемые записи"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr "Просмотреть последние прокомментированные записи"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr "Просмотреть все признанные недостойными комментарии"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr "Просмотреть наиболее обсуждаемые записи"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr "Просмотреть записи с последними рецензиями"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr "Просмотреть все признанные недостойными рецензии"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Просмотреть всех пользователей, о которых было сообщено"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Руководство"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Комментарии и обзоры отключены"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"Пожалуйста введите идентификатор (ID) комментария/обзора для того, чтоб "
-"Вы смогли увидеть его перед тем, как решить, удалять его или нет"
+"Пожалуйста введите идентификатор (ID) комментария/обзора для того, чтоб Вы "
+"смогли увидеть его перед тем, как решить, удалять его или нет"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "Идентификатор (ID) комментария:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 "Или введите идентификатор (ID) записи, чтобы отобразить все связанные "
 "комментарии/рецензии"
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr "Идентификатор (ID) записи"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Просмотреть комментария"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Там не было никаких отчетов до сих пор."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Просмотр всех %s комментариев"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Просмотр всех %s обзоров"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 #, fuzzy
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
 "Список пользователей, передавших по крайней мере один комментарий, "
 "отсортированный по общему числу сообщений."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Имя (псевдоним)"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "Идентификатор (ID) пользователя"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Число положительных голосов"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Число отрицательных голосов"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Общее число голосов"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Общее число сообщений"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Просмотр всех переданных пользователями комментариев/рецензий"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Об этой рецензии сообщили %i раз"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Об этом комментарии сообщили %i раз"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Автор:"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Общая информация"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Удалить выбранные обзоры"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Скрыть выбранные оскорбительные сообщения"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr "Отменить удаление выбранных обзоров"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr "Отменить удаление выбранных комментариев"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Удалить выбранные комментарии"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Переданные обзоры пользователя %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Переданные комментарии пользователя %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Обзор %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Комментарий %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Рецензия %(x_cmtID)s написана пользователем %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Комментарий %(x_cmtID)s написан пользователем %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr ""
 "Все представленные рецензии, отсортированные по максимальному количеству "
 "упоминаний"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr ""
-"Все представленные комментарии, отсортированные по максимальному "
-"количеству упоминаний"
+"Все представленные комментарии, отсортированные по максимальному количеству "
+"упоминаний"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr "Все рецензии к записи %i, отсортированные по частоте запросов"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr "Показать комментарии"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr "Все комментарии к записи %i, отсортированные по частоте запросов"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr "Показать отзывы"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "идентификатор (ID) комментария"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "успешно удалено"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr "успешно восстановлено"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "оскорбительное сообщение успешно скрыто"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
 msgstr "Еще не рецензированная"
 
-#: invenio/legacy/webcomment/templates.py:2257
+#: invenio/legacy/webcomment/templates.py:2256
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 "Следующая рецензия была отправлена на %(CFG_SITE_NAME)s пользователем "
 "%(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2258
+#: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 "Следующий комментарий был отправлен на %(CFG_SITE_NAME)s пользователем "
 "%(user_nickname)s:"
 
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr "Это автоматическое сообщение, пожалуйста, не отвечайте на него."
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr "Чтобы отправить другой комментарий, перейдите по ссылке <%(x_url)s>."
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
-"Чтобы ответить на этот конкретный комментарий, перейдите по ссылке "
-"<%(x_url)s>"
+"Чтобы ответить на этот конкретный комментарий, перейдите по ссылке <"
+"%(x_url)s>"
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr "Чтобы отписаться от этого обсуждения, перейдите по ссылке <%(x_url)s>"
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
-msgstr "По любым вопросам пожалуйста обращайтесь на <%(CFG_SITE_SUPPORT_EMAIL)s>"
+msgstr ""
+"По любым вопросам пожалуйста обращайтесь на <%(CFG_SITE_SUPPORT_EMAIL)s>"
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "Ваш комментарий успешно добавлен"
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Удалить комментарии"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "сначала последний запрос"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "Просмотреть последние прокомментированные записи"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "Подробности и комментарии"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "записей найдено"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Комментарии"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "%i элементов"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Добавить элементы"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "Показать"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Дата заказа"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Следующая страница"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Показать уведомления"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8402,103 +8348,103 @@ msgstr "Показать уведомления"
 msgid "Refresh"
 msgstr "Обновить"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Отменить оповещение о комментарии"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "найдено элементов: %i"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Запись не найдена"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "У Вас недостаточно прав для просмотра этого элемента."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Добавить комментарий"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "Просмотреть все комментарии"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr "Страница не найдена"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr "Не удалось найти запрошенный комментарий"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr "Не удалось найти запрошенный файл"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Вам не разрешено использовать прокат."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Комментарии"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "Просмотреть все комментарии"
@@ -8613,9 +8559,10 @@ msgstr "Извините, страница %s не существует"
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
-msgstr "Вы можете посмотреть%(x_url_open)s%(x_category)s страницы%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
+msgstr ""
+"Вы можете посмотреть%(x_url_open)s%(x_category)s страницы%(x_url_close)s."
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
 #, fuzzy, python-format
@@ -8678,8 +8625,8 @@ msgstr "Невозможно предоставить никаких журна�
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr "Похоже, журналы, показанные на сервере, отсутстуют."
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8706,11 +8653,11 @@ msgstr "Невозможно найти информацию о последне
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
-"Вероятно,конфигурация для текущего издания пуста. Попробуйте задать номер"
-" издания или проерить его."
+"Вероятно,конфигурация для текущего издания пуста. Попробуйте задать номер "
+"издания или проерить его."
 
 #: invenio/legacy/webjournal/config.py:298
 msgid "Issue number badly formed"
@@ -8808,11 +8755,6 @@ msgstr ""
 msgid "Apply"
 msgstr "Применить"
 
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "Имя (псевдоним)"
-
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 msgid "WebJournal Admin"
 msgstr "Администрирование WebJournal"
@@ -8892,9 +8834,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8916,8 +8857,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9029,8 +8969,8 @@ msgid ""
 "Your message is too long, please shorten it. Maximum size allowed is "
 "%(x_size)i characters."
 msgstr ""
-"Ваше сообщение слишком длинное, пожалуйста, отредактируйте его. "
-"Максимальный размер %i символов"
+"Ваше сообщение слишком длинное, пожалуйста, отредактируйте его. Максимальный "
+"размер %i символов"
 
 #: invenio/legacy/webmessage/api.py:402
 #, fuzzy, python-format
@@ -9055,8 +8995,7 @@ msgid ""
 "Your message could not be sent to the following recipients as it would "
 "exceed their quotas:"
 msgstr ""
-"Сообщение не может быть отослано следующим получателям в сязи с их "
-"квотами:"
+"Сообщение не может быть отослано следующим получателям в сязи с их квотами:"
 
 #: invenio/legacy/webmessage/api.py:457
 msgid "Your message has been sent."
@@ -9395,19 +9334,19 @@ msgstr "Ищем также:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
-"Эта коллекция закрыта. Если Вам разрешен к ней доступ, пожалуйстанажмите "
-"на кнопку поиска."
+"Эта коллекция закрыта. Если Вам разрешен к ней доступ, пожалуйстанажмите на "
+"кнопку поиска."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
-"Это внешняя коллекция. Пожалуйста, нажмите на кнопку поиска чтобы увидеть"
-" ее содержимое."
+"Это внешняя коллекция. Пожалуйста, нажмите на кнопку поиска чтобы увидеть ее "
+"содержимое."
 
 #: invenio/legacy/websearch/templates.py:1619
 msgid "This collection does not contain any document yet."
@@ -9501,8 +9440,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found %(x_nb_records)s "
 "records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sПросмотр результатов:%(x_fmt_close)s Найдено "
-"%(x_nb_records)s записей за %(x_nb_seconds)s секунд."
+"%(x_fmt_open)sПросмотр результатов:%(x_fmt_close)s Найдено %(x_nb_records)s "
+"записей за %(x_nb_seconds)s секунд."
 
 #: invenio/legacy/websearch/templates.py:3132
 #, python-format
@@ -9515,8 +9454,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found at least "
 "%(x_nb_records)s records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sПросмотр результатов:%(x_fmt_close)s найдено "
-"%(x_nb_records)s записей за %(x_nb_seconds)s секунд."
+"%(x_fmt_open)sПросмотр результатов:%(x_fmt_close)s найдено %(x_nb_records)s "
+"записей за %(x_nb_seconds)s секунд."
 
 #: invenio/legacy/websearch/templates.py:3184
 #, fuzzy
@@ -9543,11 +9482,9 @@ msgstr "Дополнительная информация"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
-"Запрос не дал никакого результата. Пожалуйста сформулируйте ваш запрос "
-"иначе."
+"Запрос не дал никакого результата. Пожалуйста сформулируйте ваш запрос иначе."
 
 #: invenio/legacy/websearch/templates.py:3357
 msgid "See also: similar author names"
@@ -9572,12 +9509,12 @@ msgstr "Вы можете начать просмотр с %s."
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "Установите персональное %(x_url1_open)semail оповещение%(x_url1_close)s\n"
-"                                  или подпишитесь на "
-"%(x_url2_open)sRSS-канал%(x_url2_close)s."
+"                                  или подпишитесь на %(x_url2_open)sRSS-канал"
+"%(x_url2_close)s."
 
 #: invenio/legacy/websearch/templates.py:3832
 #, python-format
@@ -9768,7 +9705,8 @@ msgid "in"
 msgstr "в"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "не нашли то, что искали? Попробуйте поискать на других серверах"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9813,8 +9751,8 @@ msgid ""
 "You can consult the list of your external groups directly in the "
 "%(x_url_open)sgroups page%(x_url_close)s."
 msgstr ""
-"Вы можете просматривать список Ваших внешних групп с "
-"%(x_url_open)sстраницы групп%(x_url_close)s."
+"Вы можете просматривать список Ваших внешних групп с %(x_url_open)sстраницы "
+"групп%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:110
 msgid "External user groups"
@@ -9864,8 +9802,8 @@ msgstr "обязательный"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9875,8 +9813,8 @@ msgstr "Создать новую книжную полку"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 "Если Вы хотите изменить Ваш email или задать в перый раз nickname, "
 "пожалуйста, введите новые значения в следующей форме."
@@ -9895,19 +9833,18 @@ msgstr "Установите новое значение"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
-"Т.к. это является подписью под комментариями и обзорами, его изменять "
-"нельзя."
+"Т.к. это является подписью под комментариями и обзорами, его изменять нельзя."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
-"Если Вы хотите изменить пароль, введите старый пароль,затем введите новый"
-" в следующей форме."
+"Если Вы хотите изменить пароль, введите старый пароль,затем введите новый в "
+"следующей форме."
 
 #: invenio/legacy/websession/templates.py:327
 msgid "Old password"
@@ -9944,8 +9881,8 @@ msgstr "Установите новый пароль"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 "Если Вы используете учетную запись CERN Вы можете %(x_url_open)sизменить "
 "пароль%(x_url_close)s."
@@ -9956,8 +9893,8 @@ msgid ""
 "You can change or reset your CERN account password by means of the "
 "%(x_url_open)sCERN account system%(x_url_close)s."
 msgstr ""
-"Вы можете изменить пароль учетной записи CERN при помощи "
-"%(x_url_open)sCERN account системы%(x_url_close)s."
+"Вы можете изменить пароль учетной записи CERN при помощи %(x_url_open)sCERN "
+"account системы%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:372
 msgid "Edit cataloging interface settings"
@@ -10039,14 +9976,13 @@ msgstr "Выбрать метод"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"Если Вы забыли пароль %(sitename)s %(x_fmt_open)sвнутренней учетной "
-"записи%(x_fmt_close)s, пожалуйста, введите Ваш email адрес в следующей "
-"форме, чтобы Вам прислали ссылку для смены пароля."
+"Если Вы забыли пароль %(sitename)s %(x_fmt_open)sвнутренней учетной записи"
+"%(x_fmt_close)s, пожалуйста, введите Ваш email адрес в следующей форме, "
+"чтобы Вам прислали ссылку для смены пароля."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10062,21 +9998,21 @@ msgstr "Прислать ссылку для смены пароля"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 "Если Вы используете %(x_fmt_open)sCERN login систему%(x_fmt_close)s, Вы "
-"можете восстановить пароль через %(x_url_open)sCERN систему "
-"аутентификации%(x_url_close)s."
+"можете восстановить пароль через %(x_url_open)sCERN систему аутентификации"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
-"Если Вы используете внешнюю систему входа, мы не в состоянии ничего "
-"сделать, обратитесь туда."
+"Если Вы используете внешнюю систему входа, мы не в состоянии ничего сделать, "
+"обратитесь туда."
 
 #: invenio/legacy/websession/templates.py:573
 #, fuzzy, python-format
@@ -10084,16 +10020,15 @@ msgid ""
 "Alternatively, you can ask %(x_name)s to change your login system from "
 "external to internal."
 msgstr ""
-"Вы можете также попросить %s изменить систему входа с внешней на "
-"внутреннюю."
+"Вы можете также попросить %s изменить систему входа с внешней на внутреннюю."
 
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 "%s предлагает Вам возможность персонализировать интерфейс, создать Вашу "
 "собстенную библиотеку документов или создать автоматический запрос с "
@@ -10110,21 +10045,22 @@ msgid ""
 "Set or change your account email address or password. Specify your "
 "preferences about the look and feel of the interface."
 msgstr ""
-"Установите или измените Ваш email адрес или пароль.Укажите предпочтения в"
-" отношении внешнего вида интерфейса."
+"Установите или измените Ваш email адрес или пароль.Укажите предпочтения в "
+"отношении внешнего вида интерфейса."
 
 #: invenio/legacy/websession/templates.py:620
 msgid "View all the searches you performed during the last 30 days."
-msgstr "Просмотреть все поиски, которые Вы выполнили в течение последних 30 дней."
+msgstr ""
+"Просмотреть все поиски, которые Вы выполнили в течение последних 30 дней."
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
-"с помощью книжных полок Вы можете определить конкретные наборы элементов,"
-" запомнить интересные документы, которые Вы захотите просмотреть позже "
-"или поделиться ими с другими."
+"с помощью книжных полок Вы можете определить конкретные наборы элементов, "
+"запомнить интересные документы, которые Вы захотите просмотреть позже или "
+"поделиться ими с другими."
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10141,37 +10077,37 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
-"Проверить взятую книги, отправить запрос на книгу и т.д. Требуется CERN "
-"ID."
+"Проверить взятую книги, отправить запрос на книгу и т.д. Требуется CERN ID."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
-"Вы вошли как пользователь-гость, поэтому Ваши уведомления исчезнут в "
-"конце текущего сеанса."
+"Вы вошли как пользователь-гость, поэтому Ваши уведомления исчезнут в конце "
+"текущего сеанса."
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
-"Вы вошли как %(x_user)s. Вы можете a) "
-"%(x_url1_open)sвыйти%(x_url1_close)s; b) редактировать ваши "
-"%(x_url2_open)sпараметры учетной записи%(x_url2_close)s."
+"Вы вошли как %(x_user)s. Вы можете a) %(x_url1_open)sвыйти%(x_url1_close)s; "
+"b) редактировать ваши %(x_url2_open)sпараметры учетной записи"
+"%(x_url2_close)s."
 
 #: invenio/legacy/websession/templates.py:785
 #, fuzzy, python-format
 msgid ""
 "You can consult the list of %(x_url_open)syour comments%(x_url_close)s "
 "submitted so far."
-msgstr "Вы можете просмотреть список %(x_url_open)sВаших запросов%(x_url_close)s."
+msgstr ""
+"Вы можете просмотреть список %(x_url_open)sВаших запросов%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:790
 msgid "Your Alert Searches"
@@ -10180,8 +10116,8 @@ msgstr "Ваши поиски с уведомлением"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 "Вы можете просмотреть список %(x_url_open)sгрупп%(x_url_close)s, "
 "администратором или членом которых Вы являетесь."
@@ -10195,11 +10131,11 @@ msgstr "Ваши группы"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"Вы можете просмотреть список %(x_url_open)sВаших депонированных "
-"документов%(x_url_close)s и узнать их статус."
+"Вы можете просмотреть список %(x_url_open)sВаших депонированных документов"
+"%(x_url_close)s и узнать их статус."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -10209,11 +10145,11 @@ msgstr "Внесенные Вами документы"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"Вы можете просмотреть список %(x_url_open)sВаших одобрений%(x_url_close)s"
-" с документами, которые Вы одобряете или реферируете."
+"Вы можете просмотреть список %(x_url_open)sВаших одобрений%(x_url_close)s с "
+"документами, которые Вы одобряете или реферируете."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10223,7 +10159,8 @@ msgstr "Ваши одобрения"
 #: invenio/legacy/websession/templates.py:815
 #, python-format
 msgid "You can consult the list of %(x_url_open)syour tickets%(x_url_close)s."
-msgstr "Вы можете просмотреть список %(x_url_open)sВаших запросов%(x_url_close)s."
+msgstr ""
+"Вы можете просмотреть список %(x_url_open)sВаших запросов%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:818
 msgid "Your Tickets"
@@ -10263,7 +10200,8 @@ msgstr "для того, чтобы подтвердить срок действ
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 "Пожалуйста, имейте в виду, что этот URL будет действительным только в "
 "течение %(days)s дней."
@@ -10317,14 +10255,14 @@ msgstr "Если Вы хотите, можете сделать %(x_url_open)slo
 #: invenio/legacy/websession/templates.py:1011
 msgid "If you already have an account, please login using the form below."
 msgstr ""
-"Если у Вас уже есть учетная запись, пожалуйста, войдите, используя "
-"следующую форму."
+"Если у Вас уже есть учетная запись, пожалуйста, войдите, используя следующую "
+"форму."
 
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 "Если у Вас еще нет CERN учетной записи, Вы можете зарегистрироваться: "
 "%(x_url_open)snew CERN lightweight account%(x_url_close)s."
@@ -10332,12 +10270,11 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"Если у Вас еше нет учетной записи, пожалуйста "
-"%(x_url_open)sзарегистрируйтесь%(x_url_close)s с внутренней учетной "
-"записью"
+"Если у Вас еше нет учетной записи, пожалуйста %(x_url_open)sзарегистрируйтесь"
+"%(x_url_close)s с внутренней учетной записью"
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
@@ -10372,9 +10309,10 @@ msgstr "Вы можете использовать nickname или email адр�
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
-msgstr "Пожалуйста, установите новый желаемый пароль, используя следующую форму."
+"Your request is valid. Please set the new desired password in the following "
+"form."
+msgstr ""
+"Пожалуйста, установите новый желаемый пароль, используя следующую форму."
 
 #: invenio/legacy/websession/templates.py:1150
 msgid "Set a new password for"
@@ -10398,8 +10336,8 @@ msgstr "Пожалуйста, введите Ваш email адрес и жела
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr "Невозможно использовать учетную запись до ее проверки и активации."
 
 #: invenio/legacy/websession/templates.py:1228
@@ -10416,32 +10354,32 @@ msgstr "регистрироваться"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
-"Пожалуйста, не используйте в качестве пароля Ваши Unix, AFS или NICE "
-"пароли. Ваш email адрес останется конфиденциальным и не будет "
-"передаваться третьей стороне. Он будет использоваться для оказания Вам "
-"персональных услуг %s. Например, поиск новых поступлений с автоматическим"
-" ежедненым уведомлением по email."
+"Пожалуйста, не используйте в качестве пароля Ваши Unix, AFS или NICE пароли. "
+"Ваш email адрес останется конфиденциальным и не будет передаваться третьей "
+"стороне. Он будет использоваться для оказания Вам персональных услуг %s. "
+"Например, поиск новых поступлений с автоматическим ежедненым уведомлением по "
+"email."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr "Вы не можете самостоятельно создать учетную запись. свяжитесь с %s."
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
-"Вы пользователь-гость. Сначала Вы должны сделать "
-"%(x_url_open)slogin%(x_url_close)s"
+"Вы пользователь-гость. Сначала Вы должны сделать %(x_url_open)slogin"
+"%(x_url_close)s"
 
 #: invenio/legacy/websession/templates.py:1267
 msgid "You are not authorized to access administrative functions."
@@ -10571,11 +10509,11 @@ msgstr "Несколько интересных web admin ссылок для В
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
-"Для действий на уровне Администратора смотрите полный "
-"%(x_url_open)sОбласть администратора%(x_url_close)s."
+"Для действий на уровне Администратора смотрите полный %(x_url_open)sОбласть "
+"администратора%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1378
 msgid "guest"
@@ -10802,10 +10740,11 @@ msgstr "Пользователь хочет присоединиться к гр
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
-"Пожалуйста, %(x_url_open)sпримите или отклоните%(x_url_close)s запрос "
-"этого пользователя."
+"Пожалуйста, %(x_url_open)sпримите или отклоните%(x_url_close)s запрос этого "
+"пользователя."
 
 #: invenio/legacy/websession/templates.py:2400
 #, fuzzy, python-format
@@ -10846,89 +10785,83 @@ msgstr "Группа %s была удалена ее администратор�
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"Вы можете просмотреть список %(x_url_open)s%(x_nb_total)i "
-"групп%(x_url_close)s, на которые Вы подписаны в качестве члена "
-"(%(x_nb_member)i) или администратора (%(x_nb_admin)i)."
+"Вы можете просмотреть список %(x_url_open)s%(x_nb_total)i групп"
+"%(x_url_close)s, на которые Вы подписаны в качестве члена (%(x_nb_member)i) "
+"или администратора (%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
-"Предупреждение: Пароль, установленный для root-пользователя MySQL, "
-"совпадает с предустановленным паролем Invenio. Для большей безопасности "
-"Вам стоит изменить этот пароль."
+"Предупреждение: Пароль, установленный для root-пользователя MySQL, совпадает "
+"с предустановленным паролем Invenio. Для большей безопасности Вам стоит "
+"изменить этот пароль."
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
-"Предупреждение: Пароль, установленный для root-пользователя MySQL "
-"совпадает с предустановленным паролем по умолчанию. Для большей "
-"безопасности Вам стоит изменить этот пароль."
+"Предупреждение: Пароль, установленный для root-пользователя MySQL совпадает "
+"с предустановленным паролем по умолчанию. Для большей безопасности Вам стоит "
+"изменить этот пароль."
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
-"Предупреждение: Пароль для администратора Invenio не задан (пустой "
-"пароль).Для большей безопасности категорически рекомендуется установить "
-"пароль."
+"Предупреждение: Пароль для администратора Invenio не задан (пустой пароль)."
+"Для большей безопасности категорически рекомендуется установить пароль."
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 "Предупреждение: Почтовый адрес поддержки установлен как info@invenio-"
 "software.org. Рекомендуется поменять его на Ваш собственный адрес."
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr "Более новая версия Invenio доступна для загрузки. Подробнее "
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
-"Невозможно загрузить или обработать информацию о выпуске с  http"
-"://invenio-software.org/repo/invenio/tree/RELEASE-NOTES"
+"Невозможно загрузить или обработать информацию о выпуске с  http://invenio-"
+"software.org/repo/invenio/tree/RELEASE-NOTES"
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
-"Вы вошли в систему как 'гость'. Вы можете войти как постоянный "
-"пользователь %(x_url_open)slogin%(x_url_close)s."
+"Вы вошли в систему как 'гость'. Вы можете войти как постоянный пользователь "
+"%(x_url_open)slogin%(x_url_close)s."
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 "%(x_fmt_open)sпользователь-гость%(x_fmt_close)s должен сначала "
 "%(x_url_open)sзарегистрироваться%(x_url_close)s"
@@ -10939,16 +10872,16 @@ msgstr "Запросы не найдены"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
-"Эта коллекция ограниченного пользования. Если Вы считаете, что должны "
-"иметь доступ к ней, проведите аутентификацию."
+"Эта коллекция ограниченного пользования. Если Вы считаете, что должны иметь "
+"доступ к ней, проведите аутентификацию."
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 "Доступ к этому файлу закрыт. Если Вы полагаете, что у Вас есть права на "
 "доступ к нему, пожалуйста, пройдите аутентификацию."
@@ -10959,8 +10892,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -10972,8 +10905,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11053,8 +10986,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11110,8 +11042,8 @@ msgstr "Пожалуйста, подождите, пока администра�
 #, python-format
 msgid "You can now go to %(x_url_open)syour account page%(x_url_close)s."
 msgstr ""
-"Вы можете перейти на %(x_url_open)sстраницу Вашей учетной "
-"записи%(x_url_close)s."
+"Вы можете перейти на %(x_url_open)sстраницу Вашей учетной записи"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:136
 #: invenio/legacy/websession/webinterface.py:145
@@ -11124,11 +11056,9 @@ msgstr "Вы уже подтердили правильность Вашего e
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
-"Запрос на подтерждение email-адреса является недопустимым или "
-"просроченным."
+"Запрос на подтерждение email-адреса является недопустимым или просроченным."
 
 #: invenio/legacy/websession/webinterface.py:153
 msgid "This request for an authorization is not valid or is expired."
@@ -11191,10 +11121,10 @@ msgstr "Переключено на внутренний login-метод."
 #: invenio/legacy/websession/webinterface.py:423
 #, fuzzy
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 "Обратите внимание, что если это первый раз, когда Вы зашли в эту учетную "
 "запись с помощью внутреннего login-метода, то система установила Вам "
@@ -11230,8 +11160,8 @@ msgstr "Login-метод успешно выбран."
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 "Внешний login-метод %s не поддерживает login на основе почтового адреса. "
 "Пожалуйста, свяжитесь с администраторами сайта."
@@ -11251,8 +11181,8 @@ msgid ""
 "Note that if you have changed your email address, you will have to "
 "%(x_url_open)sreset your password%(x_url_close)s anew."
 msgstr ""
-"Имейте в виду, что если вы сменили свой почтовый адрес, Вам следует снова"
-" %(x_url_open)sсменить пароль%(x_url_close)s."
+"Имейте в виду, что если вы сменили свой почтовый адрес, Вам следует снова "
+"%(x_url_open)sсменить пароль%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:487
 #: invenio/legacy/websession/webinterface.py:1003
@@ -11409,33 +11339,31 @@ msgid ""
 "In order to confirm its validity, an email message containing an account "
 "activation key has been sent to the given email address."
 msgstr ""
-"Еmail-сообщение, содержащее ключ активации учетной записи, было отослано "
-"по указанному email-адресу."
+"Еmail-сообщение, содержащее ключ активации учетной записи, было отослано по "
+"указанному email-адресу."
 
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
-"Пожалуйста, следуйте инструкциям для завершения процесса регистрации "
-"учетной записи."
+"Пожалуйста, следуйте инструкциям для завершения процесса регистрации учетной "
+"записи."
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
-"Второе email-сообщение будет послано, когда учетная запись будет "
-"актиирована."
+"Второе email-сообщение будет послано, когда учетная запись будет актиирована."
 
 #: invenio/legacy/websession/webinterface.py:989
 #, python-format
 msgid "You can now access your %(x_url_open)saccount%(x_url_close)s."
 msgstr ""
-"Теперь Вы имеете доступ к своей %(x_url_open)sучетной "
-"записи%(x_url_close)s."
+"Теперь Вы имеете доступ к своей %(x_url_open)sучетной записи%(x_url_close)s."
 
 #: invenio/legacy/websession/webinterface.py:996
 #: invenio/legacy/websession/webinterface.py:1001
@@ -11470,7 +11398,8 @@ msgstr "Выбранный nickname %s уже существует в базе �
 #: invenio/legacy/websession/webinterface.py:1019
 #: invenio/modules/accounts/views/accounts.py:143
 msgid "Users cannot register themselves, only admin can register them."
-msgstr "Пользователь не может сам себя зарегистрировать, это делает администратор."
+msgstr ""
+"Пользователь не может сам себя зарегистрировать, это делает администратор."
 
 #: invenio/legacy/websession/webinterface.py:1023
 #: invenio/modules/accounts/views/accounts.py:148
@@ -11543,7 +11472,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 "Запись создана %(x_date_creation)s, последняя модификация "
 "%(x_date_modification)s"
@@ -11568,37 +11498,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11606,15 +11536,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11678,9 +11608,10 @@ msgstr "Невозможно определить число внесенных 
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
-msgstr "Невозможно создать папку для этого сообщения. Администратор был оповещен."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
+msgstr ""
+"Невозможно создать папку для этого сообщения. Администратор был оповещен."
 
 #: invenio/legacy/websubmit/engine.py:440
 #: invenio/legacy/websubmit/engine.py:1058
@@ -11714,12 +11645,12 @@ msgstr "Внести"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 "Была обнаружена серьезная ошибка функционирования. Администраторы были "
-"извещены. <br /><em>Это могло произойти из-за неверных символов в "
-"форме</em> (например, при копировании текста из PDF файла)"
+"извещены. <br /><em>Это могло произойти из-за неверных символов в форме</em> "
+"(например, при копировании текста из PDF файла)"
 
 #: invenio/legacy/websubmit/engine.py:1501
 #, fuzzy, python-format
@@ -11761,12 +11692,13 @@ msgstr "Заметка"
 
 #: invenio/legacy/websubmit/templates.py:341
 msgid "Select a category and then click on an action button."
-msgstr "Выберите категорию, затем нажмите кнопку для выбора необходимого действия."
+msgstr ""
+"Выберите категорию, затем нажмите кнопку для выбора необходимого действия."
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 "Чтобы продолжить прерванное ранее депонирование документа, введите код "
 "доступа в следующее поле:"
@@ -11797,11 +11729,11 @@ msgstr "Возврат к главному меню"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
-"Это Ваш код доступа к процессу внесения документа. он может "
-"использоваться для продолжения прерванного внесения."
+"Это Ваш код доступа к процессу внесения документа. он может использоваться "
+"для продолжения прерванного внесения."
 
 #: invenio/legacy/websubmit/templates.py:548
 msgid "Mandatory fields appear in red in the SUMMARY window."
@@ -11849,11 +11781,10 @@ msgstr "Внесение №"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
-msgstr ""
-"%(x_action)sсписок функций для %(x_doctype)s документов на этапе "
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
 "%(x_step)s"
+msgstr ""
+"%(x_action)sсписок функций для %(x_doctype)s документов на этапе %(x_step)s"
 
 #: invenio/legacy/websubmit/templates.py:1041
 msgid "Function"
@@ -11934,8 +11865,7 @@ msgstr "Список реферируемых типов документов"
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr "Выберите один из типов документов для изменения статуса документов"
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -12072,7 +12002,8 @@ msgstr "Заметка об одобрении:"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr "Этот документ все еще %(x_fmt_open)sждет одобрения%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -12113,8 +12044,8 @@ msgid ""
 "As a referee for this document, you may approve or reject it from the "
 "submission interface"
 msgstr ""
-"Как референт этого документа, Вы можете нажать кнопку, одобряя или "
-"отклоняя его."
+"Как референт этого документа, Вы можете нажать кнопку, одобряя или отклоняя "
+"его."
 
 #: invenio/legacy/websubmit/templates.py:2155
 msgid "Approve/Reject"
@@ -12169,11 +12100,11 @@ msgstr "Выбрать референта"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
-"Референт отослал свои окончательные рекомендации в комитет по  "
-"публикациям по "
+"Референт отослал свои окончательные рекомендации в комитет по  публикациям "
+"по "
 
 #: invenio/legacy/websubmit/templates.py:2281
 #: invenio/legacy/websubmit/templates.py:2342
@@ -12191,11 +12122,11 @@ msgstr "Отправить рекомендации"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
-"Комитет по публикациям отослал свои окончательные рекомендации "
-"руководителю проекта по "
+"Комитет по публикациям отослал свои окончательные рекомендации руководителю "
+"проекта по "
 
 #: invenio/legacy/websubmit/templates.py:2291
 #: invenio/legacy/websubmit/templates.py:2358
@@ -12235,7 +12166,8 @@ msgid "Take a decision"
 msgstr "Примите решение"
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr "Комитетом по публикациям выбрана редакционная коллегия по "
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12256,14 +12188,14 @@ msgstr "Редакционная коллегия выбрала референ�
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
-msgstr "Референт выслал редакционной коллегии свои окончательные рекомендации по "
+"The referee has sent his final recommendations to the editorial board on the "
+msgstr ""
+"Референт выслал редакционной коллегии свои окончательные рекомендации по "
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 "Редакционная коллегия выслала комитету по публикациям свои окончательные "
 "рекомендации по "
@@ -12379,21 +12311,20 @@ msgid ""
 "available within a few minutes and searchable within an hour or "
 "thereabouts.\n"
 msgstr ""
-"Очередь задач сейчас работает в автоматическом режиме, и %s задач ожидают"
-" выполнения. Ваша запись должна быть доступна в течении нескольких минут "
-"и попадет в поиск приблизительно через час.\n"
+"Очередь задач сейчас работает в автоматическом режиме, и %s задач ожидают "
+"выполнения. Ваша запись должна быть доступна в течении нескольких минут и "
+"попадет в поиск приблизительно через час.\n"
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
-"Из-за вмешательства пользователей либо из-за технической временной "
-"проблемы очередь задач находится в ручном режиме. Ваше сообщение уже "
-"зарегистрировано, но внесение в базу и поиск может занять больше времени,"
-" чем обычно.\n"
+"Из-за вмешательства пользователей либо из-за технической временной проблемы "
+"очередь задач находится в ручном режиме. Ваше сообщение уже "
+"зарегистрировано, но внесение в базу и поиск может занять больше времени, "
+"чем обычно.\n"
 
 #: invenio/legacy/websubmit/web/approve.py:53
 msgid "approve.py: cannot determine document reference"
@@ -12674,8 +12605,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12718,11 +12649,6 @@ msgstr "присоединенный"
 #, fuzzy
 msgid "Role details"
 msgstr "Дополнительная информация"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Руководство"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12838,11 +12764,11 @@ msgstr "email адрес %s уже есть в базе данных"
 #: invenio/modules/accounts/forms.py:94
 #, fuzzy, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
-"Имейте в виду, что если вы сменили свой почтовый адрес, Вам следует снова"
-" %(x_url_open)sсменить пароль%(x_url_close)s."
+"Имейте в виду, что если вы сменили свой почтовый адрес, Вам следует снова "
+"%(x_url_open)sсменить пароль%(x_url_close)s."
 
 #: invenio/modules/accounts/forms.py:117
 #, fuzzy, python-format
@@ -12906,9 +12832,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, fuzzy, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 "Вы по-прежнему распознаетесь централизованной\n"
 "                %(x_fmt_open)sSSO%(x_fmt_close)s системой. Вы можете\n"
@@ -12935,8 +12860,8 @@ msgstr "Установите новый пароль"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr "Пожалуйста, введите Ваш email адрес и желаемые nickname и пароль:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -12966,11 +12891,10 @@ msgid "Problem with login."
 msgstr "Сравнить с исходным"
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr ""
-"Теперь Вы имеете доступ к своей %(x_url_open)sучетной "
-"записи%(x_url_close)s."
+"Теперь Вы имеете доступ к своей %(x_url_open)sучетной записи%(x_url_close)s."
 
 #: invenio/modules/accounts/views/accounts.py:152
 #, fuzzy, python-format
@@ -13011,8 +12935,7 @@ msgstr "Авторизация в bibcatalog не удалась."
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13084,13 +13007,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13099,9 +13021,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13274,8 +13196,7 @@ msgstr "коллекции"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13366,8 +13287,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13459,13 +13380,13 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
-"Ваше сообщение слишком длинное, пожалуйста, отредактируйте его. "
-"Максимальный размер %i символов"
+"Ваше сообщение слишком длинное, пожалуйста, отредактируйте его. Максимальный "
+"размер %i символов"
 
 #: invenio/modules/comments/forms.py:55
 #, fuzzy
@@ -13508,12 +13429,12 @@ msgid "Review was sent"
 msgstr "Написать комментарий"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Об этом комментарии сообщили %i раз"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Об этом комментарии сообщили %i раз"
 
@@ -13566,9 +13487,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13587,8 +13507,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13598,7 +13518,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "Файл с именем %s уже существует. Пожалуйста, выберите другое имя."
 
@@ -13639,12 +13559,6 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: invenio/modules/deposit/templates/deposit/completed_base.html:30
-#: invenio/modules/editor/templates/editor/viewmenu.html:21
-#, fuzzy
-msgid "View"
-msgstr "рецензия"
-
 #: invenio/modules/deposit/templates/deposit/completed_base.html:37
 #, fuzzy
 msgid "Preview"
@@ -13654,8 +13568,7 @@ msgstr "рецензия"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13695,8 +13608,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13743,7 +13655,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "Функция '%s' не существует"
 
@@ -13828,11 +13740,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "Статус сбора"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Ваши запросы"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -13867,8 +13774,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13889,8 +13796,8 @@ msgstr "Не найден словарный индекс для %s."
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13906,8 +13813,7 @@ msgstr "Проверка элемента формата %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14027,7 +13933,7 @@ msgstr "Показать всех %i авторов"
 msgid "Manage Files of This Record"
 msgstr "Управление файлами этой записи"
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr "Редактировать эту запись"
 
@@ -14125,10 +14031,6 @@ msgstr "1 обзор"
 msgid "Authors"
 msgstr "автор"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14221,8 +14123,8 @@ msgstr "Права администратора группы"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "У Вас недостаточно прав для просмотра этого элемента."
 
 #: invenio/modules/groups/views.py:279
@@ -14235,12 +14137,12 @@ msgstr "Вы не являетесь администратором никако
 msgid "Members"
 msgstr "Нет участников."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Не введено имя базы знаний"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14250,11 +14152,11 @@ msgstr "Ничего"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "любое поле"
@@ -14300,13 +14202,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "Нет записей, цитируемых %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "Нет записей, цитируемых %s."
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14461,28 +14364,28 @@ msgstr "Неизвестный тип документа"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14547,8 +14450,8 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 "Если Вы хотите закончить регистрацию этой учетной записи, пожалуйста, "
 "перейдите:"
@@ -14924,7 +14827,7 @@ msgid "Tag name"
 msgstr "Имя (псевдоним)"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "nickname %s уже используется"
 
@@ -15030,11 +14933,6 @@ msgstr ""
 msgid "Saving..."
 msgstr "Загрузить"
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "Ничего"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15076,8 +14974,7 @@ msgstr "Опции проката"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15284,7 +15181,7 @@ msgid "just now"
 msgstr "Вы теперь должны"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s секунд"
 
@@ -15343,6 +15240,60 @@ msgstr "любой год"
 msgid " years ago"
 msgstr "год"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "Администрирование BibCheck"
+
+#~ msgid "Not authorized"
+#~ msgstr "Не авторизированы"
+
+#~ msgid "Limit to knowledge bases containing string:"
+#~ msgstr "Ограничиться базами знаний, содержащими строку:"
+
+#~ msgid "Really delete"
+#~ msgstr "Точно удалить"
+
+#~ msgid "Verify syntax"
+#~ msgstr "Проверить синтаксис"
+
+#~ msgid "Calling bibcheck -verify failed."
+#~ msgstr "Вызов bibcheck-verify не удался."
+
+#~ msgid "Verify BibCheck config file"
+#~ msgstr "Проверить конфигурационный файл BibCheck"
+
+#~ msgid "Verify problem"
+#~ msgstr "Проверить затруднение"
+
+#~ msgid "File"
+#~ msgstr "Файл"
+
+#~ msgid "Edit BibCheck config file"
+#~ msgstr "Редактировать конфигурационный файл BibCheck"
+
+#~ msgid "Save BibCheck config file"
+#~ msgstr "Сохранить конфигурационный файл BibCheck"
+
+#~ msgid "Delete BibCheck config file"
+#~ msgstr "Удалить конфигурационный файл BibCheck"
+
+#~ msgid "niceName"
+#~ msgstr "Имя"
+
+#~ msgid "Id"
+#~ msgstr "Идентификатор"
+
+#~ msgid "View"
+#~ msgstr "Просмотр"
+
+#~ msgid "Tickets"
+#~ msgstr "запросы"
+
+#~ msgid "by"
+#~ msgstr "от"
+
+#~ msgid "Done"
+#~ msgstr "выполнено"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Предупреждение: Пожалуйста, выберите допустимое время"
 
@@ -15360,9 +15311,6 @@ msgstr "год"
 
 #~ msgid "*** basket name ***"
 #~ msgstr "*** имя книжной полки ***"
-
-#~ msgid ""
-#~ msgstr ""
 
 #~ msgid "%(x_name)s"
 #~ msgstr "%(x_sitename)s ссылка"
@@ -15466,12 +15414,6 @@ msgstr "год"
 #~ msgid "now"
 #~ msgstr "сейчас"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "Администрирование BibCheck"
-
-#~ msgid "Not authorized"
-#~ msgstr "Не авторизированы"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "Пользователь %s не существует."
 
@@ -15480,30 +15422,6 @@ msgstr "год"
 
 #~ msgid "ERROR: %s is not writable"
 #~ msgstr "не доступно для записи"
-
-#~ msgid "Limit to knowledge bases containing string:"
-#~ msgstr "Ограничиться базами знаний, содержащими строку:"
-
-#~ msgid "Really delete"
-#~ msgstr "Точно удалить"
-
-#~ msgid "Verify syntax"
-#~ msgstr "Проверить синтаксис"
-
-#~ msgid "Calling bibcheck -verify failed."
-#~ msgstr "Вызов bibcheck-verify не удался."
-
-#~ msgid "Verify BibCheck config file"
-#~ msgstr "Проверить конфигурационный файл BibCheck"
-
-#~ msgid "Verify problem"
-#~ msgstr "Проверить затруднение"
-
-#~ msgid "File"
-#~ msgstr "Файл"
-
-#~ msgid "Edit BibCheck config file"
-#~ msgstr "Редактировать конфигурационный файл BibCheck"
 
 #~ msgid "File %s already exists."
 #~ msgstr "Файл уже существует"
@@ -15514,17 +15432,11 @@ msgstr "год"
 #~ msgid "File %s: write failed."
 #~ msgstr "запись не удалась."
 
-#~ msgid "Save BibCheck config file"
-#~ msgstr "Сохранить конфигурационный файл BibCheck"
-
 #~ msgid "File %s deleted."
 #~ msgstr "Группа '%s' не существует."
 
 #~ msgid "File %s: delete failed."
 #~ msgstr "удалить не получилось"
-
-#~ msgid "Delete BibCheck config file"
-#~ msgstr "Удалить конфигурационный файл BibCheck"
 
 #~ msgid "Guests are not authorized to run batchuploader"
 #~ msgstr "Гостям не разрешено выполнять пакетную загрузку."
@@ -15574,9 +15486,6 @@ msgstr "год"
 #~ msgid "Not Mine!"
 #~ msgstr "Не установлено"
 
-#~ msgid "Tickets"
-#~ msgstr "запросы"
-
 #~ msgid "Request Tickets"
 #~ msgstr "Запросы"
 
@@ -15612,9 +15521,6 @@ msgstr "год"
 
 #~ msgid "Create a new Person for your search"
 #~ msgstr "Нет результатов Вашего поиска."
-
-#~ msgid "Id"
-#~ msgstr "Идентификатор"
 
 #~ msgid "There %s request(s) on the book who has been returned."
 #~ msgstr "%s запрос(ов) на эту возвращенную книгу."
@@ -15697,9 +15603,6 @@ msgstr "год"
 #~ msgid "Verbose"
 #~ msgstr "Детальный"
 
-#~ msgid "Done"
-#~ msgstr "выполнено"
-
 #~ msgid "Move up"
 #~ msgstr "поднять вверх"
 
@@ -15741,9 +15644,6 @@ msgstr "год"
 
 #~ msgid "Edit record %(x_recid)s, field %(x_field)s"
 #~ msgstr "Редактирование записи %(x_recid)s, поле %(x_field)s"
-
-#~ msgid "Edit record %(x_recid)s, field %(x_field)s - Add a subfield"
-#~ msgstr ""
 
 #~ msgid "Submit and save record %s"
 #~ msgstr "Внесите и сохраните запись %s"
@@ -15787,9 +15687,6 @@ msgstr "год"
 #~ msgid "Number of views"
 #~ msgstr "Количество просмотров"
 
-#~ msgid "View"
-#~ msgstr "Просмотр"
-
 #~ msgid "Non-shared basket"
 #~ msgstr "Необщая книжная полка"
 
@@ -15816,9 +15713,6 @@ msgstr "год"
 
 #~ msgid "Back to baskets"
 #~ msgstr "Назад к книжным полкам"
-
-#~ msgid "by"
-#~ msgstr "от"
 
 #~ msgid "on"
 #~ msgstr "на"
@@ -16219,9 +16113,6 @@ msgstr "год"
 #~ msgid "Editing topic"
 #~ msgstr "Редактировать тему"
 
-#~ msgid "niceName"
-#~ msgstr "Имя"
-
 #~ msgid "Apply Changes"
 #~ msgstr "Сохранить изменения"
 
@@ -16236,9 +16127,6 @@ msgstr "год"
 
 #~ msgid "Frequently publishes in:"
 #~ msgstr "Часто публикуется в:"
-
-#~ msgid "This record does not exist. Please try another record ID."
-#~ msgstr ""
 
 #~ msgid "current version"
 #~ msgstr "текущая версия"
@@ -16294,34 +16182,11 @@ msgstr "год"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "Руководство Администратора для модуля WebSubmit"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "Выполнить поиск"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Удален"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "Вы член следующих групп:"
@@ -16335,12 +16200,6 @@ msgstr "год"
 #~ msgid "Invert Selection"
 #~ msgstr "Выбор референта"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Автор"
 
@@ -16352,12 +16211,6 @@ msgstr "год"
 
 #~ msgid "No status information found."
 #~ msgstr "Информация о прокатах"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "Исправление"
@@ -16374,15 +16227,6 @@ msgstr "год"
 #~ msgid "The author has an internal ID!"
 #~ msgstr "Внутренняя ошибка"
 
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "комментарии"
 
@@ -16392,32 +16236,8 @@ msgstr "год"
 #~ msgid " Delete this ticket"
 #~ msgstr "Удалить книжную полку"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "Нет доступных журналов"
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Выберите оценку"
@@ -16428,51 +16248,11 @@ msgstr "год"
 #~ msgid "Paper title: "
 #~ msgstr "Название журнала"
 
-#~ msgid "Ignore"
-#~ msgstr ""
-
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "Следующие файлы были успешно поставлены в очередь: "
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "Выберите оценку"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "Информация о новом продавце"
@@ -16480,35 +16260,14 @@ msgstr "год"
 #~ msgid "Please provide your first name"
 #~ msgstr "Пожалуйста, выполните сначала login"
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "Вы одолжили"
-
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
 
 #~ msgid "Your eMail:"
 #~ msgstr "Ваши оповещения"
 
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
 #~ msgid "Continue claiming*"
 #~ msgstr "Все равно продолжить"
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "Удалить выбранные обзоры"
@@ -16516,36 +16275,14 @@ msgstr "год"
 #~ msgid "Mark as your documents"
 #~ msgstr "все типы документов"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "Вернуться к документу"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Вернуться к документу"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "создать новый"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
 
 #~ msgid "Assign paper"
 #~ msgstr "редактировать другую запись"
@@ -16553,146 +16290,23 @@ msgstr "год"
 #~ msgid "Add to merge list"
 #~ msgstr "Добавить к пользователям"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Работы: "
-
-#~ msgid "Showing the"
-#~ msgstr ""
 
 #~ msgid "most recent documents:"
 #~ msgstr "Список реферируемых документов"
 
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Управление файлами документов"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Выбрать файл"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Дата публикации"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "%(x_sitename) ссылка"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "депонирование"
@@ -16700,157 +16314,20 @@ msgstr "год"
 #~ msgid "Choose system"
 #~ msgstr "Выбрать тему"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Следующие файлы были успешно поставлены в очередь: "
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Вы не авторизованы для доступа к административным функциям"
 
 #~ msgid "Claim this paper"
 #~ msgstr "добавить этого пользователя"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Ссылаются на: %s записи"
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
 
 #~ msgid "Revision"
 #~ msgstr "Исправление"
 
 #~ msgid "Failed to create a ticket"
 #~ msgstr "Не удалось создать запрос"
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Редактировать шаблон "
@@ -16930,89 +16407,20 @@ msgstr "год"
 #~ msgid "No Record Found for %s."
 #~ msgstr "Запись не найдена"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Группа '%s' не существует."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "Параметры формата вывода %s"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "Зависимости шаблона формата %s"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "Проверка элемента формата %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "Зависимости элемента формата %s"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Ограниченный формат вывода"
@@ -17068,75 +16476,17 @@ msgstr "год"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Проверка элемента формата %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "Проверка формата"
 
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "База знаний %s"
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "Не установлено"
 
 #~ msgid "never"
 #~ msgstr "никогда"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "раз"
@@ -17165,17 +16515,11 @@ msgstr "год"
 #~ msgid "Affiliations"
 #~ msgstr "Принадлежность:"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
 #~ msgid "No Frequent Co-authors"
 #~ msgstr "Часто встречающиеся соавторы"
 
 #~ msgid "Citations%s"
 #~ msgstr "Цитирования:"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Дата публикации"
@@ -17186,36 +16530,6 @@ msgstr "год"
 #~ msgid "No publications available"
 #~ msgstr "Нет информации"
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr "Процитировано в 1 записи"
 
@@ -17225,17 +16539,11 @@ msgstr "год"
 #~ msgid "%i reviews"
 #~ msgstr "%i обзоров"
 
-#~ msgid "%s of"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "Работы: "
 
 #~ msgid "Frequent co-authors"
 #~ msgstr "Часто встречающиеся соавторы"
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "Цитирования:"
@@ -17243,23 +16551,8 @@ msgstr "год"
 #~ msgid "No Citation Information available"
 #~ msgstr "Нет информации"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Обсуждение"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Ваши оповещения"
@@ -17282,13 +16575,6 @@ msgstr "год"
 #~ msgid "Group: %s"
 #~ msgstr "Группа: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "Страница %s не найдена"
 
@@ -17296,69 +16582,5 @@ msgstr "год"
 #~ msgstr "Поле %s является обязательным."
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "Невозможно определить число внесенных страниц."
-

--- a/invenio/base/translations/rw/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/rw/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2009, 2010, 2011 CERN.
+# # Copyright (C) 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2006-10-12 17:50+0200\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:58+0200\n"
 "Last-Translator: Sylvie Mboyo <sylvie.mboyo@gmail.com>\n"
 "Language-Team: RW <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -55,8 +55,8 @@ msgstr ""
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -199,7 +199,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr ""
 
@@ -220,17 +220,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -256,45 +256,49 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+msgid "Provided data is not valid"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 msgid "Authorization failure"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 msgid "Please sign in to continue."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 msgid "Authorization failure."
 msgstr ""
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -493,7 +497,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -694,7 +699,8 @@ msgid "The following errors have occurred:"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -711,8 +717,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -794,7 +800,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -836,8 +842,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr ""
@@ -852,8 +858,8 @@ msgstr ""
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr ""
 
@@ -1062,7 +1068,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1111,8 +1118,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1125,25 +1132,23 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1167,13 +1172,14 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1201,9 +1207,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1268,8 +1273,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1277,8 +1282,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1300,9 +1305,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1343,8 +1347,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1399,11 +1403,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1414,11 +1418,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1431,8 +1435,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1522,8 +1526,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1542,29 +1546,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1573,9 +1577,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 msgid "Requested record does not seem to exist."
 msgstr ""
 
@@ -1892,16 +1896,14 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -1921,8 +1923,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2066,8 +2068,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2174,7 +2176,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr ""
 
@@ -2366,8 +2368,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2637,9 +2639,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2690,7 +2691,7 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr ""
 
@@ -2698,8 +2699,8 @@ msgstr ""
 #, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3150,8 +3151,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr ""
 
@@ -3939,8 +3940,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -3958,8 +3959,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4018,17 +4019,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4378,25 +4379,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4455,15 +4456,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4474,10 +4475,10 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4490,15 +4491,15 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4509,7 +4510,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4528,17 +4530,15 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4556,14 +4556,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4614,8 +4613,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4665,8 +4664,8 @@ msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -4777,9 +4776,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -4792,8 +4791,8 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -4918,11 +4917,10 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5046,7 +5044,7 @@ msgid "Total"
 msgstr ""
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr ""
 
@@ -5202,8 +5200,8 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5258,56 +5256,56 @@ msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5345,7 +5343,7 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5395,15 +5393,15 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5618,8 +5616,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -5693,8 +5690,8 @@ msgstr ""
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -5708,8 +5705,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr ""
 
@@ -5867,8 +5864,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -5894,8 +5891,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -5906,8 +5903,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -5917,108 +5913,108 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 msgid "No match found, please enter different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6032,11 +6028,11 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
 
@@ -6079,10 +6075,9 @@ msgstr ""
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
 
 #: invenio/legacy/webalert/htmlparser.py:186
@@ -6272,15 +6267,15 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:453
@@ -6338,7 +6333,7 @@ msgstr ""
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6402,7 +6397,7 @@ msgstr ""
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6462,7 +6457,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6484,7 +6480,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6511,7 +6508,8 @@ msgid "You do not have permission to delete this note."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6541,8 +6539,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6562,8 +6560,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6594,8 +6592,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -6665,8 +6663,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
@@ -6692,8 +6689,7 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -6853,8 +6849,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7034,15 +7030,16 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2131
@@ -7052,7 +7049,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr ""
 
@@ -7213,7 +7210,7 @@ msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7344,207 +7341,207 @@ msgstr ""
 msgid "Record ID %(x_rec)s does not exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, python-format
 msgid "%(x_nb)i Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, python-format
 msgid "View all %(x_name)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 msgid "Be the first to review this document.</div>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 msgid "Close"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 msgid "Undelete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 msgid "Unreport comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 msgid "Undelete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 msgid "Delete review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 msgid "Unreport review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -7553,487 +7550,489 @@ msgstr ""
 msgid "Record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 msgid "Max one file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, python-format
 msgid "Max %(maxfiles)i files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 msgid "Add comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 msgid "Add review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 msgid "View most commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 msgid "View latest commented records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all comments reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 msgid "View most reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 msgid "View latest reviewed records"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 msgid "View all reviews reported as abuse"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 msgid "Record ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 msgid "Undelete selected reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 msgid "Undelete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, python-format
 msgid "Here is review %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, python-format
 msgid "Here is comment %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 msgid "Show comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 msgid "Show reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 msgid "successfully undeleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
+msgstr ""
+
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 msgid "Your comment will be lost."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 msgid "Oldest comment first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 msgid "Latest comment first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 msgid "Group by record, latest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 msgid "Records and comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 msgid "Records only"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 msgid "Comments only"
 msgstr ""
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, python-format
 msgid "%(x_i)s items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 msgid "All items"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 msgid "Order by"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 msgid "Per page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 msgid "Display options"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8041,98 +8040,98 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 msgid "(in reply to a comment)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, python-format
 msgid "%(x_num)i items found in total"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 msgid "You do not have access to the specified comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 msgid "You cannot report a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 msgid "Page Not Found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 msgid "The requested comment could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 msgid "The requested file could not be found"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 msgid "You are not authorized to use comments."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 msgid "Your Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr ""
@@ -8247,8 +8246,8 @@ msgstr ""
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8312,8 +8311,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8340,8 +8339,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -8515,9 +8514,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -8538,8 +8536,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9004,14 +9001,14 @@ msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9141,8 +9138,7 @@ msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3357
@@ -9168,8 +9164,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3832
@@ -9351,7 +9347,8 @@ msgid "in"
 msgstr ""
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr ""
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -9440,8 +9437,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -9450,8 +9447,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:271
@@ -9468,14 +9465,14 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:327
@@ -9513,8 +9510,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:343
 #, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:346
@@ -9601,10 +9598,9 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:559
@@ -9621,15 +9617,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:573
@@ -9642,10 +9638,10 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:611
@@ -9665,8 +9661,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:636
@@ -9681,22 +9677,22 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:785
@@ -9713,8 +9709,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:799
@@ -9726,8 +9722,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:805
@@ -9738,8 +9734,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:811
@@ -9785,7 +9781,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -9833,15 +9830,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1027
@@ -9877,8 +9874,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -9903,8 +9900,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1228
@@ -9921,24 +9918,24 @@ msgstr ""
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1235
 #, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1267
@@ -10065,8 +10062,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1378
@@ -10285,7 +10282,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2400
@@ -10327,71 +10325,66 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:127
@@ -10400,14 +10393,14 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -10416,8 +10409,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -10429,8 +10422,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -10499,8 +10492,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -10563,8 +10555,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -10627,10 +10618,10 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -10658,8 +10649,8 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:452
 #, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -10834,15 +10825,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:989
@@ -10956,7 +10947,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:707
@@ -10979,37 +10971,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11017,15 +11009,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11089,8 +11081,8 @@ msgstr ""
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11125,8 +11117,8 @@ msgstr ""
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11172,8 +11164,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:366
@@ -11202,8 +11194,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:548
@@ -11252,8 +11244,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1041
@@ -11335,8 +11327,7 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -11473,7 +11464,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -11565,8 +11557,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -11585,8 +11577,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -11627,7 +11619,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -11648,14 +11641,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -11766,10 +11758,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12040,8 +12031,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12188,8 +12179,8 @@ msgstr ""
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -12248,9 +12239,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -12271,8 +12261,8 @@ msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -12338,8 +12328,7 @@ msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -12402,13 +12391,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -12417,9 +12405,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -12581,8 +12569,7 @@ msgstr ""
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -12664,8 +12651,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -12754,8 +12741,8 @@ msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:55
@@ -12845,9 +12832,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -12866,8 +12852,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -12925,8 +12911,7 @@ msgstr ""
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -12963,8 +12948,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13114,8 +13098,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13136,8 +13120,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13153,8 +13137,7 @@ msgstr ""
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -13270,7 +13253,7 @@ msgstr ""
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr ""
 
@@ -13452,8 +13435,8 @@ msgstr ""
 #: invenio/modules/groups/views.py:223
 #, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr ""
 
 #: invenio/modules/groups/views.py:279
@@ -13465,11 +13448,11 @@ msgstr ""
 msgid "Members"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 msgid "Knowledge base name"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 msgid "-None-"
 msgstr ""
@@ -13478,11 +13461,11 @@ msgstr ""
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 msgid "Index fields"
 msgstr ""
 
@@ -13528,7 +13511,7 @@ msgid "Create new record \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
+msgid "Create KB \"Written As\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
@@ -13665,28 +13648,28 @@ msgstr ""
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -13747,8 +13730,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -14202,8 +14185,7 @@ msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -14451,1706 +14433,3 @@ msgstr ""
 #: invenio/utils/date.py:581
 msgid " years ago"
 msgstr ""
-
-#~ msgid "Export as"
-#~ msgstr ""
-
-#~ msgid "Search Services"
-#~ msgstr ""
-
-#~ msgid "Citation Metrics"
-#~ msgstr ""
-
-#~ msgid "WebSearch Admin Guide"
-#~ msgstr ""
-
-#~ msgid "Submit Guide"
-#~ msgstr ""
-
-#~ msgid "Add to personal basket"
-#~ msgstr ""
-
-#~ msgid "WebSubmit Admin Guide"
-#~ msgstr ""
-
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
-#~ msgid "Quit searching."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
-#~ msgid "Cancel merging"
-#~ msgstr ""
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Your options"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
-
-#~ msgid "Search for a person to assign the paper to"
-#~ msgstr ""
-
-#~ msgid "Select All"
-#~ msgstr ""
-
-#~ msgid "Select None"
-#~ msgstr ""
-
-#~ msgid "Invert Selection"
-#~ msgstr ""
-
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
-#~ msgid "Author Name"
-#~ msgstr ""
-
-#~ msgid "Experiment"
-#~ msgstr ""
-
-#~ msgid "Not assigned"
-#~ msgstr ""
-
-#~ msgid "No status information found."
-#~ msgstr ""
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
-
-#~ msgid "Review Transaction"
-#~ msgstr ""
-
-#~ msgid "On all pages"
-#~ msgstr ""
-
-#~ msgid "With selected do"
-#~ msgstr ""
-
-#~ msgid "View name variants"
-#~ msgstr ""
-
-#~ msgid "The author has an internal ID!"
-#~ msgstr ""
-
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
-#~ msgid "Not provided"
-#~ msgstr ""
-
-#~ msgid "Not available"
-#~ msgstr ""
-
-#~ msgid "No comments"
-#~ msgstr ""
-
-#~ msgid "Not Available"
-#~ msgstr ""
-
-#~ msgid " Delete this ticket"
-#~ msgstr ""
-
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
-#~ msgid "No title available"
-#~ msgstr ""
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
-
-#~ msgid "Select name for"
-#~ msgstr ""
-
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
-#~ msgid "Paper title: "
-#~ msgstr ""
-
-#~ msgid "Ignore"
-#~ msgstr ""
-
-#~ msgid "The following names have been automatically chosen:"
-#~ msgstr ""
-
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
-#~ msgid "Selected name on paper"
-#~ msgstr ""
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
-
-#~ msgid "Please provide your information"
-#~ msgstr ""
-
-#~ msgid "Please provide your first name"
-#~ msgstr ""
-
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
-#~ msgid "Your last name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
-#~ msgid "Your eMail:"
-#~ msgstr ""
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
-
-#~ msgid "!Delete the entire request!"
-#~ msgstr ""
-
-#~ msgid "Mark as your documents"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
-#~ msgid "Mark as their documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
-
-#~ msgid "Mark as _not_ their documents"
-#~ msgstr ""
-
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
-#~ msgid "Create new profile"
-#~ msgstr ""
-
-#~ msgid "Create a new Person"
-#~ msgstr ""
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
-
-#~ msgid "Add to merge list"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
-#~ msgid "Recent Papers"
-#~ msgstr ""
-
-#~ msgid "Publication List "
-#~ msgstr ""
-
-#~ msgid "Showing the"
-#~ msgstr ""
-
-#~ msgid "most recent documents:"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
-#~ msgid "Manage your profile"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
-
-#~ msgid "Choose your profile"
-#~ msgstr ""
-
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
-#~ msgid "Manage publication list"
-#~ msgstr ""
-
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
-#~ msgid "add external id"
-#~ msgstr ""
-
-#~ msgid "delete selected ids"
-#~ msgstr ""
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
-
-#~ msgid "suggest missing ids"
-#~ msgstr ""
-
-#~ msgid "Choose system"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr ""
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
-#~ msgid "Fatal: You are not allowed to access this functionality."
-#~ msgstr ""
-
-#~ msgid "Claim this paper"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "You have %i tickets."
-#~ msgstr ""
-
-#~ msgid "The publication date of this book is %s."
-#~ msgstr ""
-
-#~ msgid "You can see your library account %(x_url_open)shere%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid "%i items found."
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
-#~ msgid "Unweighted %s keywords:"
-#~ msgstr ""
-
-#~ msgid "Weighted %s keywords:"
-#~ msgstr ""
-
-#~ msgid "Unknown type: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file named %s already exists. Please choose another name."
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Record #%i"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
-#~ msgid "Revision"
-#~ msgstr ""
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Could not find format element named %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s could not be found."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
-
-#~ msgid "Output format with code %s could not be found."
-#~ msgstr ""
-
-#~ msgid "Could not find output format named %s."
-#~ msgstr ""
-
-#~ msgid "Could not find a fresh name for output format %s."
-#~ msgstr ""
-
-#~ msgid "Modify Template Attributes"
-#~ msgstr ""
-
-#~ msgid "Template Editor"
-#~ msgstr ""
-
-#~ msgid "Check Dependencies"
-#~ msgstr ""
-
-#~ msgid "Update Format Attributes"
-#~ msgstr ""
-
-#~ msgid "Show Documentation"
-#~ msgstr ""
-
-#~ msgid "Hide Documentation"
-#~ msgstr ""
-
-#~ msgid "Last Modification Date"
-#~ msgstr ""
-
-#~ msgid "Manage Output Formats"
-#~ msgstr ""
-
-#~ msgid "Manage Format Templates"
-#~ msgstr ""
-
-#~ msgid "Format Elements Documentation"
-#~ msgstr ""
-
-#~ msgid "Add New Format Template"
-#~ msgstr ""
-
-#~ msgid "Check Format Templates Extensively"
-#~ msgstr ""
-
-#~ msgid "Code"
-#~ msgstr ""
-
-#~ msgid "Add New Output Format"
-#~ msgstr ""
-
-#~ msgid "menu"
-#~ msgstr ""
-
-#~ msgid "Close Output Format"
-#~ msgstr ""
-
-#~ msgid "Rules"
-#~ msgstr ""
-
-#~ msgid "Modify Output Format Attributes"
-#~ msgstr ""
-
-#~ msgid "Remove Rule"
-#~ msgstr ""
-
-#~ msgid "Add New Rule"
-#~ msgstr ""
-
-#~ msgid "No problem found with format"
-#~ msgstr ""
-
-#~ msgid "An error has been found"
-#~ msgstr ""
-
-#~ msgid "The following errors have been found"
-#~ msgstr ""
-
-#~ msgid "BibFormat Admin"
-#~ msgstr ""
-
-#~ msgid "Test with record:"
-#~ msgstr ""
-
-#~ msgid "Enter a search query here."
-#~ msgstr ""
-
-#~ msgid "No Record Found for %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
-#~ msgid "Template \"%s\" does not exist at line %s."
-#~ msgstr ""
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
-
-#~ msgid "Output format %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
-#~ msgid "Format template %s calls undefined element \"%s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
-
-#~ msgid "Error in format element %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Show all %i authors"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
-
-#~ msgid "Restricted Output Format"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Rules"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Output Format"
-#~ msgstr ""
-
-#~ msgid "Cannot create output format"
-#~ msgstr ""
-
-#~ msgid "Format template %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Delete Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Element %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Test Format Element %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Output Format %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Element"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Element %s"
-#~ msgstr ""
-
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
-#~ msgid "Format Validation"
-#~ msgstr ""
-
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid "Your rule: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Download history:"
-#~ msgstr ""
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid "Cannot send error request, %s parameter missing."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Not Set"
-#~ msgstr ""
-
-#~ msgid "never"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Your account on '%s' has been activated"
-#~ msgstr ""
-
-#~ msgid "Your account earlier created on '%s' has been activated:"
-#~ msgstr ""
-
-#~ msgid "Account created on '%s'"
-#~ msgstr ""
-
-#~ msgid "An account has been created for you on '%s':"
-#~ msgstr ""
-
-#~ msgid "Account rejected on '%s'"
-#~ msgstr ""
-
-#~ msgid "Your request for an account has been rejected on '%s':"
-#~ msgstr ""
-
-#~ msgid "Username/Email: %s"
-#~ msgstr ""
-
-#~ msgid "Account deleted on '%s'"
-#~ msgstr ""
-
-#~ msgid "Your account on '%s' has been deleted:"
-#~ msgstr ""
-
-#~ msgid "You already have an alert named %s."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been added to your profile."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been successfully updated."
-#~ msgstr ""
-
-#~ msgid "You have defined %s alerts."
-#~ msgstr ""
-
-#~ msgid "Here are the %s most popular searches."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display searches"
-#~ msgstr ""
-
-#~ msgid "%s, personalize"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Set a new alert"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Modify alert settings"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Display alerts"
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
-
-#~ msgid "times"
-#~ msgstr ""
-
-#~ msgid "Papers"
-#~ msgstr ""
-
-#~ msgid "No Keywords"
-#~ msgstr ""
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
-
-#~ msgid "No Subject categories"
-#~ msgstr ""
-
-#~ msgid "Subject categories"
-#~ msgstr ""
-
-#~ msgid "No Collaborations"
-#~ msgstr ""
-
-#~ msgid "Collaborations"
-#~ msgstr ""
-
-#~ msgid "unknown affiliation"
-#~ msgstr ""
-
-#~ msgid "No Affiliations"
-#~ msgstr ""
-
-#~ msgid "Affiliations"
-#~ msgstr ""
-
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
-#~ msgid "Citations%s"
-#~ msgstr ""
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
-
-#~ msgid "No Publication Graph"
-#~ msgstr ""
-
-#~ msgid "<strong> Publications list </strong>"
-#~ msgstr ""
-
-#~ msgid "No publications available"
-#~ msgstr ""
-
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "Sorry, you do not have sufficient rights to add record #%i."
-#~ msgstr ""
-
-#~ msgid "%i matching items"
-#~ msgstr ""
-
-#~ msgid "%i items have been successfully added to your basket"
-#~ msgstr ""
-
-#~ msgid "Adding %i items to your baskets"
-#~ msgstr ""
-
-#~ msgid "%i users are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "%i user groups are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "You have set %i alerts on this basket."
-#~ msgstr ""
-
-#~ msgid "%i items"
-#~ msgstr ""
-
-#~ msgid "%i notes"
-#~ msgstr ""
-
-#~ msgid "%i subscribers"
-#~ msgstr ""
-
-#~ msgid "Record %i"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s does not exist in the database."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is an invalid ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "Showing the latest %i comments:"
-#~ msgstr ""
-
-#~ msgid "Sorry, the record %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "Sorry, %s is not a valid ID value."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s"
-#~ msgstr ""
-
-#~ msgid "Readers found the following %s reviews to be most helpful."
-#~ msgstr ""
-
-#~ msgid "View all %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s comments"
-#~ msgstr ""
-
-#~ msgid "Note: Your nickname, %s, will be displayed as author of this comment."
-#~ msgstr ""
-
-#~ msgid "Max %i files"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Note: Your nickname, %s, will be "
-#~ "displayed as the author of this "
-#~ "review."
-#~ msgstr ""
-
-#~ msgid "View all %s reported comments"
-#~ msgstr ""
-
-#~ msgid "View all %s reported reviews"
-#~ msgstr ""
-
-#~ msgid "This review has been reported %i times"
-#~ msgstr ""
-
-#~ msgid "This comment has been reported %i times"
-#~ msgstr ""
-
-#~ msgid "Here are the reported reviews of user %s"
-#~ msgstr ""
-
-#~ msgid "Here are the reported comments of user %s"
-#~ msgstr ""
-
-#~ msgid "Here is review %s"
-#~ msgstr ""
-
-#~ msgid "Here is comment %s"
-#~ msgstr ""
-
-#~ msgid "Here are all reviews for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "Here are all comments for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "%s items"
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid "%i items found in total"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "%s View your previously submitted comments"
-#~ msgstr ""
-
-#~ msgid "Comment ID %s does not exist."
-#~ msgstr ""
-
-#~ msgid "Record ID %s does not exist."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your message is too long, please "
-#~ "shorten it. Maximum size allowed is "
-#~ "%i characters."
-#~ msgstr ""
-
-#~ msgid "Group %s does not exist."
-#~ msgstr ""
-
-#~ msgid "User %s does not exist."
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
-#~ msgid "There are no records referring to %s."
-#~ msgstr ""
-
-#~ msgid "There are no records modified by %s."
-#~ msgstr ""
-
-#~ msgid "There are no records cited by %s."
-#~ msgstr ""
-
-#~ msgid "No word index is available for %s."
-#~ msgstr ""
-
-#~ msgid "No phrase index is available for %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Search term %s did not match any"
-#~ " record. Nearest terms in any "
-#~ "collection are:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, %s does not seem to be "
-#~ "a valid sort option. The records "
-#~ "will not be sorted."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, sorting is allowed on sets "
-#~ "of up to %d records only. Using"
-#~ " default sort order."
-#~ msgstr ""
-
-#~ msgid "The record %d replaces it."
-#~ msgstr ""
-
-#~ msgid "%s results found"
-#~ msgstr ""
-
-#~ msgid "%s seconds"
-#~ msgstr ""
-
-#~ msgid "Search %s records for"
-#~ msgstr ""
-
-#~ msgid "Cited by %i records"
-#~ msgstr ""
-
-#~ msgid "%s records found"
-#~ msgstr ""
-
-#~ msgid "Search took %s seconds."
-#~ msgstr ""
-
-#~ msgid "Cited by 1 record"
-#~ msgstr ""
-
-#~ msgid "%i comments"
-#~ msgstr ""
-
-#~ msgid "%i reviews"
-#~ msgstr ""
-
-#~ msgid "Collection %s Not Found"
-#~ msgstr ""
-
-#~ msgid "Sorry, collection %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s."
-#~ msgstr ""
-
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid "Cited by: %s records"
-#~ msgstr ""
-
-#~ msgid "Co-cited with: %s records"
-#~ msgstr ""
-
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
-#~ msgid "No Papers"
-#~ msgstr ""
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
-
-#~ msgid "Citations:"
-#~ msgstr ""
-
-#~ msgid "No Citation Information available"
-#~ msgstr ""
-
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Sorry, DOI %s could not be resolved."
-#~ msgstr ""
-
-#~ msgid "DOI \"%s\" Not Found"
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
-#~ msgid "Discussion"
-#~ msgstr ""
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If you are using a lightweight CERN account you can\n"
-#~ "                %(x_url_open)sreset the password%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Alternatively, you can ask %s to "
-#~ "change your login system from external"
-#~ " to internal."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "%s offers you the possibility to "
-#~ "personalize the interface, to set up "
-#~ "your own personal library of documents,"
-#~ " or to set up an automatic "
-#~ "alert query that would run periodically"
-#~ " and would notify you of search "
-#~ "results by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid "Okay, a password reset link has been emailed to %s."
-#~ msgstr ""
-
-#~ msgid "If you don't own an account yet, please contact %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please do not use valuable passwords "
-#~ "such as your Unix, AFS or NICE "
-#~ "passwords with this service. Your email"
-#~ " address will stay strictly confidential"
-#~ " and will not be disclosed to "
-#~ "any third party. It will be used"
-#~ " to identify you for personal "
-#~ "services of %s. For example, you "
-#~ "may set up an automatic alert "
-#~ "search that will look for new "
-#~ "preprints and will notify you daily "
-#~ "of new arrivals by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "It is not possible to create an"
-#~ " account yourself. Contact %s if you"
-#~ " want an account."
-#~ msgstr ""
-
-#~ msgid "Your alerts"
-#~ msgstr ""
-
-#~ msgid "Your approvals"
-#~ msgstr ""
-
-#~ msgid "Your baskets"
-#~ msgstr ""
-
-#~ msgid "Your comments"
-#~ msgstr ""
-
-#~ msgid "Your groups"
-#~ msgstr ""
-
-#~ msgid "Your loans"
-#~ msgstr ""
-
-#~ msgid "Your submissions"
-#~ msgstr ""
-
-#~ msgid "Your searches"
-#~ msgstr ""
-
-#~ msgid "Administration"
-#~ msgstr ""
-
-#~ msgid "Statistics"
-#~ msgstr ""
-
-#~ msgid "Edit %s members"
-#~ msgstr ""
-
-#~ msgid "Edit group %s"
-#~ msgstr ""
-
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
-#~ msgid "Group: %s"
-#~ msgstr ""
-
-#~ msgid "Group %s: New membership request"
-#~ msgstr ""
-
-#~ msgid "A user wants to join the group %s."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been accepted"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been accepted."
-#~ msgstr ""
-
-#~ msgid "Group %s: Join request has been rejected"
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been rejected."
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted"
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted by its administrator."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Your Settings"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown to the external login "
-#~ "system."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The external login method %s does "
-#~ "not support email address based logins."
-#~ "  Please contact the site administrators."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is already in use."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "Sorry, page %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
-#~ msgid "Page %s Not Found"
-#~ msgstr ""
-
-#~ msgid "Please contact %s quoting the following information:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
-
-#~ msgid "Unable to find the submission directory for the action: %s"
-#~ msgstr ""
-
-#~ msgid "Unable to find document type: %s"
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory."
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory. Please fill it in."
-#~ msgstr ""
-
-#~ msgid "Function %s does not exist."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s%s'"
-#~ msgstr ""
-

--- a/invenio/base/translations/sk/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/sk/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,16 +16,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2012-02-16 22:53+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:58+0200\n"
 "Last-Translator: Tibor Simko <tibor.simko@cern.ch>\n"
 "Language-Team: SK <info@invenio-software.org>\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -59,8 +59,8 @@ msgstr "hlavná stránka"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -206,7 +206,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 msgid "Hello:"
 msgstr "Ahoj:"
 
@@ -227,17 +227,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -263,48 +263,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Tento záznam neexistuje."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Nie ste vlastníkom tohto košíka."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Zlyhanie registrácie"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Prosíme vyberte jeden alebo viac:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Zlyhanie registrácie"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -507,7 +512,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -580,9 +586,9 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"Ste prihlásený ako %(x_user)s.  Môžete a) %(x_url1_open)ssa "
-"odhlásiť%(x_url1_close)s; b) editovať %(x_url2_open)sparametre Vášho "
-"konta%(x_url2_close)s."
+"Ste prihlásený ako %(x_user)s.  Môžete a) %(x_url1_open)ssa odhlásiť"
+"%(x_url1_close)s; b) editovať %(x_url2_open)sparametre Vášho konta"
+"%(x_url2_close)s."
 
 #: invenio/legacy/batchuploader/templates.py:282
 msgid "No metadata files have been uploaded yet."
@@ -718,7 +724,8 @@ msgid "The following errors have occurred:"
 msgstr "Avízo %s bolo úspešne aktualizované."
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -735,8 +742,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -818,7 +825,7 @@ msgstr "ID"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -861,8 +868,8 @@ msgstr "Vaše košíky"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Predošlé"
@@ -878,8 +885,8 @@ msgstr "Skóre"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Nasledujúce"
 
@@ -894,18 +901,6 @@ msgstr "Nasledujúce"
 #: invenio/legacy/weblinkback/adminlib.py:55
 msgid "Admin Area"
 msgstr "Areál Administrátora"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "autor"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
@@ -925,11 +920,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
 msgid "Limit to knowledge bases containing string:"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "úspešne vymazané"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -959,10 +949,6 @@ msgstr "úspešne vymazané"
 msgid "Delete"
 msgstr "Zmazať"
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:140
-msgid "Verify syntax"
-msgstr ""
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:145
 #: invenio/modules/communities/views.py:258
 #, fuzzy
@@ -981,16 +967,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
 msgid "Verify BibCheck config file"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Databázový problém"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "súbor(y)"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
@@ -1097,7 +1073,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1148,8 +1125,8 @@ msgstr "Vaše konto bolo úspešne vytvorené."
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1163,25 +1140,23 @@ msgstr "Prelistuj"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "Vaše konto bolo úspešne vytvorené."
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "Vaše konto bolo úspešne vytvorené."
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1206,13 +1181,14 @@ msgstr "Vytvoriť novú"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "Vaše konto bolo úspešne vytvorené."
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1244,9 +1220,8 @@ msgstr "súčasný stav:"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "Vaše konto bolo úspešne vytvorené."
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1313,8 +1288,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1322,8 +1297,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1345,9 +1320,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "Vaše konto bolo úspešne vytvorené."
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1389,8 +1363,8 @@ msgstr "%s záznamov nájdených"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1449,11 +1423,11 @@ msgstr "Vaše konto bolo úspešne vytvorené."
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1464,11 +1438,11 @@ msgstr "Áno"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1481,8 +1455,8 @@ msgstr "Nie"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1579,8 +1553,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1600,29 +1574,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1631,9 +1605,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 #, fuzzy
 msgid "Requested record does not seem to exist."
 msgstr "Ľutujem, záznam %s sa nezdá že by existoval."
@@ -1995,16 +1969,14 @@ msgstr "Záznam bol vymazaný."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2025,8 +1997,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2188,8 +2160,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2298,7 +2270,7 @@ msgstr "Akcia"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Popis"
 
@@ -2493,8 +2465,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2780,9 +2752,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "Ak si prajete, môžete sa %(x_url_open)sprihlásiť tu%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2838,7 +2809,7 @@ msgstr "Zamietnuté"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "OK"
 
@@ -2846,8 +2817,8 @@ msgstr "OK"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "Vaše konto bolo úspešne vytvorené."
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3319,8 +3290,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "Elektronická adresa"
 
@@ -3822,8 +3793,8 @@ msgstr "Detaily novej kópie"
 #, fuzzy, python-format
 msgid "A %(x_url_open)snew copy%(x_url_close)s has been added."
 msgstr ""
-"Prosím %(x_url_open)sprijmite alebo zamietnite%(x_url_close)s žiadosť "
-"tohto užívateľa."
+"Prosím %(x_url_open)sprijmite alebo zamietnite%(x_url_close)s žiadosť tohto "
+"užívateľa."
 
 #: invenio/legacy/bibcirculation/templates.py:7443
 #, fuzzy
@@ -4162,8 +4133,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4181,8 +4152,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4242,17 +4213,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4631,25 +4602,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "Záznam bol vymazaný."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4709,15 +4680,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4728,10 +4699,10 @@ msgstr "Zvoľte súbor"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4744,15 +4715,15 @@ msgstr "Prístup"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4763,7 +4734,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4782,17 +4754,15 @@ msgstr "Žiadaná prezývka %s už v databáze existuje."
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "Žiadaná prezývka %s už v databáze existuje."
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4810,14 +4780,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4870,8 +4839,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4921,8 +4890,8 @@ msgstr "Žiadaný záznam sa nezdá byť uložený."
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -5042,9 +5011,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -5059,8 +5028,8 @@ msgstr "Uložte zmeny"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -5204,11 +5173,10 @@ msgstr "Naspäť ku výsledkom hľadania"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5345,7 +5313,7 @@ msgid "Total"
 msgstr "voliteľné"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Vyber"
 
@@ -5510,8 +5478,8 @@ msgstr "Zruš bázu poznania"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5568,56 +5536,56 @@ msgstr "Prosím najskôr sa prihláste."
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5655,7 +5623,7 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5708,15 +5676,15 @@ msgstr "Vaše pravidlo: %s"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5941,8 +5909,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -6018,8 +5985,8 @@ msgstr "Referencia nebola ešte daná"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6034,8 +6001,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Výsledky hľadania"
 
@@ -6196,8 +6163,8 @@ msgstr "Žiadne hodnoty nenájdené."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6223,8 +6190,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6235,8 +6202,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -6248,95 +6214,94 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
 "Žiaden záznam nebol nájdený v kolekcii %(x_collection)s. Ostatné verejne "
-"dostupné kolekcie dali %(x_url_open)s%(x_nb_hits)d "
-"záznamov%(x_url_close)s."
+"dostupné kolekcie dali %(x_url_open)s%(x_nb_hits)d záznamov%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
-"Žiadna verejne prístupná kolekcia nevyhovuje Vašej otázke. Ak ste hľadali"
-" dokumenty verejne neprístupné, zvoľte prosím najskôr príslušnú neverejnú"
-" kolekciu."
+"Žiadna verejne prístupná kolekcia nevyhovuje Vašej otázke. Ak ste hľadali "
+"dokumenty verejne neprístupné, zvoľte prosím najskôr príslušnú neverejnú "
+"kolekciu."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
-"Žiadna verejne prístupná kolekcia nevyhovuje Vašej otázke. Ak ste hľadali"
-" dokumenty verejne neprístupné, zvoľte prosím najskôr príslušnú neverejnú"
-" kolekciu."
+"Žiadna verejne prístupná kolekcia nevyhovuje Vašej otázke. Ak ste hľadali "
+"dokumenty verejne neprístupné, zvoľte prosím najskôr príslušnú neverejnú "
+"kolekciu."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
-"Hľadaný výraz %s neodpovedá žiadnemu záznamu. Najbližšie termíny "
-"nezávisle na kolekcii sú:"
+"Hľadaný výraz %s neodpovedá žiadnemu záznamu. Najbližšie termíny nezávisle "
+"na kolekcii sú:"
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "Použite odlišné hľadacie výrazy."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Existuje %i košíkov"
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Existuje %i košíkov"
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Existuje %i košíkov"
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Index slov nie je dostupný pre"
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Index viet nie je dostupný pre"
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
-"Hľadaný výraz %(x_term)s v indexe %(x_index)s neodpovedá žiadnemu "
-"záznamu. Najbližšie termíny nezávisle na kolekcii sú:"
+"Hľadaný výraz %(x_term)s v indexe %(x_index)s neodpovedá žiadnemu záznamu. "
+"Najbližšie termíny nezávisle na kolekcii sú:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr ""
-"Hľadaný výraz %s neodpovedá žiadnemu záznamu. Najbližšie termíny "
-"nezávisle na kolekcii sú:"
+"Hľadaný výraz %s neodpovedá žiadnemu záznamu. Najbližšie termíny nezávisle "
+"na kolekcii sú:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
@@ -6345,35 +6310,35 @@ msgstr ""
 "Ľutujem, %s nie je platné nastavenie pre triedenie.  Použijem triedenie "
 "podľa názvu namiesto neho."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 "Ľutujem, triedenie je povolené len do %d záznamov.  Použijem štandardné "
 "triedenie."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 "Ľutujem, %s nie je platné nastavenie pre triedenie.  Použijem triedenie "
 "podľa názvu namiesto neho."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Tento záznam neexistuje."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Použite odlišné hľadacie výrazy."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6387,17 +6352,17 @@ msgstr "Použite odlišné hľadacie výrazy."
 msgid "Browse"
 msgstr "Prelistuj"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr ""
-"Žiaden výsledok nevyhovuje Vašim časovým kritériám, podmienka nie je "
-"vzatá do úvahy..."
+"Žiaden výsledok nevyhovuje Vašim časovým kritériám, podmienka nie je vzatá "
+"do úvahy..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr ""
-"Žiaden výsledok nevyhovuje Vašim limitným kritériám, podmienky nie sú "
-"vzaté do úvahy..."
+"Žiaden výsledok nevyhovuje Vašim limitným kritériám, podmienky nie sú vzaté "
+"do úvahy..."
 
 #: invenio/legacy/webalert/api.py:54
 #, fuzzy, python-format
@@ -6439,15 +6404,13 @@ msgstr "Avízo %s bolo úspešne aktualizované."
 #: invenio/legacy/webalert/api.py:428
 #, fuzzy, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Spravili ste %(x_nb)s hľadaní. %(x_url_open)sDetailný "
-"zoznam%(x_url_close)s je k dispozícii s možnosťou (a) zobraziť výsledy "
-"hľadania a (b) prihlásiť sa k automatickému elektronickému avízovému "
-"systému pre tieto hľadania."
+"Spravili ste %(x_nb)s hľadaní. %(x_url_open)sDetailný zoznam%(x_url_close)s "
+"je k dispozícii s možnosťou (a) zobraziť výsledy hľadania a (b) prihlásiť sa "
+"k automatickému elektronickému avízovému systému pre tieto hľadania."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6521,8 +6484,8 @@ msgid ""
 "This alert will notify you each time/only if a new item satisfies the "
 "following query:"
 msgstr ""
-"Toto avízo Vás upovedomí vždy keď nejaká nová položka vyhovuje "
-"nasledujúcej otázke:"
+"Toto avízo Vás upovedomí vždy keď nejaká nová položka vyhovuje nasledujúcej "
+"otázke:"
 
 #: invenio/legacy/webalert/templates.py:173
 msgid "QUERY"
@@ -6641,8 +6604,8 @@ msgstr "Definovali ste %s avíz."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 "Ešte ste nevykonali žiadne hľadanie. Prosím najprv choďte do "
 "%(x_url_open)shľadacieho rozhrania%(x_url_close)s."
@@ -6650,11 +6613,11 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
-"Vykonali ste %(x_nb1)s hľadaní (%(x_nb2)s rôznych otázok) počas "
-"posledných zhruba 30 dní."
+"Vykonali ste %(x_nb1)s hľadaní (%(x_nb2)s rôznych otázok) počas posledných "
+"zhruba 30 dní."
 
 #: invenio/legacy/webalert/templates.py:453
 #, fuzzy, python-format
@@ -6712,7 +6675,7 @@ msgstr "Vaše hľadania"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6776,7 +6739,7 @@ msgstr "Nastaviť nové avízo"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6836,7 +6799,8 @@ msgstr "Zobraziť alerty"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6860,7 +6824,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "Nemáte dostatočné práva na zobrazenie obsahu tohto košíka."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6888,7 +6853,8 @@ msgid "You do not have permission to delete this note."
 msgstr "Nemáte dostatočné práva na zobrazenie obsahu tohto košíka."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6919,8 +6885,8 @@ msgstr "Tento záznam neexistuje."
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6942,8 +6908,8 @@ msgstr "Skopíruj záznam do košíka"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6976,8 +6942,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7047,8 +7013,7 @@ msgstr "Verejné košíky"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 "Máte %(x_nb_perso)s osobných košíkov a ste prihlásení k odberu "
 "%(x_nb_group)s košíkov grúp a %(x_nb_public)s verejných košíkov iných "
@@ -7079,8 +7044,7 @@ msgstr "%i grúp používateľov sa prihlásilo k odberu tohto košíka."
 #: invenio/legacy/webbasket/templates.py:108
 #, fuzzy, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr "Teraz môžete pristúpiť k Vášmu %(x_url_open)skontu%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -7253,8 +7217,8 @@ msgstr "Externý záznam"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7439,20 +7403,21 @@ msgstr "Zdieľať košík s novou grupou"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
-"Ste prihlásený ako anonymný hosť, takže Vaše košíky zmiznú na konci "
-"terajšej seanse."
+"Ste prihlásený ako anonymný hosť, takže Vaše košíky zmiznú na konci terajšej "
+"seanse."
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
-"Ak si prajete, môžete sa %(x_url_open)sprihlásiť alebo zaregistrovať "
-"tu%(x_url_close)s."
+"Ak si prajete, môžete sa %(x_url_open)sprihlásiť alebo zaregistrovať tu"
+"%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
 #: invenio/legacy/websession/webinterface.py:287
@@ -7461,7 +7426,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Táto funkcia je neprístupná anonymným hosťom."
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Naspäť ku výsledkom hľadania"
 
@@ -7636,7 +7601,7 @@ msgstr "Pridaj k užívateľom"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7783,219 +7748,218 @@ msgstr "Užívateľ %s neexistuje."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "Užívateľ %s neexistuje."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Napíšte komentár"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_name)s napísal dňa %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "%i komentárov"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Zobrazujúc posledných %i komentárov:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Diskutujte o tomto dokumente"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Začnite diskusiu o hocakom aspekte tohto dokumentu."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Ľutujem, záznam %s sa nezdá že by existoval."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "Ľutujem, %s nie je platná hodnota ID."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "Ľutujem, žiadne ID záznamu nebolo dodané."
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Môžete chcieť začať prehliadať z %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_name)s napísal dňa %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Bolo toto hodnotenie užitočné?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Napíšte hodnotenie"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 "Priemerné skóre hodnotení: %(x_nb_score)s založené na %(x_nb_reviews)s "
 "hodnoteniach"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "Čitatelia pokladali nasledujúcich %s hodnotení za najužitočnejšie."
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Zobraz všetky %s hodnotenia"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Ohodnoťte tento dokument"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Buďte prvý kto ohodnotí tento dokument."
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "Skóre"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Hlás zneužitie"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 #, fuzzy
 msgid "Undelete comment"
 msgstr "zmaž komentáre"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Zmazať komentár"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 #, fuzzy
 msgid "Unreport comment"
 msgstr "Zmazať komentár"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Ohodnotené %(x_nickname)s dňa %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
-"%(x_nb_people)i z %(x_nb_total)i čitateľov pokladá túto kritiku za "
-"užitočnú"
+"%(x_nb_people)i z %(x_nb_total)i čitateľov pokladá túto kritiku za užitočnú"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 #, fuzzy
 msgid "Undelete review"
 msgstr "Zruš vybrané hodnotenia"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 #, fuzzy
 msgid "Delete review"
 msgstr "Zruš vybrané hodnotenia"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 #, fuzzy
 msgid "Unreport review"
 msgstr "Napíšte Vaše hodnotenie"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Komentáre"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Ohodnotenia"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Existuje celkovo %s hodnotení"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Existuje celkovo %s komentárov"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Buďte prvý kto ohodnotí tento dokument."
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Prihlásiť sa k odberu"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 #, fuzzy
 msgid "Unsubscribe"
 msgstr "Prihlásiť sa k odberu"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -8004,43 +7968,42 @@ msgstr "Prihlásiť sa k odberu"
 msgid "Record"
 msgstr "Záznam"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "ohodnotenie"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "komentár"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Hodnotenie"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Zobrazenie"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Strana:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 #, fuzzy
 msgid "You are not authorized to comment or review."
 msgstr "Nie ste vlastníkom tohto košíka."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr "Poznámka: Vaša prezývka, %s, bude zobrazená ako autor tohto komentára"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
@@ -8049,476 +8012,480 @@ msgstr ""
 "Poznámka: Ešte ste si %(x_url_open)snezvolili prezývku%(x_url_close)s. "
 "%(x_nickname)s bude zobrazené ako autor tohto komentára."
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 #, fuzzy
 msgid "Max one file"
 msgstr "Pridaj hodnotenie"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "súbor(y)"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Správa"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 #, fuzzy
 msgid "Add comment"
 msgstr "Pridaj komentár"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
-msgstr "Poznámka: Vaša prezývka, %s, bude zobrazená ako autor tohto hodnotenia."
+msgstr ""
+"Poznámka: Vaša prezývka, %s, bude zobrazená ako autor tohto hodnotenia."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Ohodnoťte tento článok"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Vyber skóre"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Zadajte názov vášho hodnotenia"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Napíšte Vaše hodnotenie"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 #, fuzzy
 msgid "Add review"
 msgstr "Pridaj hodnotenie"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Pridaj hodnotenie"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Vaše hodnotenie bolo úspešne pridané."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Váš komentár bol úspešne pridaný."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Naspäť ku záznamu"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr "Môžete si prezrieť zoznam %(x_url_open)sVašich grúp%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 #, fuzzy
 msgid "View most commented records"
 msgstr "zobraz komentáre"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 #, fuzzy
 msgid "View latest commented records"
 msgstr "zobraz komentáre"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all comments reported as abuse"
 msgstr "Zobraz všektých hlásených používateľov"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 #, fuzzy
 msgid "View most reviewed records"
 msgstr "zruš záznamy"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 #, fuzzy
 msgid "View latest reviewed records"
 msgstr "Zobraz všetky %s hodnotenia"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all reviews reported as abuse"
 msgstr "Zobraz všektých hlásených používateľov"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Zobraz všetkých používateľov ktorí boli hlásení"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Príručka"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Komentáre a hodnotenia sú blokované"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"Prosím zadajte ID komentára/hodnotenia aby ste ho mohli zobraziť pred tým"
-" ako sa rozhodnete či ho zmazať alebo nie"
+"Prosím zadajte ID komentára/hodnotenia aby ste ho mohli zobraziť pred tým "
+"ako sa rozhodnete či ho zmazať alebo nie"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "ID komentára:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 #, fuzzy
 msgid "Record ID:"
 msgstr "ID záznamu"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Zobraziť komentár"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Ešte neboli žiadne hlásenia."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Zobraziť všetky %s ohlásené komentáre"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Zobraziť všetky %s ohlásené hodnotenia"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-"Tu je zoznam, utriedený podľa celkového počtu oznámení, všetkých "
-"užívateľov ktorí mali aspoň jedno oznámenie na ich komentáre."
+"Tu je zoznam, utriedený podľa celkového počtu oznámení, všetkých užívateľov "
+"ktorí mali aspoň jedno oznámenie na ich komentáre."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Prezývka"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "ID používateľa"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Počet kladných hlasov"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Počet záporných hlasov"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Celkový počet hlasov"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Celkový počet ohlásení"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Zobraziť všetky užívateľmi ohlásené komentáre a hodnotenia"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Toto hodnotenie bolo hlásené %i krát"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Tento komentár bol hlásený %i krát"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Napísal"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Všeobecné informácie"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Zruš vybrané hodnotenia"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Potlač zvolené správy o zneužití"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 #, fuzzy
 msgid "Undelete selected reviews"
 msgstr "Zruš vybrané hodnotenia"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 #, fuzzy
 msgid "Undelete selected comments"
 msgstr "Zruš vybrané komentáre"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Zruš vybrané komentáre"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Tu sú hlásené hodnotenia užívateľa %s"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Tu sú hlásené komentáre užívateľa %s"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Tu je komentár/hodnotenie %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Tu je komentár/hodnotenie %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, fuzzy, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Tu je komentár/hodnotenie %(x_cmtID)s napísaný používateľom %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, fuzzy, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Tu je komentár/hodnotenie %(x_cmtID)s napísaný používateľom %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "Tu sú všetky hlásené hodnotenia zoradené podľa najviac hlásených"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "Tu sú všetky hlásené komentáre zoradené podľa najviac hlásených"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr "Tu sú všetky hlásené hodnotenia zoradené podľa najviac hlásených"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 #, fuzzy
 msgid "Show comments"
 msgstr "zobraz komentáre"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr "Tu sú všetky hlásené komentáre zoradené podľa najviac hlásených"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 #, fuzzy
 msgid "Show reviews"
 msgstr "ohodnotenie"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "ID komentára"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "úspešne vymazané"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 #, fuzzy
 msgid "successfully undeleted"
 msgstr "úspešne vymazané"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "úspešne potlačené správy o zneužití"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 #, fuzzy
 msgid "Not yet reviewed"
 msgstr "Napíšte Vaše hodnotenie"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "Váš komentár bol úspešne poslaný"
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Zmaž komentáre"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "posledný záznam najskôr"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "zobraz komentáre"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "Podrobnosti a komentáre"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "%s záznamov nájdených"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Komentáre"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "Čas"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Pridaj k užívateľom"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "Zobraz"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Dátum objednávky"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Nasledujúca stránka"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Zobraziť alerty"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8527,106 +8494,106 @@ msgstr "Zobraziť alerty"
 msgid "Refresh"
 msgstr "Referencia"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Zmazať komentár"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "Žiadne hodnoty nenájdené."
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Záznam nenájdený"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "Nemáte dostatočné práva na zobrazenie obsahu tohto košíka."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Pridaj komentár"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "Zobraz všetky ohlásené komentáre"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 #, fuzzy
 msgid "Page Not Found"
 msgstr "Kolekcia %s nenájdená"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 #, fuzzy
 msgid "The requested comment could not be found"
 msgstr "Tento záznam neexistuje."
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 #, fuzzy
 msgid "The requested file could not be found"
 msgstr "Tento záznam neexistuje."
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Nie ste vlastníkom tohto košíka."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Komentáre"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "Zobraz všetky ohlásené komentáre"
@@ -8745,8 +8712,8 @@ msgstr "Ľutujem, stránka %s zdá sa neexistuje."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, fuzzy, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr "Teraz môžete pristúpiť k Vášmu %(x_url_open)skontu%(x_url_close)s."
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8818,8 +8785,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8847,8 +8814,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -8952,11 +8919,6 @@ msgstr ""
 msgid "Apply"
 msgstr "apríl"
 
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "Prezývka"
-
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 #, fuzzy
 msgid "WebJournal Admin"
@@ -9041,9 +9003,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -9065,8 +9026,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9180,8 +9140,8 @@ msgid ""
 "Your message is too long, please shorten it. Maximum size allowed is "
 "%(x_size)i characters."
 msgstr ""
-"Vaša správa je príliš dlhá, prosím upravte ju. Maximálna pripustená dĺžka"
-" je %i znakov."
+"Vaša správa je príliš dlhá, prosím upravte ju. Maximálna pripustená dĺžka je "
+"%i znakov."
 
 #: invenio/legacy/webmessage/api.py:402
 #, fuzzy, python-format
@@ -9205,7 +9165,8 @@ msgstr "Napíš správu"
 msgid ""
 "Your message could not be sent to the following recipients as it would "
 "exceed their quotas:"
-msgstr "Vaša správa nemohla byť poslaná nasledujúcim príjemcom kvôli ich kvóte:"
+msgstr ""
+"Vaša správa nemohla byť poslaná nasledujúcim príjemcom kvôli ich kvóte:"
 
 #: invenio/legacy/webmessage/api.py:457
 msgid "Your message has been sent."
@@ -9545,16 +9506,16 @@ msgstr "Hľadaj tiež:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
-"Táto kolekcia je chránená.  Ak máte prístupové práva, tak prosím kliknite"
-" na tlačidlo Hľadaj."
+"Táto kolekcia je chránená.  Ak máte prístupové práva, tak prosím kliknite na "
+"tlačidlo Hľadaj."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9649,8 +9610,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found %(x_nb_records)s "
 "records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sPrehľad výsledkov:%(x_fmt_close)s Nájdených "
-"%(x_nb_records)s záznamov za %(x_nb_seconds)s sekúnd."
+"%(x_fmt_open)sPrehľad výsledkov:%(x_fmt_close)s Nájdených %(x_nb_records)s "
+"záznamov za %(x_nb_seconds)s sekúnd."
 
 #: invenio/legacy/websearch/templates.py:3132
 #, fuzzy, python-format
@@ -9663,8 +9624,8 @@ msgid ""
 "%(x_fmt_open)sResults overview:%(x_fmt_close)s Found at least "
 "%(x_nb_records)s records in %(x_nb_seconds)s seconds."
 msgstr ""
-"%(x_fmt_open)sPrehľad výsledkov:%(x_fmt_close)s Nájdených "
-"%(x_nb_records)s záznamov za %(x_nb_seconds)s sekúnd."
+"%(x_fmt_open)sPrehľad výsledkov:%(x_fmt_close)s Nájdených %(x_nb_records)s "
+"záznamov za %(x_nb_seconds)s sekúnd."
 
 #: invenio/legacy/websearch/templates.py:3184
 #, fuzzy
@@ -9691,11 +9652,10 @@ msgstr "Vaše pridania"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
-"Booleovská otázka nevrátila žiaden výsledok. Skúste skombinovať dané "
-"termíny inakšie."
+"Booleovská otázka nevrátila žiaden výsledok. Skúste skombinovať dané termíny "
+"inakšie."
 
 #: invenio/legacy/websearch/templates.py:3357
 msgid "See also: similar author names"
@@ -9720,11 +9680,11 @@ msgstr "Môžete chcieť začať prehliadať z %s"
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
-"Založte si osobný %(x_url1_open)semail alert%(x_url1_close)s alebo "
-"použite %(x_url2_open)sRSS feed%(x_url2_close)s."
+"Založte si osobný %(x_url1_open)semail alert%(x_url1_close)s alebo použite "
+"%(x_url2_open)sRSS feed%(x_url2_close)s."
 
 #: invenio/legacy/websearch/templates.py:3832
 #, fuzzy, python-format
@@ -9916,7 +9876,8 @@ msgid "in"
 msgstr "v"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "Nenašli ste čo ste hľadali? Skúste Vašu otázku na iných serveroch:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -10010,8 +9971,8 @@ msgstr "nutné"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -10022,11 +9983,11 @@ msgstr "Vytvoriť nový košík"
 #: invenio/legacy/websession/templates.py:270
 #, fuzzy
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
-"Ak chcete zmeniť Vašu elektronickú adresu alebo heslo, prosím nastavte "
-"nové hodnoty v doleuvedenom formulári."
+"Ak chcete zmeniť Vašu elektronickú adresu alebo heslo, prosím nastavte nové "
+"hodnoty v doleuvedenom formulári."
 
 #: invenio/legacy/websession/templates.py:271
 msgid "Edit login credentials"
@@ -10042,18 +10003,18 @@ msgstr "Nastavte nové hodnoty"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:325
 #, fuzzy
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
-"Ak chcete zmeniť Vašu elektronickú adresu alebo heslo, prosím nastavte "
-"nové hodnoty v doleuvedenom formulári."
+"Ak chcete zmeniť Vašu elektronickú adresu alebo heslo, prosím nastavte nové "
+"hodnoty v doleuvedenom formulári."
 
 #: invenio/legacy/websession/templates.py:327
 msgid "Old password"
@@ -10090,11 +10051,11 @@ msgstr "Nastav nové heslo"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
-"Ak si prajete, môžete sa %(x_url_open)sprihlásiť alebo zaregistrovať "
-"tu%(x_url_close)s."
+"Ak si prajete, môžete sa %(x_url_open)sprihlásiť alebo zaregistrovať tu"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:346
 #, fuzzy, python-format
@@ -10174,7 +10135,8 @@ msgstr "Editujte prihlasovaciu metódu"
 msgid ""
 "Please select which login method you would like to use to authenticate "
 "yourself"
-msgstr "Prosíme vyberte si metódu ktorú by ste chceli používať na prihlásenie sa"
+msgstr ""
+"Prosíme vyberte si metódu ktorú by ste chceli používať na prihlásenie sa"
 
 #: invenio/legacy/websession/templates.py:503
 #: invenio/legacy/websession/templates.py:518
@@ -10184,14 +10146,13 @@ msgstr "Vyber metódu"
 #: invenio/legacy/websession/templates.py:537
 #, fuzzy, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"Ak ste stratili heslo k internému kontu Invenio, tak prosíme vyplňte Vašu"
-" adresu elektronickej pošty do formulára nižšie. Vaše heslo Vám bude "
-"obratom zaslané elektronickou poštou."
+"Ak ste stratili heslo k internému kontu Invenio, tak prosíme vyplňte Vašu "
+"adresu elektronickej pošty do formulára nižšie. Vaše heslo Vám bude obratom "
+"zaslané elektronickou poštou."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10207,19 +10168,19 @@ msgstr "Pošli linku na resetovanie strateného hesla"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 #, fuzzy
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
-"Ak ste používali externý systém pre prihlásenie sa (napr. CERN NICE), tak"
-" Vám nemôžeme poslúžiť a musíte sa spýtať tam."
+"Ak ste používali externý systém pre prihlásenie sa (napr. CERN NICE), tak "
+"Vám nemôžeme poslúžiť a musíte sa spýtať tam."
 
 #: invenio/legacy/websession/templates.py:573
 #, fuzzy, python-format
@@ -10233,15 +10194,14 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
-"%s Vám dáva možnosť personalizovať rozhranie, definovat Vašu vlastnú "
-"osobnú knižnicu dokumentov, alebo nastaviť automatické avíza ktoré budú "
-"vykonávané periodicky a budú Vás informovať o výsledkoch hľadania "
-"elektronickou poštou."
+"%s Vám dáva možnosť personalizovať rozhranie, definovat Vašu vlastnú osobnú "
+"knižnicu dokumentov, alebo nastaviť automatické avíza ktoré budú vykonávané "
+"periodicky a budú Vás informovať o výsledkoch hľadania elektronickou poštou."
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10262,12 +10222,12 @@ msgstr "Zobraziť všetky hľadania ktoré ste vykonali počas uplynulých 30 dn
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
-"S košíkmi môžete definovať špecifické zbierky položiek, uschovať "
-"zaujímavé záznamy ku ktorým budete môcť pristúpiť neskôr alebo ktoré "
-"budete môcť zdiaľať s ostatnými užívateľmi."
+"S košíkmi môžete definovať špecifické zbierky položiek, uschovať zaujímavé "
+"záznamy ku ktorým budete môcť pristúpiť neskôr alebo ktoré budete môcť "
+"zdiaľať s ostatnými užívateľmi."
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10279,35 +10239,35 @@ msgid ""
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
 "Zapíšte sa na hľadanie ktoré bude periodicky vykonávané našou službou. "
-"Výsledky hľadania Vám môžu byť poslané elektronickou poštou alebo môžu "
-"byť uložené do Vašich košíkov."
+"Výsledky hľadania Vám môžu byť poslané elektronickou poštou alebo môžu byť "
+"uložené do Vašich košíkov."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
-"Skontrolujte knihu ktorú máte požičanú, pošlite výpožičné požiadavky, "
-"atď.  Táto služba vyžaduje CERN ID."
+"Skontrolujte knihu ktorú máte požičanú, pošlite výpožičné požiadavky, atď.  "
+"Táto služba vyžaduje CERN ID."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
-"Ste prihlásený ako anonymný hosť, takže Vaše avíza zmiznú na konci "
-"terajšej seanse."
+"Ste prihlásený ako anonymný hosť, takže Vaše avíza zmiznú na konci terajšej "
+"seanse."
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
-"Ste prihlásený ako %(x_user)s.  Môžete a) %(x_url1_open)ssa "
-"odhlásiť%(x_url1_close)s; b) editovať %(x_url2_open)sparametre Vášho "
-"konta%(x_url2_close)s."
+"Ste prihlásený ako %(x_user)s.  Môžete a) %(x_url1_open)ssa odhlásiť"
+"%(x_url1_close)s; b) editovať %(x_url2_open)sparametre Vášho konta"
+"%(x_url2_close)s."
 
 #: invenio/legacy/websession/templates.py:785
 #, fuzzy, python-format
@@ -10323,8 +10283,8 @@ msgstr "Vaše avíza"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 "Môžete si prezrieť zoznam %(x_url_open)sVašich grúp%(x_url_close)s ktoré "
 "spravujete alebo ktorých ste členom."
@@ -10338,8 +10298,8 @@ msgstr "Vaše grupy"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
 "Môžete si prezrieť zoznam %(x_url_open)sVašich pridaní%(x_url_close)s a "
 "dozvedieť sa a ich stave."
@@ -10352,11 +10312,11 @@ msgstr "Vaše pridania"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"Môžete si prezrieť zoznam %(x_url_open)sVašich schválení%(x_url_close)s a"
-" dokumenty ktoré ste schválili alebo zamietli."
+"Môžete si prezrieť zoznam %(x_url_open)sVašich schválení%(x_url_close)s a "
+"dokumenty ktoré ste schválili alebo zamietli."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10402,7 +10362,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -10451,8 +10412,8 @@ msgstr "Ak už máte konto, prihláste sa doleuvedeným formulárom."
 #: invenio/legacy/websession/templates.py:1015
 #, fuzzy, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 "Ak ešte konto nemáte, prosím %(x_url_open)szaregistrujte%(x_url_close)s "
 "interné konto."
@@ -10460,8 +10421,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
 "Ak ešte konto nemáte, prosím %(x_url_open)szaregistrujte%(x_url_close)s "
 "interné konto."
@@ -10497,12 +10458,13 @@ msgstr "Stratili ste heslo?"
 
 #: invenio/legacy/websession/templates.py:1094
 msgid "You can use your nickname or your email address to login."
-msgstr "Na prihlásenie môžete použiť Vašu prezývku alebo Vašu elektronickú adresu."
+msgstr ""
+"Na prihlásenie môžete použiť Vašu prezývku alebo Vašu elektronickú adresu."
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -10531,8 +10493,8 @@ msgstr "Prosíme zadajte Vašu elektronickú adresu a žiadanú prezývku a hesl
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr "Konto nebude možné použiť pred tým než bude overené a aktivované."
 
 #: invenio/legacy/websession/templates.py:1228
@@ -10549,33 +10511,33 @@ msgstr "zaregistrujte sa"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
-"Prosím nepoužívajte hodnotné heslá ako napríklad Vaše Unix, AFS alebo "
-"NICE heslo.  Vaša elektronická adresa zostane prísne dôverná a nebude "
-"poskytnutá žiadnej tretej stránke.  Bude použitá na Vašu identifikáciu "
-"pre personalizované služby %s.  Napríklad budete si môcť nastaviť "
-"automatické hľadacie avíza ktoré budú hľadať nové preprinty a ktoré Vás "
-"upovedomia o nových prírastkoch prostredníctvom elektronickej pošty."
+"Prosím nepoužívajte hodnotné heslá ako napríklad Vaše Unix, AFS alebo NICE "
+"heslo.  Vaša elektronická adresa zostane prísne dôverná a nebude poskytnutá "
+"žiadnej tretej stránke.  Bude použitá na Vašu identifikáciu pre "
+"personalizované služby %s.  Napríklad budete si môcť nastaviť automatické "
+"hľadacie avíza ktoré budú hľadať nové preprinty a ktoré Vás upovedomia o "
+"nových prírastkoch prostredníctvom elektronickej pošty."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr "Nie je možné vytvoriť si konto sám.  Obráťte sa na %s ak chcete konto."
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
-"Zdáte sa byť užívateľom-hosťom.  Musíte sa vopred "
-"%(x_url_open)sprihlásiť%(x_url_close)s."
+"Zdáte sa byť užívateľom-hosťom.  Musíte sa vopred %(x_url_open)sprihlásiť"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1267
 msgid "You are not authorized to access administrative functions."
@@ -10705,11 +10667,11 @@ msgstr "Tu sú nejaké zaujímavé administratívne linky pre Vás:"
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
-"Pre viac administratívnych aktivít, pozrite kompletný %(x_url_open)sAreál"
-" Adminstrátora%(x_url_close)s."
+"Pre viac administratívnych aktivít, pozrite kompletný %(x_url_open)sAreál "
+"Adminstrátora%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1378
 msgid "guest"
@@ -10931,10 +10893,11 @@ msgstr "Užívateľ sa chce pripojiť ku grupe %s."
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
-"Prosím %(x_url_open)sprijmite alebo zamietnite%(x_url_close)s žiadosť "
-"tohto užívateľa."
+"Prosím %(x_url_open)sprijmite alebo zamietnite%(x_url_close)s žiadosť tohto "
+"užívateľa."
 
 #: invenio/legacy/websession/templates.py:2400
 #, fuzzy, python-format
@@ -10975,76 +10938,71 @@ msgstr "Grupa %s bola zrušená jej administrátorom."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"Môžete si prezrieť zoznam %(x_url_open)s%(x_nb_total)i Vašich "
-"grúp%(x_url_close)s ktorých ste členom (%(x_nb_member)i) alebo ktoré "
-"spravujete (%(x_nb_admin)i)."
+"Môžete si prezrieť zoznam %(x_url_open)s%(x_nb_total)i Vašich grúp"
+"%(x_url_close)s ktorých ste členom (%(x_nb_member)i) alebo ktoré spravujete "
+"(%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
-"Ste prihlásený ako anonymný hosť.  Môžete sa "
-"%(x_url_open)sprihlásiť%(x_url_close)s ako riadny užívateľ."
+"Ste prihlásený ako anonymný hosť.  Môžete sa %(x_url_open)sprihlásiť"
+"%(x_url_close)s ako riadny užívateľ."
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 "%(x_fmt_open)sAnonymní hostia%(x_fmt_close)s sa musia najprv "
 "%(x_url_open)szaregistrovať%(x_url_close)s"
@@ -11055,14 +11013,14 @@ msgstr "Nenájdené žiadne hľadania"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -11071,8 +11029,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11084,8 +11042,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11161,8 +11119,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11226,8 +11183,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -11293,10 +11249,10 @@ msgstr "Editujte prihlasovaciu metódu"
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -11325,8 +11281,8 @@ msgstr "Prihlasovacia metóda úspešne zvolená."
 #: invenio/legacy/websession/webinterface.py:452
 #, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -11469,8 +11425,8 @@ msgid ""
 "The entered email address is incorrect, please check that it is written "
 "correctly (e.g. johndoe@example.com)."
 msgstr ""
-"Zadaná elektronická adresa je neplatná, prosím skontrolujte či je správne"
-" napísaná (napr. johndoe@example.com)."
+"Zadaná elektronická adresa je neplatná, prosím skontrolujte či je správne "
+"napísaná (napr. johndoe@example.com)."
 
 #: invenio/legacy/websession/webinterface.py:684
 msgid "Incorrect email address"
@@ -11511,15 +11467,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 "Druhá elektronická správa bude zaslaná keď bude konto aktivované and keď "
 "bude môcť byť používané."
@@ -11640,7 +11596,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr "Záznam vytvorený %(x_date_creation)s, zmenený %(x_date_modification)s"
 
 #: invenio/legacy/webstyle/templates.py:707
@@ -11663,37 +11620,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11701,15 +11658,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11776,8 +11733,8 @@ msgstr "Nemožno určiť počet strán pridania."
 #: invenio/legacy/websubmit/engine.py:931
 #, fuzzy
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr "Nemožno vytvoriť adresár pre pridanie."
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11814,8 +11771,8 @@ msgstr "Pridaj"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11862,11 +11819,11 @@ msgstr "Zvoľte kategóriu a potom kliknite na tlačidlo nejakej akcie."
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
-"Na pokračovanie predošle prerušeného pridania, vložte Vaše prístupové "
-"číslo do nižšieuvedeného boxu:"
+"Na pokračovanie predošle prerušeného pridania, vložte Vaše prístupové číslo "
+"do nižšieuvedeného boxu:"
 
 #: invenio/legacy/websubmit/templates.py:366
 msgid "GO"
@@ -11894,11 +11851,11 @@ msgstr "Naspät do hlavného menu"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
-"Toto je Vaše prístupové číslo pridania.  Môže byť použité na pokračovanie"
-" prerušeného procesu pridania v prípade problémov."
+"Toto je Vaše prístupové číslo pridania.  Môže byť použité na pokračovanie "
+"prerušeného procesu pridania v prípade problémov."
 
 #: invenio/legacy/websubmit/templates.py:548
 msgid "Mandatory fields appear in red in the SUMMARY window."
@@ -11946,8 +11903,8 @@ msgstr "Číslo pridania"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 "Tu je %(x_action)s zoznam funkcií pre %(x_doctype)s dokumenty na úrovni "
 "%(x_step)s"
@@ -12031,8 +11988,7 @@ msgstr "Zoznam referovaných typov dokumentov"
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
 "Zvoľte jeden z nasledujúcich typov dokumentov pre skontrolovanie stavu "
 "dokumentu."
@@ -12171,7 +12127,8 @@ msgstr "Poznámka schválenia:"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr "Tento dokument stále %(x_fmt_open)sčaká na schválenie%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -12194,8 +12151,7 @@ msgid ""
 "You can send an approval request email again by clicking the following "
 "button:"
 msgstr ""
-"Môžte opäť zaslať požiadavku na schválenie kliknutím na nasledujúce "
-"tlačidlo:"
+"Môžte opäť zaslať požiadavku na schválenie kliknutím na nasledujúce tlačidlo:"
 
 #: invenio/legacy/websubmit/templates.py:2149
 #: invenio/legacy/websubmit/web/publiline.py:367
@@ -12204,7 +12160,8 @@ msgstr "Pošlite opäť"
 
 #: invenio/legacy/websubmit/templates.py:2150
 msgid "WARNING! Upon confirmation, an email will be sent to the referee."
-msgstr "UPOZORNENIE! Ak potvrdíte, elektronická pošta bude zaslaná referentovi."
+msgstr ""
+"UPOZORNENIE! Ak potvrdíte, elektronická pošta bude zaslaná referentovi."
 
 #: invenio/legacy/websubmit/templates.py:2153
 #, fuzzy
@@ -12212,8 +12169,8 @@ msgid ""
 "As a referee for this document, you may approve or reject it from the "
 "submission interface"
 msgstr ""
-"Ako referent pre tento dokument môžete kliknúť na toto tlačidlo aby ste "
-"ho schválili alebo zamietli."
+"Ako referent pre tento dokument môžete kliknúť na toto tlačidlo aby ste ho "
+"schválili alebo zamietli."
 
 #: invenio/legacy/websubmit/templates.py:2155
 msgid "Approve/Reject"
@@ -12268,8 +12225,8 @@ msgstr "Vyber referenta"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -12288,8 +12245,8 @@ msgstr "Napíšte odporúčanie"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -12330,7 +12287,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12351,14 +12309,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -12473,10 +12430,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12767,8 +12723,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12811,11 +12767,6 @@ msgstr "pripojený"
 #, fuzzy
 msgid "Role details"
 msgstr "Detaily článku"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Príručka"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12931,8 +12882,8 @@ msgstr "Dodaná elektronická adresa %s už v databáze existuje."
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -12997,9 +12948,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -13023,8 +12973,8 @@ msgstr "Nastav nové heslo"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr "Prosíme zadajte Vašu elektronickú adresu a žiadanú prezývku a heslo:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -13053,7 +13003,7 @@ msgid "Problem with login."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "Teraz môžete pristúpiť k Vášmu %(x_url_open)skontu%(x_url_close)s."
 
@@ -13097,8 +13047,7 @@ msgstr "Editovanie parametrov zlyhalo"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13170,13 +13119,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13185,9 +13133,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13364,8 +13312,7 @@ msgstr "kolekcie"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13455,8 +13402,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13548,13 +13495,13 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
-"Vaša správa je príliš dlhá, prosím upravte ju. Maximálna pripustená dĺžka"
-" je %i znakov."
+"Vaša správa je príliš dlhá, prosím upravte ju. Maximálna pripustená dĺžka je "
+"%i znakov."
 
 #: invenio/modules/comments/forms.py:55
 #, fuzzy
@@ -13597,12 +13544,12 @@ msgid "Review was sent"
 msgstr "Napíšte komentár"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Tento komentár bol hlásený %i krát"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Tento komentár bol hlásený %i krát"
 
@@ -13655,9 +13602,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13676,8 +13622,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13687,7 +13633,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "Žiadaná prezývka %s už v databáze existuje."
 
@@ -13743,8 +13689,7 @@ msgstr "ohodnotenie"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13784,8 +13729,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13832,7 +13776,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "Funkcia %s neexistuje."
 
@@ -13915,11 +13859,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "súčasný stav:"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Vaše košíky"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -13954,8 +13893,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13976,8 +13915,8 @@ msgstr "Index slov nie je dostupný pre"
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13993,8 +13932,7 @@ msgstr ""
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14114,7 +14052,7 @@ msgstr ""
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 msgid "Edit This Record"
 msgstr "Edituj tento záznam"
 
@@ -14212,10 +14150,6 @@ msgstr "1 hodnotenie"
 msgid "Authors"
 msgstr "autor"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14308,8 +14242,8 @@ msgstr "Spravujte práva pre grupy"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "Ľutujeme, ale nemáte dostatočné práva pre túto skupinu."
 
 #: invenio/modules/groups/views.py:279
@@ -14322,12 +14256,12 @@ msgstr "Nie ste administrátorom žiadnej grupy."
 msgid "Members"
 msgstr "Žiadni členovia."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Zruš košík"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14337,11 +14271,11 @@ msgstr "na"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "všetky polia"
@@ -14387,13 +14321,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "Existuje %i košíkov"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "Existuje %i košíkov"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14549,28 +14484,28 @@ msgstr "Neznámy typ dokumentu"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14634,8 +14569,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -15006,7 +14941,7 @@ msgid "Tag name"
 msgstr "Prezývka"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "Žiadaná prezývka %s je už použitá."
 
@@ -15112,11 +15047,6 @@ msgstr ""
 msgid "Saving..."
 msgstr "Nahraj"
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "na"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15158,8 +15088,7 @@ msgstr "Voľby hľadania:"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15368,7 +15297,7 @@ msgid "just now"
 msgstr "Teraz musíte"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s sekúnd"
 
@@ -15427,6 +15356,39 @@ msgstr "hocaký rok"
 msgid " years ago"
 msgstr "rok"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "WebComment administrácia"
+
+#~ msgid "Not authorized"
+#~ msgstr "Neautorizované"
+
+#~ msgid "Really delete"
+#~ msgstr "Skutočne zmaž"
+
+#~ msgid "Verify syntax"
+#~ msgstr "Over syntax"
+
+#~ msgid "Verify problem"
+#~ msgstr "Over problém"
+
+#~ msgid "File"
+#~ msgstr "Súbor"
+
+#~ msgid "niceName"
+#~ msgstr "Meno"
+
+#~ msgid "Id"
+#~ msgstr "ID"
+
+#~ msgid "Tickets"
+#~ msgstr "Čas"
+
+#~ msgid "by"
+#~ msgstr "od"
+
+#~ msgid "Done"
+#~ msgstr "na"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Upozornenie: prosím zvoľte platný čas"
 
@@ -15444,9 +15406,6 @@ msgstr "rok"
 
 #~ msgid "*** basket name ***"
 #~ msgstr "Meno košíka"
-
-#~ msgid ""
-#~ msgstr ""
 
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "Editujte prihlasovaciu metódu"
@@ -15514,26 +15473,8 @@ msgstr "rok"
 #~ msgid "now"
 #~ msgstr "teraz"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "WebComment administrácia"
-
-#~ msgid "Not authorized"
-#~ msgstr "Neautorizované"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "Užívateľ %s neexistuje."
-
-#~ msgid "Really delete"
-#~ msgstr "Skutočne zmaž"
-
-#~ msgid "Verify syntax"
-#~ msgstr "Over syntax"
-
-#~ msgid "Verify problem"
-#~ msgstr "Over problém"
-
-#~ msgid "File"
-#~ msgstr "Súbor"
 
 #~ msgid "File %s already exists."
 #~ msgstr "Užívateľ %s neexistuje."
@@ -15586,9 +15527,6 @@ msgstr "rok"
 #~ msgid "Not Mine!"
 #~ msgstr "Poznámka"
 
-#~ msgid "Tickets"
-#~ msgstr "Čas"
-
 #~ msgid "Request Tickets"
 #~ msgstr "hosť"
 
@@ -15624,9 +15562,6 @@ msgstr "rok"
 
 #~ msgid "Create a new Person for your search"
 #~ msgstr "Žiadne hodnoty nenájdené."
-
-#~ msgid "Id"
-#~ msgstr "ID"
 
 #~ msgid "0 borrower(s) found."
 #~ msgstr "%s záznamov nájdených"
@@ -15691,9 +15626,6 @@ msgstr "rok"
 #~ msgid "creating a new basket"
 #~ msgstr "Vytvoriť nový košík"
 
-#~ msgid "by"
-#~ msgstr "od"
-
 #~ msgid "on"
 #~ msgstr "na"
 
@@ -15711,9 +15643,6 @@ msgstr "rok"
 
 #~ msgid "Editing topic"
 #~ msgstr "Edituj košík"
-
-#~ msgid "niceName"
-#~ msgstr "Meno"
 
 #~ msgid "Apply Changes"
 #~ msgstr "Uložte zmeny"
@@ -15822,9 +15751,6 @@ msgstr "rok"
 
 #~ msgid "Verbose"
 #~ msgstr "Mnohoslovný"
-
-#~ msgid "Done"
-#~ msgstr "na"
 
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "Vaše zmeny sú DOČASNÉ."
@@ -16033,9 +15959,6 @@ msgstr "rok"
 #~ msgid "Citation Metrics"
 #~ msgstr "Citačná metrika"
 
-#~ msgid "WebSearch Admin Guide"
-#~ msgstr ""
-
 #~ msgid "Submit Guide"
 #~ msgstr "Príručka pridávania"
 
@@ -16045,34 +15968,11 @@ msgstr "rok"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "Príručka Administrácie Pridávania"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "Vykonaj hľadanie"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Zrušené"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "Ste členom nasledujúcich grúp:"
@@ -16086,12 +15986,6 @@ msgstr "rok"
 #~ msgid "Invert Selection"
 #~ msgstr "Referencia nebola ešte daná"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Autor:"
 
@@ -16103,12 +15997,6 @@ msgstr "rok"
 
 #~ msgid "No status information found."
 #~ msgstr "Viac informácií:"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "oddelenie"
@@ -16122,18 +16010,6 @@ msgstr "rok"
 #~ msgid "View name variants"
 #~ msgstr "zobraz komentáre"
 
-#~ msgid "The author has an internal ID!"
-#~ msgstr ""
-
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "komentáre"
 
@@ -16143,87 +16019,20 @@ msgstr "rok"
 #~ msgid " Delete this ticket"
 #~ msgstr "Zruš košík"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "Žiadne typy dokumentov nie sú prístupné."
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Vyber skóre"
 
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
 #~ msgid "Paper title: "
 #~ msgstr "Strana:"
-
-#~ msgid "Ignore"
-#~ msgstr ""
 
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "Avízo %s bolo úspešne aktualizované."
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "Vyber skóre"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "Viac informácií:"
@@ -16231,35 +16040,11 @@ msgstr "rok"
 #~ msgid "Please provide your first name"
 #~ msgstr "Prosím najskôr sa prihláste."
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "Vaše pôžičky"
 
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
 #~ msgid "Your eMail:"
 #~ msgstr "Vaše avíza"
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "Zruš vybrané hodnotenia"
@@ -16267,186 +16052,35 @@ msgstr "rok"
 #~ msgid "Mark as your documents"
 #~ msgstr "všetky typy dokumentov"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "Ohodnoťte tento dokument"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Ohodnoťte tento dokument"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "alebo vytvorte novú"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "Pridaj k užívateľom"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Strana:"
-
-#~ msgid "Showing the"
-#~ msgstr ""
 
 #~ msgid "most recent documents:"
 #~ msgstr "Zoznam referovaných dokumentov"
 
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Spravujte práva pre grupy"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Zvoľte súbor"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Dátum vytnorenia"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "Externé linky"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "pridania"
@@ -16454,199 +16088,17 @@ msgstr "rok"
 #~ msgid "Choose system"
 #~ msgstr "Zvoľte tému"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Avízo %s bolo úspešne aktualizované."
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "Nie ste oprávnení k prístupu k administratívnym funkciám."
 
 #~ msgid "Claim this paper"
 #~ msgstr "Pridaj k užívateľom"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Citované: %s záznamami"
 
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
 #~ msgid "Revision"
 #~ msgstr "Revízia"
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Could not find format element named %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
-
-#~ msgid "Could not find output format named %s."
-#~ msgstr ""
-
-#~ msgid "Modify Template Attributes"
-#~ msgstr ""
-
-#~ msgid "Template Editor"
-#~ msgstr ""
-
-#~ msgid "Check Dependencies"
-#~ msgstr ""
-
-#~ msgid "Update Format Attributes"
-#~ msgstr ""
 
 #~ msgid "Show Documentation"
 #~ msgstr "Ukáž dokumentáciu"
@@ -16660,21 +16112,6 @@ msgstr "rok"
 #~ msgid "Manage Output Formats"
 #~ msgstr "Spravuj výstupné formáty"
 
-#~ msgid "Manage Format Templates"
-#~ msgstr ""
-
-#~ msgid "Format Elements Documentation"
-#~ msgstr ""
-
-#~ msgid "Add New Format Template"
-#~ msgstr ""
-
-#~ msgid "Check Format Templates Extensively"
-#~ msgstr ""
-
-#~ msgid "Code"
-#~ msgstr ""
-
 #~ msgid "Add New Output Format"
 #~ msgstr "Pridaj nový Výstupný formát"
 
@@ -16687,119 +16124,20 @@ msgstr "rok"
 #~ msgid "Rules"
 #~ msgstr "Pravidlá"
 
-#~ msgid "Modify Output Format Attributes"
-#~ msgstr ""
-
 #~ msgid "Remove Rule"
 #~ msgstr "Odstráň pravidlo"
-
-#~ msgid "Add New Rule"
-#~ msgstr ""
-
-#~ msgid "No problem found with format"
-#~ msgstr ""
 
 #~ msgid "An error has been found"
 #~ msgstr "Chyba bola nájdená"
 
-#~ msgid "The following errors have been found"
-#~ msgstr ""
-
 #~ msgid "BibFormat Admin"
 #~ msgstr "Administrácia Formátov"
-
-#~ msgid "Enter a search query here."
-#~ msgstr ""
 
 #~ msgid "No Record Found for %s."
 #~ msgstr "Záznam nenájdený"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Užívateľ %s neexistuje."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
-
-#~ msgid "Output format %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
-#~ msgid "Format template %s calls undefined element \"%s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
-
-#~ msgid "Error in format element %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Show all %i authors"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Chránený výstupný formát"
@@ -16807,161 +16145,20 @@ msgstr "rok"
 #~ msgid "Output Format %s Rules"
 #~ msgstr "Výstupný formát %s pravidlá"
 
-#~ msgid "Output Format %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Dependencies"
-#~ msgstr ""
-
 #~ msgid "Delete Output Format"
 #~ msgstr "Zmaž výstupný formát"
 
 #~ msgid "Cannot create output format"
 #~ msgstr "Nemožno vytvoriť výstupný formát"
 
-#~ msgid "Format template %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Dependencies"
-#~ msgstr ""
-
 #~ msgid "Delete Format Template"
 #~ msgstr "Zmaž šablónu formátu"
-
-#~ msgid "Format Element %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Test Format Element %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Output Format %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Element"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Element %s"
-#~ msgstr ""
-
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
-#~ msgid "Format Validation"
-#~ msgstr ""
-
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "Nenastavené"
 
 #~ msgid "never"
 #~ msgstr "nikdy"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "krát"
@@ -16990,17 +16187,11 @@ msgstr "rok"
 #~ msgid "Affiliations"
 #~ msgstr "Afiliácie"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
 #~ msgid "No Frequent Co-authors"
 #~ msgstr "Žiadni častí spoluautori"
 
 #~ msgid "Citations%s"
 #~ msgstr "Citácie"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Dátum vytnorenia"
@@ -17010,42 +16201,6 @@ msgstr "rok"
 
 #~ msgid "No publications available"
 #~ msgstr "Žiadne typy dokumentov nie sú prístupné."
-
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
 
 #~ msgid "Cited by 1 record"
 #~ msgstr "Citované 1 záznamom"
@@ -17059,17 +16214,11 @@ msgstr "rok"
 #~ msgid "%s of"
 #~ msgstr "%s z"
 
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "Žiadne články"
 
 #~ msgid "Frequent co-authors"
 #~ msgstr "Častí spoluautori"
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "Citácie:"
@@ -17077,35 +16226,8 @@ msgstr "rok"
 #~ msgid "No Citation Information available"
 #~ msgstr "Žiadne typy dokumentov nie sú prístupné."
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Diskusia"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Vaše avíza"
@@ -17125,127 +16247,15 @@ msgstr "rok"
 #~ msgid "Statistics"
 #~ msgstr "Stav"
 
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
 #~ msgid "Group: %s"
 #~ msgstr "Grupa: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown to the external login "
-#~ "system."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The external login method %s does "
-#~ "not support email address based logins."
-#~ "  Please contact the site administrators."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "Stránka %s nebola nájdená"
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "Pole %s je povinné."
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "Nemožno určiť počet strán pridania."
-

--- a/invenio/base/translations/sv/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/sv/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2008-06-06 15:55+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:58+0200\n"
 "Last-Translator: Marko Niinimaki <man@cern.ch>\n"
 "Language-Team: SV <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -58,8 +58,8 @@ msgstr "Administratörsarea"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -205,7 +205,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 #, fuzzy
 msgid "Hello:"
 msgstr "Hej"
@@ -227,17 +227,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -263,48 +263,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Den här journalen existerar inte."
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Du är inte ägaren av den här korgen."
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "Registreringen misslyckades"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "Var god välj en eller flera:"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "Role authorization begära"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -510,7 +515,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -587,9 +593,9 @@ msgid ""
 "%(x_url1_open)supload history%(x_url1_close)s or %(x_url2_open)ssubmit "
 "another file%(x_url2_close)s"
 msgstr ""
-"Du är inloggad som %(x_user)s. Vill du kanske a) %(x_url1_open)slogga "
-"ut%(x_url1_close)s; b) redigera dina  "
-"%(x_url2_open)skontoinställningar%(x_url2_close)s."
+"Du är inloggad som %(x_user)s. Vill du kanske a) %(x_url1_open)slogga ut"
+"%(x_url1_close)s; b) redigera dina  %(x_url2_open)skontoinställningar"
+"%(x_url2_close)s."
 
 #: invenio/legacy/batchuploader/templates.py:282
 #, fuzzy
@@ -733,7 +739,8 @@ msgid "The following errors have occurred:"
 msgstr "De följande problemen hittades"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -750,8 +757,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -833,7 +840,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -876,8 +883,8 @@ msgstr "Dina korgar"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "Föregående"
@@ -893,8 +900,8 @@ msgstr "Poäng"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "Nästa"
 
@@ -909,18 +916,6 @@ msgstr "Nästa"
 #: invenio/legacy/weblinkback/adminlib.py:55
 msgid "Admin Area"
 msgstr "Administratörsarea"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "författare"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
@@ -940,11 +935,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
 msgid "Limit to knowledge bases containing string:"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "raderad"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -996,16 +986,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
 msgid "Verify BibCheck config file"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "Databasproblem"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "fil(er)"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
@@ -1112,7 +1092,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1163,8 +1144,8 @@ msgstr "Ditt användarkonto har skapats"
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1178,25 +1159,23 @@ msgstr "Bläddra"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "Ditt användarkonto har skapats"
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "Ditt användarkonto har skapats"
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1221,13 +1200,14 @@ msgstr "Skapa nytt ämne"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "Ditt användarkonto har skapats"
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1259,9 +1239,8 @@ msgstr "Nuvarande status:"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "Ditt användarkonto har skapats"
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1328,8 +1307,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1337,8 +1316,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1360,9 +1339,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "Ditt användarkonto har skapats"
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1404,8 +1382,8 @@ msgstr "Sök i %s journaler efter:"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1464,11 +1442,11 @@ msgstr "Ditt användarkonto har skapats"
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1479,11 +1457,11 @@ msgstr "Ja"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1496,8 +1474,8 @@ msgstr "Nej"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1594,8 +1572,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1615,29 +1593,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1646,9 +1624,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 #, fuzzy
 msgid "Requested record does not seem to exist."
 msgstr "Tyvärr verkar inte dokumentet %s existera."
@@ -2010,16 +1988,14 @@ msgstr "Journalen har raderats."
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2040,8 +2016,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2203,8 +2179,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2313,7 +2289,7 @@ msgstr "Aktion"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "Beskrivning"
 
@@ -2508,8 +2484,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2795,9 +2771,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "Om du vill kan du %(x_url_open)slogga in här%(x_url_close)s."
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2853,7 +2828,7 @@ msgstr "Avslagna"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "OK"
 
@@ -2861,8 +2836,8 @@ msgstr "OK"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "Ditt användarkonto har skapats"
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3336,8 +3311,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "Epost"
 
@@ -4190,8 +4165,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4209,8 +4184,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4276,17 +4251,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4674,25 +4649,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "Journalen har raderats."
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4753,15 +4728,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4773,10 +4748,10 @@ msgstr "Välj ämnesområde"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4790,15 +4765,15 @@ msgstr "Regler"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4809,7 +4784,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4828,17 +4804,15 @@ msgstr "Smeknamnet %s är upptaget"
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "Smeknamnet %s är upptaget"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4857,14 +4831,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4918,8 +4891,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4974,8 +4947,8 @@ msgstr "Tyvärr verkar inte dokumentet %s existera."
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -5096,9 +5069,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -5113,8 +5086,8 @@ msgstr "Spara ändringar"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -5258,11 +5231,10 @@ msgstr "Tillbaka till sökresultat"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5399,7 +5371,7 @@ msgid "Total"
 msgstr "Valfritt"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "Välj"
 
@@ -5570,8 +5542,8 @@ msgstr "Ta bort kunskapsbas"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5630,56 +5602,56 @@ msgstr "Var god logga in först."
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5719,7 +5691,7 @@ msgstr "Kunskapsbasberoenden"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5773,15 +5745,15 @@ msgstr "Dina alarm"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5880,7 +5852,8 @@ msgstr "Tack för att Ni hjälper till att förbättra Invenio!"
 
 #: invenio/legacy/errorlib/webinterface.py:155
 msgid "Use the back button of your browser to return to the previous page."
-msgstr "Använd din webbläsares bakåtpil för att återvända till föregående sida."
+msgstr ""
+"Använd din webbläsares bakåtpil för att återvända till föregående sida."
 
 #: invenio/legacy/errorlib/webinterface.py:158
 msgid "Thank you!"
@@ -6010,8 +5983,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -6090,8 +6062,8 @@ msgstr "Referens finns ännu inte"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6106,8 +6078,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Sökresultat"
 
@@ -6268,8 +6240,8 @@ msgstr "Inga värden funna."
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6295,8 +6267,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6307,8 +6279,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -6318,29 +6289,29 @@ msgstr "Ingen exakt träff för %(x_query1)s, använder %(x_query2)s istället..
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
-"Ingen träff i samlingen %(x_collection)s. Andra publika samlingar "
-"gav%(x_url_open)s%(x_nb_hits)d träffar%(x_url_close)s."
+"Ingen träff i samlingen %(x_collection)s. Andra publika samlingar gav"
+"%(x_url_open)s%(x_nb_hits)d träffar%(x_url_close)s."
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
 "Inga publika samlingar motsvarar din sökning. Välj de åtkomstbegränsade "
 "samlingarna först."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
@@ -6348,93 +6319,93 @@ msgstr ""
 "Inga publika samlingar motsvarar din sökning. Välj de åtkomstbegränsade "
 "samlingarna först."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr ""
-"Söktermen %s matchade inga journaler. Närmsta sökterm, oavsett samling, "
-"är:"
+"Söktermen %s matchade inga journaler. Närmsta sökterm, oavsett samling, är:"
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "Använd andra söktermer."
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "Det finns %i korgar"
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "Det finns %i korgar"
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "Det finns %i korgar"
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Inget ordindex tillgängligt för"
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Inget frasindex tillgängligt för"
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr ""
-"Söktermen %(x_term)s i index %(x_index)s matchade inga journaler. Närmsta"
-" söktermer, oavsett samling, är:"
+"Söktermen %(x_term)s i index %(x_index)s matchade inga journaler. Närmsta "
+"söktermer, oavsett samling, är:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr ""
-"Söktermen %s matchade inga journaler. Närmsta sökterm, oavsett samling, "
-"är:"
+"Söktermen %s matchade inga journaler. Närmsta sökterm, oavsett samling, är:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
-msgstr "%s är inte en tillänglig rangordning. Använder titelsortering istället."
+msgstr ""
+"%s är inte en tillänglig rangordning. Använder titelsortering istället."
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr "Sortering är endast tillåten för mängder med upp till %d journaler."
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
-msgstr "%s är inte en tillänglig rangordning. Använder titelsortering istället."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
+msgstr ""
+"%s är inte en tillänglig rangordning. Använder titelsortering istället."
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Den här journalen existerar inte."
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "Använd andra söktermer."
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6448,13 +6419,15 @@ msgstr "Använd andra söktermer."
 msgid "Browse"
 msgstr "Bläddra"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
-msgstr "Ingen träff funnen inom den angivna tidsramen, använder ej dessa kriterier"
+msgstr ""
+"Ingen träff funnen inom den angivna tidsramen, använder ej dessa kriterier"
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
-msgstr "Inga träffer funna inom de angivna sökkriterierna, använder ej dessa..."
+msgstr ""
+"Inga träffer funna inom de angivna sökkriterierna, använder ej dessa..."
 
 #: invenio/legacy/webalert/api.py:54
 #, fuzzy, python-format
@@ -6474,8 +6447,7 @@ msgstr "Du har inte tillräckliga rättigheter för att visa korgens innehåll."
 #: invenio/legacy/webalert/api.py:198
 msgid "You already have an alert defined for the specified query and basket."
 msgstr ""
-"Du har redan ett alarm definierat för den specifierade sökfrågan och "
-"korgen"
+"Du har redan ett alarm definierat för den specifierade sökfrågan och korgen"
 
 #: invenio/legacy/webalert/api.py:221 invenio/legacy/webalert/api.py:345
 msgid "The alert name cannot be empty."
@@ -6498,14 +6470,13 @@ msgstr "Alarmet %s har uppdaterats korrekt."
 #: invenio/legacy/webalert/api.py:428
 #, fuzzy, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
-"Du har ställt %(x_nb)s sökfrågor. En %(x_url_open)sdetaljerad "
-"lista%(x_url_close)s finns tillänglig med möjligheten att (a) visa "
-"sökresultat (b) prenumerera på epost-uppdateringar för utvalda sökfrågor."
+"Du har ställt %(x_nb)s sökfrågor. En %(x_url_open)sdetaljerad lista"
+"%(x_url_close)s finns tillänglig med möjligheten att (a) visa sökresultat "
+"(b) prenumerera på epost-uppdateringar för utvalda sökfrågor."
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6579,8 +6550,8 @@ msgid ""
 "This alert will notify you each time/only if a new item satisfies the "
 "following query:"
 msgstr ""
-"Detta alarm kommer endast meddela dig om en ny artikel motsvaras av "
-"följande sökfråga:"
+"Detta alarm kommer endast meddela dig om en ny artikel motsvaras av följande "
+"sökfråga:"
 
 #: invenio/legacy/webalert/templates.py:173
 msgid "QUERY"
@@ -6646,9 +6617,8 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"Sätt ett nytt alarm utifrån %(x_url1_open)sdina "
-"sökningar%(x_url1_close)s, %(x_url2_open)spopulära "
-"sökningar%(x_url2_close)s eller dataformuläret."
+"Sätt ett nytt alarm utifrån %(x_url1_open)sdina sökningar%(x_url1_close)s, "
+"%(x_url2_open)spopulära sökningar%(x_url2_close)s eller dataformuläret."
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6699,8 +6669,8 @@ msgstr "Du har definierat %s alarm."
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 "Du har inte genomfört någon sökning ännu. Var god gå till "
 "%(x_url_open)ssökgränssnittet%(x_url_close)s först."
@@ -6708,11 +6678,11 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
-"Du har genomfört %(x_nb1)s sökningar (%(x_nb2)s olika sökfrågor) under de"
-" senaste ungefär 30 dagarna."
+"Du har genomfört %(x_nb1)s sökningar (%(x_nb2)s olika sökfrågor) under de "
+"senaste ungefär 30 dagarna."
 
 #: invenio/legacy/webalert/templates.py:453
 #, fuzzy, python-format
@@ -6771,7 +6741,7 @@ msgstr "Dina sökningar"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6835,7 +6805,7 @@ msgstr "Sätt ett nytt alarm"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6895,7 +6865,8 @@ msgstr "Visa alarm"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6919,7 +6890,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "Du har inte tillräckliga rättigheter för att visa korgens innehåll."
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6947,7 +6919,8 @@ msgid "You do not have permission to delete this note."
 msgstr "Du har inte tillräckliga rättigheter för att visa korgens innehåll."
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6978,8 +6951,8 @@ msgstr "Den här journalen existerar inte."
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -7001,8 +6974,8 @@ msgstr "Kopiera journal till en korg"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -7035,8 +7008,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7109,8 +7082,7 @@ msgstr "Publik korg"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 "Du har %(x_nb_perso)s personliga korgar. Du prenumerar på %(x_nb_group)s "
 "gruppkorgar och %(x_nb_public)s andra användares korgar."
@@ -7140,8 +7112,7 @@ msgstr "%i användargrupper prenumererar på den här korgen"
 #: invenio/legacy/webbasket/templates.py:108
 #, fuzzy, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr "Du kan nu logga in till ditt %(x_url_open)skonto%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -7312,8 +7283,8 @@ msgstr "Extern journal"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7498,17 +7469,18 @@ msgstr "Dela ut korgen till en ny grupp"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
-"Du är inloggad som gästanvändare, de korgar du definierar kommer att "
-"raderas vid sessionens slut."
+"Du är inloggad som gästanvändare, de korgar du definierar kommer att raderas "
+"vid sessionens slut."
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr "Du kan %(x_url_open)slogga in eller registrera dig här%(x_url_close)s."
 
 #: invenio/legacy/webbasket/templates.py:2131
@@ -7518,7 +7490,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "Denna funktionalitet är förbjuden för gästanvändare"
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "Tillbaka till sökresultat"
 
@@ -7693,7 +7665,7 @@ msgstr "Addera till användare"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7840,219 +7812,218 @@ msgstr "Användare %s existerar inte."
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "Användare %s existerar inte."
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "Skriv en kommentar"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_name)s skrev den %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "Visar de %i senaste kommentarerna:"
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "Diskutera det här dokumentet"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "Starta en diskussion kring det här dokumentet."
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Tyvärr verkar inte dokumentet %s existera."
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "%s är inte ett fungerande ID."
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "Inget ID angavs"
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "Du vill antagligen börja browsa på %s"
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_name)s skrev den %(x_date)s:"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "Var den här recensionen hjälpfull?"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "Skriv en recension"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
-"Genomsnittlig recensionspoäng: %(x_nb_score)s baserad på %(x_nb_reviews)s"
-" recensioner"
+"Genomsnittlig recensionspoäng: %(x_nb_score)s baserad på %(x_nb_reviews)s "
+"recensioner"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "Läsare fann de följande %s recensionerna hjälpfulla"
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "Visa alla %s recensioner"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "Betygsätt det här dokumentet"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "Bli först att skriva recensionen till det här dokumentet"
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "Poäng"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "Rapportera missbruk"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 #, fuzzy
 msgid "Undelete comment"
 msgstr "radera kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "Radera kommentar"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 #, fuzzy
 msgid "Unreport comment"
 msgstr "Radera kommentar"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Recenserad av %(x_nickname)s den %(x_date)s"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
-"%(x_nb_people)i av totalt %(x_nb_total)i fann den här recensionen "
-"hjälpfull"
+"%(x_nb_people)i av totalt %(x_nb_total)i fann den här recensionen hjälpfull"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 #, fuzzy
 msgid "Undelete review"
 msgstr "Radera valda recensioner"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 #, fuzzy
 msgid "Delete review"
 msgstr "Radera valda recensioner"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 #, fuzzy
 msgid "Unreport review"
 msgstr "Skriv en recension"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "Kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "Recensioner"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "Det finns totalt %s recensioner"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "Det finns totalt %s kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "Bli först att skriva recensionen till det här dokumentet"
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "Prenumerera"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 #, fuzzy
 msgid "Unsubscribe"
 msgstr "Prenumerera"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -8061,96 +8032,94 @@ msgstr "Prenumerera"
 msgid "Record"
 msgstr "Spela in"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "recension"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "Kommentar"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "Recension"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "Visning"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "Sida:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 #, fuzzy
 msgid "You are not authorized to comment or review."
 msgstr "Du är inte ägaren av den här korgen."
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 "OBS att ditt smeknamn, %s, kommer att visas som författaren till det här "
 "dokumentet"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
-"OBS att du inte har %(x_url_open)sdefinierat ditt "
-"smeknamn%(x_url_close)s. %(x_nickname)s kommer att visas som författare "
-"till det här dokumentet."
+"OBS att du inte har %(x_url_open)sdefinierat ditt smeknamn%(x_url_close)s. "
+"%(x_nickname)s kommer att visas som författare till det här dokumentet."
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 #, fuzzy
 msgid "Max one file"
 msgstr "Lägg till regel"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "fil(er)"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "Artikel"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 #, fuzzy
 msgid "Add comment"
 msgstr "Lägg till kommentar"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
@@ -8159,428 +8128,431 @@ msgstr ""
 "OBS att ditt smeknamn, %s, kommer att visas som författare av den här "
 "recensionen."
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "Betygsätt den här artikeln"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "Välj en poäng"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "Ange en titel till din recension"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "Skriv en recension"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 #, fuzzy
 msgid "Add review"
 msgstr "Lägg till recension"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "Lägg till recension"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "Din recension lades till."
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "Din kommentar lades till."
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "Tillbaka till journal"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr "Du kan konsultera listan av %(x_url_open)sdina grupper%(x_url_close)s."
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 #, fuzzy
 msgid "View most commented records"
 msgstr "visa kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 #, fuzzy
 msgid "View latest commented records"
 msgstr "visa kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all comments reported as abuse"
 msgstr "Visa alla rapporterade användare"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 #, fuzzy
 msgid "View most reviewed records"
 msgstr "radera journaler"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 #, fuzzy
 msgid "View latest reviewed records"
 msgstr "Visa alla %s recensioner"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all reviews reported as abuse"
 msgstr "Visa alla rapporterade användare"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "Den här journalen har rapporterats"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Guide"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "Möjligheten att kommentera och recensera är avstängd"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
-"Var god ange ID:et för kommentaren/recensionen för att granska den innan "
-"du avgör om den skall tas bort eller ej"
+"Var god ange ID:et för kommentaren/recensionen för att granska den innan du "
+"avgör om den skall tas bort eller ej"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "Kommentarsid:"
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 #, fuzzy
 msgid "Record ID:"
 msgstr "journal"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "Visa kommentar"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "Inga rapporter hittills."
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Visa alla %s rapporterade kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Visa alla % rapporterade recensioner"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
-"Listning, sorterad på mängd rapporter, av alla användare som har ådragit "
-"sig en kommentarsrapport åtminstone en gång."
+"Listning, sorterad på mängd rapporter, av alla användare som har ådragit sig "
+"en kommentarsrapport åtminstone en gång."
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "Smeknamn"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "Användarid"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "Antal positiva betyg"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "Antal negativa betyg"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "Totalt antal betyg"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "Totalt antal rapporter"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "Visa alla användares rapporterade kommentarer/recensioner"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Den här recensioner har rapporterats %i gånger"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Den här kommentaren har rapporterats %i gånger"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "Författad av"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "Allmän information"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "Radera valda recensioner"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "Radera valda missbruksrapporter"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 #, fuzzy
 msgid "Undelete selected reviews"
 msgstr "Radera valda recensioner"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 #, fuzzy
 msgid "Undelete selected comments"
 msgstr "Radera valda kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "Radera valda kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "Här visas användare %s rapporterade recensioner"
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "Här visas användare %s rapporterade kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "Kommentar/recension %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "Kommentar/recension %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, fuzzy, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "Kommentar/recension %(x_cmtID)s författad av användare %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, fuzzy, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "Kommentar/recension %(x_cmtID)s författad av användare %(x_user)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "Samtliga rapporterade recensioner sorterad efter flest rapporter"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "Samtliga rapporterade kommentarer sorterad efter flest rapporter"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr "Samtliga rapporterade recensioner sorterad efter flest rapporter"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 #, fuzzy
 msgid "Show comments"
 msgstr "visa kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr "Samtliga rapporterade kommentarer sorterad efter flest rapporter"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 #, fuzzy
 msgid "Show reviews"
 msgstr "recension"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "kommentarsid"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "raderad"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 #, fuzzy
 msgid "successfully undeleted"
 msgstr "raderad"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "raderade missbruksrapport"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 #, fuzzy
 msgid "Not yet reviewed"
 msgstr "Skriv en recension"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "Din kommentar har skickats in"
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "Radera kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "senaste först"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "visa kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "Detaljer och kommentarer"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "Sök i %s journaler efter:"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "Kommentarer"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "Tid"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Addera till användare"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "Visa"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "Datum för skapning"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "Nästa sida"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Visa alarm"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8589,106 +8561,106 @@ msgstr "Visa alarm"
 msgid "Refresh"
 msgstr "referens"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "Radera kommentar"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "Inga värden funna."
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "Journalen %s existerar inte"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "Du har inte tillräckliga rättigheter för att visa korgens innehåll."
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "Lägg till kommentar"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "Visa alla rapporterade kommentarer"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 #, fuzzy
 msgid "Page Not Found"
 msgstr "Samlingen %s existerar inte"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 #, fuzzy
 msgid "The requested comment could not be found"
 msgstr "Den här journalen existerar inte."
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 #, fuzzy
 msgid "The requested file could not be found"
 msgstr "Den här journalen existerar inte."
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Du är inte ägaren av den här korgen."
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "Kommentarer"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "Visa alla rapporterade kommentarer"
@@ -8809,8 +8781,8 @@ msgstr "Tyvärr verkar inte dokumentet %s existera."
 #: invenio/legacy/webdoc/webinterface.py:200
 #, fuzzy, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr "Du kan nu logga in till ditt %(x_url_open)skonto%(x_url_close)s."
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8882,8 +8854,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8911,8 +8883,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -9016,11 +8988,6 @@ msgstr ""
 msgid "Apply"
 msgstr "april"
 
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "Smeknamn"
-
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 #, fuzzy
 msgid "WebJournal Admin"
@@ -9105,9 +9072,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -9129,8 +9095,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9244,8 +9209,8 @@ msgid ""
 "Your message is too long, please shorten it. Maximum size allowed is "
 "%(x_size)i characters."
 msgstr ""
-"Ditt meddelande är för långt, var god redigera det. Maximal storlek är %i"
-" tecken."
+"Ditt meddelande är för långt, var god redigera det. Maximal storlek är %i "
+"tecken."
 
 #: invenio/legacy/webmessage/api.py:402
 #, fuzzy, python-format
@@ -9270,8 +9235,8 @@ msgid ""
 "Your message could not be sent to the following recipients as it would "
 "exceed their quotas:"
 msgstr ""
-"Ditt meddelande kunde inte skickas till de följande mottagarna på grund "
-"av storleksbegränsningen på deras inboxar:"
+"Ditt meddelande kunde inte skickas till de följande mottagarna på grund av "
+"storleksbegränsningen på deras inboxar:"
 
 #: invenio/legacy/webmessage/api.py:457
 msgid "Your message has been sent."
@@ -9621,14 +9586,14 @@ msgstr "Sökresultat"
 #: invenio/legacy/websearch/templates.py:1589
 #, fuzzy
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr "Denna samling är begränsad. Logga in VSG."
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9766,11 +9731,10 @@ msgstr "Dina submissions"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
-"Den booleska sökningen returnerade inga journaler. Kombinera dina "
-"söktermer annorlunda."
+"Den booleska sökningen returnerade inga journaler. Kombinera dina söktermer "
+"annorlunda."
 
 #: invenio/legacy/websearch/templates.py:3357
 msgid "See also: similar author names"
@@ -9795,8 +9759,8 @@ msgstr "Du vill antagligen börja browsa från %s."
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "Sätta upp ett %(x_url1_open)sepost-alarm%(x_url1_close)s\n"
 "                                  eller starta en prenumeration på "
@@ -9992,7 +9956,8 @@ msgid "in"
 msgstr "i"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "Har du inte funnit vad du söker efter? Försök på andra platser:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -10008,8 +9973,8 @@ msgid ""
 "The external search engine has not responded in time. You can check its "
 "results here:"
 msgstr ""
-"Den externa sökmotorn svarade inte tillräckligt snabbt. Du kan dock själv"
-" kontrollera resultatet här: "
+"Den externa sökmotorn svarade inte tillräckligt snabbt. Du kan dock själv "
+"kontrollera resultatet här: "
 
 #: invenio/legacy/websearch_external_collections/templates.py:146
 #: invenio/legacy/websearch_external_collections/templates.py:154
@@ -10088,8 +10053,8 @@ msgstr "Obligatorisk"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -10099,11 +10064,11 @@ msgstr "Skapa ny korg"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
-"Om du vill ändra din epost-adress, eller ange ett smeknamn, var god "
-"använd formuläret nedan."
+"Om du vill ändra din epost-adress, eller ange ett smeknamn, var god använd "
+"formuläret nedan."
 
 #: invenio/legacy/websession/templates.py:271
 msgid "Edit login credentials"
@@ -10119,14 +10084,14 @@ msgstr "Ange nya värden"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr "Singaturet kan inte ändras."
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
 "Om du vill ändra ditt lösenord, var god ange det gamla och det nya i "
 "formuläret nedan."
@@ -10166,8 +10131,8 @@ msgstr "Sätt nytt lösenord"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr "Du kan %(x_url_open)slogga in eller registrera dig här%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:346
@@ -10258,13 +10223,12 @@ msgstr "Välj metod"
 #: invenio/legacy/websession/templates.py:537
 #, fuzzy, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
-"Om du förlorat ditt lösenord till ett internt Invenio konto kan du återfå"
-" det genom att ange din epost-adress nedan."
+"Om du förlorat ditt lösenord till ett internt Invenio konto kan du återfå "
+"det genom att ange din epost-adress nedan."
 
 #: invenio/legacy/websession/templates.py:559
 #: invenio/legacy/websession/templates.py:1220
@@ -10281,23 +10245,23 @@ msgstr "Skicka lösenord"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
-"Om ni har användad %(x_fmt_open)sCERN login system%(x_fmt_close)s, ni kan"
-" återställa ditt lösenord med %(x_url_open)sCERN authentication "
-"system%(x_url_close)s."
+"Om ni har användad %(x_fmt_open)sCERN login system%(x_fmt_close)s, ni kan "
+"återställa ditt lösenord med %(x_url_open)sCERN authentication system"
+"%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:571
 #, fuzzy
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 "OBS att om du har använt ett externt lösenord för att logga in till CDS "
-"Invenio (såsom CERN's NICE-konton) så måste du istället kontakta din "
-"lokala systemadministratör."
+"Invenio (såsom CERN's NICE-konton) så måste du istället kontakta din lokala "
+"systemadministratör."
 
 #: invenio/legacy/websession/templates.py:573
 #, fuzzy, python-format
@@ -10311,14 +10275,14 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 "%s medger möjligheten att personifiera gränssnittet, att finjustera ditt "
-"eget digitala bibliotek, samt att ställa in automatiska sökalarm som körs"
-" periodvis och kan meddela dig om nya sökresultat via epost."
+"eget digitala bibliotek, samt att ställa in automatiska sökalarm som körs "
+"periodvis och kan meddela dig om nya sökresultat via epost."
 
 #: invenio/legacy/websession/templates.py:611
 #: invenio/legacy/websession/webinterface.py:331
@@ -10337,12 +10301,12 @@ msgstr "Visa alla sökningar du genomfört under de senaste 30 dagarna."
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 "Med \"korgar\" kan du specifiera samlingar av journaler och lagra "
-"intressanta journaler som du vill kunna nå snabbt och smidigt senare, "
-"eller dela med andra användare. "
+"intressanta journaler som du vill kunna nå snabbt och smidigt senare, eller "
+"dela med andra användare. "
 
 #: invenio/legacy/websession/templates.py:636
 msgid "Display all the comments you have submitted so far."
@@ -10353,33 +10317,34 @@ msgid ""
 "Subscribe to a search which will be run periodically by our service. The "
 "result can be sent to you via Email or stored in one of your baskets."
 msgstr ""
-"Prenumerera på en sökning som körs periodvis. Resultatet kan skickas till"
-" dig via epost, eller lagras i en av dina korgar."
+"Prenumerera på en sökning som körs periodvis. Resultatet kan skickas till "
+"dig via epost, eller lagras i en av dina korgar."
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
-msgstr "Checka ut bok du lånat, skicka in en lånansökan, etc. Kräver ett CERN-id."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
+msgstr ""
+"Checka ut bok du lånat, skicka in en lånansökan, etc. Kräver ett CERN-id."
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
-"Du är inloggad som en gästanvändare, dina alarm kommer därför att "
-"försvinna vid sessionens slut."
+"Du är inloggad som en gästanvändare, dina alarm kommer därför att försvinna "
+"vid sessionens slut."
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
-"Du är inloggad som %(x_user)s. Vill du kanske a) %(x_url1_open)slogga "
-"ut%(x_url1_close)s; b) redigera dina  "
-"%(x_url2_open)skontoinställningar%(x_url2_close)s."
+"Du är inloggad som %(x_user)s. Vill du kanske a) %(x_url1_open)slogga ut"
+"%(x_url1_close)s; b) redigera dina  %(x_url2_open)skontoinställningar"
+"%(x_url2_close)s."
 
 #: invenio/legacy/websession/templates.py:785
 #, fuzzy, python-format
@@ -10395,11 +10360,11 @@ msgstr "Dina alarmsökningar"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
-"Du kan konsultera listan av  %(x_url_open)sde grupper%(x_url_close)s som "
-"du administrerar eller är medlem i."
+"Du kan konsultera listan av  %(x_url_open)sde grupper%(x_url_close)s som du "
+"administrerar eller är medlem i."
 
 #: invenio/legacy/websession/templates.py:799
 #: invenio/legacy/websession/templates.py:2348
@@ -10410,11 +10375,11 @@ msgstr "Dina grupper"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
-"Du kan konsultera listan av dina %(x_url_open)ssubmissions%(x_url_close)s"
-" och göra statusförfrågningar."
+"Du kan konsultera listan av dina %(x_url_open)ssubmissions%(x_url_close)s "
+"och göra statusförfrågningar."
 
 #: invenio/legacy/websession/templates.py:805
 #: invenio/legacy/websubmit/web/yoursubmissions.py:154
@@ -10424,11 +10389,11 @@ msgstr "Dina submissions"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
-"Du kan konsultera listan av %(x_url_open)sgodkända "
-"dokument%(x_url_close)s som du godkänt."
+"Du kan konsultera listan av %(x_url_open)sgodkända dokument%(x_url_close)s "
+"som du godkänt."
 
 #: invenio/legacy/websession/templates.py:811
 #: invenio/legacy/websubmit/web/yourapprovals.py:88
@@ -10461,8 +10426,8 @@ msgid ""
 "for a password reset at %(x_sitename)s\n"
 "for the account \"%(x_email)s\".x_sitename"
 msgstr ""
-"Någon (kanske ni) från %(x_ip_address)s  har bett för en återställning av"
-" lösenord i  %(x_sitename)s\n"
+"Någon (kanske ni) från %(x_ip_address)s  har bett för en återställning av "
+"lösenord i  %(x_sitename)s\n"
 "för kontot  \"%(x_email)s\"."
 
 #: invenio/legacy/websession/templates.py:877
@@ -10477,7 +10442,8 @@ msgstr "För att kontrollera giltigheten av denna begäran"
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr "OBS: att denna URL är giltig för bar cirka %(days)s dagar."
 
 #: invenio/legacy/websession/templates.py:909
@@ -10516,8 +10482,8 @@ msgid ""
 "                %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 "Ni är fortfarande inloggad med centraliserad\n"
-" %(x_fmt_open)sSSO%(x_fmt_close)s system.Ni kan %(x_url_open)slogga ut "
-"fran SSO%(x_url_close)s."
+" %(x_fmt_open)sSSO%(x_fmt_close)s system.Ni kan %(x_url_open)slogga ut fran "
+"SSO%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:978
 #, python-format
@@ -10531,27 +10497,27 @@ msgstr "Om du redan har ett användarkonto, var god logga in nedanför."
 #: invenio/legacy/websession/templates.py:1015
 #, fuzzy, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
-"Om du inte ännu har ett användarkonto, var god %(x_url_open)sregistrera "
-"dig%(x_url_close)s för ett internt konto."
+"Om du inte ännu har ett användarkonto, var god %(x_url_open)sregistrera dig"
+"%(x_url_close)s för ett internt konto."
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
-"Om du inte ännu har ett användarkonto, var god %(x_url_open)sregistrera "
-"dig%(x_url_close)s för ett internt konto."
+"Om du inte ännu har ett användarkonto, var god %(x_url_open)sregistrera dig"
+"%(x_url_close)s för ett internt konto."
 
 #: invenio/legacy/websession/templates.py:1027
 #, fuzzy, python-format
 msgid "If you don't own an account yet, please contact %(x_name)s."
 msgstr ""
-"Om du inte ännu har ett användarkonto, var god %(x_url_open)sregistrera "
-"dig%(x_url_close)s för ett internt konto."
+"Om du inte ännu har ett användarkonto, var god %(x_url_open)sregistrera dig"
+"%(x_url_close)s för ett internt konto."
 
 #: invenio/legacy/websession/templates.py:1051
 msgid "Login method:"
@@ -10581,8 +10547,8 @@ msgstr "Du kan använda ditt smeknamn eller din epost-adress för att logga in."
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr "Er begäran är giltig. Ange det nya lösenordet i form."
 
 #: invenio/legacy/websession/templates.py:1150
@@ -10611,8 +10577,8 @@ msgstr "Var god ange din epost-adress och ditt önskade smeknamn och lösenord:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
 "Det kommer inte att vara möjligt att använda lösenordet förrän det är "
 "verifierat och aktiverat."
@@ -10631,21 +10597,20 @@ msgstr "registrera"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
-"Använd inte värdefulla lösenord! Din epost-adress kommer att lagras högst"
-" konfidentiellt och kommer inte röjas till tredje part. Det kommer bara "
-"användas för att identifiera dig mot Invenio's personliga tjänster som "
-"%s."
+"Använd inte värdefulla lösenord! Din epost-adress kommer att lagras högst "
+"konfidentiellt och kommer inte röjas till tredje part. Det kommer bara "
+"användas för att identifiera dig mot Invenio's personliga tjänster som %s."
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 "Det är ännu inte möjligt att själv registrera användarkonton. Kontakt "
 "istället %s som hjälper dig."
@@ -10653,9 +10618,10 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
-msgstr "Du är en gästanvändare. Du måste %(x_url_open)slogga in%(x_url_close)s ."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
+msgstr ""
+"Du är en gästanvändare. Du måste %(x_url_open)slogga in%(x_url_close)s ."
 
 #: invenio/legacy/websession/templates.py:1267
 msgid "You are not authorized to access administrative functions."
@@ -10788,8 +10754,8 @@ msgstr "Här är några intressanta WebAdmin-länkar:"
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 "För fler administratörs-funktioner, besök "
 "%(x_url_open)sadministratörssektionen%(x_url_close)s."
@@ -10968,8 +10934,8 @@ msgid ""
 "If you want to invite new members to join your group, please use the "
 "%(x_url_open)sweb message%(x_url_close)s system."
 msgstr ""
-"Om du vill bjuda in flera användare för att joina din grupp, var god "
-"använd %(x_url_open)sWebMessage%(x_url_close)s."
+"Om du vill bjuda in flera användare för att joina din grupp, var god använd "
+"%(x_url_open)sWebMessage%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:2100
 #, fuzzy, python-format
@@ -11012,7 +10978,8 @@ msgstr "En användare vill joina gruppen %s."
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 "Var god %(x_url_open)sacceptera eller avslå%(x_url_close)s användarens "
 "förfrågan."
@@ -11056,67 +11023,62 @@ msgstr "Grupp %s har raderats av en administratör."
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"Du kan konsultera listan av %(x_url_open)s%(x_nb_total)i "
-"grupper%(x_url_close)s som du är medlem i (%(x_nb_member)i) eller "
-"administrerar (%(x_nb_admin)i)."
+"Du kan konsultera listan av %(x_url_open)s%(x_nb_total)i grupper"
+"%(x_url_close)s som du är medlem i (%(x_nb_member)i) eller administrerar "
+"(%(x_nb_admin)i)."
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
 "Du är inloggad som gäst. Du kan %(x_url_open)slogga in%(x_url_close) som "
 "vanliga användare."
@@ -11124,11 +11086,11 @@ msgstr ""
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
-"%(x_fmt_open)sGäst användare%(x_fmt_close)s behöver "
-"%(x_url_open)sregistrera%(x_url_close)s sig först"
+"%(x_fmt_open)sGäst användare%(x_fmt_close)s behöver %(x_url_open)sregistrera"
+"%(x_url_close)s sig först"
 
 #: invenio/legacy/websession/webaccount.py:127
 msgid "No queries found"
@@ -11136,15 +11098,15 @@ msgstr "Inga sökfrågor hittades"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr "Denna samling är begränsad. Logga in VSG."
 
 #: invenio/legacy/websession/webaccount.py:399
 #, fuzzy
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr "Denna samling är begränsad. Logga in VSG."
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -11153,8 +11115,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11166,8 +11128,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11247,8 +11209,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11286,8 +11247,8 @@ msgid ""
 "authorization will last until %(x_expiration)s and until you close your "
 "browser if you are a guest user."
 msgstr ""
-"Ni är godkänd som  %(x_role)s! Detta pågår till %(x_expiration)s (tills "
-"ni stänger er webbläsare om ni är gäst användare)."
+"Ni är godkänd som  %(x_role)s! Detta pågår till %(x_expiration)s (tills ni "
+"stänger er webbläsare om ni är gäst användare)."
 
 #: invenio/legacy/websession/webinterface.py:128
 msgid "You have confirmed the validity of your email address!"
@@ -11316,8 +11277,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -11384,17 +11344,17 @@ msgstr "Byta till intern inloggningsmetod"
 #: invenio/legacy/websession/webinterface.py:423
 #, fuzzy
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 "OBS att om det här är första gången som\n"
 "                        som du använder den här inloggningsmetoden\n"
 "                        så har systemet tilldelat dig ett randomiserat "
 "lösenord\n"
-"                        som du kan ha få tillgång till genom att klicka "
-"på följande\n"
+"                        som du kan ha få tillgång till genom att klicka på "
+"följande\n"
 "                        knapp:</p>"
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -11407,8 +11367,8 @@ msgid ""
 "Unable to switch to external login method %(x_name)s, because your email "
 "address is unknown."
 msgstr ""
-"Kunde inte byta till extern inloggningsmetod %s, eftersom din epost-"
-"adress är okänd."
+"Kunde inte byta till extern inloggningsmetod %s, eftersom din epost-adress "
+"är okänd."
 
 #: invenio/legacy/websession/webinterface.py:445
 #, fuzzy, python-format
@@ -11416,8 +11376,8 @@ msgid ""
 "Unable to switch to external login method %(x_meth)s, because your email "
 "address is unknown to the external login system."
 msgstr ""
-"Kunde inte byta till extern inloggningsmetod %s, eftersom din epost-"
-"adress är okänd till det externa systemet."
+"Kunde inte byta till extern inloggningsmetod %s, eftersom din epost-adress "
+"är okänd till det externa systemet."
 
 #: invenio/legacy/websession/webinterface.py:449
 msgid "Login method successfully selected."
@@ -11426,11 +11386,11 @@ msgstr "Inloggningsmetod vald."
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
-"Det externa inloggningssystemet %s stödjer inte email-baserade "
-"inloggningar. Kontakta administratör."
+"Det externa inloggningssystemet %s stödjer inte email-baserade inloggningar. "
+"Kontakta administratör."
 
 #: invenio/legacy/websession/webinterface.py:464
 #, fuzzy
@@ -11613,15 +11573,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 "Ett andra epost kommer att skickas då kontot blivit aktiverats och är "
 "färdigt för att användas."
@@ -11665,8 +11625,8 @@ msgstr "Smeknamnet %s är upptaget"
 #: invenio/modules/accounts/views/accounts.py:143
 msgid "Users cannot register themselves, only admin can register them."
 msgstr ""
-"Användare kan inte registrera sig själva, bara administratörer kan utföra"
-" registreringar."
+"Användare kan inte registrera sig själva, bara administratörer kan utföra "
+"registreringar."
 
 #: invenio/legacy/websession/webinterface.py:1023
 #: invenio/modules/accounts/views/accounts.py:148
@@ -11742,7 +11702,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr ""
 "Journalen skapades %(x_date_creation)s, och modifierades senast "
 "%(x_date_modification)s"
@@ -11767,37 +11728,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11805,15 +11766,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11881,8 +11842,8 @@ msgstr "Kunde inte avgöra antalet sidor."
 #: invenio/legacy/websubmit/engine.py:931
 #, fuzzy
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr "Kunde inte skapa en katalog för inskicket."
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11918,8 +11879,8 @@ msgstr "Skicka in"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11967,11 +11928,11 @@ msgstr "Välj en kategori och klicka sedan på en aktion-knapp"
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
-"För att fortsätta med en avbruten inskickning, ange ett accessnummer i "
-"rutan nedanför:"
+"För att fortsätta med en avbruten inskickning, ange ett accessnummer i rutan "
+"nedanför:"
 
 #: invenio/legacy/websubmit/templates.py:366
 msgid "GO"
@@ -11999,11 +11960,11 @@ msgstr "Tillbaka till huvudmenyn"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
-"Detta är ditt inskicknings accessnummer. Det kan användas för att "
-"fortsätta en avbruten inskickning ifall problem uppstår."
+"Detta är ditt inskicknings accessnummer. Det kan användas för att fortsätta "
+"en avbruten inskickning ifall problem uppstår."
 
 #: invenio/legacy/websubmit/templates.py:548
 msgid "Mandatory fields appear in red in the SUMMARY window."
@@ -12051,11 +12012,11 @@ msgstr "Bidragsnummer"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
-"Här är den exakta %(x_action)s funktionslistan för %(x_doctype)s dokument"
-" på nivå %(x_step)s"
+"Här är den exakta %(x_action)s funktionslistan för %(x_doctype)s dokument på "
+"nivå %(x_step)s"
 
 #: invenio/legacy/websubmit/templates.py:1041
 msgid "Function"
@@ -12137,8 +12098,7 @@ msgstr "Lista av dömda typer av dokument"
 #: invenio/legacy/websubmit/templates.py:1479
 #, fuzzy
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
 "Välj en av de följande dokumenttyperna för att se status för relaterade "
 "dokument."
@@ -12282,10 +12242,11 @@ msgstr "Godkända"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
-"Det här dokumentet väntar fortfarande på "
-"%(x_fmt_open)sgodkännande%(x_fmt_close)s."
+"Det här dokumentet väntar fortfarande på %(x_fmt_open)sgodkännande"
+"%(x_fmt_close)s."
 
 #: invenio/legacy/websubmit/templates.py:2142
 #: invenio/legacy/websubmit/templates.py:2163
@@ -12307,8 +12268,8 @@ msgid ""
 "You can send an approval request email again by clicking the following "
 "button:"
 msgstr ""
-"Du kan skicka ett godkännande-förfrågan igen genom att klicka på följande"
-" knapp:"
+"Du kan skicka ett godkännande-förfrågan igen genom att klicka på följande "
+"knapp:"
 
 #: invenio/legacy/websubmit/templates.py:2149
 #: invenio/legacy/websubmit/web/publiline.py:367
@@ -12325,8 +12286,7 @@ msgid ""
 "As a referee for this document, you may approve or reject it from the "
 "submission interface"
 msgstr ""
-"I egenskap av domare för den här dokumenttypen, godkänn eller avslå "
-"ansökan."
+"I egenskap av domare för den här dokumenttypen, godkänn eller avslå ansökan."
 
 #: invenio/legacy/websubmit/templates.py:2155
 msgid "Approve/Reject"
@@ -12383,8 +12343,8 @@ msgstr "Välj en poäng"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -12404,8 +12364,8 @@ msgstr "Skriv en kommentar"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -12446,7 +12406,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12468,14 +12429,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -12597,10 +12557,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12894,8 +12853,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12938,11 +12897,6 @@ msgstr "Välj användaren"
 #, fuzzy
 msgid "Role details"
 msgstr "Artikel"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "Göm"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -13058,8 +13012,8 @@ msgstr "Den angivna epost-adressen %s existerar redan i databasen."
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -13124,13 +13078,12 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, fuzzy, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 "Ni är fortfarande inloggad med centraliserad\n"
-" %(x_fmt_open)sSSO%(x_fmt_close)s system.Ni kan %(x_url_open)slogga ut "
-"fran SSO%(x_url_close)s."
+" %(x_fmt_open)sSSO%(x_fmt_close)s system.Ni kan %(x_url_open)slogga ut fran "
+"SSO%(x_url_close)s."
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
 #, fuzzy, python-format
@@ -13153,8 +13106,8 @@ msgstr "Sätt nytt lösenord"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr "Var god ange din epost-adress och ditt önskade smeknamn och lösenord:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -13183,7 +13136,7 @@ msgid "Problem with login."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "Du kan nu logga in till ditt %(x_url_open)skonto%(x_url_close)s."
 
@@ -13227,8 +13180,7 @@ msgstr "Misslyckades att ändra inställningar"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13300,13 +13252,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13315,9 +13266,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13494,8 +13445,7 @@ msgstr "samlingar"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13585,8 +13535,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13678,13 +13628,13 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
-"Ditt meddelande är för långt, var god redigera det. Maximal storlek är %i"
-" tecken."
+"Ditt meddelande är för långt, var god redigera det. Maximal storlek är %i "
+"tecken."
 
 #: invenio/modules/comments/forms.py:55
 #, fuzzy
@@ -13727,12 +13677,12 @@ msgid "Review was sent"
 msgstr "Skriv en kommentar"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Den här kommentaren har rapporterats %i gånger"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Den här kommentaren har rapporterats %i gånger"
 
@@ -13785,9 +13735,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13806,8 +13755,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13817,7 +13766,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "Smeknamnet %s är upptaget"
 
@@ -13873,8 +13822,7 @@ msgstr "recension"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13914,8 +13862,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13961,7 +13908,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "Funktion %s existerar inte."
 
@@ -14044,11 +13991,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "Nuvarande status:"
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "Dina korgar"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -14083,8 +14025,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -14105,8 +14047,8 @@ msgstr "Inget ordindex tillgängligt för"
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -14122,8 +14064,7 @@ msgstr "Validering av formatelement %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14243,7 +14184,7 @@ msgstr "Visa alla %i författare"
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 #, fuzzy
 msgid "Edit This Record"
 msgstr "Var god pröva ett annat journal ID."
@@ -14347,10 +14288,6 @@ msgstr "recension"
 msgid "Authors"
 msgstr "författare"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14443,8 +14380,8 @@ msgstr "Hantera grupprättigheter"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "Du har inte tillräckliga rättigheter för att visa korgens innehåll."
 
 #: invenio/modules/groups/views.py:279
@@ -14457,12 +14394,12 @@ msgstr "Du är inte administratör för någon grupp."
 msgid "Members"
 msgstr "Inga medlemmmar."
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "Kunskapsbasmappningar"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14472,11 +14409,11 @@ msgstr "Klar"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "samtliga fält"
@@ -14522,13 +14459,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "Det finns %i korgar"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "Det finns %i korgar"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14684,28 +14622,28 @@ msgstr "Okänd dokumenttyp"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14770,8 +14708,8 @@ msgstr ""
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 #, fuzzy
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr "Om ni vill fortsätta med konto registreringen, gå till:"
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -15142,7 +15080,7 @@ msgid "Tag name"
 msgstr "Smeknamn"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "Smeknamnet %s används redan."
 
@@ -15246,11 +15184,6 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "Klar"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15292,8 +15225,7 @@ msgstr "Sökalternativ:"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15502,7 +15434,7 @@ msgid "just now"
 msgstr "Du måste veta"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s sekunder"
 
@@ -15561,6 +15493,36 @@ msgstr "alla år"
 msgid " years ago"
 msgstr "år"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "BibFormat's administratörsgränssnitt"
+
+#~ msgid "Not authorized"
+#~ msgstr "författare"
+
+#~ msgid "Really delete"
+#~ msgstr "raderad"
+
+#~ msgid "Verify problem"
+#~ msgstr "Databasproblem"
+
+#~ msgid "File"
+#~ msgstr "titel"
+
+#~ msgid "niceName"
+#~ msgstr "Namn"
+
+#~ msgid "Id"
+#~ msgstr "id"
+
+#~ msgid "Tickets"
+#~ msgstr "Tid"
+
+#~ msgid "by"
+#~ msgstr "av"
+
+#~ msgid "Done"
+#~ msgstr "Klar"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "Var god välj en kategori."
 
@@ -15575,9 +15537,6 @@ msgstr "år"
 
 #~ msgid "*** basket name ***"
 #~ msgstr "Korgens namn"
-
-#~ msgid ""
-#~ msgstr ""
 
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "ytterligare filer"
@@ -15639,23 +15598,8 @@ msgstr "år"
 #~ msgid "now"
 #~ msgstr "Nej"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "BibFormat's administratörsgränssnitt"
-
-#~ msgid "Not authorized"
-#~ msgstr "författare"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "Användare %s existerar inte."
-
-#~ msgid "Really delete"
-#~ msgstr "raderad"
-
-#~ msgid "Verify problem"
-#~ msgstr "Databasproblem"
-
-#~ msgid "File"
-#~ msgstr "titel"
 
 #~ msgid "File %s already exists."
 #~ msgstr "Användare %s existerar inte."
@@ -15708,9 +15652,6 @@ msgstr "år"
 #~ msgid "Not Mine!"
 #~ msgstr "Notera"
 
-#~ msgid "Tickets"
-#~ msgstr "Tid"
-
 #~ msgid "Request Tickets"
 #~ msgstr "Regler"
 
@@ -15746,9 +15687,6 @@ msgstr "år"
 
 #~ msgid "Create a new Person for your search"
 #~ msgstr "Inga träffar hittades"
-
-#~ msgid "Id"
-#~ msgstr "id"
 
 #~ msgid "A %s has been added."
 #~ msgstr "Grupp %s har raderats."
@@ -15801,9 +15739,6 @@ msgstr "år"
 #~ msgid "creating a new basket"
 #~ msgstr "Skapa ny korg"
 
-#~ msgid "by"
-#~ msgstr "av"
-
 #~ msgid "on"
 #~ msgstr "på"
 
@@ -15822,9 +15757,6 @@ msgstr "år"
 #~ msgid "Editing topic"
 #~ msgstr "Redigera korg"
 
-#~ msgid "niceName"
-#~ msgstr "Namn"
-
 #~ msgid "Apply Changes"
 #~ msgstr "Spara förändringar"
 
@@ -15839,9 +15771,6 @@ msgstr "år"
 
 #~ msgid "Edit record %(x_recid)s, field %(x_field)s"
 #~ msgstr "Redigera journal %(x_recid)s, fält %(x_field)s"
-
-#~ msgid "Edit record %(x_recid)s, field %(x_field)s - Add a subfield"
-#~ msgstr ""
 
 #~ msgid "Submit and save record %s"
 #~ msgstr "Skicka in och spara journalen %s"
@@ -15912,9 +15841,6 @@ msgstr "år"
 #~ msgid "Cannot edit deleted record.\""
 #~ msgstr "Misslyckades att redigera borttagen journal."
 
-#~ msgid "The record will be deleted as soon as the task queue is empty."
-#~ msgstr ""
-
 #~ msgid "Please enter the ID of the record you want to edit"
 #~ msgstr "Var god ange ID:et för journalen du vill redigera"
 
@@ -15935,9 +15861,6 @@ msgstr "år"
 
 #~ msgid "Verbose"
 #~ msgstr "Detaljerad"
-
-#~ msgid "Done"
-#~ msgstr "Klar"
 
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "Dina ändringar är TEMPORÄRA"
@@ -16119,34 +16042,11 @@ msgstr "år"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "WebSubmit administration"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "Genomför sökning"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "Avbryt"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "Du är medlem av de följande grupperna:"
@@ -16160,12 +16060,6 @@ msgstr "år"
 #~ msgid "Invert Selection"
 #~ msgstr "Referens finns ännu inte"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "Författare:"
 
@@ -16177,12 +16071,6 @@ msgstr "år"
 
 #~ msgid "No status information found."
 #~ msgstr "Mer information:"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "division"
@@ -16196,18 +16084,6 @@ msgstr "år"
 #~ msgid "View name variants"
 #~ msgstr "visa kommentarer"
 
-#~ msgid "The author has an internal ID!"
-#~ msgstr ""
-
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "kommentarer"
 
@@ -16217,87 +16093,20 @@ msgstr "år"
 #~ msgid " Delete this ticket"
 #~ msgstr "Radera korg"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "Inga dokumenttyper finns tillängliga."
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "Välj en poäng"
 
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
 #~ msgid "Paper title: "
 #~ msgstr "Sida:"
-
-#~ msgid "Ignore"
-#~ msgstr ""
 
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "De följande problemen hittades"
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "Välj en poäng"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "Mer information:"
@@ -16305,35 +16114,11 @@ msgstr "år"
 #~ msgid "Please provide your first name"
 #~ msgstr "Var god logga in först."
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "Dina lån"
 
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
 #~ msgid "Your eMail:"
 #~ msgstr "Dina alarm"
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "Radera valda recensioner"
@@ -16341,186 +16126,35 @@ msgstr "år"
 #~ msgid "Mark as your documents"
 #~ msgstr "alla dokumenttyper"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "Betygsätt det här dokumentet"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "Betygsätt det här dokumentet"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "eller skapa ett nytt"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "Addera till användare"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "Sida:"
-
-#~ msgid "Showing the"
-#~ msgstr ""
 
 #~ msgid "most recent documents:"
 #~ msgstr "Lista på dömda dokument"
 
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "Hantera formatmallar"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "Välj ämnesområde"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "Datum för skapning"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "extern %(link_or_links)s"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "bidrag"
@@ -16528,190 +16162,18 @@ msgstr "år"
 #~ msgid "Choose system"
 #~ msgstr "Välj ämnesområde"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "De följande problemen hittades"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
-#~ msgstr "Du är inte berättigad till access till de administrativa funktionerna."
+#~ msgstr ""
+#~ "Du är inte berättigad till access till de administrativa funktionerna."
 
 #~ msgid "Claim this paper"
 #~ msgstr "Addera till användare"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Refererad av: %s records"
 
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
 #~ msgid "Revision"
 #~ msgstr "division"
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "Redigera mallattribut"
@@ -16791,89 +16253,20 @@ msgstr "år"
 #~ msgid "No Record Found for %s."
 #~ msgstr "Journalen %s existerar inte"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Användare %s existerar inte."
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "Visningsformatet %s attribut"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "Visningsformatet %s bereoenden"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "Validering av formatelement %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "Formateringselementet %s bereoenden "
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Begränsade visningsformat"
@@ -16929,110 +16322,17 @@ msgstr "år"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "Validering av formatelement %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "Formatvalidering"
 
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "Kunskapsbas %s"
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "Notera"
 
 #~ msgid "never"
 #~ msgstr "Konvertera"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "Tid"
@@ -17061,17 +16361,11 @@ msgstr "år"
 #~ msgid "Affiliations"
 #~ msgstr "Referenshistorik"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
 #~ msgid "No Frequent Co-authors"
 #~ msgstr "Populära sökord"
 
 #~ msgid "Citations%s"
 #~ msgstr "Referenshistorik"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "Datum för skapning"
@@ -17082,42 +16376,6 @@ msgstr "år"
 #~ msgid "No publications available"
 #~ msgstr "Inga dokumenttyper finns tillängliga."
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr "Refererad av: %s records"
 
@@ -17127,17 +16385,11 @@ msgstr "år"
 #~ msgid "%i reviews"
 #~ msgstr "recension"
 
-#~ msgid "%s of"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "Sida:"
 
 #~ msgid "Frequent co-authors"
 #~ msgstr "Populära sökord"
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "Referenshistorik"
@@ -17145,23 +16397,8 @@ msgstr "år"
 #~ msgid "No Citation Information available"
 #~ msgstr "Inga dokumenttyper finns tillängliga."
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "Diskussion"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "Dina alarm"
@@ -17181,102 +16418,15 @@ msgstr "år"
 #~ msgid "Statistics"
 #~ msgstr "statistik"
 
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
 #~ msgid "Group: %s"
 #~ msgstr "Grupp: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "Samlingen %s existerar inte"
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "Fältet %s är obligatoriskt."
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "Kunde inte avgöra antalet sidor."
-

--- a/invenio/base/translations/uk/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/uk/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,16 +16,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2008-02-29 15:25+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:58+0200\n"
 "Last-Translator: Vasyl Ostrovskyi <vo@imath.kiev.ua>\n"
 "Language-Team: UK <info@invenio-software.org>\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -59,8 +59,8 @@ msgstr "Область адміністратора"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -209,7 +209,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 #, fuzzy
 msgid "Hello:"
 msgstr "Допомога"
@@ -231,17 +231,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -267,46 +267,51 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "Запис видалено"
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "Цей розділ поки що не містить записів"
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 msgid "Authorization failure"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "кошики"
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 msgid "Authorization failure."
 msgstr ""
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -508,7 +513,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -726,7 +732,8 @@ msgid "The following errors have occurred:"
 msgstr "Запис видалено"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -743,8 +750,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -826,7 +833,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -868,8 +875,8 @@ msgstr "кошики"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr ""
@@ -885,8 +892,8 @@ msgstr "далі"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr ""
 
@@ -993,11 +1000,6 @@ msgstr ""
 msgid "Verify problem"
 msgstr ""
 
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "назва"
-
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
 msgstr ""
@@ -1101,7 +1103,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1152,8 +1155,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1167,25 +1170,23 @@ msgstr "Переглянути"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1210,13 +1211,14 @@ msgstr "кошики"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1248,9 +1250,8 @@ msgstr "Опції пошуку"
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1317,8 +1318,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1326,8 +1327,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1349,9 +1350,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1393,8 +1393,8 @@ msgstr "Шукати серед %s записів:"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1452,11 +1452,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1467,11 +1467,11 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1484,8 +1484,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1581,8 +1581,8 @@ msgstr "<strong>%s</strong> знайдених записів"
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1602,29 +1602,29 @@ msgstr "<strong>%s</strong> знайдених записів"
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1633,9 +1633,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 #, fuzzy
 msgid "Requested record does not seem to exist."
 msgstr "Запис видалено"
@@ -1993,16 +1993,14 @@ msgstr "Запис видалено"
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2023,8 +2021,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2186,8 +2184,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2298,7 +2296,7 @@ msgstr "розділи"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 #, fuzzy
 msgid "Description"
 msgstr "сеанс"
@@ -2493,8 +2491,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2777,9 +2775,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2835,7 +2832,7 @@ msgstr "обмежено"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr ""
 
@@ -2843,8 +2840,8 @@ msgstr ""
 #, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3312,8 +3309,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 #, fuzzy
 msgid "Email"
 msgstr "детальний"
@@ -4150,8 +4147,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4169,8 +4166,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4235,17 +4232,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4624,25 +4621,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "Запис видалено"
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4702,15 +4699,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4721,10 +4718,10 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4738,15 +4735,15 @@ msgstr "гість"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4757,7 +4754,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4776,17 +4774,15 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4805,14 +4801,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4864,8 +4859,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4920,8 +4915,8 @@ msgstr "Запис видалено"
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -5039,9 +5034,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -5055,8 +5050,8 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -5200,11 +5195,10 @@ msgstr "Результати пошуку"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5339,7 +5333,7 @@ msgid "Total"
 msgstr ""
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 #, fuzzy
 msgid "Select"
 msgstr "кошики"
@@ -5507,8 +5501,8 @@ msgstr "кошики"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5566,56 +5560,56 @@ msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5655,7 +5649,7 @@ msgstr ""
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5708,15 +5702,15 @@ msgstr "кошики"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -5943,8 +5937,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -6023,8 +6016,8 @@ msgstr "кошики"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6039,8 +6032,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "Результати пошуку"
 
@@ -6201,8 +6194,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6228,8 +6221,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6240,8 +6233,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -6253,119 +6245,118 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
 "В роділі %s результатів не знайдено. В інших загальнодоступних розділах "
-"знайдено <a class=\"nearestterms\" href=\"%s/search.py?%s\">%d "
-"співпадінь</a>"
+"знайдено <a class=\"nearestterms\" href=\"%s/search.py?%s\">%d співпадінь</a>"
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr ""
-"Серед загальнодоступних розділів відповідностей запиту не знайдено. Якщо "
-"Ви шукаєте документ з обмеженим доступом, спочатку виберіть відповідий "
-"розділ з обмеженим доступом."
+"Серед загальнодоступних розділів відповідностей запиту не знайдено. Якщо Ви "
+"шукаєте документ з обмеженим доступом, спочатку виберіть відповідий розділ з "
+"обмеженим доступом."
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr ""
-"Серед загальнодоступних розділів відповідностей запиту не знайдено. Якщо "
-"Ви шукаєте документ з обмеженим доступом, спочатку виберіть відповідий "
-"розділ з обмеженим доступом."
+"Серед загальнодоступних розділів відповідностей запиту не знайдено. Якщо Ви "
+"шукаєте документ з обмеженим доступом, спочатку виберіть відповідий розділ з "
+"обмеженим доступом."
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr "не знайдено. Найближчі терміни в розділі:"
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 msgid "No match found, please enter different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "кошики"
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "кошики"
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "кошики"
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "Не знайдено лексичний вказівник для"
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "Не знайдений вказівник фраз для"
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, fuzzy, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr "не знайдено. Найближчі терміни в розділі:"
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr "не знайдено. Найближчі терміни в розділі:"
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "Запис видалено"
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6379,11 +6370,11 @@ msgstr ""
 msgid "Browse"
 msgstr "Переглянути"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr "За відведений час результатів не знайдено, умову скасовано"
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr "За даних обмежень результатів не знайдено, умова скасовується"
 
@@ -6426,10 +6417,9 @@ msgstr "Запис видалено"
 #: invenio/legacy/webalert/api.py:428
 #, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
 msgstr ""
 
 #: invenio/legacy/webalert/htmlparser.py:186
@@ -6627,15 +6617,15 @@ msgstr ""
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr ""
 
 #: invenio/legacy/webalert/templates.py:453
@@ -6697,7 +6687,7 @@ msgstr "Пошук"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6762,7 +6752,7 @@ msgstr "Показати результат:"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6824,7 +6814,8 @@ msgstr "Показати результат:"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6848,7 +6839,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "Цей розділ поки що не містить записів"
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6876,7 +6868,8 @@ msgid "You do not have permission to delete this note."
 msgstr "Цей розділ поки що не містить записів"
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6907,8 +6900,8 @@ msgstr "Запис видалено"
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6930,8 +6923,8 @@ msgstr "Шукати серед %s записів:"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -6964,8 +6957,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7043,8 +7036,7 @@ msgstr "кошики"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
@@ -7071,8 +7063,7 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:108
 #, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -7250,8 +7241,8 @@ msgstr "Детальний запис"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7442,15 +7433,16 @@ msgstr ""
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2131
@@ -7460,7 +7452,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 #, fuzzy
 msgid "Back to search results"
 msgstr "Результати пошуку"
@@ -7641,7 +7633,7 @@ msgstr "Детальний запис"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7789,216 +7781,216 @@ msgstr "Запис видалено"
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "Запис видалено"
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "Cited by: %s records"
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "Запис видалено"
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "Cited by: %s records"
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, python-format
 msgid "View all %(x_name)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 msgid "Be the first to review this document.</div>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "далі"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 #, fuzzy
 msgid "Report abuse"
 msgstr "вересень"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 #, fuzzy
 msgid "Undelete comment"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 #, fuzzy
 msgid "Delete comment"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 #, fuzzy
 msgid "Unreport comment"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, fuzzy, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "Cited by: %s records"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 #, fuzzy
 msgid "Undelete review"
 msgstr "кошики"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 #, fuzzy
 msgid "Delete review"
 msgstr "кошики"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 #, fuzzy
 msgid "Unreport review"
 msgstr "далі"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 #, fuzzy
 msgid "Reviews"
 msgstr "далі"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 msgid "Unsubscribe"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -8007,521 +7999,523 @@ msgstr ""
 msgid "Record"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 #, fuzzy
 msgid "Review"
 msgstr "далі"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 msgid "You are not authorized to comment or review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 #, fuzzy
 msgid "Max one file"
 msgstr "далі"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, python-format
 msgid "Max %(maxfiles)i files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 #, fuzzy
 msgid "Article"
 msgstr "квітень"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 #, fuzzy
 msgid "Add comment"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 #, fuzzy
 msgid "Select a score"
 msgstr "кошики"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 #, fuzzy
 msgid "Add review"
 msgstr "далі"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 #, fuzzy
 msgid "Your comment was successfully added."
 msgstr "Запис видалено"
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 #, fuzzy
 msgid "Back to record"
 msgstr "перейти до запису:"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 #, fuzzy
 msgid "View most commented records"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 #, fuzzy
 msgid "View latest commented records"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all comments reported as abuse"
 msgstr "Подібні записи"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 #, fuzzy
 msgid "View most reviewed records"
 msgstr "Детальний запис"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 #, fuzzy
 msgid "View latest reviewed records"
 msgstr "Подібні записи"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all reviews reported as abuse"
 msgstr "Подібні записи"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 #, fuzzy
 msgid "View all users who have been reported"
 msgstr "Запис видалено"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "Керівництво"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 #, fuzzy
 msgid "Record ID:"
 msgstr "номер запису"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "Подібні записи"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "Подібні записи"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "Запис видалено"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "Запис видалено"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 #, fuzzy
 msgid "Written by"
 msgstr "Cited by"
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 #, fuzzy
 msgid "Delete selected reviews"
 msgstr "кошики"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 #, fuzzy
 msgid "Undelete selected reviews"
 msgstr "кошики"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 #, fuzzy
 msgid "Undelete selected comments"
 msgstr "кошики"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 #, fuzzy
 msgid "Delete selected comments"
 msgstr "кошики"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "кошики"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 #, fuzzy
 msgid "Show comments"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 #, fuzzy
 msgid "Show reviews"
 msgstr "далі"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 #, fuzzy
 msgid "successfully undeleted"
 msgstr "Запис видалено"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 msgid "Not yet reviewed"
+msgstr ""
+
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "Запис видалено"
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "останні спочатку"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "Шукати серед %s записів:"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 msgid "Comments only"
 msgstr ""
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "назва"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "Детальний запис"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 #, fuzzy
 msgid "Display"
 msgstr "Показати результат:"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "кошики"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 msgid "Per page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "Показати результат:"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8529,106 +8523,106 @@ msgstr "Показати результат:"
 msgid "Refresh"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "Розділ %s не існує"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 #, fuzzy
 msgid "Record Not Found"
 msgstr "Розділ %s не існує"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "Цей розділ поки що не містить записів"
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 msgid "You cannot report a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 #, fuzzy
 msgid "Page Not Found"
 msgstr "Розділ %s не існує"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 #, fuzzy
 msgid "The requested comment could not be found"
 msgstr "Запис видалено"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 #, fuzzy
 msgid "The requested file could not be found"
 msgstr "Запис видалено"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "Цей розділ поки що не містить записів"
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "обліковий запис"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr ""
@@ -8751,8 +8745,8 @@ msgstr "Запис видалено"
 #: invenio/legacy/webdoc/webinterface.py:200
 #, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8824,8 +8818,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8852,8 +8846,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -9042,9 +9036,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -9066,8 +9059,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9561,14 +9553,14 @@ msgstr "Результати пошуку"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9708,8 +9700,7 @@ msgstr "додане"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr ""
 "Результатів для умовного запиту не знайдено. Виберіть іншу комбінацію "
 "термінів."
@@ -9737,8 +9728,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:3832
@@ -9934,7 +9925,8 @@ msgstr "в"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
 #, fuzzy
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "Не знайшли потрібного? Спробуйте пошуковий сервер:"
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -10030,8 +10022,8 @@ msgstr "будь-який день"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -10041,8 +10033,8 @@ msgstr "кошики"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:271
@@ -10059,14 +10051,14 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:327
@@ -10104,8 +10096,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:343
 #, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:346
@@ -10198,10 +10190,9 @@ msgstr "кошики"
 #: invenio/legacy/websession/templates.py:537
 #, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:559
@@ -10218,15 +10209,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:573
@@ -10239,10 +10230,10 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:600
 #, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:611
@@ -10263,8 +10254,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:636
@@ -10279,22 +10270,22 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:785
@@ -10312,8 +10303,8 @@ msgstr "Пошук"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:799
@@ -10326,8 +10317,8 @@ msgstr "підтвердження"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:805
@@ -10339,8 +10330,8 @@ msgstr "додане"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:811
@@ -10388,7 +10379,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -10437,15 +10429,15 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1015
 #, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1027
@@ -10482,8 +10474,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -10508,8 +10500,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1228
@@ -10526,24 +10518,24 @@ msgstr ""
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1235
 #, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1267
@@ -10677,8 +10669,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1378
@@ -10912,7 +10904,8 @@ msgstr ""
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2400
@@ -10954,71 +10947,66 @@ msgstr "Запис видалено"
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:127
@@ -11027,14 +11015,14 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -11043,8 +11031,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11056,8 +11044,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11131,8 +11119,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11196,8 +11183,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -11261,10 +11247,10 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:423
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -11292,8 +11278,8 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:452
 #, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -11471,15 +11457,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:989
@@ -11599,7 +11585,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, fuzzy, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr "Запис створено %s, остання зміна %s"
 
 #: invenio/legacy/webstyle/templates.py:707
@@ -11622,37 +11609,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11660,15 +11647,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11735,8 +11722,8 @@ msgstr ""
 #: invenio/legacy/websubmit/engine.py:301
 #: invenio/legacy/websubmit/engine.py:931
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11771,8 +11758,8 @@ msgstr "Додати"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11821,8 +11808,8 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:366
@@ -11853,8 +11840,8 @@ msgstr "кошики"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:548
@@ -11904,8 +11891,8 @@ msgstr "додане"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1041
@@ -11992,8 +11979,7 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:1434
 #: invenio/legacy/websubmit/templates.py:1479
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -12137,7 +12123,8 @@ msgstr "підтвердження"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -12235,8 +12222,8 @@ msgstr "кошики"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -12255,8 +12242,8 @@ msgstr ""
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -12297,7 +12284,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12319,14 +12307,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -12446,10 +12433,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12735,8 +12721,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12899,8 +12885,8 @@ msgstr ""
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -12960,9 +12946,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -12983,8 +12968,8 @@ msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -13054,8 +13039,7 @@ msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13126,13 +13110,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13141,9 +13124,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13317,8 +13300,7 @@ msgstr "розділи"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13407,8 +13389,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13498,8 +13480,8 @@ msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:55
@@ -13541,12 +13523,12 @@ msgid "Review was sent"
 msgstr "результати"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "Запис видалено"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "Запис видалено"
 
@@ -13599,9 +13581,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13620,8 +13601,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13686,8 +13667,7 @@ msgstr "далі"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13726,8 +13706,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13853,11 +13832,6 @@ msgstr ""
 msgid "Checking status"
 msgstr ""
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "кошики"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -13892,8 +13866,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13914,8 +13888,8 @@ msgstr "Не знайдено лексичний вказівник для"
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13931,8 +13905,7 @@ msgstr ""
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14053,7 +14026,7 @@ msgstr ""
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 #, fuzzy
 msgid "Edit This Record"
 msgstr "Детальний запис"
@@ -14250,8 +14223,8 @@ msgstr "Останнє поновлення"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "Цей розділ поки що не містить записів"
 
 #: invenio/modules/groups/views.py:279
@@ -14264,12 +14237,12 @@ msgstr ""
 msgid "Members"
 msgstr "листопад"
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "кошики"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14279,11 +14252,11 @@ msgstr "травень"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "всі поля"
@@ -14329,13 +14302,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "кошики"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "кошики"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 msgid "Are you sure you want to delete this record?"
@@ -14486,28 +14460,28 @@ msgstr "повідомлення"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14571,8 +14545,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -15037,11 +15011,6 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "травень"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15082,8 +15051,7 @@ msgstr "Опції пошуку"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15304,7 +15272,7 @@ msgid "just now"
 msgstr ""
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "Шукати серед %s записів:"
 
@@ -15363,6 +15331,15 @@ msgstr "будь-який рік"
 msgid " years ago"
 msgstr "рік"
 
+#~ msgid "File"
+#~ msgstr "назва"
+
+#~ msgid "Tickets"
+#~ msgstr "назва"
+
+#~ msgid "Done"
+#~ msgstr "травень"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "кошики"
 
@@ -15371,9 +15348,6 @@ msgstr "рік"
 
 #~ msgid "*** basket name ***"
 #~ msgstr "кошики"
-
-#~ msgid ""
-#~ msgstr ""
 
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "обліковий запис"
@@ -15404,9 +15378,6 @@ msgstr "рік"
 
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "Запис видалено"
-
-#~ msgid "File"
-#~ msgstr "назва"
 
 #~ msgid "File %s already exists."
 #~ msgstr "Запис видалено"
@@ -15449,9 +15420,6 @@ msgstr "рік"
 
 #~ msgid "These are not mine!"
 #~ msgstr "кошики"
-
-#~ msgid "Tickets"
-#~ msgstr "назва"
 
 #~ msgid "Request Tickets"
 #~ msgstr "гість"
@@ -15590,9 +15558,6 @@ msgstr "рік"
 
 #~ msgid "Verbose"
 #~ msgstr "Переглянути"
-
-#~ msgid "Done"
-#~ msgstr "травень"
 
 #~ msgid "Edit current version"
 #~ msgstr "кошики"
@@ -15738,9 +15703,6 @@ msgstr "рік"
 #~ msgid "Citation Metrics"
 #~ msgstr "Citation history:"
 
-#~ msgid "WebSearch Admin Guide"
-#~ msgstr ""
-
 #~ msgid "Submit Guide"
 #~ msgstr "Допомога в поданні"
 
@@ -15750,38 +15712,6 @@ msgstr "рік"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "Адміністрування подання"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
-#~ msgid "Quit searching."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
-#~ msgid "Cancel merging"
-#~ msgstr ""
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
-
-#~ msgid "Search for a person to assign the paper to"
-#~ msgstr ""
-
 #~ msgid "Select All"
 #~ msgstr "кошики"
 
@@ -15790,12 +15720,6 @@ msgstr "рік"
 
 #~ msgid "Invert Selection"
 #~ msgstr "кошики"
-
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
 
 #~ msgid "Author Name"
 #~ msgstr "автор"
@@ -15809,17 +15733,8 @@ msgstr "рік"
 #~ msgid "No status information found."
 #~ msgstr "адміністрування"
 
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
-
 #~ msgid "Review Transaction"
 #~ msgstr "підрозділ"
-
-#~ msgid "On all pages"
-#~ msgstr ""
 
 #~ msgid "With selected do"
 #~ msgstr "обмежено"
@@ -15827,141 +15742,32 @@ msgstr "рік"
 #~ msgid "View name variants"
 #~ msgstr "обліковий запис"
 
-#~ msgid "The author has an internal ID!"
-#~ msgstr ""
-
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "Not Available"
 #~ msgstr "Не знайдено лексичний вказівник для"
 
 #~ msgid " Delete this ticket"
 #~ msgstr "кошики"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "Не знайдено лексичний вказівник для"
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "кошики"
 
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
 #~ msgid "Paper title: "
 #~ msgstr "повідомлення"
-
-#~ msgid "Ignore"
-#~ msgstr ""
 
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "Запис видалено"
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "кошики"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
-
-#~ msgid "Please provide your information"
-#~ msgstr ""
-
-#~ msgid "Please provide your first name"
-#~ msgstr ""
-
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
 
 #~ msgid "Your last name:"
 #~ msgstr "підтвердження"
 
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
 #~ msgid "Your eMail:"
 #~ msgstr "кошики"
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "кошики"
@@ -15969,428 +15775,44 @@ msgstr "рік"
 #~ msgid "Mark as your documents"
 #~ msgstr "кошики"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "кошики"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "кошики"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
-
 #~ msgid "Add to merge list"
 #~ msgstr "Персоналізація"
-
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
 
 #~ msgid "Recent Papers"
 #~ msgstr "повідомлення"
 
-#~ msgid "Showing the"
-#~ msgstr ""
-
-#~ msgid "most recent documents:"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
-#~ msgid "Manage your profile"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Choose your profile"
 #~ msgstr "підтвердження"
-
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
 
 #~ msgid "Manage publication list"
 #~ msgstr "кошики"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "кошики"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "додане"
 
-#~ msgid "Choose system"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "Запис видалено"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
-#~ msgid "Fatal: You are not allowed to access this functionality."
-#~ msgstr ""
-
-#~ msgid "Claim this paper"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "You can see your library account %(x_url_open)shere%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "Cited by: %s records"
-
-#~ msgid "Unknown type: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file named %s already exists. Please choose another name."
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
 
 #~ msgid "Revision"
 #~ msgstr "підрозділ"
 
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Could not find format element named %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
-
-#~ msgid "Could not find output format named %s."
-#~ msgstr ""
-
-#~ msgid "Modify Template Attributes"
-#~ msgstr ""
-
-#~ msgid "Template Editor"
-#~ msgstr ""
-
-#~ msgid "Check Dependencies"
-#~ msgstr ""
-
-#~ msgid "Update Format Attributes"
-#~ msgstr ""
-
 #~ msgid "Show Documentation"
 #~ msgstr "обліковий запис"
-
-#~ msgid "Hide Documentation"
-#~ msgstr ""
-
-#~ msgid "Last Modification Date"
-#~ msgstr ""
 
 #~ msgid "Manage Output Formats"
 #~ msgstr "Формат представлення:"
 
-#~ msgid "Manage Format Templates"
-#~ msgstr ""
-
-#~ msgid "Format Elements Documentation"
-#~ msgstr ""
-
-#~ msgid "Add New Format Template"
-#~ msgstr ""
-
-#~ msgid "Check Format Templates Extensively"
-#~ msgstr ""
-
-#~ msgid "Code"
-#~ msgstr ""
-
 #~ msgid "Add New Output Format"
 #~ msgstr "Формат представлення:"
-
-#~ msgid "menu"
-#~ msgstr ""
 
 #~ msgid "Close Output Format"
 #~ msgstr "Формат представлення:"
@@ -16398,119 +15820,17 @@ msgstr "рік"
 #~ msgid "Rules"
 #~ msgstr "гість"
 
-#~ msgid "Modify Output Format Attributes"
-#~ msgstr ""
-
 #~ msgid "Remove Rule"
 #~ msgstr "далі"
-
-#~ msgid "Add New Rule"
-#~ msgstr ""
-
-#~ msgid "No problem found with format"
-#~ msgstr ""
 
 #~ msgid "An error has been found"
 #~ msgstr "Запис видалено"
 
-#~ msgid "The following errors have been found"
-#~ msgstr ""
-
-#~ msgid "BibFormat Admin"
-#~ msgstr ""
-
-#~ msgid "Enter a search query here."
-#~ msgstr ""
-
 #~ msgid "No Record Found for %s."
 #~ msgstr "Розділ %s не існує"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "Запис видалено"
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
-
-#~ msgid "Output format %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
-#~ msgid "Format template %s calls undefined element \"%s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
-
-#~ msgid "Error in format element %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Show all %i authors"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "Формат представлення:"
@@ -16518,191 +15838,14 @@ msgstr "рік"
 #~ msgid "Output Format %s Rules"
 #~ msgstr "Формат представлення:"
 
-#~ msgid "Output Format %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Output Format %s Dependencies"
-#~ msgstr ""
-
 #~ msgid "Delete Output Format"
 #~ msgstr "Формат представлення:"
 
 #~ msgid "Cannot create output format"
 #~ msgstr "Формат представлення:"
 
-#~ msgid "Format template %s cannot not be read. %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Template"
-#~ msgstr ""
-
-#~ msgid "Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Format Template %s Dependencies"
-#~ msgstr ""
-
 #~ msgid "Delete Format Template"
 #~ msgstr "обліковий запис"
-
-#~ msgid "Format Element %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "Test Format Element %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Output Format %s"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Template %s"
-#~ msgstr ""
-
-#~ msgid "Restricted Format Element"
-#~ msgstr ""
-
-#~ msgid "Validation of Format Element %s"
-#~ msgstr ""
-
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
-#~ msgid "Format Validation"
-#~ msgstr ""
-
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Attributes"
-#~ msgstr ""
-
-#~ msgid "Knowledge Base %s Dependencies"
-#~ msgstr ""
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid "Cannot send error request, %s parameter missing."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Not Set"
-#~ msgstr ""
-
-#~ msgid "never"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Your account on '%s' has been activated"
-#~ msgstr ""
-
-#~ msgid "Your request for an account has been rejected on '%s':"
-#~ msgstr ""
-
-#~ msgid "You already have an alert named %s."
-#~ msgstr ""
-
-#~ msgid "The alert %s has been added to your profile."
-#~ msgstr ""
-
-#~ msgid "You have defined %s alerts."
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Set a new alert"
-#~ msgstr ""
-
-#~ msgid "%s Personalize, Modify alert settings"
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "назва"
@@ -16712,9 +15855,6 @@ msgstr "рік"
 
 #~ msgid "No Keywords"
 #~ msgstr "ключеве слово"
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
 
 #~ msgid "No Subject categories"
 #~ msgstr "кошики"
@@ -16731,17 +15871,8 @@ msgstr "рік"
 #~ msgid "Affiliations"
 #~ msgstr "Citation history:"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
 #~ msgid "Citations%s"
 #~ msgstr "Citation history:"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "кошики"
@@ -16752,141 +15883,6 @@ msgstr "рік"
 #~ msgid "No publications available"
 #~ msgstr "Не знайдено лексичний вказівник для"
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%i users are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "%i user groups are subscribed to this basket."
-#~ msgstr ""
-
-#~ msgid "You have set %i alerts on this basket."
-#~ msgstr ""
-
-#~ msgid "%i subscribers"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s does not exist in the database."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is an invalid ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "Showing the latest %i comments:"
-#~ msgstr ""
-
-#~ msgid "Sorry, the record %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "Sorry, %s is not a valid ID value."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s"
-#~ msgstr ""
-
-#~ msgid "Readers found the following %s reviews to be most helpful."
-#~ msgstr ""
-
-#~ msgid "View all %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s reviews"
-#~ msgstr ""
-
-#~ msgid "There is a total of %s comments"
-#~ msgstr ""
-
-#~ msgid "Note: Your nickname, %s, will be displayed as author of this comment."
-#~ msgstr ""
-
-#~ msgid "Max %i files"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Note: Your nickname, %s, will be "
-#~ "displayed as the author of this "
-#~ "review."
-#~ msgstr ""
-
-#~ msgid "View all %s reported comments"
-#~ msgstr ""
-
-#~ msgid "View all %s reported reviews"
-#~ msgstr ""
-
-#~ msgid "Here are the reported reviews of user %s"
-#~ msgstr ""
-
-#~ msgid "Here are the reported comments of user %s"
-#~ msgstr ""
-
-#~ msgid "Here are all reviews for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "Here are all comments for record %i, sorted by the most reported"
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "%s View your previously submitted comments"
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your message is too long, please "
-#~ "shorten it. Maximum size allowed is "
-#~ "%i characters."
-#~ msgstr ""
-
-#~ msgid "Group %s does not exist."
-#~ msgstr ""
-
-#~ msgid "User %s does not exist."
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, %s does not seem to be "
-#~ "a valid sort option. The records "
-#~ "will not be sorted."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Sorry, sorting is allowed on sets "
-#~ "of up to %d records only. Using"
-#~ " default sort order."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr "Cited by: %s records"
 
@@ -16896,26 +15892,8 @@ msgstr "рік"
 #~ msgid "%i reviews"
 #~ msgstr "далі"
 
-#~ msgid "Sorry, collection %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "You may want to start browsing from %s."
-#~ msgstr ""
-
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "повідомлення"
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "Citation history:"
@@ -16923,83 +15901,8 @@ msgstr "рік"
 #~ msgid "No Citation Information available"
 #~ msgstr "Не знайдено лексичний вказівник для"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "сеанс"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If you are using a lightweight CERN account you can\n"
-#~ "                %(x_url_open)sreset the password%(x_url_close)s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Alternatively, you can ask %s to "
-#~ "change your login system from external"
-#~ " to internal."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "%s offers you the possibility to "
-#~ "personalize the interface, to set up "
-#~ "your own personal library of documents,"
-#~ " or to set up an automatic "
-#~ "alert query that would run periodically"
-#~ " and would notify you of search "
-#~ "results by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid "Okay, a password reset link has been emailed to %s."
-#~ msgstr ""
-
-#~ msgid "If you don't own an account yet, please contact %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please do not use valuable passwords "
-#~ "such as your Unix, AFS or NICE "
-#~ "passwords with this service. Your email"
-#~ " address will stay strictly confidential"
-#~ " and will not be disclosed to "
-#~ "any third party. It will be used"
-#~ " to identify you for personal "
-#~ "services of %s. For example, you "
-#~ "may set up an automatic alert "
-#~ "search that will look for new "
-#~ "preprints and will notify you daily "
-#~ "of new arrivals by email."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "It is not possible to create an"
-#~ " account yourself. Contact %s if you"
-#~ " want an account."
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "кошики"
@@ -17016,178 +15919,8 @@ msgstr "рік"
 #~ msgid "Your submissions"
 #~ msgstr "додане"
 
-#~ msgid "Statistics"
-#~ msgstr ""
-
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
 #~ msgid "Group: %s"
 #~ msgstr "кошики"
 
-#~ msgid "Group %s: New membership request"
-#~ msgstr ""
-
-#~ msgid "A user wants to join the group %s."
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been accepted."
-#~ msgstr ""
-
-#~ msgid "Your request for joining group %s has been rejected."
-#~ msgstr ""
-
-#~ msgid "Group %s has been deleted by its administrator."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to switch to external login "
-#~ "method %s, because your email address"
-#~ " is unknown to the external login "
-#~ "system."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The external login method %s does "
-#~ "not support email address based logins."
-#~ "  Please contact the site administrators."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s is invalid."
-#~ msgstr ""
-
-#~ msgid "Supplied email address %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s is already in use."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Desired nickname %s already exists in the database."
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "Sorry, page %s does not seem to exist."
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "Розділ %s не існує"
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
-
-#~ msgid "Unable to find the submission directory for the action: %s"
-#~ msgstr ""
-
-#~ msgid "Unable to find document type: %s"
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory."
-#~ msgstr ""
-
-#~ msgid "The field %s is mandatory. Please fill it in."
-#~ msgstr ""
-
-#~ msgid "Function %s does not exist."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s%s'"
-#~ msgstr ""
-

--- a/invenio/base/translations/zh_CN/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/zh_CN/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2008-02-29 15:37+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:59+0200\n"
 "Last-Translator: Kam-ming Ku <kmku@hkusua.hku.hk>\n"
 "Language-Team: ZH_CN <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -58,8 +58,8 @@ msgstr "管理"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -205,7 +205,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 #, fuzzy
 msgid "Hello:"
 msgstr "您好"
@@ -227,17 +227,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -263,48 +263,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "这记录并不存在。"
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "您并不是这收藏篮的拥有者。"
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "注册失败"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "请选择："
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "注册失败"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -508,7 +513,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -730,7 +736,8 @@ msgid "The following errors have occurred:"
 msgstr "发现以下错误"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -747,8 +754,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -830,7 +837,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -873,8 +880,8 @@ msgstr "收藏"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "前一个"
@@ -890,8 +897,8 @@ msgstr "评分"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "下一个"
 
@@ -906,18 +913,6 @@ msgstr "下一个"
 #: invenio/legacy/weblinkback/adminlib.py:55
 msgid "Admin Area"
 msgstr "管理"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "作者"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
@@ -937,11 +932,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
 msgid "Limit to knowledge bases containing string:"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "成功删除"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -993,16 +983,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
 msgid "Verify BibCheck config file"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "数据库错误"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "文档"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
@@ -1109,7 +1089,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1160,8 +1141,8 @@ msgstr "帐号已建立。"
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1175,25 +1156,23 @@ msgstr "浏览"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "帐号已建立。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "帐号已建立。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1218,13 +1197,14 @@ msgstr "创建主题"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "帐号已建立。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1256,9 +1236,8 @@ msgstr "现在的状况："
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "帐号已建立。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1325,8 +1304,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1334,8 +1313,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1357,9 +1336,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "帐号已建立。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1401,8 +1379,8 @@ msgstr "找到 %s 笔记录"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1461,11 +1439,11 @@ msgstr "帐号已建立。"
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1476,11 +1454,11 @@ msgstr "是"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1493,8 +1471,8 @@ msgstr "否"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1591,8 +1569,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1612,29 +1590,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1643,9 +1621,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 #, fuzzy
 msgid "Requested record does not seem to exist."
 msgstr "对不起，记录 %s 并不存在。"
@@ -2007,16 +1985,14 @@ msgstr "记录已被删除。"
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2037,8 +2013,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2200,8 +2176,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2310,7 +2286,7 @@ msgstr "行动"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "描述"
 
@@ -2505,8 +2481,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2792,9 +2768,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "您可以%(x_url_open)s登入%(x_url_close)s。"
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2850,7 +2825,7 @@ msgstr "已拒绝"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "是"
 
@@ -2858,8 +2833,8 @@ msgstr "是"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "帐号已建立。"
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3332,8 +3307,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "电邮"
 
@@ -4184,8 +4159,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4203,8 +4178,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4270,17 +4245,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4668,25 +4643,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "记录已被删除。"
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4746,15 +4721,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4766,10 +4741,10 @@ msgstr "选择主题"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4783,15 +4758,15 @@ msgstr "规则"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4802,7 +4777,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4821,17 +4797,15 @@ msgstr "诨号 %s 已被使用。"
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "诨号 %s 已被使用。"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4850,14 +4824,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4911,8 +4884,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4967,8 +4940,8 @@ msgstr "对不起，记录 %s 并不存在。"
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -5089,9 +5062,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -5106,8 +5079,8 @@ msgstr "储存更改"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -5251,11 +5224,10 @@ msgstr "返回检索结果页"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5392,7 +5364,7 @@ msgid "Total"
 msgstr "可选择的"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "选择"
 
@@ -5563,8 +5535,8 @@ msgstr "删除知识库"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5623,56 +5595,56 @@ msgstr "您必须先登入。"
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5712,7 +5684,7 @@ msgstr "知识库从属关系"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5766,15 +5738,15 @@ msgstr "警报"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -6004,8 +5976,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -6084,8 +6055,8 @@ msgstr "并没有参考"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6100,8 +6071,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "检索结果"
 
@@ -6262,8 +6233,8 @@ msgstr "没有找到。"
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6289,8 +6260,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6301,8 +6272,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -6312,113 +6282,113 @@ msgstr "用 %(x_query1)s 没有确实匹配任何记录，现尝试用 %(x_query
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
-"在专辑 %(x_collection)s 里没有匹配任何记录；但在其他的专辑里找到%(x_url_open)s%(x_nb_hits)d "
-"笔记录%(x_url_close)s。"
+"在专辑 %(x_collection)s 里没有匹配任何记录；但在其他的专辑里找"
+"到%(x_url_open)s%(x_nb_hits)d 笔记录%(x_url_close)s。"
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr "没有在专辑里匹配任何记录。您可尝试在限制的专辑里找寻。"
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr "没有在专辑里匹配任何记录。您可尝试在限制的专辑里找寻。"
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr "匹配不到关於 %s 的任何记录。接近的短语是："
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "用其他关键词。"
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "总共有 %i 个收藏篮"
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "总共有 %i 个收藏篮"
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "总共有 %i 个收藏篮"
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "没有可用的字索引给"
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "没有可用的短语索引给"
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr "在索引 %(x_index)s 匹配不到关於 %(x_term)s 的任何记录。接近的短语是："
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr "匹配不到关於 %s 的任何记录。接近的短语是："
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr "对不起，%s 不是一正确的排序选项，请选用标题排序。"
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr "对不起，这排序功能只被允许在最多 %d 纪录中使用。请用正常排序。"
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr "对不起，%s 不是一正确的排序选项，请选用标题排序。"
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "这记录并不存在。"
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "用其他关键词。"
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6432,11 +6402,11 @@ msgstr "用其他关键词。"
 msgid "Browse"
 msgstr "浏览"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr "没有在时限内匹配到记录, 放弃中..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr "没有在找寻限制内匹配到记录, 放弃中..."
 
@@ -6480,11 +6450,12 @@ msgstr "这警报 %s 已成功被修改。"
 #: invenio/legacy/webalert/api.py:428
 #, fuzzy, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
-msgstr "您已有 %(x_nb)s 条查询。您可以用%(x_url_open)s详细列表%(x_url_close)s a)查阅搜寻结果；b)订阅警报电邮。"
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
+msgstr ""
+"您已有 %(x_nb)s 条查询。您可以用%(x_url_open)s详细列表%(x_url_close)s a)查阅"
+"搜寻结果；b)订阅警报电邮。"
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6623,8 +6594,8 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"从%(x_url1_open)s您的检索%(x_url1_close)s、 "
-"%(x_url2_open)s热门检索%(x_url2_close)s或表格中建设新的警报。"
+"从%(x_url1_open)s您的检索%(x_url1_close)s、 %(x_url2_open)s热门检"
+"索%(x_url2_close)s或表格中建设新的警报。"
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6675,15 +6646,15 @@ msgstr "您已定义 %s 警报。"
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr "您未执行任何查寻。请先到%(x_url_open)s搜索介面%(x_url_close)s。"
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr "在之前的三十天，您已执行了%(x_nb1)s 搜索 (%(x_nb2)s 不同的问题)。"
 
 #: invenio/legacy/webalert/templates.py:453
@@ -6743,7 +6714,7 @@ msgstr "您的搜寻结果"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6807,7 +6778,7 @@ msgstr "设置新警报"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6867,7 +6838,8 @@ msgstr "显示警报"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6891,7 +6863,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "您没有足够权限以读取这收藏篮。"
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6919,7 +6892,8 @@ msgid "You do not have permission to delete this note."
 msgstr "您没有足够权限以读取这收藏篮。"
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6950,8 +6924,8 @@ msgstr "这记录并不存在。"
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6973,8 +6947,8 @@ msgstr "拷贝记录进收藏篮"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -7007,8 +6981,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7081,11 +7055,10 @@ msgstr "共享收藏篮"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
-"您有 %(x_nb_perso)s 个个人收藏篮、订阅 %(x_nb_group)s 组别收藏篮和%(x_nb_public)s "
-"其他用户的共享收藏篮。"
+"您有 %(x_nb_perso)s 个个人收藏篮、订阅 %(x_nb_group)s 组别收藏篮"
+"和%(x_nb_public)s 其他用户的共享收藏篮。"
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
 #, fuzzy
@@ -7112,8 +7085,7 @@ msgstr "%i 用户组别已订阅这收藏篮。"
 #: invenio/legacy/webbasket/templates.py:108
 #, fuzzy, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr "您可以使用您的%(x_url_open)s帐号%(x_url_close)s。"
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -7284,8 +7256,8 @@ msgstr "外部记录"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7470,15 +7442,16 @@ msgstr "分享这收藏篮于组别"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr "您是用游客登录, 因此您的收藏篮将不会保存在这系统中。"
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr "您可以%(x_url_open)s登入或%(x_url_close)s注册。"
 
 #: invenio/legacy/webbasket/templates.py:2131
@@ -7488,7 +7461,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "游客是被禁止使用这功能。"
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "返回检索结果页"
 
@@ -7663,7 +7636,7 @@ msgstr "加入至用户"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7810,215 +7783,215 @@ msgstr "用户 %s 并不存在。"
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "用户 %s 并不存在。"
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "撰写意见"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_name)s 在 %(x_date)s 写："
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "意见"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "显示最後的 %i 意见："
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "讨论这评论"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "讨论这文件。"
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "对不起，记录 %s 并不存在。"
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "对不起，%s 不是一有效数值。"
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "对不起，并没有提供记录ID。"
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "您可以从%s开始浏览 "
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_name)s 在 %(x_date)s 写："
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "这评论有用吗？"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "撰写评论"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr "平均评论得分：%(x_nb_score)s 基于 %(x_nb_reviews)s 条评论"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "读者觉得以下 %s 评论是有用的。"
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "阅读全部%s评论"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "评价这文件"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "成为第一个读者去评论这文件。"
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "评分"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "举报滥用"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 #, fuzzy
 msgid "Undelete comment"
 msgstr "删除意见"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "删除意见"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 #, fuzzy
 msgid "Unreport comment"
 msgstr "删除意见"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "%(x_nickname)s 在 %(x_date)s 评论这文件"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr "%(x_nb_people)i/%(x_nb_total)i个读者评价这评论是有用的"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 #, fuzzy
 msgid "Undelete review"
 msgstr "删除已选择的评论"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 #, fuzzy
 msgid "Delete review"
 msgstr "删除已选择的评论"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 #, fuzzy
 msgid "Unreport review"
 msgstr "撰写评论"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "意见"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "评论"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "总共有 %s 评论"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "总共有 %s "
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "成为第一个读者去评论这文件。"
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "订阅"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 #, fuzzy
 msgid "Unsubscribe"
 msgstr "订阅"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -8027,515 +8000,519 @@ msgstr "订阅"
 msgid "Record"
 msgstr "记录"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "评论"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "意见"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "评论"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "阅读"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "页:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 #, fuzzy
 msgid "You are not authorized to comment or review."
 msgstr "您并不是这收藏篮的拥有者。"
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr "注意：您的诨号 - %s - 将会成显示为文件的作者名称。"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
-msgstr "注意：您并未%(x_url_open)s定义您的诨号%(x_url_close)s。%(x_nickname)s 是会成显示为文件的作者名称。"
+msgstr ""
+"注意：您并未%(x_url_open)s定义您的诨号%(x_url_close)s。%(x_nickname)s 是会成"
+"显示为文件的作者名称。"
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 #, fuzzy
 msgid "Max one file"
 msgstr "增添规则"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "文档"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "文章"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 #, fuzzy
 msgid "Add comment"
 msgstr "新增评论"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr "您的诨号 - %s - 将会成显示为评论的作者名称。"
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "评价这文章"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "选择评分"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "输入评论标题"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "撰写评论"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 #, fuzzy
 msgid "Add review"
 msgstr "新增评论"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "新增评论"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "您的评论已被接受。"
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "您的意见已被接受。"
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "返回记录"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr "您可直接在%(x_url_open)s这里%(x_url_close)s咨询您的组别名单。"
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 #, fuzzy
 msgid "View most commented records"
 msgstr "阅读意见"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 #, fuzzy
 msgid "View latest commented records"
 msgstr "阅读意见"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all comments reported as abuse"
 msgstr "查阅全部用户"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 #, fuzzy
 msgid "View most reviewed records"
 msgstr "移除记录"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 #, fuzzy
 msgid "View latest reviewed records"
 msgstr "阅读全部%s评论"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all reviews reported as abuse"
 msgstr "查阅全部用户"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "查阅全部曾给予意见/评论的用户"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "指南"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "意见和评论已被禁止"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr "请输入意见/评论ID以便查阅，之後您可以决定是否删除它。"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "意见ID："
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 #, fuzzy
 msgid "Record ID:"
 msgstr "记录号"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "查阅意见"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "没有任何报告记录。"
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "查阅全部 %s 意见"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "查阅全部 %s 评论"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr "这名单列出全部曾提交意见或评论的用户。"
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "诨号"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "用户ID"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "正面的投票"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "负面的投票"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "全部投票数目"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "报告数目"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "查阅全部用户的意见和评论"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "这评论已被报告了%i次"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "这意见已被报告了%i次"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "作者："
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "一般资料"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "删除已选择的评论"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "查禁已选择的滥用报告"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 #, fuzzy
 msgid "Undelete selected reviews"
 msgstr "删除已选择的评论"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 #, fuzzy
 msgid "Undelete selected comments"
 msgstr "删除已选择的意见"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "删除已选择的意见"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "用户 %s 的评论："
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "用户 %s 的意见："
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "评论/意见 %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "评论/意见 %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, fuzzy, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "用户 %(x_user)s 的评论/意见 %(x_cmtID)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, fuzzy, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "用户 %(x_user)s 的评论/意见 %(x_cmtID)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "全部评论 (以最多提供评论者排序)"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "全部意见 (以最多提供意见者排序)"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr "全部评论 (以最多提供评论者排序)"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 #, fuzzy
 msgid "Show comments"
 msgstr "阅读意见"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr "全部意见 (以最多提供意见者排序)"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 #, fuzzy
 msgid "Show reviews"
 msgstr "评论"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "意见ID"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "成功删除"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 #, fuzzy
 msgid "successfully undeleted"
 msgstr "成功删除"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "成功查禁滥用报告"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 #, fuzzy
 msgid "Not yet reviewed"
 msgstr "撰写评论"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "您的意见已被张贴。"
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "删除意见"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "时间"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "阅读意见"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "详细资料和意见"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "找到 %s 笔记录"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "意见"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "时间"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "加入至用户"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "显示"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "创建日期"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "下一页"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "显示警报"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8544,106 +8521,106 @@ msgstr "显示警报"
 msgid "Refresh"
 msgstr "参考"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "删除意见"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "没有找到。"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "找不到记录"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "您没有足够权限以读取这收藏篮。"
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "新增评论"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "阅读所有意见"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 #, fuzzy
 msgid "Page Not Found"
 msgstr "找不到 %s 专辑"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 #, fuzzy
 msgid "The requested comment could not be found"
 msgstr "这记录并不存在。"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 #, fuzzy
 msgid "The requested file could not be found"
 msgstr "这记录并不存在。"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "您并不是这收藏篮的拥有者。"
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "意见"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "阅读所有意见"
@@ -8765,8 +8742,8 @@ msgstr "对不起，记录 %s 并不存在。"
 #: invenio/legacy/webdoc/webinterface.py:200
 #, fuzzy, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr "您可以使用您的%(x_url_open)s帐号%(x_url_close)s。"
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8838,8 +8815,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8867,8 +8844,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -8972,11 +8949,6 @@ msgstr ""
 msgid "Apply"
 msgstr "四月"
 
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "诨号"
-
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 #, fuzzy
 msgid "WebJournal Admin"
@@ -9061,9 +9033,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -9085,8 +9056,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9572,14 +9542,14 @@ msgstr "也搜寻:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9717,8 +9687,7 @@ msgstr "提交"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr "匹配不到记录，请试用其他关键词。"
 
 #: invenio/legacy/websearch/templates.py:3357
@@ -9744,8 +9713,8 @@ msgstr "您可以从 %s 开始浏览。"
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "建立您的%(x_url1_open)s电邮警报%(x_url1_close)s\n"
 "或订阅%(x_url2_open)sRSS feed%(x_url2_close)s."
@@ -9941,7 +9910,8 @@ msgid "in"
 msgstr "在"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "没有寻找到什么? 尝试在以下的服务器查寻："
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -10033,8 +10003,8 @@ msgstr "必须的"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -10044,8 +10014,8 @@ msgstr "创建收藏篮"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr "请用以下表格来改变您的电邮或诨号。"
 
 #: invenio/legacy/websession/templates.py:271
@@ -10062,14 +10032,14 @@ msgstr "重设"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr "请用以下表格来改变您的电邮。"
 
 #: invenio/legacy/websession/templates.py:327
@@ -10107,8 +10077,8 @@ msgstr "建立密码"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr "您可以%(x_url_open)s登入或%(x_url_close)s注册。"
 
 #: invenio/legacy/websession/templates.py:346
@@ -10198,10 +10168,9 @@ msgstr "选择方法"
 #: invenio/legacy/websession/templates.py:537
 #, fuzzy, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr "如果您丢失了密码，请输入您的电邮，我们会电邮密码给您。"
 
 #: invenio/legacy/websession/templates.py:559
@@ -10219,16 +10188,16 @@ msgstr "发送密码"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 #, fuzzy
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr "如果您是用外部的登录系统，那麽我们将不能帮助您。"
 
 #: invenio/legacy/websession/templates.py:573
@@ -10241,10 +10210,10 @@ msgstr "另外，您可以向 %s 重设登录系统。"
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr "%s 提供以下服务：个人化介面、个人收藏篮、设定电邮警报。"
 
 #: invenio/legacy/websession/templates.py:611
@@ -10264,8 +10233,8 @@ msgstr "查阅您过去三十天没内曾进行过搜索。"
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr "您可以用收藏篮定义记录收藏、贮藏有用的记录以便稍後阅览或分享。"
 
 #: invenio/legacy/websession/templates.py:636
@@ -10276,26 +10245,27 @@ msgstr ""
 msgid ""
 "Subscribe to a search which will be run periodically by our service. The "
 "result can be sent to you via Email or stored in one of your baskets."
-msgstr "订阅查寻条件；我们的服务器具定时执行搜索，并把结果发到您的电邮或收藏篮子中。"
+msgstr ""
+"订阅查寻条件；我们的服务器具定时执行搜索，并把结果发到您的电邮或收藏篮子中。"
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr "借出书本、提交借出要求等。须要 CERN ID。"
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr "您是用游客登录, 因此您的警报将不会保存在这系统中。"
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 "您是用%(x_user)s身分登录，你可以 a)%(x_url1_open)s登出%(x_url1_close)s； b) "
 "修改您的%(x_url2_open)s户囗设定%(x_url2_close)s。"
@@ -10314,8 +10284,8 @@ msgstr "搜查警报"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr "您可直接在%(x_url_open)s这里%(x_url_close)s咨询您的组别名单。"
 
 #: invenio/legacy/websession/templates.py:799
@@ -10327,8 +10297,8 @@ msgstr "组别"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr "您可直接在%(x_url_open)s这里%(x_url_close)s咨询您的提交名单。"
 
 #: invenio/legacy/websession/templates.py:805
@@ -10339,8 +10309,8 @@ msgstr "提交"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr "您可直接在%(x_url_open)s这里%(x_url_close)s咨询您的批核名单。"
 
 #: invenio/legacy/websession/templates.py:811
@@ -10387,7 +10357,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -10436,15 +10407,15 @@ msgstr "如果您已经登记帐号, 请登入."
 #: invenio/legacy/websession/templates.py:1015
 #, fuzzy, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr "如果您没有帐号, 请先%(x_url_open)s注册%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr "如果您没有帐号, 请先%(x_url_open)s注册%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1027
@@ -10480,8 +10451,8 @@ msgstr "您可以使用您的诨号或电邮登入."
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -10510,8 +10481,8 @@ msgstr "请输入您的电邮、诨号、密码:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr "您的帐户要被核实後才可使用."
 
 #: invenio/legacy/websession/templates.py:1228
@@ -10528,24 +10499,26 @@ msgstr "注册"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
-msgstr "请不要使用您自己沿用的密码。您的电邮不会被透露到第三方，它只会使用以辨认您的%s服务。"
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
+msgstr ""
+"请不要使用您自己沿用的密码。您的电邮不会被透露到第三方，它只会使用以辨认您"
+"的%s服务。"
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr "请联络 %s 关於创建帐号事情。"
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr "您的身分是游客。您需要先%(x_url_open)s登入%(x_url_close)s。"
 
 #: invenio/legacy/websession/templates.py:1267
@@ -10679,8 +10652,8 @@ msgstr "以下是一些有用的连结："
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr "请到%(x_url_open)s管理区%(x_url_close)s以便使用更多管理功能。"
 
 #: invenio/legacy/websession/templates.py:1378
@@ -10899,7 +10872,8 @@ msgstr "用户要求加入组别 %s。"
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr "请%(x_url_open)s接纳或拒绝%(x_url_close)s用户要求。"
 
 #: invenio/legacy/websession/templates.py:2400
@@ -10941,74 +10915,70 @@ msgstr "组别 %s 已被管理员删除。"
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"您可直接在%(x_url_open)s这里%(x_url_close)s咨询您的%(x_nb_total)i组别给(%(x_nb_member)i)"
-" or 管理 (%(x_nb_admin)i)名单。"
+"您可直接在%(x_url_open)s这里%(x_url_close)s咨询您的%(x_nb_total)i组别给"
+"(%(x_nb_member)i) or 管理 (%(x_nb_admin)i)名单。"
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr "您的身分是游客。您需要先%(x_url_open)s登入%(x_url_close)s。"
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
-msgstr "%(x_fmt_open)s游客%(x_fmt_close)s 需要先%(x_url_open)s注册%(x_url_close)s。"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
+msgstr ""
+"%(x_fmt_open)s游客%(x_fmt_close)s 需要先%(x_url_open)s注册%(x_url_close)s。"
 
 #: invenio/legacy/websession/webaccount.py:127
 msgid "No queries found"
@@ -11016,14 +10986,14 @@ msgstr "没有找到查询"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -11032,8 +11002,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11045,8 +11015,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11126,8 +11096,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11193,8 +11162,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -11261,10 +11229,10 @@ msgstr "<p>转用内部登录方法。"
 #: invenio/legacy/websession/webinterface.py:423
 #, fuzzy
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr "注意：如您是首次使用内部登录方法登入，您可以点击以下按钮已取得密码："
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -11292,8 +11260,8 @@ msgstr "登录方法已成功选择。"
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr "外部登录方法 %s 并不支援用电邮登入；请联络管理员。"
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -11473,15 +11441,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr "当您的帐号已经开通，我们会再发送电邮给您。"
 
 #: invenio/legacy/websession/webinterface.py:989
@@ -11598,7 +11566,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr "记录创建於%(x_date_creation)s，最後更新在%(x_date_modification)s"
 
 #: invenio/legacy/webstyle/templates.py:707
@@ -11621,37 +11590,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11659,15 +11628,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11735,8 +11704,8 @@ msgstr "不能确定提交页数数量。"
 #: invenio/legacy/websubmit/engine.py:931
 #, fuzzy
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr "不能创建提交目录。"
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11772,8 +11741,8 @@ msgstr "提交"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11821,8 +11790,8 @@ msgstr "请选择类别并点击行动按钮。"
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr "请输入存取号码以便继续上次中断的提交："
 
 #: invenio/legacy/websubmit/templates.py:366
@@ -11851,8 +11820,8 @@ msgstr "返回主目录"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr "这是您的存取号码，您可以用它以重试中断的提交。"
 
 #: invenio/legacy/websubmit/templates.py:548
@@ -11901,8 +11870,8 @@ msgstr "提交号码"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr "这是 %(x_action)s 功能名单  %(x_doctype)s 文件 在 级别 %(x_step)s"
 
 #: invenio/legacy/websubmit/templates.py:1041
@@ -11985,8 +11954,7 @@ msgstr "文件类型名单"
 #: invenio/legacy/websubmit/templates.py:1479
 #, fuzzy
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr "选择以下之文件类型以检查其状态。"
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -12128,7 +12096,8 @@ msgstr "已批核"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr "这文件还在%(x_fmt_open)s等候批核中%(x_fmt_close)s。"
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -12223,8 +12192,8 @@ msgstr "选择评分"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -12244,8 +12213,8 @@ msgstr "撰写意见"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -12286,7 +12255,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12308,14 +12278,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -12438,10 +12407,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12735,8 +12703,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12779,11 +12747,6 @@ msgstr "选择收藏篮"
 #, fuzzy
 msgid "Role details"
 msgstr "文章"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "隐藏"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12899,8 +12862,8 @@ msgstr "电邮 %s 已被使用。"
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -12965,9 +12928,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -12991,8 +12953,8 @@ msgstr "建立密码"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr "请输入您的电邮、诨号、密码:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -13021,7 +12983,7 @@ msgid "Problem with login."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "您可以使用您的%(x_url_open)s帐号%(x_url_close)s。"
 
@@ -13065,8 +13027,7 @@ msgstr "修改设定失败"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13138,13 +13099,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13153,9 +13113,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13332,8 +13292,7 @@ msgstr "专辑"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13423,8 +13382,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13516,10 +13475,10 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr "您的讯息太长，请修改它。最大允许是%i个字。"
 
 #: invenio/modules/comments/forms.py:55
@@ -13563,12 +13522,12 @@ msgid "Review was sent"
 msgstr "撰写意见"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "这意见已被报告了%i次"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "这意见已被报告了%i次"
 
@@ -13621,9 +13580,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13642,8 +13600,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13653,7 +13611,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "诨号 %s 已被使用。"
 
@@ -13709,8 +13667,7 @@ msgstr "评论"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13750,8 +13707,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13797,7 +13753,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "功能 %s 并不存在。"
 
@@ -13880,11 +13836,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "现在的状况："
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "收藏"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -13919,8 +13870,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13941,8 +13892,8 @@ msgstr "没有可用的字索引给"
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13958,8 +13909,7 @@ msgstr "验证格式元件 %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14079,7 +14029,7 @@ msgstr "显示全部 %i 名作者"
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 #, fuzzy
 msgid "Edit This Record"
 msgstr "请使用其他记录ID重试。"
@@ -14182,10 +14132,6 @@ msgstr "评论"
 msgid "Authors"
 msgstr "作者"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14278,8 +14224,8 @@ msgstr "管理组别权利"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "您没有足够权限以读取这收藏篮。"
 
 #: invenio/modules/groups/views.py:279
@@ -14292,12 +14238,12 @@ msgstr "您不是以下组别的管理人："
 msgid "Members"
 msgstr "没有成员"
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "知识库对照"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14307,11 +14253,11 @@ msgstr "完成"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "任何字段"
@@ -14357,13 +14303,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "总共有 %i 个收藏篮"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "总共有 %i 个收藏篮"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14519,28 +14466,28 @@ msgstr "不知名文件种类"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14604,8 +14551,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -14977,7 +14924,7 @@ msgid "Tag name"
 msgstr "诨号"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "诨号 %s 正被使用中。"
 
@@ -15081,11 +15028,6 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "完成"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15127,8 +15069,7 @@ msgstr "检索选项"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15337,7 +15278,7 @@ msgid "just now"
 msgstr "您要先"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s 秒"
 
@@ -15396,6 +15337,36 @@ msgstr "任何年份"
 msgid " years ago"
 msgstr "年份"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "BibFormat 管理"
+
+#~ msgid "Not authorized"
+#~ msgstr "作者"
+
+#~ msgid "Really delete"
+#~ msgstr "成功删除"
+
+#~ msgid "Verify problem"
+#~ msgstr "数据库错误"
+
+#~ msgid "File"
+#~ msgstr "标题"
+
+#~ msgid "niceName"
+#~ msgstr "名称"
+
+#~ msgid "Id"
+#~ msgstr "Id"
+
+#~ msgid "Tickets"
+#~ msgstr "时间"
+
+#~ msgid "by"
+#~ msgstr "由"
+
+#~ msgid "Done"
+#~ msgstr "完成"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "请选择类别"
 
@@ -15410,9 +15381,6 @@ msgstr "年份"
 
 #~ msgid "*** basket name ***"
 #~ msgstr "收藏篮名称"
-
-#~ msgid ""
-#~ msgstr "我们已经发送有关帐号的电邮给您。"
 
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "编辑登入资料"
@@ -15474,23 +15442,8 @@ msgstr "年份"
 #~ msgid "now"
 #~ msgstr "否"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "BibFormat 管理"
-
-#~ msgid "Not authorized"
-#~ msgstr "作者"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "用户 %s 并不存在。"
-
-#~ msgid "Really delete"
-#~ msgstr "成功删除"
-
-#~ msgid "Verify problem"
-#~ msgstr "数据库错误"
-
-#~ msgid "File"
-#~ msgstr "标题"
 
 #~ msgid "File %s already exists."
 #~ msgstr "用户 %s 并不存在。"
@@ -15543,9 +15496,6 @@ msgstr "年份"
 #~ msgid "Not Mine!"
 #~ msgstr "注意"
 
-#~ msgid "Tickets"
-#~ msgstr "时间"
-
 #~ msgid "Request Tickets"
 #~ msgstr "规则"
 
@@ -15581,9 +15531,6 @@ msgstr "年份"
 
 #~ msgid "Create a new Person for your search"
 #~ msgstr "找寻不到记录"
-
-#~ msgid "Id"
-#~ msgstr "Id"
 
 #~ msgid "A %s has been added."
 #~ msgstr "组别 %s 已被删除"
@@ -15636,9 +15583,6 @@ msgstr "年份"
 #~ msgid "creating a new basket"
 #~ msgstr "创建收藏篮"
 
-#~ msgid "by"
-#~ msgstr "由"
-
 #~ msgid "on"
 #~ msgstr "在"
 
@@ -15656,9 +15600,6 @@ msgstr "年份"
 
 #~ msgid "Editing topic"
 #~ msgstr "编辑收藏篮"
-
-#~ msgid "niceName"
-#~ msgstr "名称"
 
 #~ msgid "Apply Changes"
 #~ msgstr "储存"
@@ -15767,9 +15708,6 @@ msgstr "年份"
 
 #~ msgid "Verbose"
 #~ msgstr "详细"
-
-#~ msgid "Done"
-#~ msgstr "完成"
 
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "这更改是临时性的"
@@ -15930,9 +15868,6 @@ msgstr "年份"
 #~ msgid "Citation Metrics"
 #~ msgstr "引用之历史记录"
 
-#~ msgid "WebSearch Admin Guide"
-#~ msgstr ""
-
 #~ msgid "Submit Guide"
 #~ msgstr "提交帮助"
 
@@ -15942,34 +15877,11 @@ msgstr "年份"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "WebSubmit 管理"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "执行搜索"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "取消"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "您是以下组别的成员："
@@ -15983,12 +15895,6 @@ msgstr "年份"
 #~ msgid "Invert Selection"
 #~ msgstr "并没有参考"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "作者"
 
@@ -16000,12 +15906,6 @@ msgstr "年份"
 
 #~ msgid "No status information found."
 #~ msgstr "更多资料"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "分类"
@@ -16019,18 +15919,6 @@ msgstr "年份"
 #~ msgid "View name variants"
 #~ msgstr "阅读意见"
 
-#~ msgid "The author has an internal ID!"
-#~ msgstr ""
-
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "意见"
 
@@ -16040,87 +15928,20 @@ msgstr "年份"
 #~ msgid " Delete this ticket"
 #~ msgstr "删除收藏篮"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "没有可使用的文件种类。"
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "选择评分"
 
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
 #~ msgid "Paper title: "
 #~ msgstr "页:"
-
-#~ msgid "Ignore"
-#~ msgstr ""
 
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "发现以下错误"
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "选择评分"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "更多资料"
@@ -16128,35 +15949,11 @@ msgstr "年份"
 #~ msgid "Please provide your first name"
 #~ msgstr "您必须先登入。"
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "外借"
 
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
 #~ msgid "Your eMail:"
 #~ msgstr "警报"
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "删除已选择的评论"
@@ -16164,186 +15961,35 @@ msgstr "年份"
 #~ msgid "Mark as your documents"
 #~ msgstr "全部文件类型"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "评价这文件"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "评价这文件"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "或创建"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "加入至用户"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "页:"
-
-#~ msgid "Showing the"
-#~ msgstr ""
 
 #~ msgid "most recent documents:"
 #~ msgstr "文件名单"
 
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "管理格式模板"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "选择主题"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "创建日期"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "一般设定"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "提交"
@@ -16351,190 +15997,17 @@ msgstr "年份"
 #~ msgid "Choose system"
 #~ msgstr "选择主题"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "发现以下错误"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "您不能使用管理功能。"
 
 #~ msgid "Claim this paper"
 #~ msgstr "加入至用户"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "已有 %s 记录引用"
 
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
 #~ msgid "Revision"
 #~ msgstr "分类"
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "修改模板属性"
@@ -16614,89 +16087,20 @@ msgstr "年份"
 #~ msgid "No Record Found for %s."
 #~ msgstr "找不到记录"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "用户 %s 并不存在。"
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "输出格式 %s 属性"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "格式模板 %s 从属关系"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "验证格式元件 %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "格式元件 %s 从属关系"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "限制输出格式"
@@ -16752,113 +16156,17 @@ msgstr "年份"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "验证格式元件 %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "验证格式"
 
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "知识库 %s"
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "注意"
 
 #~ msgid "never"
 #~ msgstr "转换"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "时间"
@@ -16868,9 +16176,6 @@ msgstr "年份"
 
 #~ msgid "No Keywords"
 #~ msgstr "关键词"
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
 
 #~ msgid "No Subject categories"
 #~ msgstr "共享收藏篮列表"
@@ -16887,17 +16192,8 @@ msgstr "年份"
 #~ msgid "Affiliations"
 #~ msgstr "引用之历史记录"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
 #~ msgid "Citations%s"
 #~ msgstr "引用之历史记录"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "创建日期"
@@ -16908,42 +16204,6 @@ msgstr "年份"
 #~ msgid "No publications available"
 #~ msgstr "没有可使用的文件种类。"
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr "已有 %s 记录引用"
 
@@ -16953,20 +16213,8 @@ msgstr "年份"
 #~ msgid "%i reviews"
 #~ msgstr "评论"
 
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "页:"
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "引用之历史记录"
@@ -16974,35 +16222,8 @@ msgstr "年份"
 #~ msgid "No Citation Information available"
 #~ msgstr "没有可使用的文件种类。"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "連線階段"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "警报"
@@ -17022,108 +16243,15 @@ msgstr "年份"
 #~ msgid "Statistics"
 #~ msgstr "状态"
 
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
 #~ msgid "Group: %s"
 #~ msgstr "组别: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "找不到 %s 专辑"
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "栏位 %s 不可留空。"
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "不能确定提交页数数量。"
-

--- a/invenio/base/translations/zh_TW/LC_MESSAGES/messages.po
+++ b/invenio/base/translations/zh_TW/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # # This file is part of Invenio.
-# # Copyright (C) 2007, 2008, 2009, 2010, 2011 CERN.
+# # Copyright (C) 2007, 2008, 2009, 2010, 2011, 2015 CERN.
 # #
 # # Invenio is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU General Public License as
@@ -16,15 +16,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Invenio 1.2.0\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-03-04 16:44+0100\n"
-"PO-Revision-Date: 2008-02-29 15:40+0100\n"
+"POT-Creation-Date: 2015-08-27 12:32+0200\n"
+"PO-Revision-Date: 2015-08-27 12:59+0200\n"
 "Last-Translator: Kam-ming Ku <kmku@hkusua.hku.hk>\n"
 "Language-Team: ZH_TW <info@invenio-software.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: invenio/base/decorators.py:133
 #, python-format
@@ -58,8 +58,8 @@ msgstr "管理"
 #: invenio/base/templates/401.html:37
 #, python-format
 msgid ""
-"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s "
-"and login with a different user."
+"Or, %(x_url_open)s%(x_url_open_1)s%(x_url_open_2)slogout%(x_url_close)s and "
+"login with a different user."
 msgstr ""
 
 #: invenio/base/templates/404.html:26
@@ -205,7 +205,7 @@ msgstr ""
 
 #: invenio/base/templates/mail_html.tpl:20
 #: invenio/base/templates/mail_text.tpl:20
-#: invenio/legacy/webcomment/templates.py:2256
+#: invenio/legacy/webcomment/templates.py:2255
 #, fuzzy
 msgid "Hello:"
 msgstr "您好"
@@ -227,17 +227,17 @@ msgstr ""
 #: invenio/ext/email/__init__.py:247
 #, python-format
 msgid ""
-"The system is not attempting to send an email from %(x_from)s, to "
-"%(x_to)s, with body %(x_body)s."
+"The system is not attempting to send an email from %(x_from)s, to %(x_to)s, "
+"with body %(x_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:269
 #, python-format
 msgid ""
-"Error in sending message.                         Waiting %(sec)s "
-"seconds. Exception is %(exc)s,                         while sending "
-"email from %(sender)s to %(receipient)s                         with body"
-" %(email_body)s."
+"Error in sending message.                         Waiting %(sec)s seconds. "
+"Exception is %(exc)s,                         while sending email from "
+"%(sender)s to %(receipient)s                         with body "
+"%(email_body)s."
 msgstr ""
 
 #: invenio/ext/email/__init__.py:287
@@ -263,48 +263,53 @@ msgstr ""
 msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:68
+#: invenio/ext/login/__init__.py:61
+#, fuzzy
+msgid "Provided data is not valid"
+msgstr "這記錄並不存在。"
+
+#: invenio/ext/login/__init__.py:73
 #: invenio/legacy/websession/webinterface.py:679
 msgid "Password reset request for"
 msgstr ""
 
-#: invenio/ext/login/__init__.py:124
+#: invenio/ext/login/__init__.py:129
 #, fuzzy, python-format
 msgid "You are not authorized to use '%(x_login_method)s' login method."
 msgstr "您並不是這收藏籃的擁有者。"
 
-#: invenio/ext/login/__init__.py:130
+#: invenio/ext/login/__init__.py:135
 #, python-format
 msgid ""
 "You have not yet confirmed the email address for the             "
 "'%(login_method)s' authentication method."
 msgstr ""
 
-#: invenio/ext/login/__init__.py:148 invenio/modules/annotations/views.py:156
+#: invenio/ext/login/__init__.py:153 invenio/modules/annotations/views.py:156
 #: invenio/modules/comments/views.py:204 invenio/modules/comments/views.py:238
 #: invenio/modules/records/views.py:80
 #, fuzzy
 msgid "Authorization failure"
 msgstr "註冊失敗"
 
-#: invenio/ext/login/__init__.py:154
+#: invenio/ext/login/__init__.py:159
 #, fuzzy
 msgid "Please sign in to continue."
 msgstr "請選擇："
 
-#: invenio/ext/login/__init__.py:158
+#: invenio/ext/login/__init__.py:163
 #, fuzzy
 msgid "Authorization failure."
 msgstr "註冊失敗"
 
-#: invenio/ext/script/__init__.py:116
+#: invenio/ext/script/__init__.py:143
 #, python-format
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit <a href=\"%(wiki)s\">%()s</a>"
+"A newer version of Invenio is available for download. You may want to visit "
+"<a href=\"%(wiki)s\">%()s</a>"
 msgstr ""
 
-#: invenio/ext/script/__init__.py:126
+#: invenio/ext/script/__init__.py:153
 #, python-format
 msgid "Cannot download or parse release notes from %(release_notes)s"
 msgstr ""
@@ -508,7 +513,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/engine.py:563
 #: invenio/legacy/batchuploader/engine.py:576
 #, python-format
-msgid "The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
+msgid ""
+"The user '%(x_user)s' is not authorized to modify collection '%(x_coll)s'"
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:235
@@ -730,7 +736,8 @@ msgid "The following errors have occurred:"
 msgstr "發現以下錯誤"
 
 #: invenio/legacy/batchuploader/templates.py:583
-msgid "Some files could not be moved to DONE folder. Please remove them manually."
+msgid ""
+"Some files could not be moved to DONE folder. Please remove them manually."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:585
@@ -747,8 +754,8 @@ msgstr ""
 #: invenio/legacy/batchuploader/templates.py:597
 #, python-format
 msgid ""
-"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s "
-"for executing these actions periodically."
+"Check the %(x_url_open)sBatch Uploader daemon help page%(x_url_close)s for "
+"executing these actions periodically."
 msgstr ""
 
 #: invenio/legacy/batchuploader/templates.py:602
@@ -830,7 +837,7 @@ msgstr ""
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:467
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:54
 #: invenio/modules/groups/forms.py:46
-#: invenio/modules/oauth2server/models.py:142
+#: invenio/modules/oauth2server/models.py:143
 #: invenio/modules/search/admin_forms.py:34 invenio/modules/tags/forms.py:162
 #: invenio/modules/tags/forms.py:262
 msgid "Name"
@@ -873,8 +880,8 @@ msgstr "收藏"
 
 #: invenio/legacy/bibcatalog/templates.py:52
 #: invenio/legacy/bibknowledge/templates.py:170
-#: invenio/legacy/webcomment/templates.py:900
-#: invenio/legacy/webcomment/templates.py:2586
+#: invenio/legacy/webcomment/templates.py:899
+#: invenio/legacy/webcomment/templates.py:2585
 #: invenio/legacy/websearch/templates.py:2038
 msgid "Previous"
 msgstr "前一個"
@@ -890,8 +897,8 @@ msgstr "評分"
 
 #: invenio/legacy/bibcatalog/templates.py:74
 #: invenio/legacy/bibknowledge/templates.py:168
-#: invenio/legacy/webcomment/templates.py:916
-#: invenio/legacy/webcomment/templates.py:2610
+#: invenio/legacy/webcomment/templates.py:915
+#: invenio/legacy/webcomment/templates.py:2609
 msgid "Next"
 msgstr "下一個"
 
@@ -906,18 +913,6 @@ msgstr "下一個"
 #: invenio/legacy/weblinkback/adminlib.py:55
 msgid "Admin Area"
 msgstr "管理"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:59
-msgid "BibCheck Admin"
-msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:69
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:249
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:288
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:325
-#, fuzzy
-msgid "Not authorized"
-msgstr "作者"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:79
 #, fuzzy, python-format
@@ -937,11 +932,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:116
 msgid "Limit to knowledge bases containing string:"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:134
-#, fuzzy
-msgid "Really delete"
-msgstr "成功刪除"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:136
 #: invenio/legacy/bibcirculation/templates.py:1243
@@ -993,16 +983,6 @@ msgstr ""
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:181
 msgid "Verify BibCheck config file"
 msgstr ""
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:182
-#, fuzzy
-msgid "Verify problem"
-msgstr "數據庫錯誤"
-
-#: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:204
-#, fuzzy
-msgid "File"
-msgstr "文檔"
 
 #: invenio/legacy/bibcheck/web/admin/bibcheckadmin.py:238
 msgid "Save Changes"
@@ -1109,7 +1089,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:880
 #: invenio/legacy/bibcirculation/adminlib.py:1874
 #, python-format
-msgid "%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
+msgid ""
+"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s Unknown barcode."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:365
@@ -1160,8 +1141,8 @@ msgstr "帳號已建立。"
 #: invenio/legacy/bibcirculation/adminlib.py:403
 #, fuzzy, python-format
 msgid ""
-"Another user is waiting for the book: "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s. \n"
+"Another user is waiting for the book: %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s. \n"
 "\n"
 " If you want continue with this loan choose "
 "%(x_strong_tag_open)s[Continue]%(x_strong_tag_close)s."
@@ -1175,25 +1156,23 @@ msgstr "瀏覽"
 #: invenio/legacy/bibcirculation/adminlib.py:481
 #, fuzzy, python-format
 msgid ""
-"The items with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s are already on "
-"loan."
+"The items with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s are already on loan."
 msgstr "帳號已建立。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:499
 #, python-format
 msgid ""
-"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s "
-"is not a valid date or date format"
+"The given due date %(x_strong_tag_open)s%(x_date)s%(x_strong_tag_close)s is "
+"not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:541
 #, fuzzy, python-format
 msgid ""
-"A loan for the item "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
-"registered with success."
+"A loan for the item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, "
+"with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
+"been registered with success."
 msgstr "帳號已建立。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:542
@@ -1218,13 +1197,14 @@ msgstr "創建主題"
 #: invenio/legacy/bibcirculation/adminlib.py:1882
 #, fuzzy, python-format
 msgid ""
-"The item with the barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is on loan."
+"The item with the barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is on loan."
 msgstr "帳號已建立。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:663
 #, python-format
-msgid "The given barcode \"%(x_barcode)s\" does not correspond to requested item."
+msgid ""
+"The given barcode \"%(x_barcode)s\" does not correspond to requested item."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:702
@@ -1256,9 +1236,8 @@ msgstr "現在的狀況："
 #: invenio/legacy/bibcirculation/adminlib.py:884
 #, fuzzy, python-format
 msgid ""
-"The item the with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is not on loan. "
-"Please, try again."
+"The item the with barcode %(x_strong_tag_open)s%(x_barcode)s"
+"%(x_strong_tag_close)s is not on loan. Please, try again."
 msgstr "帳號已建立。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:969
@@ -1325,8 +1304,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4504
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sFrom: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sFrom: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1291
@@ -1334,8 +1313,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:4511
 #, python-format
 msgid ""
-"The period of interest %(x_strong_tag_open)sTo: "
-"%(x_date)s%(x_strong_tag_close)s is not a valid date or date format"
+"The period of interest %(x_strong_tag_open)sTo: %(x_date)s"
+"%(x_strong_tag_close)s is not a valid date or date format"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1414
@@ -1357,9 +1336,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:1540
 #, fuzzy, python-format
 msgid ""
-"Item with barcode "
-"%(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s is already on "
-"loan."
+"Item with barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s "
+"is already on loan."
 msgstr "帳號已建立。"
 
 #: invenio/legacy/bibcirculation/adminlib.py:1551
@@ -1401,8 +1379,8 @@ msgstr "找到 %s 筆記錄"
 #: invenio/legacy/bibcirculation/adminlib.py:4376
 #, python-format
 msgid ""
-"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does"
-" not exist on BibCirculation database."
+"The barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s does "
+"not exist on BibCirculation database."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:1945
@@ -1461,11 +1439,11 @@ msgstr "帳號已建立。"
 #: invenio/legacy/bibcirculation/adminlib.py:3543
 #: invenio/legacy/bibcirculation/adminlib.py:3587
 #: invenio/legacy/webbasket/templates.py:1839
-#: invenio/legacy/webcomment/templates.py:253
-#: invenio/legacy/webcomment/templates.py:714
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:252
+#: invenio/legacy/webcomment/templates.py:713
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:508
 #: invenio/legacy/websession/templates.py:2236
 #: invenio/legacy/websession/templates.py:2276
@@ -1476,11 +1454,11 @@ msgstr "是"
 #: invenio/legacy/bibcirculation/adminlib.py:2434
 #: invenio/legacy/bibcirculation/adminlib.py:3548
 #: invenio/legacy/webalert/templates.py:320
-#: invenio/legacy/webcomment/templates.py:254
-#: invenio/legacy/webcomment/templates.py:716
-#: invenio/legacy/webcomment/templates.py:2114
-#: invenio/legacy/webcomment/templates.py:2138
-#: invenio/legacy/webcomment/templates.py:2164
+#: invenio/legacy/webcomment/templates.py:253
+#: invenio/legacy/webcomment/templates.py:715
+#: invenio/legacy/webcomment/templates.py:2113
+#: invenio/legacy/webcomment/templates.py:2137
+#: invenio/legacy/webcomment/templates.py:2163
 #: invenio/legacy/webmessage/templates.py:509
 #: invenio/legacy/websession/templates.py:2237
 #: invenio/legacy/websession/templates.py:2277
@@ -1493,8 +1471,8 @@ msgstr "否"
 #: invenio/legacy/bibcirculation/adminlib.py:3591
 #, python-format
 msgid ""
-"Another user is waiting for this book "
-"%(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s."
+"Another user is waiting for this book %(x_strong_tag_open)s%(x_title)s"
+"%(x_strong_tag_close)s."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2440
@@ -1591,8 +1569,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:2803
 #, python-format
 msgid ""
-"It was NOT possible to delete the copy with barcode "
-"<strong>%(x_name)s</strong>"
+"It was NOT possible to delete the copy with barcode <strong>%(x_name)s</"
+"strong>"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:2860
@@ -1612,29 +1590,29 @@ msgstr ""
 #: invenio/legacy/bibcirculation/adminlib.py:3023
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was "
-"not modified</strong>."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>status was not "
+"modified</strong>."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3035
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it is already in use."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it is already in use."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3038
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated to "
-"<strong>[%(x_new)s]</strong> with success."
+"Item <strong>[%(x_name)s]</strong> updated to <strong>[%(x_new)s]</strong> "
+"with success."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3041
 #, python-format
 msgid ""
-"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was "
-"not modified</strong> because it was not found (!?)."
+"Item <strong>[%(x_name)s]</strong> updated, but the <strong>barcode was not "
+"modified</strong> because it was not found (!?)."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/adminlib.py:3145
@@ -1643,9 +1621,9 @@ msgstr ""
 #: invenio/legacy/bibdocfile/webinterface.py:145
 #: invenio/legacy/search_engine/__init__.py:2223
 #: invenio/legacy/search_engine/__init__.py:2232
-#: invenio/legacy/search_engine/__init__.py:5972
-#: invenio/legacy/search_engine/__init__.py:6034
-#: invenio/legacy/search_engine/__init__.py:6125
+#: invenio/legacy/search_engine/__init__.py:5978
+#: invenio/legacy/search_engine/__init__.py:6040
+#: invenio/legacy/search_engine/__init__.py:6131
 #, fuzzy
 msgid "Requested record does not seem to exist."
 msgstr "對不起，記錄 %s 並不存在。"
@@ -2007,16 +1985,14 @@ msgstr "記錄已被刪除。"
 #: invenio/legacy/bibcirculation/api.py:198
 msgid ""
 "If you think this book is interesting, suggest it and tell us why you "
-"consider this                   book is important. The library will "
-"consider your opinion and if we decide to buy the                   book,"
-" we will issue a loan for you as soon as it arrives and send it by "
-"internal mail."
+"consider this                   book is important. The library will consider "
+"your opinion and if we decide to buy the                   book, we will "
+"issue a loan for you as soon as it arrives and send it by internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:202
 msgid ""
-"In case we decide not to buy the book, we will offer you an interlibrary "
-"loan"
+"In case we decide not to buy the book, we will offer you an interlibrary loan"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:268
@@ -2037,8 +2013,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/api.py:710
 #: invenio/legacy/bibcirculation/api.py:778
 msgid ""
-"Your ILL request has been registered and the document will be sent to you"
-" via internal mail."
+"Your ILL request has been registered and the document will be sent to you "
+"via internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/api.py:672
@@ -2200,8 +2176,8 @@ msgstr ""
 #, python-format
 msgid ""
 "All the copies of %(strong_tag_open)s%(title)s%(strong_tag_close)s are "
-"missing. You can request a copy using "
-"%(strong_tag_open)s%(ill_link)s%(strong_tag_close)s"
+"missing. You can request a copy using %(strong_tag_open)s%(ill_link)s"
+"%(strong_tag_close)s"
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:341
@@ -2310,7 +2286,7 @@ msgstr "行動"
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:471
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:56
 #: invenio/modules/groups/forms.py:50
-#: invenio/modules/oauth2server/models.py:153
+#: invenio/modules/oauth2server/models.py:154
 msgid "Description"
 msgstr "描述"
 
@@ -2505,8 +2481,8 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:524
 msgid ""
-"Your request has been registered and the document will be sent to you via"
-" internal mail."
+"Your request has been registered and the document will be sent to you via "
+"internal mail."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:529
@@ -2792,9 +2768,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:1047
 #, fuzzy, python-format
 msgid ""
-"You can see your library account "
-"%(x_url_open)shere%(x_url_close)s.x_url_open<a "
-"href=\"/yourloans/display\">"
+"You can see your library account %(x_url_open)shere%(x_url_close)s."
+"x_url_open<a href=\"/yourloans/display\">"
 msgstr "您可以%(x_url_open)s登入%(x_url_close)s。"
 
 #: invenio/legacy/bibcirculation/templates.py:1129
@@ -2850,7 +2825,7 @@ msgstr "已拒絕"
 #: invenio/legacy/bibcirculation/templates.py:1772
 #: invenio/legacy/bibexport/templates.py:494
 #: invenio/legacy/bibexport/templates.py:557
-#: invenio/legacy/webcomment/templates.py:2061
+#: invenio/legacy/webcomment/templates.py:2060
 msgid "OK"
 msgstr "是"
 
@@ -2858,8 +2833,8 @@ msgstr "是"
 #, fuzzy, python-format
 msgid ""
 "The item %(x_strong_tag_open)s%(x_title)s%(x_strong_tag_close)s, with "
-"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has "
-"been returned with success."
+"barcode %(x_strong_tag_open)s%(x_barcode)s%(x_strong_tag_close)s, has been "
+"returned with success."
 msgstr "帳號已建立。"
 
 #: invenio/legacy/bibcirculation/templates.py:1588
@@ -3332,8 +3307,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:15749
 #: invenio/legacy/bibcirculation/templates.py:16003
 #: invenio/legacy/bibcirculation/utils.py:455
-#: invenio/legacy/webcomment/templates.py:1738
-#: invenio/legacy/webcomment/templates.py:1770
+#: invenio/legacy/webcomment/templates.py:1737
+#: invenio/legacy/webcomment/templates.py:1769
 msgid "Email"
 msgstr "電郵"
 
@@ -4184,8 +4159,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:9720
 #, python-format
 msgid ""
-"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the "
-"service in particular the return of books in due time."
+"Borrower accepts the %(x_url_open)sconditions%(x_url_close)s of the service "
+"in particular the return of books in due time."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:9721
@@ -4203,8 +4178,8 @@ msgstr ""
 #: invenio/legacy/bibcirculation/templates.py:10260
 #, python-format
 msgid ""
-"Check if the book already exists on %(CFG_SITE_NAME)s, before sending "
-"your ILL request."
+"Check if the book already exists on %(CFG_SITE_NAME)s, before sending your "
+"ILL request."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10332
@@ -4270,17 +4245,17 @@ msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10941
 msgid ""
-"We will process your order immediately and contact you"
-"                                         as soon as the document is "
+"We will process your order immediately and contact "
+"you                                         as soon as the document is "
 "received."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10943
 msgid ""
-"According to a decision from the Scientific Information Policy Board,"
-"             books purchased with budget codes other than Team accounts "
-"will be added to the Library catalogue,             with the indication "
-"of the purchaser."
+"According to a decision from the Scientific Information Policy "
+"Board,             books purchased with budget codes other than Team "
+"accounts will be added to the Library catalogue,             with the "
+"indication of the purchaser."
 msgstr ""
 
 #: invenio/legacy/bibcirculation/templates.py:10961
@@ -4668,25 +4643,25 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibcirculation/webinterface.py:854
-#: invenio/legacy/search_engine/__init__.py:4757
-#: invenio/legacy/search_engine/__init__.py:5117
-#: invenio/legacy/search_engine/__init__.py:5311
-#: invenio/legacy/search_engine/__init__.py:5334
-#: invenio/legacy/search_engine/__init__.py:5342
-#: invenio/legacy/search_engine/__init__.py:5350
-#: invenio/legacy/search_engine/__init__.py:5396
-#: invenio/legacy/webcomment/templates.py:199
-#: invenio/legacy/webcomment/templates.py:2511
+#: invenio/legacy/search_engine/__init__.py:4763
+#: invenio/legacy/search_engine/__init__.py:5123
+#: invenio/legacy/search_engine/__init__.py:5317
+#: invenio/legacy/search_engine/__init__.py:5340
+#: invenio/legacy/search_engine/__init__.py:5348
+#: invenio/legacy/search_engine/__init__.py:5356
+#: invenio/legacy/search_engine/__init__.py:5402
+#: invenio/legacy/webcomment/templates.py:198
+#: invenio/legacy/webcomment/templates.py:2510
 #: invenio/modules/comments/api.py:1862
 msgid "The record has been deleted."
 msgstr "記錄已被刪除。"
 
 #: invenio/legacy/bibclassify/templates.py:127
 msgid ""
-"Automatically generated <span class=\"keyword single\">single</span>,"
-"        <span class=\"keyword composite\">composite</span>, <span "
-"class=\"keyword author-kw\">author</span>,        and <span "
-"class=\"keyword other-kw\">other keywords</span>."
+"Automatically generated <span class=\"keyword single\">single</span>,        "
+"<span class=\"keyword composite\">composite</span>, <span class=\"keyword "
+"author-kw\">author</span>,        and <span class=\"keyword other-kw\">other "
+"keywords</span>."
 msgstr ""
 
 #: invenio/legacy/bibclassify/templates.py:230
@@ -4746,15 +4721,15 @@ msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:247
 msgid ""
-"We have registered your request, the automatedkeyword extraction will run"
-" after some time. Please return back in a while."
+"We have registered your request, the automatedkeyword extraction will run "
+"after some time. Please return back in a while."
 msgstr ""
 
 #: invenio/legacy/bibclassify/webinterface.py:252
 msgid ""
 "Unfortunately, we don't have a PDF fulltext for this record in the "
-"storage,                     keywords cannot be generated using an "
-"automated process."
+"storage,                     keywords cannot be generated using an automated "
+"process."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:398
@@ -4766,10 +4741,10 @@ msgstr "選擇主題"
 #: invenio/legacy/bibdocfile/managedocfiles.py:404
 #: invenio/legacy/bibexport/templates.py:347
 #: invenio/legacy/bibexport/templates.py:401
-#: invenio/legacy/webcomment/templates.py:1024
-#: invenio/legacy/webcomment/templates.py:1343
-#: invenio/legacy/webcomment/templates.py:1791
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1023
+#: invenio/legacy/webcomment/templates.py:1342
+#: invenio/legacy/webcomment/templates.py:1790
+#: invenio/legacy/webcomment/templates.py:2027
 #: invenio/legacy/websubmit/templates.py:2505
 #: invenio/legacy/websubmit/functions/Create_Upload_Files_Interface.py:475
 msgid "Comment"
@@ -4783,15 +4758,15 @@ msgstr "規則"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:560
 msgid ""
-"The file you want to edit is protected against modifications. Your action"
-" has not been applied"
+"The file you want to edit is protected against modifications. Your action "
+"has not been applied"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:580
 #, python-format
 msgid ""
-"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
-" considered"
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been "
+"considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:585
@@ -4802,7 +4777,8 @@ msgid ""
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:591
-msgid "The uploaded file name is too long and has therefore not been considered"
+msgid ""
+"The uploaded file name is too long and has therefore not been considered"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:603
@@ -4821,17 +4797,15 @@ msgstr "諢號 %s 已被使用。"
 #: invenio/legacy/bibdocfile/managedocfiles.py:648
 #, fuzzy, python-format
 msgid ""
-"A file with format '%(x_name)s' already exists. Please upload another "
-"format."
+"A file with format '%(x_name)s' already exists. Please upload another format."
 msgstr "諢號 %s 已被使用。"
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:656
 #: invenio/legacy/bibdocfile/managedocfiles.py:756
 msgid ""
-"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
-"file names. Choose a different name and upload your file again. In "
-"particular, note that you should not include the extension in the "
-"renaming field."
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file "
+"names. Choose a different name and upload your file again. In particular, "
+"note that you should not include the extension in the renaming field."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:836
@@ -4850,14 +4824,13 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:901
 msgid ""
 "When you revise a file, the additional formats that you might have "
-"previously uploaded are removed, since they no longer up-to-date with the"
-" new file."
+"previously uploaded are removed, since they no longer up-to-date with the "
+"new file."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:902
 msgid ""
-"Alternative formats uploaded for current version of this file will be "
-"removed"
+"Alternative formats uploaded for current version of this file will be removed"
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:903
@@ -4911,8 +4884,8 @@ msgstr ""
 #: invenio/legacy/bibdocfile/managedocfiles.py:935
 #, python-format
 msgid ""
-"Having a problem adding or revising a file? Send the new/revised version "
-"to %(mailto_link)s."
+"Having a problem adding or revising a file? Send the new/revised version to "
+"%(mailto_link)s."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/managedocfiles.py:1061
@@ -4967,8 +4940,8 @@ msgstr "對不起，記錄 %s 並不存在。"
 
 #: invenio/legacy/bibdocfile/webinterface.py:139
 msgid ""
-"The system has encountered an error in retrieving the list of files for "
-"this document."
+"The system has encountered an error in retrieving the list of files for this "
+"document."
 msgstr ""
 
 #: invenio/legacy/bibdocfile/webinterface.py:140
@@ -5089,9 +5062,9 @@ msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:359
 msgid ""
-"Specify the criteria you'd like to use for filtering records that will be"
-" changed. Use \"Search\" to see which records would have been filtered "
-"using these criteria."
+"Specify the criteria you'd like to use for filtering records that will be "
+"changed. Use \"Search\" to see which records would have been filtered using "
+"these criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:361
@@ -5106,8 +5079,8 @@ msgstr "儲存更改"
 
 #: invenio/legacy/bibeditmulti/templates.py:614
 msgid ""
-"Specify fields and their subfields that should be changed in every record"
-" matching the search criteria."
+"Specify fields and their subfields that should be changed in every record "
+"matching the search criteria."
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:615
@@ -5251,11 +5224,10 @@ msgstr "返回檢索結果頁"
 
 #: invenio/legacy/bibeditmulti/templates.py:708
 msgid ""
-"WARNING: The following records are pending execution"
-"                        in the task queue.                        If you "
-"proceed with the changes, the modifications made                        "
-"with other tool (e.g. BibEdit) to these records will"
-"                        be lost"
+"WARNING: The following records are pending execution                        "
+"in the task queue.                        If you proceed with the changes, "
+"the modifications made                        with other tool (e.g. BibEdit) "
+"to these records will                        be lost"
 msgstr ""
 
 #: invenio/legacy/bibeditmulti/templates.py:736
@@ -5392,7 +5364,7 @@ msgid "Total"
 msgstr "可選擇的"
 
 #: invenio/legacy/bibexport/templates.py:652
-#: invenio/legacy/webcomment/templates.py:2031
+#: invenio/legacy/webcomment/templates.py:2030
 msgid "Select"
 msgstr "選擇"
 
@@ -5563,8 +5535,8 @@ msgstr "刪除知識庫"
 #: invenio/legacy/bibknowledge/templates.py:51
 #, python-format
 msgid ""
-"Limit display to knowledge bases matching %(keyword_field)s in their "
-"rules and descriptions"
+"Limit display to knowledge bases matching %(keyword_field)s in their rules "
+"and descriptions"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:84
@@ -5623,56 +5595,56 @@ msgstr "您必須先登入。"
 
 #: invenio/legacy/bibknowledge/templates.py:237
 msgid ""
-"A dynamic knowledge base is a list of values of a"
-"                          given field. The list is generated dynamically "
-"by                          searching the records using a search "
-"expression."
+"A dynamic knowledge base is a list of values of a                          "
+"given field. The list is generated dynamically by                          "
+"searching the records using a search expression."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:241
 msgid ""
-"Example: Your records contain field 270__a for                          "
-"the name and address of the author's institute.                          "
-"If you set the field to '270__a' and the expression"
-"                          to '270__a:*Paris*', a list of institutes in "
-"Paris                          will be created."
+"Example: Your records contain field 270__a for                          the "
+"name and address of the author's institute.                          If you "
+"set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:246
 msgid ""
-"If the expression is empty, a list of all values"
-"                          in 270__a will be created."
+"If the expression is empty, a list of all values                          in "
+"270__a will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:248
 #, python-format
 msgid ""
-"If the expression contains '%%', like '270__a:*%%*',"
-"                          it will be replaced by a search string when the"
-"                          knowledge base is used."
+"If the expression contains '%%', like '270__a:*"
+"%%*',                          it will be replaced by a search string when "
+"the                          knowledge base is used."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:251
 msgid ""
-"You can enter a collection name if the expression"
-"                          should be evaluated in a specific collection."
+"You can enter a collection name if the expression                          "
+"should be evaluated in a specific collection."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:253
 msgid ""
-"Example 1: Your records contain field 270__a for"
-"                          the name and address of the author's institute."
-"                          If you set the field to '270__a' and the "
-"expression                          to '270__a:*Paris*', a list of "
-"institutes in Paris                          will be created."
+"Example 1: Your records contain field 270__a for                          "
+"the name and address of the author's institute.                          If "
+"you set the field to '270__a' and the expression                          to "
+"'270__a:*Paris*', a list of institutes in Paris                          "
+"will be created."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:258
 #, python-format
 msgid ""
-"Example 2: Return the institute's name (100__a) when the"
-"                          user gives its postal code (270__a):"
-"                          Set field to 100__a, expression to 270__a:*%%*."
+"Example 2: Return the institute's name (100__a) when "
+"the                          user gives its postal code "
+"(270__a):                          Set field to 100__a, expression to 270__a:"
+"*%%*."
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:262
@@ -5712,7 +5684,7 @@ msgstr "知識庫從屬關係"
 #: invenio/legacy/bibknowledge/templates.py:329
 #: invenio/legacy/bibknowledge/templates.py:589
 #: invenio/legacy/bibknowledge/templates.py:658
-#: invenio/legacy/webcomment/templates.py:1619
+#: invenio/legacy/webcomment/templates.py:1618
 #: invenio/legacy/webjournal/templates.py:203
 #: invenio/legacy/webjournal/templates.py:575
 #: invenio/legacy/webjournal/templates.py:716
@@ -5766,15 +5738,15 @@ msgstr "警報"
 #: invenio/legacy/bibknowledge/templates.py:706
 #, python-format
 msgid ""
-"The left side of the rule (%(x_rule)s) already appears in these knowledge"
-" bases:"
+"The left side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:709
 #, python-format
 msgid ""
-"The right side of the rule (%(x_rule)s) already appears in these "
-"knowledge bases:"
+"The right side of the rule (%(x_rule)s) already appears in these knowledge "
+"bases:"
 msgstr ""
 
 #: invenio/legacy/bibknowledge/templates.py:722
@@ -6004,8 +5976,7 @@ msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1321
 msgid ""
-"Error when formatting the Holding Pen entry. Probably its content is "
-"broken"
+"Error when formatting the Holding Pen entry. Probably its content is broken"
 msgstr ""
 
 #: invenio/legacy/oaiharvest/admin.py:1326
@@ -6084,8 +6055,8 @@ msgstr "並沒有參考"
 #: invenio/legacy/oairepository/admin.py:352
 #, python-format
 msgid ""
-"Do you want to touch the OAI set %(x_name)s? Note that this will force "
-"all clients to re-harvest the whole set."
+"Do you want to touch the OAI set %(x_name)s? Note that this will force all "
+"clients to re-harvest the whole set."
 msgstr ""
 
 #: invenio/legacy/oairepository/admin.py:360
@@ -6100,8 +6071,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:935
 #: invenio/legacy/search_engine/__init__.py:968
-#: invenio/legacy/search_engine/__init__.py:6020
-#: invenio/legacy/search_engine/__init__.py:6114
+#: invenio/legacy/search_engine/__init__.py:6026
+#: invenio/legacy/search_engine/__init__.py:6120
 msgid "Search Results"
 msgstr "檢索結果"
 
@@ -6262,8 +6233,8 @@ msgstr "沒有找到。"
 
 #: invenio/legacy/search_engine/__init__.py:2141
 msgid ""
-"Full-text search is currently available for all arXiv papers, many "
-"theses, a few report series and some journal articles"
+"Full-text search is currently available for all arXiv papers, many theses, a "
+"few report series and some journal articles"
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2143
@@ -6289,8 +6260,8 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2165
 msgid ""
-"Search term after reference operator too generic, displaying only partial"
-" results..."
+"Search term after reference operator too generic, displaying only partial "
+"results..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2169
@@ -6301,8 +6272,7 @@ msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2173
 msgid ""
-"No phrase index available for fulltext yet, looking for word "
-"combination..."
+"No phrase index available for fulltext yet, looking for word combination..."
 msgstr ""
 
 #: invenio/legacy/search_engine/__init__.py:2213
@@ -6312,113 +6282,113 @@ msgstr "用 %(x_query1)s 沒有確實匹配任何記錄，現嘗試用 %(x_query
 
 #: invenio/legacy/search_engine/__init__.py:2352
 msgid ""
-"Search syntax misunderstood. Ignoring all parentheses in the query. If "
-"this doesn't help, please check your search and try again."
+"Search syntax misunderstood. Ignoring all parentheses in the query. If this "
+"doesn't help, please check your search and try again."
 msgstr ""
 
-#: invenio/legacy/search_engine/__init__.py:3232
+#: invenio/legacy/search_engine/__init__.py:3238
 #, fuzzy, python-format
 msgid ""
 "No match found in collection %(x_collection)s. Other collections gave "
 "%(x_url_open)s%(x_nb_hits)d hits%(x_url_close)s."
 msgstr ""
-"在專輯 %(x_collection)s 裡沒有匹配任何記錄；但在其他的專輯裡找到%(x_url_open)s%(x_nb_hits)d "
-"筆記錄%(x_url_close)s。"
+"在專輯 %(x_collection)s 裡沒有匹配任何記錄；但在其他的專輯裡找"
+"到%(x_url_open)s%(x_nb_hits)d 筆記錄%(x_url_close)s。"
 
-#: invenio/legacy/search_engine/__init__.py:3249
+#: invenio/legacy/search_engine/__init__.py:3255
 #, fuzzy
 msgid ""
-"No public collection matched your query. If you were looking for a hidden"
-" document, please type the correct URL for this record."
+"No public collection matched your query. If you were looking for a hidden "
+"document, please type the correct URL for this record."
 msgstr "沒有在專輯裡匹配任何記錄。您可嘗試在限制的專輯裡找尋。"
 
-#: invenio/legacy/search_engine/__init__.py:3253
+#: invenio/legacy/search_engine/__init__.py:3259
 msgid ""
 "No public collection matched your query. If you were looking for a non-"
 "public document, please choose the desired restricted collection first."
 msgstr "沒有在專輯裡匹配任何記錄。您可嘗試在限制的專輯裡找尋。"
 
-#: invenio/legacy/search_engine/__init__.py:3360
+#: invenio/legacy/search_engine/__init__.py:3366
 #, fuzzy
 msgid "Your search did not match any records.  Please try again."
 msgstr "匹配不到關於 %s 的任何記錄。接近的短語是："
 
-#: invenio/legacy/search_engine/__init__.py:3369
+#: invenio/legacy/search_engine/__init__.py:3375
 #, fuzzy
 msgid "No match found, please enter different search terms."
 msgstr "用其他關鍵詞。"
 
-#: invenio/legacy/search_engine/__init__.py:3375
+#: invenio/legacy/search_engine/__init__.py:3381
 #, fuzzy, python-format
 msgid "There are no records referring to %(x_rec)s."
 msgstr "總共有 %i 個收藏籃"
 
-#: invenio/legacy/search_engine/__init__.py:3377
+#: invenio/legacy/search_engine/__init__.py:3383
 #, fuzzy, python-format
 msgid "There are no records modified by %(x_rec)s."
 msgstr "總共有 %i 個收藏籃"
 
-#: invenio/legacy/search_engine/__init__.py:3379
+#: invenio/legacy/search_engine/__init__.py:3385
 #, fuzzy, python-format
 msgid "There are no records cited by %(x_rec)s."
 msgstr "總共有 %i 個收藏籃"
 
-#: invenio/legacy/search_engine/__init__.py:3385
+#: invenio/legacy/search_engine/__init__.py:3391
 #, fuzzy, python-format
 msgid "No word index is available for %(x_name)s."
 msgstr "沒有可用的字索引給"
 
-#: invenio/legacy/search_engine/__init__.py:3396
+#: invenio/legacy/search_engine/__init__.py:3402
 #, fuzzy, python-format
 msgid "No phrase index is available for %(x_name)s."
 msgstr "沒有可用的短語索引給"
 
-#: invenio/legacy/search_engine/__init__.py:3434
+#: invenio/legacy/search_engine/__init__.py:3440
 #, python-format
 msgid ""
-"Search term %(x_term)s inside index %(x_index)s did not match any record."
-" Nearest terms in any collection are:"
+"Search term %(x_term)s inside index %(x_index)s did not match any record. "
+"Nearest terms in any collection are:"
 msgstr "在索引 %(x_index)s 匹配不到關於 %(x_term)s 的任何記錄。接近的短語是："
 
-#: invenio/legacy/search_engine/__init__.py:3439
+#: invenio/legacy/search_engine/__init__.py:3445
 #, fuzzy, python-format
 msgid ""
 "Search term %(x_name)s did not match any record. Nearest terms in any "
 "collection are:"
 msgstr "匹配不到關於 %s 的任何記錄。接近的短語是："
 
-#: invenio/legacy/search_engine/__init__.py:4340
+#: invenio/legacy/search_engine/__init__.py:4346
 #, fuzzy, python-format
 msgid ""
 "Sorry, %(x_option)s does not seem to be a valid sort option. The records "
 "will not be sorted."
 msgstr "對不起，%s 不是一正確的排序選項，請選用標題排序。"
 
-#: invenio/legacy/search_engine/__init__.py:4468
+#: invenio/legacy/search_engine/__init__.py:4474
 #, fuzzy, python-format
 msgid ""
-"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using"
-" default sort order."
+"Sorry, sorting is allowed on sets of up to %(x_name)d records only. Using "
+"default sort order."
 msgstr "對不起，這排序功能只被允許在最多 %d 紀錄中使用。請用正常排序。"
 
-#: invenio/legacy/search_engine/__init__.py:4480
+#: invenio/legacy/search_engine/__init__.py:4486
 #, fuzzy, python-format
 msgid ""
-"Sorry, %(x_name)s does not seem to be a valid sort option. The records "
-"will not be sorted."
+"Sorry, %(x_name)s does not seem to be a valid sort option. The records will "
+"not be sorted."
 msgstr "對不起，%s 不是一正確的排序選項，請選用標題排序。"
 
-#: invenio/legacy/search_engine/__init__.py:4760
-#: invenio/legacy/search_engine/__init__.py:5121
+#: invenio/legacy/search_engine/__init__.py:4766
+#: invenio/legacy/search_engine/__init__.py:5127
 #, fuzzy, python-format
 msgid "The record %(x_rec)d replaces it."
 msgstr "這記錄並不存在。"
 
-#: invenio/legacy/search_engine/__init__.py:4986
+#: invenio/legacy/search_engine/__init__.py:4992
 msgid "Use different search terms."
 msgstr "用其他關鍵詞。"
 
-#: invenio/legacy/search_engine/__init__.py:5982
+#: invenio/legacy/search_engine/__init__.py:5988
 #: invenio/legacy/websearch/templates.py:813
 #: invenio/legacy/websearch/templates.py:891
 #: invenio/legacy/websearch/templates.py:1014
@@ -6432,11 +6402,11 @@ msgstr "用其他關鍵詞。"
 msgid "Browse"
 msgstr "瀏覽"
 
-#: invenio/legacy/search_engine/__init__.py:6413
+#: invenio/legacy/search_engine/__init__.py:6419
 msgid "No match within your time limits, discarding this condition..."
 msgstr "沒有在時限內匹配到記錄, 放棄中..."
 
-#: invenio/legacy/search_engine/__init__.py:6447
+#: invenio/legacy/search_engine/__init__.py:6453
 msgid "No match within your search limits, discarding this condition..."
 msgstr "沒有在找尋限制內匹配到記錄, 放棄中..."
 
@@ -6480,11 +6450,12 @@ msgstr "這警報 %s 已成功被修改。"
 #: invenio/legacy/webalert/api.py:428
 #, fuzzy, python-format
 msgid ""
-"You have made %(x_nb)s queries. A %(x_url_open)sdetailed "
-"list%(x_url_close)s is available with a possibility to (a) view search "
-"results and (b) subscribe to an automatic email alerting service for "
-"these queries."
-msgstr "您已有 %(x_nb)s 條查詢。您可以用%(x_url_open)s详细列表%(x_url_close)s a)查閱搜尋結果；b)訂閱讀警報電郵。"
+"You have made %(x_nb)s queries. A %(x_url_open)sdetailed list%(x_url_close)s "
+"is available with a possibility to (a) view search results and (b) subscribe "
+"to an automatic email alerting service for these queries."
+msgstr ""
+"您已有 %(x_nb)s 條查詢。您可以用%(x_url_open)s详细列表%(x_url_close)s a)查閱"
+"搜尋結果；b)訂閱讀警報電郵。"
 
 #: invenio/legacy/webalert/htmlparser.py:186
 #: invenio/legacy/webbasket/templates.py:741
@@ -6623,8 +6594,8 @@ msgid ""
 "Set a new alert from %(x_url1_open)syour searches%(x_url1_close)s, the "
 "%(x_url2_open)spopular searches%(x_url2_close)s, or the input form."
 msgstr ""
-"從%(x_url1_open)s您的檢索%(x_url1_close)s、 "
-"%(x_url2_open)s熱門檢索%(x_url2_close)s或表格中建設新的警報。"
+"從%(x_url1_open)s您的檢索%(x_url1_close)s、 %(x_url2_open)s熱門檢"
+"索%(x_url2_close)s或表格中建設新的警報。"
 
 #: invenio/legacy/webalert/templates.py:322
 msgid "Search checking frequency"
@@ -6675,15 +6646,15 @@ msgstr "您已定義 %s 警報。"
 #: invenio/legacy/webalert/templates.py:439
 #, python-format
 msgid ""
-"You have not executed any search yet. Please go to the "
-"%(x_url_open)ssearch interface%(x_url_close)s first."
+"You have not executed any search yet. Please go to the %(x_url_open)ssearch "
+"interface%(x_url_close)s first."
 msgstr "您未執行任何查尋。請先到%(x_url_open)s搜索介面%(x_url_close)s。"
 
 #: invenio/legacy/webalert/templates.py:448
 #, python-format
 msgid ""
-"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) "
-"during the last 30 days or so."
+"You have performed %(x_nb1)s searches (%(x_nb2)s different questions) during "
+"the last 30 days or so."
 msgstr "在之前的三十天，您已執行了%(x_nb1)s 搜索 (%(x_nb2)s 不同的問題)。"
 
 #: invenio/legacy/webalert/templates.py:453
@@ -6743,7 +6714,7 @@ msgstr "您的搜尋結果"
 #: invenio/legacy/webbasket/webinterface.py:1026
 #: invenio/legacy/webbasket/webinterface.py:1116
 #: invenio/legacy/webbasket/webinterface.py:1260
-#: invenio/legacy/webcomment/webinterface.py:922
+#: invenio/legacy/webcomment/webinterface.py:928
 #: invenio/legacy/webmessage/templates.py:466
 #: invenio/legacy/websession/templates.py:774
 #: invenio/legacy/websession/templates.py:2350
@@ -6807,7 +6778,7 @@ msgstr "設置新警報"
 #: invenio/legacy/webalert/webinterface.py:475
 #: invenio/legacy/webalert/webinterface.py:523
 #: invenio/legacy/webalert/webinterface.py:551
-#: invenio/legacy/webcomment/webinterface.py:925
+#: invenio/legacy/webcomment/webinterface.py:931
 #: invenio/legacy/websession/webinterface.py:231
 #: invenio/legacy/websession/webinterface.py:254
 #: invenio/legacy/websession/webinterface.py:340
@@ -6867,7 +6838,8 @@ msgstr "顯示警報"
 
 #: invenio/legacy/webbasket/api.py:104 invenio/legacy/webbasket/api.py:2315
 #: invenio/legacy/webbasket/api.py:2345
-msgid "The selected public basket does not exist or you do not have access to it."
+msgid ""
+"The selected public basket does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:112
@@ -6891,7 +6863,8 @@ msgid "You do not have permission to write notes to this item."
 msgstr "您沒有足夠權限以讀取這收藏籃。"
 
 #: invenio/legacy/webbasket/api.py:429 invenio/legacy/webbasket/api.py:1560
-msgid "The note you are quoting does not exist or you do not have access to it."
+msgid ""
+"The note you are quoting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:485 invenio/legacy/webbasket/api.py:1625
@@ -6919,7 +6892,8 @@ msgid "You do not have permission to delete this note."
 msgstr "您沒有足夠權限以讀取這收藏籃。"
 
 #: invenio/legacy/webbasket/api.py:1689
-msgid "The note you are deleting does not exist or you do not have access to it."
+msgid ""
+"The note you are deleting does not exist or you do not have access to it."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1791
@@ -6950,8 +6924,8 @@ msgstr "這記錄並不存在。"
 
 #: invenio/legacy/webbasket/api.py:1842
 msgid ""
-"The url you have provided is not valid: The request contains bad syntax "
-"or cannot be fulfilled."
+"The url you have provided is not valid: The request contains bad syntax or "
+"cannot be fulfilled."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1849
@@ -6973,8 +6947,8 @@ msgstr "拷貝記錄進收藏籃"
 
 #: invenio/legacy/webbasket/api.py:1967
 msgid ""
-"Some items could not be moved. The destination basket already contains "
-"those items."
+"Some items could not be moved. The destination basket already contains those "
+"items."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:1969 invenio/legacy/webbasket/api.py:2820
@@ -7007,8 +6981,8 @@ msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2307
 msgid ""
-"You cannot subscribe to this basket, you are the either owner or you have"
-" already subscribed."
+"You cannot subscribe to this basket, you are the either owner or you have "
+"already subscribed."
 msgstr ""
 
 #: invenio/legacy/webbasket/api.py:2337
@@ -7081,11 +7055,10 @@ msgstr "共享收藏籃"
 #, python-format
 msgid ""
 "You have %(x_nb_perso)s personal baskets and are subscribed to "
-"%(x_nb_group)s group baskets and %(x_nb_public)s other users public "
-"baskets."
+"%(x_nb_group)s group baskets and %(x_nb_public)s other users public baskets."
 msgstr ""
-"您有 %(x_nb_perso)s 個個人收藏籃、訂閱 %(x_nb_group)s 組別收藏籃和%(x_nb_public)s "
-"其他用戶的共享收藏籃。"
+"您有 %(x_nb_perso)s 個個人收藏籃、訂閱 %(x_nb_group)s 組別收藏籃"
+"和%(x_nb_public)s 其他用戶的共享收藏籃。"
 
 #: invenio/legacy/webbasket/api.py:2797 invenio/legacy/webbasket/api.py:2835
 #, fuzzy
@@ -7112,8 +7085,7 @@ msgstr "%i 用戶組別已訂閱這收藏籃。"
 #: invenio/legacy/webbasket/templates.py:108
 #, fuzzy, python-format
 msgid ""
-"You may want to start by %(x_url_open)screating a new "
-"basket%(x_url_close)s."
+"You may want to start by %(x_url_open)screating a new basket%(x_url_close)s."
 msgstr "您可以使用您的%(x_url_open)s帳號%(x_url_close)s。"
 
 #: invenio/legacy/webbasket/templates.py:131
@@ -7284,8 +7256,8 @@ msgstr "外部記錄"
 
 #: invenio/legacy/webbasket/templates.py:1607
 msgid ""
-"Provide a url for the external item you wish to add and fill in a title "
-"and description"
+"Provide a url for the external item you wish to add and fill in a title and "
+"description"
 msgstr ""
 
 #: invenio/legacy/webbasket/templates.py:1612
@@ -7470,15 +7442,16 @@ msgstr "分享這收藏籃於組別"
 #: invenio/legacy/webbasket/templates.py:2116
 #: invenio/legacy/websession/templates.py:676
 msgid ""
-"You are logged in as a guest user, so your baskets will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your baskets will disappear at the end "
+"of the current session."
 msgstr "您是用遊客登錄, 因此您的收藏籃將不會保存在這系統中。"
 
 #: invenio/legacy/webbasket/templates.py:2117
 #: invenio/legacy/webbasket/templates.py:2132
 #: invenio/legacy/websession/templates.py:679
 #, python-format
-msgid "If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
+msgid ""
+"If you wish you can %(x_url_open)slogin or register here%(x_url_close)s."
 msgstr "您可以%(x_url_open)s登入或%(x_url_close)s註冊。"
 
 #: invenio/legacy/webbasket/templates.py:2131
@@ -7488,7 +7461,7 @@ msgid "This functionality is forbidden to guest users."
 msgstr "遊客是被禁止使用這功能。"
 
 #: invenio/legacy/webbasket/templates.py:2184
-#: invenio/legacy/webcomment/templates.py:1011
+#: invenio/legacy/webcomment/templates.py:1010
 msgid "Back to search results"
 msgstr "返回檢索結果頁"
 
@@ -7663,7 +7636,7 @@ msgstr "加入至用戶"
 
 #: invenio/legacy/webbasket/templates.py:3221
 #: invenio/legacy/webbasket/templates.py:4025
-#: invenio/legacy/webcomment/templates.py:409
+#: invenio/legacy/webcomment/templates.py:408
 #: invenio/legacy/webmessage/templates.py:111
 #: invenio/modules/messages/templates/messages/view_base.html:55
 msgid "Reply"
@@ -7810,215 +7783,215 @@ msgstr "用戶 %s 並不存在。"
 msgid "Record ID %(x_rec)s does not exist."
 msgstr "用戶 %s 並不存在。"
 
-#: invenio/legacy/webcomment/templates.py:83
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:82
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/legacy/websubmit/templates.py:2451
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:58
 msgid "Write a comment"
 msgstr "撰寫意見"
 
-#: invenio/legacy/webcomment/templates.py:99
+#: invenio/legacy/webcomment/templates.py:98
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments for round \"%(x_name)s\""
 msgstr "%(x_name)s 在 %(x_date)s 寫："
 
-#: invenio/legacy/webcomment/templates.py:102
+#: invenio/legacy/webcomment/templates.py:101
 #, fuzzy, python-format
 msgid "%(x_nb)i Comments"
 msgstr "意見"
 
-#: invenio/legacy/webcomment/templates.py:140
+#: invenio/legacy/webcomment/templates.py:139
 #, fuzzy, python-format
 msgid "Showing the latest %(x_num)i comments:"
 msgstr "顯示最後的 %i 意見："
 
-#: invenio/legacy/webcomment/templates.py:153
-#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:152
+#: invenio/legacy/webcomment/templates.py:178
 msgid "Discuss this document"
 msgstr "討論這評論"
 
-#: invenio/legacy/webcomment/templates.py:180
-#: invenio/legacy/webcomment/templates.py:951
+#: invenio/legacy/webcomment/templates.py:179
+#: invenio/legacy/webcomment/templates.py:950
 msgid "Start a discussion about any aspect of this document."
 msgstr "討論這文件。"
 
-#: invenio/legacy/webcomment/templates.py:197
+#: invenio/legacy/webcomment/templates.py:196
 #, fuzzy, python-format
 msgid "Sorry, the record %(x_rec)s does not seem to exist."
 msgstr "對不起，記錄 %s 並不存在。"
 
-#: invenio/legacy/webcomment/templates.py:201
+#: invenio/legacy/webcomment/templates.py:200
 #, fuzzy, python-format
 msgid "Sorry, %(x_rec)s is not a valid ID value."
 msgstr "對不起，%s 不是一有效數值。"
 
-#: invenio/legacy/webcomment/templates.py:203
+#: invenio/legacy/webcomment/templates.py:202
 msgid "Sorry, no record ID was provided."
 msgstr "對不起，並沒有提供記錄ID。"
 
-#: invenio/legacy/webcomment/templates.py:207
+#: invenio/legacy/webcomment/templates.py:206
 #, fuzzy, python-format
 msgid "You may want to start browsing from %(x_link)s"
 msgstr "您可以從%s開始瀏覽 "
 
-#: invenio/legacy/webcomment/templates.py:265
-#: invenio/legacy/webcomment/templates.py:756
-#: invenio/legacy/webcomment/templates.py:766
+#: invenio/legacy/webcomment/templates.py:264
+#: invenio/legacy/webcomment/templates.py:755
+#: invenio/legacy/webcomment/templates.py:765
 #, fuzzy, python-format
 msgid "%(x_nb)i comments for round \"%(x_name)s\""
 msgstr "%(x_name)s 在 %(x_date)s 寫："
 
-#: invenio/legacy/webcomment/templates.py:295
-#: invenio/legacy/webcomment/templates.py:861
+#: invenio/legacy/webcomment/templates.py:294
+#: invenio/legacy/webcomment/templates.py:860
 msgid "Was this review helpful?"
 msgstr "這評論有用嗎？"
 
-#: invenio/legacy/webcomment/templates.py:306
-#: invenio/legacy/webcomment/templates.py:342
-#: invenio/legacy/webcomment/templates.py:938
+#: invenio/legacy/webcomment/templates.py:305
+#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:937
 #: invenio/modules/comments/templates/comments/add_review_base.html:54
 msgid "Write a review"
 msgstr "撰寫評論"
 
-#: invenio/legacy/webcomment/templates.py:313
-#: invenio/legacy/webcomment/templates.py:925
-#: invenio/legacy/webcomment/templates.py:2185
+#: invenio/legacy/webcomment/templates.py:312
+#: invenio/legacy/webcomment/templates.py:924
+#: invenio/legacy/webcomment/templates.py:2184
 #, python-format
 msgid "Average review score: %(x_nb_score)s based on %(x_nb_reviews)s reviews"
 msgstr "平均評論得分：%(x_nb_score)s 基於 %(x_nb_reviews)s 條評論"
 
-#: invenio/legacy/webcomment/templates.py:316
+#: invenio/legacy/webcomment/templates.py:315
 #, fuzzy, python-format
 msgid "Readers found the following %(x_name)s reviews to be most helpful."
 msgstr "讀者覺得以下 %s 評論是有用的。"
 
-#: invenio/legacy/webcomment/templates.py:318
-#: invenio/legacy/webcomment/templates.py:341
+#: invenio/legacy/webcomment/templates.py:317
+#: invenio/legacy/webcomment/templates.py:340
 #, fuzzy, python-format
 msgid "View all %(x_name)s reviews"
 msgstr "閱讀全部%s評論"
 
-#: invenio/legacy/webcomment/templates.py:337
-#: invenio/legacy/webcomment/templates.py:359
-#: invenio/legacy/webcomment/templates.py:2226
+#: invenio/legacy/webcomment/templates.py:336
+#: invenio/legacy/webcomment/templates.py:358
+#: invenio/legacy/webcomment/templates.py:2225
 msgid "Rate this document"
 msgstr "評價這文件"
 
-#: invenio/legacy/webcomment/templates.py:360
+#: invenio/legacy/webcomment/templates.py:359
 #, fuzzy
 msgid "Be the first to review this document.</div>"
 msgstr "成為第一個讀者去評論這文件。"
 
-#: invenio/legacy/webcomment/templates.py:404
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:807
+#: invenio/legacy/webcomment/templates.py:403
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:806
 #: invenio/modules/workflows/templates/workflows/actions/approval_main.html:23
 #, fuzzy
 msgid "Close"
 msgstr "評分"
 
-#: invenio/legacy/webcomment/templates.py:411
-#: invenio/legacy/webcomment/templates.py:862
+#: invenio/legacy/webcomment/templates.py:410
+#: invenio/legacy/webcomment/templates.py:861
 msgid "Report abuse"
 msgstr "舉報濫用"
 
-#: invenio/legacy/webcomment/templates.py:425
+#: invenio/legacy/webcomment/templates.py:424
 #, fuzzy
 msgid "Undelete comment"
 msgstr "刪除意見"
 
-#: invenio/legacy/webcomment/templates.py:434
-#: invenio/legacy/webcomment/templates.py:436
+#: invenio/legacy/webcomment/templates.py:433
+#: invenio/legacy/webcomment/templates.py:435
 msgid "Delete comment"
 msgstr "刪除意見"
 
-#: invenio/legacy/webcomment/templates.py:442
+#: invenio/legacy/webcomment/templates.py:441
 #, fuzzy
 msgid "Unreport comment"
 msgstr "刪除意見"
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:453
+#: invenio/legacy/webcomment/templates.py:452
 msgid "Attached files"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:465
-#: invenio/legacy/webcomment/templates.py:806
+#: invenio/legacy/webcomment/templates.py:464
+#: invenio/legacy/webcomment/templates.py:805
 msgid "Open"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:534
+#: invenio/legacy/webcomment/templates.py:533
 #, python-format
 msgid "Reviewed by %(x_nickname)s on %(x_date)s"
 msgstr "%(x_nickname)s 在 %(x_date)s 評論這文件"
 
-#: invenio/legacy/webcomment/templates.py:538
+#: invenio/legacy/webcomment/templates.py:537
 #, fuzzy, python-format
 msgid "%(x_nb_people)s out of %(x_nb_total)s people found this review useful"
 msgstr "%(x_nb_people)i/%(x_nb_total)i個讀者評價這評論是有用的"
 
-#: invenio/legacy/webcomment/templates.py:560
+#: invenio/legacy/webcomment/templates.py:559
 #, fuzzy
 msgid "Undelete review"
 msgstr "刪除已選擇的評論"
 
-#: invenio/legacy/webcomment/templates.py:569
+#: invenio/legacy/webcomment/templates.py:568
 #, fuzzy
 msgid "Delete review"
 msgstr "刪除已選擇的評論"
 
-#: invenio/legacy/webcomment/templates.py:575
+#: invenio/legacy/webcomment/templates.py:574
 #, fuzzy
 msgid "Unreport review"
 msgstr "撰寫評論"
 
-#: invenio/legacy/webcomment/templates.py:682
-#: invenio/legacy/webcomment/templates.py:698
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:681
+#: invenio/legacy/webcomment/templates.py:697
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3406
 #: invenio/legacy/websubmit/templates.py:2449
 #: invenio/modules/comments/views.py:188
 msgid "Comments"
 msgstr "意見"
 
-#: invenio/legacy/webcomment/templates.py:683
-#: invenio/legacy/webcomment/templates.py:699
-#: invenio/legacy/webcomment/webinterface.py:248
-#: invenio/legacy/webcomment/webinterface.py:466
+#: invenio/legacy/webcomment/templates.py:682
+#: invenio/legacy/webcomment/templates.py:698
+#: invenio/legacy/webcomment/webinterface.py:252
+#: invenio/legacy/webcomment/webinterface.py:472
 #: invenio/legacy/websearch/adminlib.py:3407
 #: invenio/modules/comments/views.py:222
 msgid "Reviews"
 msgstr "評論"
 
-#: invenio/legacy/webcomment/templates.py:942
+#: invenio/legacy/webcomment/templates.py:941
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s reviews"
 msgstr "總共有 %s 評論"
 
-#: invenio/legacy/webcomment/templates.py:944
+#: invenio/legacy/webcomment/templates.py:943
 #, fuzzy, python-format
 msgid "There is a total of %(x_num)s comments"
 msgstr "總共有 %s "
 
-#: invenio/legacy/webcomment/templates.py:956
+#: invenio/legacy/webcomment/templates.py:955
 msgid "Be the first to review this document."
 msgstr "成為第一個讀者去評論這文件。"
 
-#: invenio/legacy/webcomment/templates.py:975
+#: invenio/legacy/webcomment/templates.py:974
 msgid "Subscribe"
 msgstr "訂閱"
 
-#: invenio/legacy/webcomment/templates.py:993
+#: invenio/legacy/webcomment/templates.py:992
 #, fuzzy
 msgid "Unsubscribe"
 msgstr "訂閱"
 
-#: invenio/legacy/webcomment/templates.py:1010
-#: invenio/legacy/webcomment/templates.py:1787
+#: invenio/legacy/webcomment/templates.py:1009
+#: invenio/legacy/webcomment/templates.py:1786
 #: invenio/legacy/websearch/templates.py:548
 #: invenio/modules/comments/templates/comments/subscriptions_base.html:40
 #: invenio/modules/editor/templates/editor/recordmenu.html:22
@@ -8027,515 +8000,519 @@ msgstr "訂閱"
 msgid "Record"
 msgstr "記錄"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "review"
 msgstr "評論"
 
-#: invenio/legacy/webcomment/templates.py:1020
-#: invenio/legacy/webcomment/templates.py:1088
+#: invenio/legacy/webcomment/templates.py:1019
+#: invenio/legacy/webcomment/templates.py:1087
 msgid "comment"
 msgstr "意見"
 
-#: invenio/legacy/webcomment/templates.py:1023
-#: invenio/legacy/webcomment/templates.py:2028
+#: invenio/legacy/webcomment/templates.py:1022
+#: invenio/legacy/webcomment/templates.py:2027
 msgid "Review"
 msgstr "評論"
 
-#: invenio/legacy/webcomment/templates.py:1086
+#: invenio/legacy/webcomment/templates.py:1085
 msgid "Viewing"
 msgstr "閱讀"
 
-#: invenio/legacy/webcomment/templates.py:1087
+#: invenio/legacy/webcomment/templates.py:1086
 msgid "Page:"
 msgstr "頁:"
 
-#: invenio/legacy/webcomment/templates.py:1101
+#: invenio/legacy/webcomment/templates.py:1100
 #, fuzzy
 msgid "You are not authorized to comment or review."
 msgstr "您並不是這收藏籃的擁有者。"
 
-#: invenio/legacy/webcomment/templates.py:1271
+#: invenio/legacy/webcomment/templates.py:1270
 #, fuzzy, python-format
 msgid ""
-"Note: Your nickname, %(nick)s, will be displayed as author of this "
-"comment."
+"Note: Your nickname, %(nick)s, will be displayed as author of this comment."
 msgstr "注意：您的諢號 - %s - 將會成顯示為文件的作者名稱。"
 
-#: invenio/legacy/webcomment/templates.py:1276
-#: invenio/legacy/webcomment/templates.py:1393
+#: invenio/legacy/webcomment/templates.py:1275
+#: invenio/legacy/webcomment/templates.py:1392
 #, python-format
 msgid ""
 "Note: you have not %(x_url_open)sdefined your nickname%(x_url_close)s. "
 "%(x_nickname)s will be displayed as the author of this comment."
-msgstr "注意：您並未%(x_url_open)s定義您的諢號%(x_url_close)s。%(x_nickname)s 是會成顯示為文件的作者名稱。"
+msgstr ""
+"注意：您並未%(x_url_open)s定義您的諢號%(x_url_close)s。%(x_nickname)s 是會成"
+"顯示為文件的作者名稱。"
 
-#: invenio/legacy/webcomment/templates.py:1293
+#: invenio/legacy/webcomment/templates.py:1292
 msgid "Once logged in, authorized users can also attach files."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1308
+#: invenio/legacy/webcomment/templates.py:1307
 msgid "Optionally, attach a file to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1309
+#: invenio/legacy/webcomment/templates.py:1308
 msgid "Optionally, attach files to this comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1310
+#: invenio/legacy/webcomment/templates.py:1309
 #, fuzzy
 msgid "Max one file"
 msgstr "增添規則"
 
-#: invenio/legacy/webcomment/templates.py:1311
+#: invenio/legacy/webcomment/templates.py:1310
 #, fuzzy, python-format
 msgid "Max %(maxfiles)i files"
 msgstr "文檔"
 
-#: invenio/legacy/webcomment/templates.py:1312
+#: invenio/legacy/webcomment/templates.py:1311
 #, python-format
 msgid "Max %(x_nb_bytes)s per file"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1327
+#: invenio/legacy/webcomment/templates.py:1326
 msgid "Send me an email when a new comment is posted"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1342
-#: invenio/legacy/webcomment/templates.py:1464
+#: invenio/legacy/webcomment/templates.py:1341
+#: invenio/legacy/webcomment/templates.py:1463
 msgid "Article"
 msgstr "文章"
 
-#: invenio/legacy/webcomment/templates.py:1344
+#: invenio/legacy/webcomment/templates.py:1343
 #, fuzzy
 msgid "Add comment"
 msgstr "新增評論"
 
-#: invenio/legacy/webcomment/templates.py:1389
+#: invenio/legacy/webcomment/templates.py:1388
 #, fuzzy, python-format
 msgid ""
 "Note: Your nickname, %(x_name)s, will be displayed as the author of this "
 "review."
 msgstr "您的諢號 - %s - 將會成顯示為評論的作者名稱。"
 
-#: invenio/legacy/webcomment/templates.py:1465
+#: invenio/legacy/webcomment/templates.py:1464
 msgid "Rate this article"
 msgstr "評價這文章"
 
-#: invenio/legacy/webcomment/templates.py:1466
+#: invenio/legacy/webcomment/templates.py:1465
 msgid "Select a score"
 msgstr "選擇評分"
 
-#: invenio/legacy/webcomment/templates.py:1467
+#: invenio/legacy/webcomment/templates.py:1466
 msgid "Give a title to your review"
 msgstr "輸入評論標題"
 
-#: invenio/legacy/webcomment/templates.py:1468
+#: invenio/legacy/webcomment/templates.py:1467
 msgid "Write your review"
 msgstr "撰寫評論"
 
-#: invenio/legacy/webcomment/templates.py:1473
+#: invenio/legacy/webcomment/templates.py:1472
 #, fuzzy
 msgid "Add review"
 msgstr "新增評論"
 
-#: invenio/legacy/webcomment/templates.py:1483
-#: invenio/legacy/webcomment/webinterface.py:511
+#: invenio/legacy/webcomment/templates.py:1482
+#: invenio/legacy/webcomment/webinterface.py:517
 msgid "Add Review"
 msgstr "新增評論"
 
-#: invenio/legacy/webcomment/templates.py:1505
+#: invenio/legacy/webcomment/templates.py:1504
 msgid "Your review was successfully added."
 msgstr "您的評論已被接受。"
 
-#: invenio/legacy/webcomment/templates.py:1507
+#: invenio/legacy/webcomment/templates.py:1506
 msgid "Your comment was successfully added."
 msgstr "您的意見已被接受。"
 
-#: invenio/legacy/webcomment/templates.py:1510
+#: invenio/legacy/webcomment/templates.py:1509
 msgid "Back to record"
 msgstr "返回記錄"
 
-#: invenio/legacy/webcomment/templates.py:1512
+#: invenio/legacy/webcomment/templates.py:1511
 #, fuzzy, python-format
 msgid ""
 "You can also view all the comments you have submitted so far on "
 "\"%(x_url_open)sYour Comments%(x_url_close)s\" page."
 msgstr "您可直接在%(x_url_open)s這裡%(x_url_close)s咨詢您的組別名單。"
 
-#: invenio/legacy/webcomment/templates.py:1592
+#: invenio/legacy/webcomment/templates.py:1591
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:171
 #, fuzzy
 msgid "View most commented records"
 msgstr "閱讀意見"
 
-#: invenio/legacy/webcomment/templates.py:1594
+#: invenio/legacy/webcomment/templates.py:1593
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:207
 #, fuzzy
 msgid "View latest commented records"
 msgstr "閱讀意見"
 
-#: invenio/legacy/webcomment/templates.py:1596
+#: invenio/legacy/webcomment/templates.py:1595
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all comments reported as abuse"
 msgstr "查閱全部用戶"
 
-#: invenio/legacy/webcomment/templates.py:1600
+#: invenio/legacy/webcomment/templates.py:1599
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:170
 #, fuzzy
 msgid "View most reviewed records"
 msgstr "移除記錄"
 
-#: invenio/legacy/webcomment/templates.py:1602
+#: invenio/legacy/webcomment/templates.py:1601
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:206
 #, fuzzy
 msgid "View latest reviewed records"
 msgstr "閱讀全部%s評論"
 
-#: invenio/legacy/webcomment/templates.py:1604
+#: invenio/legacy/webcomment/templates.py:1603
 #: invenio/legacy/webcomment/web/admin/webcommentadmin.py:140
 #, fuzzy
 msgid "View all reviews reported as abuse"
 msgstr "查閱全部用戶"
 
-#: invenio/legacy/webcomment/templates.py:1612
+#: invenio/legacy/webcomment/templates.py:1611
 msgid "View all users who have been reported"
 msgstr "查閱全部曾給予意見/評論的用戶"
 
-#: invenio/legacy/webcomment/templates.py:1614
+#: invenio/legacy/webcomment/templates.py:1613
 msgid "Guide"
 msgstr "指南"
 
-#: invenio/legacy/webcomment/templates.py:1616
+#: invenio/legacy/webcomment/templates.py:1615
 msgid "Comments and reviews are disabled"
 msgstr "意見和評論已被禁止"
 
-#: invenio/legacy/webcomment/templates.py:1636
+#: invenio/legacy/webcomment/templates.py:1635
 msgid ""
 "Please enter the ID of the comment/review so that you can view it before "
 "deciding whether to delete it or not"
 msgstr "請輸入意見/評論ID以便查閱，之後您可以決定是否刪除它。"
 
-#: invenio/legacy/webcomment/templates.py:1660
+#: invenio/legacy/webcomment/templates.py:1659
 msgid "Comment ID:"
 msgstr "意見ID："
 
-#: invenio/legacy/webcomment/templates.py:1661
+#: invenio/legacy/webcomment/templates.py:1660
 msgid "Or enter a record ID to list all the associated comments/reviews:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:1662
+#: invenio/legacy/webcomment/templates.py:1661
 #, fuzzy
 msgid "Record ID:"
 msgstr "記錄號"
 
-#: invenio/legacy/webcomment/templates.py:1664
+#: invenio/legacy/webcomment/templates.py:1663
 msgid "View Comment"
 msgstr "查閱意見"
 
-#: invenio/legacy/webcomment/templates.py:1685
+#: invenio/legacy/webcomment/templates.py:1684
 msgid "There have been no reports so far."
 msgstr "沒有任何報告記錄。"
 
-#: invenio/legacy/webcomment/templates.py:1689
+#: invenio/legacy/webcomment/templates.py:1688
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported comments"
 msgstr "查閱全部 %s 意見"
 
-#: invenio/legacy/webcomment/templates.py:1692
+#: invenio/legacy/webcomment/templates.py:1691
 #, fuzzy, python-format
 msgid "View all %(x_name)s reported reviews"
 msgstr "查閱全部 %s 評論"
 
-#: invenio/legacy/webcomment/templates.py:1729
+#: invenio/legacy/webcomment/templates.py:1728
 msgid ""
-"Here is a list, sorted by total number of reports, of all users who have "
-"had a comment reported at least once."
+"Here is a list, sorted by total number of reports, of all users who have had "
+"a comment reported at least once."
 msgstr "這名單列出全部曾提交意見或評論的用戶。"
 
-#: invenio/legacy/webcomment/templates.py:1737
-#: invenio/legacy/webcomment/templates.py:1766
+#: invenio/legacy/webcomment/templates.py:1736
+#: invenio/legacy/webcomment/templates.py:1765
 #: invenio/legacy/websession/templates.py:272
 #: invenio/legacy/websession/templates.py:1221
 #: invenio/modules/accounts/forms.py:46 invenio/modules/accounts/forms.py:164
 msgid "Nickname"
 msgstr "諢號"
 
-#: invenio/legacy/webcomment/templates.py:1739
-#: invenio/legacy/webcomment/templates.py:1768
+#: invenio/legacy/webcomment/templates.py:1738
+#: invenio/legacy/webcomment/templates.py:1767
 msgid "User ID"
 msgstr "用戶ID"
 
-#: invenio/legacy/webcomment/templates.py:1741
+#: invenio/legacy/webcomment/templates.py:1740
 msgid "Number positive votes"
 msgstr "正面的投票"
 
-#: invenio/legacy/webcomment/templates.py:1742
+#: invenio/legacy/webcomment/templates.py:1741
 msgid "Number negative votes"
 msgstr "負面的投票"
 
-#: invenio/legacy/webcomment/templates.py:1743
+#: invenio/legacy/webcomment/templates.py:1742
 msgid "Total number votes"
 msgstr "全部投票數目"
 
-#: invenio/legacy/webcomment/templates.py:1744
+#: invenio/legacy/webcomment/templates.py:1743
 msgid "Total number of reports"
 msgstr "報告數目"
 
-#: invenio/legacy/webcomment/templates.py:1745
+#: invenio/legacy/webcomment/templates.py:1744
 msgid "View all user's reported comments/reviews"
 msgstr "查閱全部用戶的意見和評論"
 
-#: invenio/legacy/webcomment/templates.py:1778
+#: invenio/legacy/webcomment/templates.py:1777
 #, fuzzy, python-format
 msgid "This review has been reported %(x_num)i times"
 msgstr "這評論已被報告了%i次"
 
-#: invenio/legacy/webcomment/templates.py:1780
+#: invenio/legacy/webcomment/templates.py:1779
 #, fuzzy, python-format
 msgid "This comment has been reported %(x_num)i times"
 msgstr "這意見已被報告了%i次"
 
-#: invenio/legacy/webcomment/templates.py:2029
+#: invenio/legacy/webcomment/templates.py:2028
 msgid "Written by"
 msgstr "作者："
 
-#: invenio/legacy/webcomment/templates.py:2030
+#: invenio/legacy/webcomment/templates.py:2029
 msgid "General informations"
 msgstr "一般資料"
 
-#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2044
 msgid "Delete selected reviews"
 msgstr "刪除已選擇的評論"
 
-#: invenio/legacy/webcomment/templates.py:2046
-#: invenio/legacy/webcomment/templates.py:2053
+#: invenio/legacy/webcomment/templates.py:2045
+#: invenio/legacy/webcomment/templates.py:2052
 msgid "Suppress selected abuse report"
 msgstr "查禁已選擇的濫用報告"
 
-#: invenio/legacy/webcomment/templates.py:2047
+#: invenio/legacy/webcomment/templates.py:2046
 #, fuzzy
 msgid "Undelete selected reviews"
 msgstr "刪除已選擇的評論"
 
-#: invenio/legacy/webcomment/templates.py:2051
+#: invenio/legacy/webcomment/templates.py:2050
 #, fuzzy
 msgid "Undelete selected comments"
 msgstr "刪除已選擇的意見"
 
-#: invenio/legacy/webcomment/templates.py:2052
+#: invenio/legacy/webcomment/templates.py:2051
 msgid "Delete selected comments"
 msgstr "刪除已選擇的意見"
 
-#: invenio/legacy/webcomment/templates.py:2067
+#: invenio/legacy/webcomment/templates.py:2066
 #, fuzzy, python-format
 msgid "Here are the reported reviews of user %(x_name)s"
 msgstr "用戶 %s 的評論："
 
-#: invenio/legacy/webcomment/templates.py:2069
+#: invenio/legacy/webcomment/templates.py:2068
 #, fuzzy, python-format
 msgid "Here are the reported comments of user %(x_name)s"
 msgstr "用戶 %s 的意見："
 
-#: invenio/legacy/webcomment/templates.py:2073
+#: invenio/legacy/webcomment/templates.py:2072
 #, fuzzy, python-format
 msgid "Here is review %(x_name)s"
 msgstr "評論/意見 %s"
 
-#: invenio/legacy/webcomment/templates.py:2075
+#: invenio/legacy/webcomment/templates.py:2074
 #, fuzzy, python-format
 msgid "Here is comment %(x_name)s"
 msgstr "評論/意見 %s"
 
-#: invenio/legacy/webcomment/templates.py:2078
+#: invenio/legacy/webcomment/templates.py:2077
 #, fuzzy, python-format
 msgid "Here is review %(x_cmtID)s written by user %(x_user)s"
 msgstr "用戶 %(x_user)s 的評論/意見 %(x_cmtID)s"
 
-#: invenio/legacy/webcomment/templates.py:2080
+#: invenio/legacy/webcomment/templates.py:2079
 #, fuzzy, python-format
 msgid "Here is comment %(x_cmtID)s written by user %(x_user)s"
 msgstr "用戶 %(x_user)s 的評論/意見 %(x_cmtID)s"
 
-#: invenio/legacy/webcomment/templates.py:2086
+#: invenio/legacy/webcomment/templates.py:2085
 msgid "Here are all reported reviews sorted by the most reported"
 msgstr "全部評論 (以最多提供評論者排序)"
 
-#: invenio/legacy/webcomment/templates.py:2088
+#: invenio/legacy/webcomment/templates.py:2087
 msgid "Here are all reported comments sorted by the most reported"
 msgstr "全部意見 (以最多提供意見者排序)"
 
-#: invenio/legacy/webcomment/templates.py:2093
+#: invenio/legacy/webcomment/templates.py:2092
 #, fuzzy, python-format
 msgid "Here are all reviews for record %(x_num)i, sorted by the most reported"
 msgstr "全部評論 (以最多提供評論者排序)"
 
-#: invenio/legacy/webcomment/templates.py:2094
+#: invenio/legacy/webcomment/templates.py:2093
 #, fuzzy
 msgid "Show comments"
 msgstr "閱讀意見"
 
-#: invenio/legacy/webcomment/templates.py:2096
+#: invenio/legacy/webcomment/templates.py:2095
 #, fuzzy, python-format
 msgid "Here are all comments for record %(x_num)i, sorted by the most reported"
 msgstr "全部意見 (以最多提供意見者排序)"
 
-#: invenio/legacy/webcomment/templates.py:2097
+#: invenio/legacy/webcomment/templates.py:2096
 #, fuzzy
 msgid "Show reviews"
 msgstr "評論"
 
-#: invenio/legacy/webcomment/templates.py:2122
-#: invenio/legacy/webcomment/templates.py:2146
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2121
+#: invenio/legacy/webcomment/templates.py:2145
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "comment ID"
 msgstr "意見ID"
 
-#: invenio/legacy/webcomment/templates.py:2122
+#: invenio/legacy/webcomment/templates.py:2121
 msgid "successfully deleted"
 msgstr "成功刪除"
 
-#: invenio/legacy/webcomment/templates.py:2146
+#: invenio/legacy/webcomment/templates.py:2145
 #, fuzzy
 msgid "successfully undeleted"
 msgstr "成功刪除"
 
-#: invenio/legacy/webcomment/templates.py:2172
+#: invenio/legacy/webcomment/templates.py:2171
 msgid "successfully suppressed abuse report"
 msgstr "成功查禁濫用報告"
 
-#: invenio/legacy/webcomment/templates.py:2189
+#: invenio/legacy/webcomment/templates.py:2188
 #, fuzzy
 msgid "Not yet reviewed"
 msgstr "撰寫評論"
 
+#: invenio/legacy/webcomment/templates.py:2256
+#, python-format
+msgid ""
+"The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgstr ""
+
 #: invenio/legacy/webcomment/templates.py:2257
 #, python-format
-msgid "The following review was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
+msgid ""
+"The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2258
-#, python-format
-msgid "The following comment was sent to %(CFG_SITE_NAME)s by %(user_nickname)s:"
-msgstr ""
-
-#: invenio/legacy/webcomment/templates.py:2285
+#: invenio/legacy/webcomment/templates.py:2284
 msgid "This is an automatic message, please don't reply to it."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2287
+#: invenio/legacy/webcomment/templates.py:2286
 #, python-format
 msgid "To post another comment, go to <%(x_url)s> instead."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2292
+#: invenio/legacy/webcomment/templates.py:2291
 #, python-format
 msgid "To specifically reply to this comment, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2297
+#: invenio/legacy/webcomment/templates.py:2296
 #, python-format
 msgid "To unsubscribe from this discussion, go to <%(x_url)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2301
+#: invenio/legacy/webcomment/templates.py:2300
 #, python-format
 msgid "For any question, please use <%(CFG_SITE_SUPPORT_EMAIL)s>"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2368
+#: invenio/legacy/webcomment/templates.py:2367
 #, fuzzy
 msgid "Your comment will be lost."
 msgstr "您的意見已被張貼。"
 
-#: invenio/legacy/webcomment/templates.py:2406
+#: invenio/legacy/webcomment/templates.py:2405
 #, fuzzy
 msgid "Oldest comment first"
 msgstr "刪除意見"
 
-#: invenio/legacy/webcomment/templates.py:2407
+#: invenio/legacy/webcomment/templates.py:2406
 #, fuzzy
 msgid "Latest comment first"
 msgstr "時間"
 
-#: invenio/legacy/webcomment/templates.py:2408
+#: invenio/legacy/webcomment/templates.py:2407
 msgid "Group by record, oldest commented first"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2409
+#: invenio/legacy/webcomment/templates.py:2408
 #, fuzzy
 msgid "Group by record, latest commented first"
 msgstr "閱讀意見"
 
-#: invenio/legacy/webcomment/templates.py:2411
+#: invenio/legacy/webcomment/templates.py:2410
 #, fuzzy
 msgid "Records and comments"
 msgstr "詳細資料和意見"
 
-#: invenio/legacy/webcomment/templates.py:2412
+#: invenio/legacy/webcomment/templates.py:2411
 #, fuzzy
 msgid "Records only"
 msgstr "找到 %s 筆記錄"
 
-#: invenio/legacy/webcomment/templates.py:2413
+#: invenio/legacy/webcomment/templates.py:2412
 #, fuzzy
 msgid "Comments only"
 msgstr "意見"
 
+#: invenio/legacy/webcomment/templates.py:2414
 #: invenio/legacy/webcomment/templates.py:2415
 #: invenio/legacy/webcomment/templates.py:2416
 #: invenio/legacy/webcomment/templates.py:2417
-#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy, python-format
 msgid "%(x_i)s items"
 msgstr "時間"
 
-#: invenio/legacy/webcomment/templates.py:2419
+#: invenio/legacy/webcomment/templates.py:2418
 #, fuzzy
 msgid "All items"
 msgstr "加入至用戶"
 
-#: invenio/legacy/webcomment/templates.py:2422
+#: invenio/legacy/webcomment/templates.py:2421
 msgid "Below is the list of the comments you have submitted so far."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2426
-msgid "You have not yet submitted any comment in the document \"discussion\" tab."
+#: invenio/legacy/webcomment/templates.py:2425
+msgid ""
+"You have not yet submitted any comment in the document \"discussion\" tab."
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2429
-#: invenio/legacy/webcomment/templates.py:2437
-#: invenio/legacy/webcomment/templates.py:2445
+#: invenio/legacy/webcomment/templates.py:2428
+#: invenio/legacy/webcomment/templates.py:2436
+#: invenio/legacy/webcomment/templates.py:2444
 msgid "You might find other comments here: "
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2457
+#: invenio/legacy/webcomment/templates.py:2456
 msgid ""
 "You have not yet submitted any comment. Browse documents from the search "
 "interface and take part to discussions!"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2485
+#: invenio/legacy/webcomment/templates.py:2484
 msgid "Display"
 msgstr "顯示"
 
-#: invenio/legacy/webcomment/templates.py:2486
+#: invenio/legacy/webcomment/templates.py:2485
 #, fuzzy
 msgid "Order by"
 msgstr "創建日期"
 
-#: invenio/legacy/webcomment/templates.py:2487
+#: invenio/legacy/webcomment/templates.py:2486
 #, fuzzy
 msgid "Per page"
 msgstr "下一頁"
 
-#: invenio/legacy/webcomment/templates.py:2491
+#: invenio/legacy/webcomment/templates.py:2490
 #, fuzzy
 msgid "Display options"
 msgstr "顯示警報"
 
-#: invenio/legacy/webcomment/templates.py:2492
+#: invenio/legacy/webcomment/templates.py:2491
 #: invenio/legacy/webjournal/adminlib.py:328
 #: invenio/legacy/webjournal/adminlib.py:345
 #: invenio/legacy/webjournal/templates.py:457
@@ -8544,106 +8521,106 @@ msgstr "顯示警報"
 msgid "Refresh"
 msgstr "參考"
 
-#: invenio/legacy/webcomment/templates.py:2521
+#: invenio/legacy/webcomment/templates.py:2520
 msgid "Comment deleted by the moderator"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2523
+#: invenio/legacy/webcomment/templates.py:2522
 msgid "You have deleted this comment: it is not visible by other users"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2530
+#: invenio/legacy/webcomment/templates.py:2529
 #, fuzzy
 msgid "(in reply to a comment)"
 msgstr "刪除意見"
 
-#: invenio/legacy/webcomment/templates.py:2535
+#: invenio/legacy/webcomment/templates.py:2534
 msgid "See comment on discussion page"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2574
+#: invenio/legacy/webcomment/templates.py:2573
 #, python-format
 msgid "%(x_num)i comments found in total (not shown on this page)"
 msgstr ""
 
-#: invenio/legacy/webcomment/templates.py:2576
+#: invenio/legacy/webcomment/templates.py:2575
 #, fuzzy, python-format
 msgid "%(x_num)i items found in total"
 msgstr "沒有找到。"
 
-#: invenio/legacy/webcomment/webinterface.py:272
-#: invenio/legacy/webcomment/webinterface.py:530
+#: invenio/legacy/webcomment/webinterface.py:276
+#: invenio/legacy/webcomment/webinterface.py:536
 msgid "Record Not Found"
 msgstr "找不到記錄"
 
-#: invenio/legacy/webcomment/webinterface.py:350
-#: invenio/legacy/webcomment/webinterface.py:591
-#: invenio/legacy/webcomment/webinterface.py:668
+#: invenio/legacy/webcomment/webinterface.py:354
+#: invenio/legacy/webcomment/webinterface.py:597
+#: invenio/legacy/webcomment/webinterface.py:674
 msgid "Specified comment does not belong to this record"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:359
-#: invenio/legacy/webcomment/webinterface.py:597
-#: invenio/legacy/webcomment/webinterface.py:674
+#: invenio/legacy/webcomment/webinterface.py:363
+#: invenio/legacy/webcomment/webinterface.py:603
+#: invenio/legacy/webcomment/webinterface.py:680
 #, fuzzy
 msgid "You do not have access to the specified comment"
 msgstr "您沒有足夠權限以讀取這收藏籃。"
 
-#: invenio/legacy/webcomment/webinterface.py:431
+#: invenio/legacy/webcomment/webinterface.py:437
 #, python-format
 msgid ""
 "The size of file \\\"%(x_file)s\\\" (%(x_size)s) is larger than maximum "
 "allowed file size (%(x_max)s). Select files again."
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:513
+#: invenio/legacy/webcomment/webinterface.py:519
 #: invenio/legacy/websubmit/templates.py:2445
 #: invenio/legacy/websubmit/templates.py:2446
 msgid "Add Comment"
 msgstr "新增評論"
 
-#: invenio/legacy/webcomment/webinterface.py:602
+#: invenio/legacy/webcomment/webinterface.py:608
 msgid "You cannot vote for a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:679
+#: invenio/legacy/webcomment/webinterface.py:685
 #, fuzzy
 msgid "You cannot report a deleted comment"
 msgstr "閱讀所有意見"
 
-#: invenio/legacy/webcomment/webinterface.py:826
-#: invenio/legacy/webcomment/webinterface.py:866
+#: invenio/legacy/webcomment/webinterface.py:832
+#: invenio/legacy/webcomment/webinterface.py:872
 #, fuzzy
 msgid "Page Not Found"
 msgstr "找不到 %s 專輯"
 
-#: invenio/legacy/webcomment/webinterface.py:827
+#: invenio/legacy/webcomment/webinterface.py:833
 #, fuzzy
 msgid "The requested comment could not be found"
 msgstr "這記錄並不存在。"
 
-#: invenio/legacy/webcomment/webinterface.py:847
+#: invenio/legacy/webcomment/webinterface.py:853
 msgid "You cannot access files of a deleted comment"
 msgstr ""
 
-#: invenio/legacy/webcomment/webinterface.py:867
+#: invenio/legacy/webcomment/webinterface.py:873
 #, fuzzy
 msgid "The requested file could not be found"
 msgstr "這記錄並不存在。"
 
-#: invenio/legacy/webcomment/webinterface.py:910
+#: invenio/legacy/webcomment/webinterface.py:916
 #, fuzzy
 msgid "You are not authorized to use comments."
 msgstr "您並不是這收藏籃的擁有者。"
 
-#: invenio/legacy/webcomment/webinterface.py:912
+#: invenio/legacy/webcomment/webinterface.py:918
 #: invenio/legacy/websession/templates.py:635
 #: invenio/legacy/websession/templates.py:788
 #, fuzzy
 msgid "Your Comments"
 msgstr "意見"
 
-#: invenio/legacy/webcomment/webinterface.py:924
+#: invenio/legacy/webcomment/webinterface.py:930
 #, fuzzy, python-format
 msgid "%(x_name)s View your previously submitted comments"
 msgstr "閱讀所有意見"
@@ -8765,8 +8742,8 @@ msgstr "對不起，記錄 %s 並不存在。"
 #: invenio/legacy/webdoc/webinterface.py:200
 #, fuzzy, python-format
 msgid ""
-"You may want to look at the %(x_url_open)s%(x_category)s "
-"pages%(x_url_close)s."
+"You may want to look at the %(x_url_open)s%(x_category)s pages"
+"%(x_url_close)s."
 msgstr "您可以使用您的%(x_url_open)s帳號%(x_url_close)s。"
 
 #: invenio/legacy/webdoc_info/webinterface.py:208
@@ -8838,8 +8815,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:213
 msgid ""
-"It seems that there are no journals defined on this server. Please "
-"contact support if this is not right."
+"It seems that there are no journals defined on this server. Please contact "
+"support if this is not right."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:239
@@ -8867,8 +8844,8 @@ msgstr ""
 
 #: invenio/legacy/webjournal/config.py:270
 msgid ""
-"The configuration for the current issue seems to be empty. Try providing "
-"an issue number or check with support."
+"The configuration for the current issue seems to be empty. Try providing an "
+"issue number or check with support."
 msgstr ""
 
 #: invenio/legacy/webjournal/config.py:298
@@ -8972,11 +8949,6 @@ msgstr ""
 msgid "Apply"
 msgstr "四月"
 
-#: invenio/legacy/webjournal/utils.py:714
-#, fuzzy
-msgid "niceName"
-msgstr "諢號"
-
 #: invenio/legacy/webjournal/web/admin/webjournaladmin.py:76
 #, fuzzy
 msgid "WebJournal Admin"
@@ -9061,9 +9033,8 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:124
 msgid ""
-"All URLs in these lists are checked for containment (infix) in any "
-"linkback request URL. A whitelist match has precedence over a blacklist "
-"match."
+"All URLs in these lists are checked for containment (infix) in any linkback "
+"request URL. A whitelist match has precedence over a blacklist match."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:127
@@ -9085,8 +9056,7 @@ msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:199
 msgid ""
-"these linkbacks are not visible to users, they must be approved or "
-"rejected."
+"these linkbacks are not visible to users, they must be approved or rejected."
 msgstr ""
 
 #: invenio/legacy/weblinkback/adminlib.py:208
@@ -9572,14 +9542,14 @@ msgstr "也搜尋:"
 
 #: invenio/legacy/websearch/templates.py:1589
 msgid ""
-"This collection is restricted.  If you are authorized to access it, "
-"please click on the Search button."
+"This collection is restricted.  If you are authorized to access it, please "
+"click on the Search button."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1604
 msgid ""
-"This is a hosted external collection. Please click on the Search button "
-"to see its content."
+"This is a hosted external collection. Please click on the Search button to "
+"see its content."
 msgstr ""
 
 #: invenio/legacy/websearch/templates.py:1619
@@ -9717,8 +9687,7 @@ msgstr "提交"
 
 #: invenio/legacy/websearch/templates.py:3325
 msgid ""
-"Boolean query returned no hits. Please combine your search terms "
-"differently."
+"Boolean query returned no hits. Please combine your search terms differently."
 msgstr "匹配不到記錄，請試用其他關鍵詞。"
 
 #: invenio/legacy/websearch/templates.py:3357
@@ -9744,8 +9713,8 @@ msgstr "您可以從 %s 開始瀏覽。"
 #, python-format
 msgid ""
 "Set up a personal %(x_url1_open)semail alert%(x_url1_close)s\n"
-"                                  or subscribe to the %(x_url2_open)sRSS "
-"feed%(x_url2_close)s."
+"                                  or subscribe to the %(x_url2_open)sRSS feed"
+"%(x_url2_close)s."
 msgstr ""
 "建立您的%(x_url1_open)s電郵警報%(x_url1_close)s\n"
 "或訂閱%(x_url2_open)sRSS feed%(x_url2_close)s."
@@ -9941,7 +9910,8 @@ msgid "in"
 msgstr "在"
 
 #: invenio/legacy/websearch_external_collections/templates.py:51
-msgid "Haven't found what you were looking for? Try your search on other servers:"
+msgid ""
+"Haven't found what you were looking for? Try your search on other servers:"
 msgstr "沒有尋找到什麼? 嘗試在以下的服務器查尋："
 
 #: invenio/legacy/websearch_external_collections/templates.py:79
@@ -10033,8 +10003,8 @@ msgstr "必須的"
 
 #: invenio/legacy/websession/templates.py:207
 msgid ""
-"The description should be something meaningful for you to recognize the "
-"API key"
+"The description should be something meaningful for you to recognize the API "
+"key"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:208
@@ -10044,8 +10014,8 @@ msgstr "創建收藏籃"
 
 #: invenio/legacy/websession/templates.py:270
 msgid ""
-"If you want to change your email or set for the first time your nickname,"
-" please set new values in the form below."
+"If you want to change your email or set for the first time your nickname, "
+"please set new values in the form below."
 msgstr "請用以下表格來改變您的電郵或諢號。"
 
 #: invenio/legacy/websession/templates.py:271
@@ -10062,14 +10032,14 @@ msgstr "重設"
 
 #: invenio/legacy/websession/templates.py:285
 msgid ""
-"Since this is considered as a signature for comments and reviews, once "
-"set it can not be changed."
+"Since this is considered as a signature for comments and reviews, once set "
+"it can not be changed."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:325
 msgid ""
-"If you want to change your password, please enter the old one and set the"
-" new value in the form below."
+"If you want to change your password, please enter the old one and set the "
+"new value in the form below."
 msgstr "請用以下表格來改變您的電郵。"
 
 #: invenio/legacy/websession/templates.py:327
@@ -10107,8 +10077,8 @@ msgstr "建立密碼"
 #: invenio/legacy/websession/templates.py:343
 #, fuzzy, python-format
 msgid ""
-"If you are using a lightweight CERN account you can %(x_url_open)sreset "
-"the password%(x_url_close)s."
+"If you are using a lightweight CERN account you can %(x_url_open)sreset the "
+"password%(x_url_close)s."
 msgstr "您可以%(x_url_open)s登入或%(x_url_close)s註冊。"
 
 #: invenio/legacy/websession/templates.py:346
@@ -10198,10 +10168,9 @@ msgstr "選擇方法"
 #: invenio/legacy/websession/templates.py:537
 #, fuzzy, python-format
 msgid ""
-"If you have lost the password for your %(sitename)s "
-"%(x_fmt_open)sinternal account%(x_fmt_close)s, then please enter your "
-"email address in the following form in order to have a password reset "
-"link emailed to you."
+"If you have lost the password for your %(sitename)s %(x_fmt_open)sinternal "
+"account%(x_fmt_close)s, then please enter your email address in the "
+"following form in order to have a password reset link emailed to you."
 msgstr "如果您丟失了密碼，請輸入您的電郵，我們會電郵密碼給您。"
 
 #: invenio/legacy/websession/templates.py:559
@@ -10219,16 +10188,16 @@ msgstr "發送密碼"
 #: invenio/legacy/websession/templates.py:567
 #, python-format
 msgid ""
-"If you have been using the %(x_fmt_open)sCERN login "
-"system%(x_fmt_close)s, then you can recover your password through the "
-"%(x_url_open)sCERN authentication system%(x_url_close)s."
+"If you have been using the %(x_fmt_open)sCERN login system%(x_fmt_close)s, "
+"then you can recover your password through the %(x_url_open)sCERN "
+"authentication system%(x_url_close)s."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:571
 #, fuzzy
 msgid ""
-"Note that if you have been using an external login system, then we cannot"
-" do anything and you have to ask there."
+"Note that if you have been using an external login system, then we cannot do "
+"anything and you have to ask there."
 msgstr "如果您是用外部的登錄系統，那麼我們將不能幫助您。"
 
 #: invenio/legacy/websession/templates.py:573
@@ -10241,10 +10210,10 @@ msgstr "另外，您可以向 %s 重設登錄系統。"
 #: invenio/legacy/websession/templates.py:600
 #, fuzzy, python-format
 msgid ""
-"%(x_name)s offers you the possibility to personalize the interface, to "
-"set up your own personal library of documents, or to set up an automatic "
-"alert query that would run periodically and would notify you of search "
-"results by email."
+"%(x_name)s offers you the possibility to personalize the interface, to set "
+"up your own personal library of documents, or to set up an automatic alert "
+"query that would run periodically and would notify you of search results by "
+"email."
 msgstr "%s 提供以下服務：個人化介面、個人收藏籃、設定電郵警報。"
 
 #: invenio/legacy/websession/templates.py:611
@@ -10264,8 +10233,8 @@ msgstr "查閱您過去三十天沒內曾進行過搜索。"
 
 #: invenio/legacy/websession/templates.py:628
 msgid ""
-"With baskets you can define specific collections of items, store "
-"interesting records you want to access later or share with others."
+"With baskets you can define specific collections of items, store interesting "
+"records you want to access later or share with others."
 msgstr "您可以用收藏籃定義記錄收藏、貯藏有用的記錄以便稍後閱覽或分享。"
 
 #: invenio/legacy/websession/templates.py:636
@@ -10276,26 +10245,27 @@ msgstr ""
 msgid ""
 "Subscribe to a search which will be run periodically by our service. The "
 "result can be sent to you via Email or stored in one of your baskets."
-msgstr "訂閱查尋條件；我們的服務器具定時執行搜索，並把結果發到您的電郵或收藏籃子中。"
+msgstr ""
+"訂閱查尋條件；我們的服務器具定時執行搜索，並把結果發到您的電郵或收藏籃子中。"
 
 #: invenio/legacy/websession/templates.py:651
 msgid ""
-"Check out book you have on loan, submit borrowing requests, etc. Requires"
-" CERN ID."
+"Check out book you have on loan, submit borrowing requests, etc. Requires "
+"CERN ID."
 msgstr "借出書本、提交借出要求等。須要 CERN ID。"
 
 #: invenio/legacy/websession/templates.py:678
 msgid ""
-"You are logged in as a guest user, so your alerts will disappear at the "
-"end of the current session."
+"You are logged in as a guest user, so your alerts will disappear at the end "
+"of the current session."
 msgstr "您是用遊客登錄, 因此您的警報將不會保存在這系統中。"
 
 #: invenio/legacy/websession/templates.py:701
 #, python-format
 msgid ""
-"You are logged in as %(x_user)s. You may want to a) "
-"%(x_url1_open)slogout%(x_url1_close)s; b) edit your "
-"%(x_url2_open)saccount settings%(x_url2_close)s."
+"You are logged in as %(x_user)s. You may want to a) %(x_url1_open)slogout"
+"%(x_url1_close)s; b) edit your %(x_url2_open)saccount settings"
+"%(x_url2_close)s."
 msgstr ""
 "您是用%(x_user)s身份登錄，你可以 a)%(x_url1_open)s登出%(x_url1_close)s； b) "
 "修改您的%(x_url2_open)s戶囗設定%(x_url2_close)s。"
@@ -10314,8 +10284,8 @@ msgstr "搜查警報"
 #: invenio/legacy/websession/templates.py:796
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you "
-"are administering or are a member of."
+"You can consult the list of %(x_url_open)syour groups%(x_url_close)s you are "
+"administering or are a member of."
 msgstr "您可直接在%(x_url_open)s這裡%(x_url_close)s咨詢您的組別名單。"
 
 #: invenio/legacy/websession/templates.py:799
@@ -10327,8 +10297,8 @@ msgstr "組別"
 #: invenio/legacy/websession/templates.py:802
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s"
-" and inquire about their status."
+"You can consult the list of %(x_url_open)syour submissions%(x_url_close)s "
+"and inquire about their status."
 msgstr "您可直接在%(x_url_open)s這裡%(x_url_close)s咨詢您的提交名單。"
 
 #: invenio/legacy/websession/templates.py:805
@@ -10339,8 +10309,8 @@ msgstr "提交"
 #: invenio/legacy/websession/templates.py:808
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s "
-"with the documents you approved or refereed."
+"You can consult the list of %(x_url_open)syour approvals%(x_url_close)s with "
+"the documents you approved or refereed."
 msgstr "您可直接在%(x_url_open)s這裡%(x_url_close)s咨詢您的批核名單。"
 
 #: invenio/legacy/websession/templates.py:811
@@ -10387,7 +10357,8 @@ msgstr ""
 #: invenio/legacy/websession/templates.py:884
 #: invenio/legacy/websession/templates.py:921
 #, python-format
-msgid "Please note that this URL will remain valid for about %(days)s days only."
+msgid ""
+"Please note that this URL will remain valid for about %(days)s days only."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:909
@@ -10436,15 +10407,15 @@ msgstr "如果您已經登記帳號, 請登入."
 #: invenio/legacy/websession/templates.py:1015
 #, fuzzy, python-format
 msgid ""
-"If you don't own a CERN account yet, you can register a %(x_url_open)snew"
-" CERN lightweight account%(x_url_close)s."
+"If you don't own a CERN account yet, you can register a %(x_url_open)snew "
+"CERN lightweight account%(x_url_close)s."
 msgstr "如果您沒有帳號, 請先%(x_url_open)s註冊%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1018
 #, python-format
 msgid ""
-"If you don't own an account yet, please "
-"%(x_url_open)sregister%(x_url_close)s an internal account."
+"If you don't own an account yet, please %(x_url_open)sregister"
+"%(x_url_close)s an internal account."
 msgstr "如果您沒有帳號, 請先%(x_url_open)s註冊%(x_url_close)s."
 
 #: invenio/legacy/websession/templates.py:1027
@@ -10480,8 +10451,8 @@ msgstr "您可以使用您的諢號或電郵登入."
 
 #: invenio/legacy/websession/templates.py:1127
 msgid ""
-"Your request is valid. Please set the new desired password in the "
-"following form."
+"Your request is valid. Please set the new desired password in the following "
+"form."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:1150
@@ -10510,8 +10481,8 @@ msgstr "請輸入您的電郵、諢號、密碼:"
 
 #: invenio/legacy/websession/templates.py:1177
 msgid ""
-"It will not be possible to use the account before it has been verified "
-"and activated."
+"It will not be possible to use the account before it has been verified and "
+"activated."
 msgstr "您的帳戶要被核實後才可使用."
 
 #: invenio/legacy/websession/templates.py:1228
@@ -10528,24 +10499,26 @@ msgstr "註冊"
 msgid ""
 "Please do not use valuable passwords such as your Unix, AFS or NICE "
 "passwords with this service. Your email address will stay strictly "
-"confidential and will not be disclosed to any third party. It will be "
-"used to identify you for personal services of %(x_name)s. For example, "
-"you may set up an automatic alert search that will look for new preprints"
-" and will notify you daily of new arrivals by email."
-msgstr "請不要使用您自己沿用的密碼。您的電郵不會被透露到第三方，它只會使用以辨認您的%s服務。"
+"confidential and will not be disclosed to any third party. It will be used "
+"to identify you for personal services of %(x_name)s. For example, you may "
+"set up an automatic alert search that will look for new preprints and will "
+"notify you daily of new arrivals by email."
+msgstr ""
+"請不要使用您自己沿用的密碼。您的電郵不會被透露到第三方，它只會使用以辨認您"
+"的%s服務。"
 
 #: invenio/legacy/websession/templates.py:1235
 #, fuzzy, python-format
 msgid ""
-"It is not possible to create an account yourself. Contact %(x_name)s if "
-"you want an account."
+"It is not possible to create an account yourself. Contact %(x_name)s if you "
+"want an account."
 msgstr "請聯絡 %s 關於創建帳號事情。"
 
 #: invenio/legacy/websession/templates.py:1261
 #, python-format
 msgid ""
-"You seem to be a guest user. You have to "
-"%(x_url_open)slogin%(x_url_close)s first."
+"You seem to be a guest user. You have to %(x_url_open)slogin%(x_url_close)s "
+"first."
 msgstr "您的身份是遊客。您需要先%(x_url_open)s登入%(x_url_close)s。"
 
 #: invenio/legacy/websession/templates.py:1267
@@ -10679,8 +10652,8 @@ msgstr "以下是一些有用的連結："
 #: invenio/legacy/websession/templates.py:1325
 #, python-format
 msgid ""
-"For more admin-level activities, see the complete %(x_url_open)sAdmin "
-"Area%(x_url_close)s."
+"For more admin-level activities, see the complete %(x_url_open)sAdmin Area"
+"%(x_url_close)s."
 msgstr "請到%(x_url_open)s管理區%(x_url_close)s以便使用更多管理功能。"
 
 #: invenio/legacy/websession/templates.py:1378
@@ -10899,7 +10872,8 @@ msgstr "用戶要求加入組別 %s。"
 
 #: invenio/legacy/websession/templates.py:2382
 #, python-format
-msgid "Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
+msgid ""
+"Please %(x_url_open)saccept or reject%(x_url_close)s this user's request."
 msgstr "請%(x_url_open)s接納或拒絕%(x_url_close)s用戶要求。"
 
 #: invenio/legacy/websession/templates.py:2400
@@ -10941,74 +10915,70 @@ msgstr "組別 %s 已被管理員刪除。"
 #: invenio/legacy/websession/templates.py:2441
 #, python-format
 msgid ""
-"You can consult the list of %(x_url_open)s%(x_nb_total)i "
-"groups%(x_url_close)s you are subscribed to (%(x_nb_member)i) or "
-"administering (%(x_nb_admin)i)."
+"You can consult the list of %(x_url_open)s%(x_nb_total)i groups"
+"%(x_url_close)s you are subscribed to (%(x_nb_member)i) or administering "
+"(%(x_nb_admin)i)."
 msgstr ""
-"您可直接在%(x_url_open)s這裡%(x_url_close)s咨詢您的%(x_nb_total)i組別給(%(x_nb_member)i)"
-" or 管理 (%(x_nb_admin)i)名單。"
+"您可直接在%(x_url_open)s這裡%(x_url_close)s咨詢您的%(x_nb_total)i組別給"
+"(%(x_nb_member)i) or 管理 (%(x_nb_admin)i)名單。"
 
 #: invenio/legacy/websession/templates.py:2460
 msgid ""
 "Warning: The password set for MySQL root user is the same as the default "
-"Invenio password. For security purposes, you may want to change the "
-"password."
+"Invenio password. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2466
 msgid ""
 "Warning: The password set for the Invenio MySQL user is the same as the "
-"shipped default. For security purposes, you may want to change the "
-"password."
+"shipped default. For security purposes, you may want to change the password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2472
 msgid ""
-"Warning: The password set for the Invenio admin user is currently empty. "
-"For security purposes, it is strongly recommended that you add a "
-"password."
+"Warning: The password set for the Invenio admin user is currently empty. For "
+"security purposes, it is strongly recommended that you add a password."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2478
 msgid ""
-"Warning: The email address set for support email is currently set to info"
-"@invenio-software.org. It is recommended that you change this to your own"
-" address."
+"Warning: The email address set for support email is currently set to "
+"info@invenio-software.org. It is recommended that you change this to your "
+"own address."
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2484
 msgid ""
-"A newer version of Invenio is available for download. You may want to "
-"visit  "
+"A newer version of Invenio is available for download. You may want to visit  "
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2491
 msgid ""
-"Cannot download or parse release notes from http://invenio-"
-"software.org/repo/invenio/tree/RELEASE-NOTES"
+"Cannot download or parse release notes from http://invenio-software.org/repo/"
+"invenio/tree/RELEASE-NOTES"
 msgstr ""
 
 #: invenio/legacy/websession/templates.py:2496
 #, python-format
 msgid ""
-"Your e-mail is auto-generated by the system. Please change your e-mail "
-"from <a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account "
-"settings</a>."
+"Your e-mail is auto-generated by the system. Please change your e-mail from "
+"<a href='%(x_site)s/youraccount/edit?ln=%(x_link)s'>account settings</a>."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:118
 #, python-format
 msgid ""
-"You are logged in as guest. You may want to "
-"%(x_url_open)slogin%(x_url_close)s as a regular user."
+"You are logged in as guest. You may want to %(x_url_open)slogin"
+"%(x_url_close)s as a regular user."
 msgstr "您的身份是遊客。您需要先%(x_url_open)s登入%(x_url_close)s。"
 
 #: invenio/legacy/websession/webaccount.py:122
 #, python-format
 msgid ""
-"The %(x_fmt_open)sguest%(x_fmt_close)s users need to "
-"%(x_url_open)sregister%(x_url_close)s first"
-msgstr "%(x_fmt_open)s遊客%(x_fmt_close)s 需要先%(x_url_open)s註冊%(x_url_close)s。"
+"The %(x_fmt_open)sguest%(x_fmt_close)s users need to %(x_url_open)sregister"
+"%(x_url_close)s first"
+msgstr ""
+"%(x_fmt_open)s遊客%(x_fmt_close)s 需要先%(x_url_open)s註冊%(x_url_close)s。"
 
 #: invenio/legacy/websession/webaccount.py:127
 msgid "No queries found"
@@ -11016,14 +10986,14 @@ msgstr "沒有找到查詢"
 
 #: invenio/legacy/websession/webaccount.py:398
 msgid ""
-"This collection is restricted.  If you think you have right to access it,"
-" please authenticate yourself."
+"This collection is restricted.  If you think you have right to access it, "
+"please authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:399
 msgid ""
-"This file is restricted.  If you think you have right to access it, "
-"please authenticate yourself."
+"This file is restricted.  If you think you have right to access it, please "
+"authenticate yourself."
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:400
@@ -11032,8 +11002,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
 msgid ""
-"python-openid package must be installed: run make install-openid-package "
-"or download manually from https://github.com/openid/python-openid/"
+"python-openid package must be installed: run make install-openid-package or "
+"download manually from https://github.com/openid/python-openid/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:401
@@ -11045,8 +11015,8 @@ msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:402
 msgid ""
-"rauth package must be installed: run make install-oauth-package or "
-"download manually from https://github.com/litl/rauth/"
+"rauth package must be installed: run make install-oauth-package or download "
+"manually from https://github.com/litl/rauth/"
 msgstr ""
 
 #: invenio/legacy/websession/webaccount.py:403
@@ -11126,8 +11096,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:651
 msgid ""
-"Please choose a user from the list if you want him to be added to the "
-"group."
+"Please choose a user from the list if you want him to be added to the group."
 msgstr ""
 
 #: invenio/legacy/websession/webgroup.py:664
@@ -11193,8 +11162,7 @@ msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:148
 msgid ""
-"This request for confirmation of an email address is not valid or is "
-"expired."
+"This request for confirmation of an email address is not valid or is expired."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:153
@@ -11261,10 +11229,10 @@ msgstr "<p>轉用內部登錄方法。"
 #: invenio/legacy/websession/webinterface.py:423
 #, fuzzy
 msgid ""
-"Please note that if this is the first time that you are using this "
-"account with the internal login method then the system has set for you a "
-"randomly generated password. Please click the following button to obtain "
-"a password reset request link sent to you via email:"
+"Please note that if this is the first time that you are using this account "
+"with the internal login method then the system has set for you a randomly "
+"generated password. Please click the following button to obtain a password "
+"reset request link sent to you via email:"
 msgstr "注意：如您是首次使用內部登錄方法登入，您可以點擊以下按鈕已取得密碼："
 
 #: invenio/legacy/websession/webinterface.py:431
@@ -11292,8 +11260,8 @@ msgstr "登錄方法已成功選擇。"
 #: invenio/legacy/websession/webinterface.py:452
 #, fuzzy, python-format
 msgid ""
-"The external login method %(x_name)s does not support email address based"
-" logins.  Please contact the site administrators."
+"The external login method %(x_name)s does not support email address based "
+"logins.  Please contact the site administrators."
 msgstr "外部登錄方法 %s 並不支援用電郵登入；請聯絡管理員。"
 
 #: invenio/legacy/websession/webinterface.py:464
@@ -11473,15 +11441,15 @@ msgstr ""
 #: invenio/legacy/websession/webinterface.py:984
 #: invenio/modules/accounts/views/accounts.py:132
 msgid ""
-"Please follow instructions presented there in order to complete the "
-"account registration process."
+"Please follow instructions presented there in order to complete the account "
+"registration process."
 msgstr ""
 
 #: invenio/legacy/websession/webinterface.py:986
 #: invenio/modules/accounts/views/accounts.py:134
 msgid ""
-"A second email will be sent when the account has been activated and can "
-"be used."
+"A second email will be sent when the account has been activated and can be "
+"used."
 msgstr "當您的帳號已經開通，我們會再發送電郵給您。"
 
 #: invenio/legacy/websession/webinterface.py:989
@@ -11598,7 +11566,8 @@ msgstr ""
 
 #: invenio/legacy/webstyle/templates.py:636
 #, python-format
-msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgid ""
+"Record created %(x_date_creation)s, last modified %(x_date_modification)s"
 msgstr "記錄創建於%(x_date_creation)s，最後更新在%(x_date_modification)s"
 
 #: invenio/legacy/webstyle/templates.py:707
@@ -11621,37 +11590,37 @@ msgstr ""
 #: invenio/legacy/websubmit/admin_engine.py:3917
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_subm)s to temporary field location"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_subm)s to temporary field location"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3929
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field at position %(x_posfrom)s to position %(x_posto)s. Please ask Admin"
-" to check that a field was not stranded in a temporary position"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field at "
+"position %(x_posfrom)s to position %(x_posto)s. Please ask Admin to check "
+"that a field was not stranded in a temporary position"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3941
 #, python-format
 msgid ""
-"Unable to swap field at position %(x_from)s with field at position "
-"%(x_to)s on page %(x_page)s of submission %(x_sub)s - could not move "
-"field that was located at position %(x_posfrom)s to position %(x_posto)s "
-"from temporary position. Field is now stranded in temporary position and "
-"must be corrected manually by an Admin"
+"Unable to swap field at position %(x_from)s with field at position %(x_to)s "
+"on page %(x_page)s of submission %(x_sub)s - could not move field that was "
+"located at position %(x_posfrom)s to position %(x_posto)s from temporary "
+"position. Field is now stranded in temporary position and must be corrected "
+"manually by an Admin"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3953
 #, python-format
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission %(x_sub)s - could not decrement the position of "
-"the fields below position %(x_pos)s. Tried to recover - please check that"
-" field ordering is not broken"
+"%(x_page)s of submission %(x_sub)s - could not decrement the position of the "
+"fields below position %(x_pos)s. Tried to recover - please check that field "
+"ordering is not broken"
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3965
@@ -11659,15 +11628,15 @@ msgstr ""
 msgid ""
 "Unable to move field at position %(x_from)s to position %(x_to)s on page "
 "%(x_page)s of submission %(x_sub)s%(x_subm)s - could not increment the "
-"position of the fields at and below position %(x_frompos)s. The field "
-"that was at position %(x_topos)s is now stranded in a temporary position."
+"position of the fields at and below position %(x_frompos)s. The field that "
+"was at position %(x_topos)s is now stranded in a temporary position."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3977
 #, python-format
 msgid ""
-"Moved field from position %(x_from)s to position %(x_to)s on page "
-"%(x_page)s of submission '%(x_sub)s%(x_subm)s'."
+"Moved field from position %(x_from)s to position %(x_to)s on page %(x_page)s "
+"of submission '%(x_sub)s%(x_subm)s'."
 msgstr ""
 
 #: invenio/legacy/websubmit/admin_engine.py:3999
@@ -11735,8 +11704,8 @@ msgstr "不能確定提交頁數數量。"
 #: invenio/legacy/websubmit/engine.py:931
 #, fuzzy
 msgid ""
-"Unable to create a directory for this submission. The administrator has "
-"been alerted."
+"Unable to create a directory for this submission. The administrator has been "
+"alerted."
 msgstr "不能創建提交目錄。"
 
 #: invenio/legacy/websubmit/engine.py:440
@@ -11772,8 +11741,8 @@ msgstr "提交"
 msgid ""
 "A serious function-error has been encountered. Adminstrators have been "
 "alerted. <br /><em>Please not that this might be due to wrong characters "
-"inserted into the form</em> (e.g. by copy and pasting some text from a "
-"PDF file)."
+"inserted into the form</em> (e.g. by copy and pasting some text from a PDF "
+"file)."
 msgstr ""
 
 #: invenio/legacy/websubmit/engine.py:1501
@@ -11821,8 +11790,8 @@ msgstr "請選擇類別並點擊行動按鈕。"
 
 #: invenio/legacy/websubmit/templates.py:364
 msgid ""
-"To continue with a previously interrupted submission, enter an access "
-"number into the box below:"
+"To continue with a previously interrupted submission, enter an access number "
+"into the box below:"
 msgstr "請輸入存取號碼以便繼續上次中斷的提交："
 
 #: invenio/legacy/websubmit/templates.py:366
@@ -11851,8 +11820,8 @@ msgstr "返回主目錄"
 
 #: invenio/legacy/websubmit/templates.py:547
 msgid ""
-"This is your submission access number. It can be used to continue with an"
-" interrupted submission in case of problems."
+"This is your submission access number. It can be used to continue with an "
+"interrupted submission in case of problems."
 msgstr "這是您的存取號碼，您可以用它以重試中斷的提交。"
 
 #: invenio/legacy/websubmit/templates.py:548
@@ -11901,8 +11870,8 @@ msgstr "提交號碼"
 #: invenio/legacy/websubmit/templates.py:1036
 #, python-format
 msgid ""
-"Here is the %(x_action)s function list for %(x_doctype)s documents at "
-"level %(x_step)s"
+"Here is the %(x_action)s function list for %(x_doctype)s documents at level "
+"%(x_step)s"
 msgstr "這是 %(x_action)s 功能名單  %(x_doctype)s 文件 在 級別 %(x_step)s"
 
 #: invenio/legacy/websubmit/templates.py:1041
@@ -11985,8 +11954,7 @@ msgstr "文件類型名單"
 #: invenio/legacy/websubmit/templates.py:1479
 #, fuzzy
 msgid ""
-"Select one of the following types of documents to check the documents "
-"status"
+"Select one of the following types of documents to check the documents status"
 msgstr "選擇以下之文件類型以檢查其狀態。"
 
 #: invenio/legacy/websubmit/templates.py:1447
@@ -12128,7 +12096,8 @@ msgstr "已批核"
 
 #: invenio/legacy/websubmit/templates.py:2139
 #, python-format
-msgid "This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
+msgid ""
+"This document is still %(x_fmt_open)swaiting for approval%(x_fmt_close)s."
 msgstr "這文件還在%(x_fmt_open)s等候批核中%(x_fmt_close)s。"
 
 #: invenio/legacy/websubmit/templates.py:2142
@@ -12223,8 +12192,8 @@ msgstr "選擇評分"
 
 #: invenio/legacy/websubmit/templates.py:2278
 msgid ""
-"The referee has sent his final recommendations to the publication "
-"committee on the "
+"The referee has sent his final recommendations to the publication committee "
+"on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2281
@@ -12244,8 +12213,8 @@ msgstr "撰寫意見"
 #: invenio/legacy/websubmit/templates.py:2288
 #: invenio/legacy/websubmit/templates.py:2356
 msgid ""
-"The publication committee has sent his final recommendations to the "
-"project leader on the "
+"The publication committee has sent his final recommendations to the project "
+"leader on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2291
@@ -12286,7 +12255,8 @@ msgid "Take a decision"
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2321
-msgid "An editorial board has been selected by the publication committee on the "
+msgid ""
+"An editorial board has been selected by the publication committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2323
@@ -12308,14 +12278,13 @@ msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2340
 msgid ""
-"The referee has sent his final recommendations to the editorial board on "
-"the "
+"The referee has sent his final recommendations to the editorial board on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2348
 msgid ""
-"The editorial board has sent his final recommendations to the publication"
-" committee on the "
+"The editorial board has sent his final recommendations to the publication "
+"committee on the "
 msgstr ""
 
 #: invenio/legacy/websubmit/templates.py:2350
@@ -12438,10 +12407,9 @@ msgstr ""
 
 #: invenio/legacy/websubmit/functions/Shared_Functions.py:208
 msgid ""
-"Because of a human intervention or a temporary problem, the task queue is"
-" currently set to the manual mode. Your submission is well registered but"
-" may take longer than usual before it is fully integrated and searchable."
-"\n"
+"Because of a human intervention or a temporary problem, the task queue is "
+"currently set to the manual mode. Your submission is well registered but may "
+"take longer than usual before it is fully integrated and searchable.\n"
 msgstr ""
 
 #: invenio/legacy/websubmit/web/approve.py:53
@@ -12735,8 +12703,8 @@ msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:56
 msgid ""
-"see all the information attached to a role and decide if you want to "
-"delete it."
+"see all the information attached to a role and decide if you want to delete "
+"it."
 msgstr ""
 
 #: invenio/modules/access/templates/access/admin/rolearea_base.html:74
@@ -12779,11 +12747,6 @@ msgstr "選擇收藏籃"
 #, fuzzy
 msgid "Role details"
 msgstr "文章"
-
-#: invenio/modules/access/templates/access/admin/showroledetails_base.html:52
-#, fuzzy
-msgid "Id"
-msgstr "隱藏"
 
 #: invenio/modules/access/templates/access/admin/showroledetails_base.html:58
 msgid "Firewall like role definition"
@@ -12899,8 +12862,8 @@ msgstr "電郵 %s 已被使用。"
 #: invenio/modules/accounts/forms.py:94
 #, python-format
 msgid ""
-"Note that if you have changed your email address, you                 "
-"will have to <a href=%(link)s>reset</a> your password anew."
+"Note that if you have changed your email address, you                 will "
+"have to <a href=%(link)s>reset</a> your password anew."
 msgstr ""
 
 #: invenio/modules/accounts/forms.py:117
@@ -12965,9 +12928,8 @@ msgstr ""
 #: invenio/modules/accounts/templates/accounts/logout_base.html:26
 #, python-format
 msgid ""
-"You are still recognized by the centralized "
-"%(x_fmt_open)sSSO%(x_fmt_close)s system. You can %(x_url_open)slogout "
-"from SSO%(x_url_close)s, too."
+"You are still recognized by the centralized %(x_fmt_open)sSSO%(x_fmt_close)s "
+"system. You can %(x_url_open)slogout from SSO%(x_url_close)s, too."
 msgstr ""
 
 #: invenio/modules/accounts/templates/accounts/logout_base.html:34
@@ -12991,8 +12953,8 @@ msgstr "建立密碼"
 #: invenio/modules/accounts/templates/accounts/settings/lost_base.html:26
 #, fuzzy
 msgid ""
-"Please enter your email address. You will receive a link to create a  new"
-" password via email."
+"Please enter your email address. You will receive a link to create a  new "
+"password via email."
 msgstr "請輸入您的電郵、諢號、密碼:"
 
 #: invenio/modules/accounts/templates/accounts/settings/profile_base.html:38
@@ -13021,7 +12983,7 @@ msgid "Problem with login."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:138
-#, fuzzy, python-format
+#, fuzzy
 msgid "You can now access your account."
 msgstr "您可以使用您的%(x_url_open)s帳號%(x_url_close)s。"
 
@@ -13065,8 +13027,7 @@ msgstr "修改設定失敗"
 
 #: invenio/modules/accounts/views/accounts.py:322
 msgid ""
-"Your email address has been validated, and you can now proceed to  sign-"
-"in."
+"Your email address has been validated, and you can now proceed to  sign-in."
 msgstr ""
 
 #: invenio/modules/accounts/views/accounts.py:328
@@ -13138,13 +13099,12 @@ msgstr ""
 
 #: invenio/modules/annotations/noteutils.py:58
 msgid ""
-"To add an annotation use the following syntax:<br>P.1: an annotation on "
-"page one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an "
-"annotation on subfigure 2a<br>S.1.2: an annotation on subsection "
-"1.2<br>P.1: T.2: L.3: an annotation on the third line of table two, which"
-" appears on the first page<br>G: an annotation on the general aspect of "
-"the paper<br>R.[Ellis98]: an annotation on a reference<br><br>The "
-"available markers are:"
+"To add an annotation use the following syntax:<br>P.1: an annotation on page "
+"one<br>P.1,2,3: an annotation on pages one to three<br>F.2a: an annotation "
+"on subfigure 2a<br>S.1.2: an annotation on subsection 1.2<br>P.1: T.2: L.3: "
+"an annotation on the third line of table two, which appears on the first "
+"page<br>G: an annotation on the general aspect of the paper<br>R.[Ellis98]: "
+"an annotation on a reference<br><br>The available markers are:"
 msgstr ""
 
 #: invenio/modules/annotations/views.py:94
@@ -13153,9 +13113,9 @@ msgstr ""
 
 #: invenio/modules/annotations/views.py:182
 msgid ""
-"This is a summary of all the comments that includes only the"
-"                  existing annotations. The full discussion is available"
-"                  <a href=\"\">here</a>."
+"This is a summary of all the comments that includes only "
+"the                  existing annotations. The full discussion is "
+"available                  <a href=\"\">here</a>."
 msgstr ""
 
 #: invenio/modules/annotations/static/js/annotations/pdf_notes_helpers.js:95
@@ -13332,8 +13292,7 @@ msgstr "專輯"
 #: invenio/modules/cloudconnector/views.py:49
 #, python-format
 msgid ""
-"Click <a href=\"%(url)s\">here</a> to connect your account with "
-"%(service)s."
+"Click <a href=\"%(url)s\">here</a> to connect your account with %(service)s."
 msgstr ""
 
 #: invenio/modules/cloudconnector/views.py:59
@@ -13423,8 +13382,8 @@ msgstr ""
 
 #: invenio/modules/comments/api.py:283
 msgid ""
-"You have been subscribed to this discussion. From now on, you will "
-"receive an email whenever a new comment is posted."
+"You have been subscribed to this discussion. From now on, you will receive "
+"an email whenever a new comment is posted."
 msgstr ""
 
 #: invenio/modules/comments/api.py:290
@@ -13516,10 +13475,10 @@ msgid "Record ID %(recid)s is not a number."
 msgstr ""
 
 #: invenio/modules/comments/forms.py:38 invenio/modules/messages/forms.py:80
-#, fuzzy, python-format
+#, fuzzy
 msgid ""
-"Your message is too long, please edit it. Maximum size allowed is "
-"%{length}i characters."
+"Your message is too long, please edit it. Maximum size allowed is %{length}i "
+"characters."
 msgstr "您的訊息太長，請修改它。最大允許是%i個字。"
 
 #: invenio/modules/comments/forms.py:55
@@ -13563,12 +13522,12 @@ msgid "Review was sent"
 msgstr "撰寫意見"
 
 #: invenio/modules/comments/views.py:263
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been reported."
 msgstr "這意見已被報告了%i次"
 
 #: invenio/modules/comments/views.py:265
-#, fuzzy, python-format
+#, fuzzy
 msgid "Comment has been already reported."
 msgstr "這意見已被報告了%i次"
 
@@ -13621,9 +13580,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:96
 msgid ""
-"Required. Only letters, numbers and dash are allowed. The identifier is "
-"used in the URL for the community collection, and cannot be modified "
-"later."
+"Required. Only letters, numbers and dash are allowed. The identifier is used "
+"in the URL for the community collection, and cannot be modified later."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:102
@@ -13642,8 +13600,8 @@ msgstr ""
 
 #: invenio/modules/communities/forms.py:122
 msgid ""
-"Optional. Please describe short and precise the policy by which you "
-"accepted/reject new uploads in this community."
+"Optional. Please describe short and precise the policy by which you accepted/"
+"reject new uploads in this community."
 msgstr ""
 
 #: invenio/modules/communities/forms.py:128
@@ -13653,7 +13611,7 @@ msgid ""
 msgstr ""
 
 #: invenio/modules/communities/forms.py:150
-#, fuzzy, python-format
+#, fuzzy
 msgid "The identifier already exists. Please choose a different one."
 msgstr "諢號 %s 已被使用。"
 
@@ -13709,8 +13667,7 @@ msgstr "評論"
 #, python-format
 msgid ""
 "This is a preview of your upload. The public version is available on "
-"%(x_link)s. If you want to remove your upload, please contact "
-"%(x_contact)s"
+"%(x_link)s. If you want to remove your upload, please contact %(x_contact)s"
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/deposition_type_base.html:27
@@ -13750,8 +13707,7 @@ msgstr ""
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:24
 #: invenio/modules/deposit/templates/deposit/run_action_bar_base.html:25
 msgid ""
-"Press \"Save\" to save your upload for editing later, as many times you "
-"like."
+"Press \"Save\" to save your upload for editing later, as many times you like."
 msgstr ""
 
 #: invenio/modules/deposit/templates/deposit/edit_action_bar_base.html:25
@@ -13797,7 +13753,7 @@ msgid "Invalid deposition type."
 msgstr ""
 
 #: invenio/modules/deposit/views/deposit.py:76
-#, fuzzy, python-format
+#, fuzzy
 msgid "Deposition does not exists."
 msgstr "功能 %s 並不存在。"
 
@@ -13880,11 +13836,6 @@ msgstr ""
 msgid "Checking status"
 msgstr "現在的狀況："
 
-#: invenio/modules/editor/templates/editor/ticketsmenu.html:22
-#, fuzzy
-msgid "Tickets"
-msgstr "收藏"
-
 #: invenio/modules/editor/templates/editor/ticketsmenu.html:26
 #, fuzzy
 msgid "loading"
@@ -13919,8 +13870,8 @@ msgstr ""
 #: invenio/modules/encoder/batch_engine.py:125
 #, python-format
 msgid ""
-"You might want to take a look at  %(guidelines_url)s and modify or redo "
-"your submission."
+"You might want to take a look at  %(guidelines_url)s and modify or redo your "
+"submission."
 msgstr ""
 
 #: invenio/modules/encoder/batch_engine.py:136
@@ -13941,8 +13892,8 @@ msgstr "沒有可用的字索引給"
 #: invenio/modules/encoder/batch_engine.py:166
 #, python-format
 msgid ""
-"If the videos quality is not as expected, you might want to take a look "
-"at %(guidelines_url)s and modify or redo your submission."
+"If the videos quality is not as expected, you might want to take a look at "
+"%(guidelines_url)s and modify or redo your submission."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:374
@@ -13958,8 +13909,7 @@ msgstr "驗證格式元件 %s"
 #: invenio/modules/formatter/engine.py:878
 #, python-format
 msgid ""
-"Error when evaluating format element %(x_name)s with parameters "
-"%(x_params)s."
+"Error when evaluating format element %(x_name)s with parameters %(x_params)s."
 msgstr ""
 
 #: invenio/modules/formatter/engine.py:887
@@ -14079,7 +14029,7 @@ msgstr "顯示全部 %i 名作者"
 msgid "Manage Files of This Record"
 msgstr ""
 
-#: invenio/modules/formatter/format_elements/bfe_edit_record.py:47
+#: invenio/modules/formatter/format_elements/bfe_edit_record.py:52
 #, fuzzy
 msgid "Edit This Record"
 msgstr "請使用其他記錄ID重試。"
@@ -14182,10 +14132,6 @@ msgstr "評論"
 msgid "Authors"
 msgstr "作者"
 
-#: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:45
-msgid "by"
-msgstr ""
-
 #: invenio/modules/formatter/templates/format/record/Video_HTML_detailed.tpl:54
 #, fuzzy
 msgid "Download Video"
@@ -14278,8 +14224,8 @@ msgstr "管理組別權利"
 #: invenio/modules/groups/views.py:223
 #, fuzzy, python-format
 msgid ""
-"Sorry, you don't have enough right to be able to manage the group "
-"\"%(name)s\""
+"Sorry, you don't have enough right to be able to manage the group \"%(name)s"
+"\""
 msgstr "您沒有足夠權限以讀取這收藏籃。"
 
 #: invenio/modules/groups/views.py:279
@@ -14292,12 +14238,12 @@ msgstr "您不是以下組別的管理人："
 msgid "Members"
 msgstr "沒有成員"
 
-#: invenio/modules/indexer/admin.py:78
+#: invenio/modules/indexer/admin.py:79
 #, fuzzy
 msgid "Knowledge base name"
 msgstr "知識庫對照"
 
-#: invenio/modules/indexer/admin.py:81 invenio/modules/indexer/admin.py:93
+#: invenio/modules/indexer/admin.py:82 invenio/modules/indexer/admin.py:93
 #: invenio/modules/knowledge/forms.py:74
 #, fuzzy
 msgid "-None-"
@@ -14307,11 +14253,11 @@ msgstr "完成"
 msgid "Stemming language"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:99
+#: invenio/modules/indexer/admin.py:98
 msgid "Tokenizer"
 msgstr ""
 
-#: invenio/modules/indexer/admin.py:105
+#: invenio/modules/indexer/admin.py:104
 #, fuzzy
 msgid "Index fields"
 msgstr "任何欄位"
@@ -14357,13 +14303,14 @@ msgid "Create KB \"Dynamic\""
 msgstr ""
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-#, fuzzy, python-format
+#, fuzzy
 msgid "Create new record \"Written As\""
 msgstr "總共有 %i 個收藏籃"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:34
-msgid "Create KB \"Writtes As\""
-msgstr ""
+#, fuzzy
+msgid "Create KB \"Written As\""
+msgstr "總共有 %i 個收藏籃"
 
 #: invenio/modules/knowledge/templates/knowledge/list.html:70
 #, fuzzy
@@ -14519,28 +14466,28 @@ msgstr "不知名文件種類"
 #: invenio/modules/oauth2server/forms.py:151
 msgid ""
 "Select confidential if your application is capable of keeping the issued "
-"client secret confidential (e.g. a web application), select public if "
-"your application cannot (e.g. a browser-based JavaScript application). If"
-" you select public, your application MUST validate the redirect URI."
+"client secret confidential (e.g. a web application), select public if your "
+"application cannot (e.g. a browser-based JavaScript application). If you "
+"select public, your application MUST validate the redirect URI."
 msgstr ""
 
 #: invenio/modules/oauth2server/forms.py:158
 msgid "Confidential"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:143
+#: invenio/modules/oauth2server/models.py:144
 msgid "Name of application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:154
+#: invenio/modules/oauth2server/models.py:155
 msgid "Optional. Description of the application (displayed to users)."
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:163
+#: invenio/modules/oauth2server/models.py:164
 msgid "Website URL"
 msgstr ""
 
-#: invenio/modules/oauth2server/models.py:164
+#: invenio/modules/oauth2server/models.py:165
 msgid "URL of your application (displayed to users)."
 msgstr ""
 
@@ -14604,8 +14551,8 @@ msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:34
 msgid ""
-"Fill in your details to complete your registration. You only have to do "
-"this once."
+"Fill in your details to complete your registration. You only have to do this "
+"once."
 msgstr ""
 
 #: invenio/modules/oauthclient/templates/oauthclient/signup_base.html:44
@@ -14977,7 +14924,7 @@ msgid "Tag name"
 msgstr "諢號"
 
 #: invenio/modules/tags/views.py:199
-#, fuzzy, python-format
+#, fuzzy
 msgid "is already in use."
 msgstr "諢號 %s 正被使用中。"
 
@@ -15081,11 +15028,6 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: invenio/modules/tags/templates/tags/tag_popover_content_base.html:46
-#, fuzzy
-msgid "Done"
-msgstr "完成"
-
 #: invenio/modules/tags/templates/tags/tag_popover_title_base.html:24
 #, fuzzy
 msgid "(browse tagged records)"
@@ -15127,8 +15069,7 @@ msgstr "檢索選項"
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
 msgid ""
-"Here is a list of actions remaining to be resolved grouped by type of "
-"action"
+"Here is a list of actions remaining to be resolved grouped by type of action"
 msgstr ""
 
 #: invenio/modules/workflows/templates/workflows/index.html:25
@@ -15337,7 +15278,7 @@ msgid "just now"
 msgstr "您要先"
 
 #: invenio/utils/date.py:555
-#, fuzzy, python-format
+#, fuzzy
 msgid " seconds ago"
 msgstr "%s 秒"
 
@@ -15396,6 +15337,36 @@ msgstr "任何年份"
 msgid " years ago"
 msgstr "年份"
 
+#~ msgid "BibCheck Admin"
+#~ msgstr "BibFormat 管理"
+
+#~ msgid "Not authorized"
+#~ msgstr "作者"
+
+#~ msgid "Really delete"
+#~ msgstr "成功刪除"
+
+#~ msgid "Verify problem"
+#~ msgstr "數據庫錯誤"
+
+#~ msgid "File"
+#~ msgstr "標題"
+
+#~ msgid "niceName"
+#~ msgstr "名稱"
+
+#~ msgid "Id"
+#~ msgstr "Id"
+
+#~ msgid "Tickets"
+#~ msgstr "時間"
+
+#~ msgid "by"
+#~ msgstr "由"
+
+#~ msgid "Done"
+#~ msgstr "完成"
+
 #~ msgid "Warning: Please, select a valid time"
 #~ msgstr "請選擇類別"
 
@@ -15410,9 +15381,6 @@ msgstr "年份"
 
 #~ msgid "*** basket name ***"
 #~ msgstr "收藏籃名稱"
-
-#~ msgid ""
-#~ msgstr "我們已經發送有關帳號的電郵給您。"
 
 #~ msgid "Additional Citation Metrics"
 #~ msgstr "編輯登入資料"
@@ -15474,23 +15442,8 @@ msgstr "年份"
 #~ msgid "now"
 #~ msgstr "否"
 
-#~ msgid "BibCheck Admin"
-#~ msgstr "BibFormat 管理"
-
-#~ msgid "Not authorized"
-#~ msgstr "作者"
-
 #~ msgid "ERROR: %s does not exist"
 #~ msgstr "用戶 %s 並不存在。"
-
-#~ msgid "Really delete"
-#~ msgstr "成功刪除"
-
-#~ msgid "Verify problem"
-#~ msgstr "數據庫錯誤"
-
-#~ msgid "File"
-#~ msgstr "標題"
 
 #~ msgid "File %s already exists."
 #~ msgstr "用戶 %s 並不存在。"
@@ -15543,9 +15496,6 @@ msgstr "年份"
 #~ msgid "Not Mine!"
 #~ msgstr "注意"
 
-#~ msgid "Tickets"
-#~ msgstr "時間"
-
 #~ msgid "Request Tickets"
 #~ msgstr "規則"
 
@@ -15581,9 +15531,6 @@ msgstr "年份"
 
 #~ msgid "Create a new Person for your search"
 #~ msgstr "找尋不到記錄"
-
-#~ msgid "Id"
-#~ msgstr "Id"
 
 #~ msgid "A %s has been added."
 #~ msgstr "組別 %s 已被刪除"
@@ -15636,9 +15583,6 @@ msgstr "年份"
 #~ msgid "creating a new basket"
 #~ msgstr "創建收藏籃"
 
-#~ msgid "by"
-#~ msgstr "由"
-
 #~ msgid "on"
 #~ msgstr "在"
 
@@ -15656,9 +15600,6 @@ msgstr "年份"
 
 #~ msgid "Editing topic"
 #~ msgstr "編輯收藏籃"
-
-#~ msgid "niceName"
-#~ msgstr "名稱"
 
 #~ msgid "Apply Changes"
 #~ msgstr "儲存"
@@ -15767,9 +15708,6 @@ msgstr "年份"
 
 #~ msgid "Verbose"
 #~ msgstr "詳細"
-
-#~ msgid "Done"
-#~ msgstr "完成"
 
 #~ msgid "Your changes are TEMPORARY."
 #~ msgstr "這更改是臨時性的"
@@ -15930,9 +15868,6 @@ msgstr "年份"
 #~ msgid "Citation Metrics"
 #~ msgstr "引用之歷史記錄"
 
-#~ msgid "WebSearch Admin Guide"
-#~ msgstr ""
-
 #~ msgid "Submit Guide"
 #~ msgstr "提交幫助"
 
@@ -15942,34 +15877,11 @@ msgstr "年份"
 #~ msgid "WebSubmit Admin Guide"
 #~ msgstr "WebSubmit 管理"
 
-#~ msgid "Click here to review the transactions."
-#~ msgstr ""
-
 #~ msgid "Quit searching."
 #~ msgstr "執行搜索"
 
-#~ msgid ""
-#~ "When you merge a set of profiles,"
-#~ " all the information stored will be"
-#~ " assigned to the primary profile. "
-#~ "This includes papers, ids or citations."
-#~ " After merging, only the primary "
-#~ "profile will remain in the system, "
-#~ "all other profiles will be automatically"
-#~ " deleted.</br>"
-#~ msgstr ""
-
 #~ msgid "Cancel merging"
 #~ msgstr "取消"
-
-#~ msgid "Merge profiles"
-#~ msgstr ""
-
-#~ msgid "Claim for yourself"
-#~ msgstr ""
-
-#~ msgid "Assign to"
-#~ msgstr ""
 
 #~ msgid "Search for a person to assign the paper to"
 #~ msgstr "您是以下組別的成員："
@@ -15983,12 +15895,6 @@ msgstr "年份"
 #~ msgid "Invert Selection"
 #~ msgstr "並沒有參考"
 
-#~ msgid "Hide successful claims"
-#~ msgstr ""
-
-#~ msgid "Paper Short Info"
-#~ msgstr ""
-
 #~ msgid "Author Name"
 #~ msgstr "作者"
 
@@ -16000,12 +15906,6 @@ msgstr "年份"
 
 #~ msgid "No status information found."
 #~ msgstr "更多資料"
-
-#~ msgid "Operator review of user actions pending"
-#~ msgstr ""
-
-#~ msgid "Sorry, there are currently no records to be found in this category."
-#~ msgstr ""
 
 #~ msgid "Review Transaction"
 #~ msgstr "分類"
@@ -16019,18 +15919,6 @@ msgstr "年份"
 #~ msgid "View name variants"
 #~ msgstr "閱讀意見"
 
-#~ msgid "The author has an internal ID!"
-#~ msgstr ""
-
-#~ msgid "These records have been marked as not being from this person."
-#~ msgstr ""
-
-#~ msgid "They will be regarded in the next run of the author "
-#~ msgstr ""
-
-#~ msgid "disambiguation algorithm and might disappear from this listing."
-#~ msgstr ""
-
 #~ msgid "No comments"
 #~ msgstr "意見"
 
@@ -16040,87 +15928,20 @@ msgstr "年份"
 #~ msgid " Delete this ticket"
 #~ msgstr "刪除收藏籃"
 
-#~ msgid " Commit this entire ticket"
-#~ msgstr ""
-
 #~ msgid "No title available"
 #~ msgstr "沒有可使用的文件種類。"
-
-#~ msgid "Make sure we match the right names!"
-#~ msgstr ""
-
-#~ msgid "Please select an author on each of the records that will be assigned."
-#~ msgstr ""
-
-#~ msgid "Papers without a name selected will be ignored in the process."
-#~ msgstr ""
-
-#~ msgid "Claim for person with id"
-#~ msgstr ""
-
-#~ msgid "This seems to be an empty profile without names associated to it yet"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "(the names will be automatically "
-#~ "gathered when the first paper is "
-#~ "claimed to this profile)."
-#~ msgstr ""
 
 #~ msgid "Select name for"
 #~ msgstr "選擇評分"
 
-#~ msgid "Error retrieving record title"
-#~ msgstr ""
-
 #~ msgid "Paper title: "
 #~ msgstr "頁:"
-
-#~ msgid "Ignore"
-#~ msgstr ""
 
 #~ msgid "The following names have been automatically chosen:"
 #~ msgstr "發現以下錯誤"
 
-#~ msgid " --  With name: "
-#~ msgstr ""
-
-#~ msgid "Symbols legend: "
-#~ msgstr ""
-
-#~ msgid "Everything is shiny, captain!"
-#~ msgstr ""
-
-#~ msgid "The result of this request will be visible immediately"
-#~ msgstr ""
-
-#~ msgid "Confirmation needed to continue"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible immediately but we need your"
-#~ " confirmation to do so for this "
-#~ "paper has been manually claimed before"
-#~ msgstr ""
-
-#~ msgid "This will create a change request for the operators"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The result of this request will be"
-#~ " visible upon confirmation through an "
-#~ "operator"
-#~ msgstr ""
-
 #~ msgid "Selected name on paper"
 #~ msgstr "選擇評分"
-
-#~ msgid "Verification needed to continue"
-#~ msgstr ""
-
-#~ msgid "This will create a request for the operators"
-#~ msgstr ""
 
 #~ msgid "Please provide your information"
 #~ msgstr "更多資料"
@@ -16128,35 +15949,11 @@ msgstr "年份"
 #~ msgid "Please provide your first name"
 #~ msgstr "您必須先登入。"
 
-#~ msgid "Your first name:"
-#~ msgstr ""
-
-#~ msgid "Please provide your last name"
-#~ msgstr ""
-
 #~ msgid "Your last name:"
 #~ msgstr "外借"
 
-#~ msgid "Please provide your eMail address"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This eMail address is reserved by "
-#~ "a user. Please log in or provide"
-#~ " an alternative eMail address"
-#~ msgstr ""
-
 #~ msgid "Your eMail:"
 #~ msgstr "警報"
-
-#~ msgid "You may leave a comment (optional)"
-#~ msgstr ""
-
-#~ msgid "Continue claiming*"
-#~ msgstr ""
-
-#~ msgid "Confirm these changes**"
-#~ msgstr ""
 
 #~ msgid "!Delete the entire request!"
 #~ msgstr "刪除已選擇的評論"
@@ -16164,186 +15961,35 @@ msgstr "年份"
 #~ msgid "Mark as your documents"
 #~ msgstr "全部文件類型"
 
-#~ msgid "Mark as _not_ your documents"
-#~ msgstr ""
-
-#~ msgid "Nothing staged as not yours"
-#~ msgstr ""
-
 #~ msgid "Mark as their documents"
 #~ msgstr "評價這文件"
-
-#~ msgid "Nothing staged in this category"
-#~ msgstr ""
 
 #~ msgid "Mark as _not_ their documents"
 #~ msgstr "評價這文件"
 
-#~ msgid "  * You can come back to this page later. Nothing will be lost. <br />"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "  ** Performs all requested changes. "
-#~ "Changes subject to permission restrictions "
-#~ "will be submitted to an operator "
-#~ "for manual review."
-#~ msgstr ""
-
 #~ msgid "Create a new Person"
 #~ msgstr "或創建"
-
-#~ msgid "This is my profile"
-#~ msgstr ""
-
-#~ msgid "Assign paper"
-#~ msgstr ""
 
 #~ msgid "Add to merge list"
 #~ msgstr "加入至用戶"
 
-#~ msgid ""
-#~ "We do not have a publication list"
-#~ " for '%s'. Try using a less "
-#~ "specific author name, or check back "
-#~ "in a few days as attributions are"
-#~ " updated frequently.  Or you can send"
-#~ " us feedback, at "
-#~ msgstr ""
-
 #~ msgid "Recent Papers"
 #~ msgstr "頁:"
-
-#~ msgid "Showing the"
-#~ msgstr ""
 
 #~ msgid "most recent documents:"
 #~ msgstr "文件名單"
 
-#~ msgid "Sorry, there are no documents known for this person"
-#~ msgstr ""
-
-#~ msgid "The following profile is the one you were viewing before logging in: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Out of %s paper(s) claimed to your"
-#~ " arXiv account, %s match this "
-#~ "profile: "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If none of the options suggested "
-#~ "above apply, you can look for "
-#~ "other possible options from the list "
-#~ "below:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"Login through arXiv is "
-#~ "needed to verify this is your "
-#~ "profile. When you log in your "
-#~ "publication list will automatically update "
-#~ "with all your arXiv publications.\n"
-#~ "You may also continue as a guest."
-#~ " In this case your input will "
-#~ "be processed by our staff and will"
-#~ " take longer to display.\"><strong> Login"
-#~ " with your arXiv.org account "
-#~ "</strong></span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv. </br> You can now manage "
-#~ "your profile.</br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have succesfully logged in via "
-#~ "arXiv.</br><div> <font color='red'>However the "
-#~ "profile you are viewing is not "
-#~ "your profile.</br></br></font>"
-#~ msgstr ""
-
 #~ msgid "Manage your profile"
 #~ msgstr "管理格式模板"
-
-#~ msgid ""
-#~ "You have succesfully logged in, but "
-#~ "</br><div><font color='red'> you are not "
-#~ "associated to a person yet. Please "
-#~ "use the button below to choose "
-#~ "your profile </br></br></font>"
-#~ msgstr ""
 
 #~ msgid "Choose your profile"
 #~ msgstr "選擇主題"
 
-#~ msgid "Please log in through arXiv to manage your profile.</br>"
-#~ msgstr ""
-
-#~ msgid "Login into Inspire through arXiv.org"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <span title=\"ORCiD (Open Researcher "
-#~ "and Contributor ID) is a unique "
-#~ "researcher identifier that distinguishes you"
-#~ " from other researchers.\n"
-#~ "It holds a record of all your "
-#~ "research activities. You can add your"
-#~ " ORCiD to all your works to "
-#~ "make sure they are associated with "
-#~ "you. \">\n"
-#~ "        <strong> Connect this profile to an ORCiD </strong> <span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This profile is already connected to "
-#~ "the following ORCiD: <strong>%s</strong></br>"
-#~ msgstr ""
-
-#~ msgid "Import your publications from ORCID"
-#~ msgstr ""
-
-#~ msgid "Visit your profile in ORCID"
-#~ msgstr ""
-
-#~ msgid "Connect an ORCiD to this profile"
-#~ msgstr ""
-
-#~ msgid "Suggest an ORCiD for this profile:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"When you add more "
-#~ "publications you make sure your "
-#~ "publication list and citations appear "
-#~ "correctly on your profile.\n"
-#~ "You can also assign publications to "
-#~ "other authors. This will help INSPIRE"
-#~ " provide more accurate publication and "
-#~ "citation statistics. \"><strong> Manage "
-#~ "publications </strong><span>"
-#~ msgstr ""
-
 #~ msgid "Manage publication list"
 #~ msgstr "創建日期"
 
-#~ msgid "<strong> Person identifiers, internal and external </strong>"
-#~ msgstr ""
-
 #~ msgid "add external id"
 #~ msgstr "一般設定"
-
-#~ msgid "Harvest missing external ids from claimed papers"
-#~ msgstr ""
-
-#~ msgid "suggest external id to add"
-#~ msgstr ""
-
-#~ msgid "suggest selected ids to delete"
-#~ msgstr ""
 
 #~ msgid "suggest missing ids"
 #~ msgstr "提交"
@@ -16351,190 +15997,17 @@ msgstr "年份"
 #~ msgid "Choose system"
 #~ msgstr "選擇主題"
 
-#~ msgid ""
-#~ "<span title=\"You don’t need to add all your publications one by one.\n"
-#~ "This list contains all your publications"
-#~ " that were automatically assigned to "
-#~ "your INSPIRE profile through arXiv and"
-#~ " ORCiD. \"><strong> Automatically assigned "
-#~ "publications </strong> </span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span id=\"autoClaimMessage\">Please wait as "
-#~ "we are assigning %s papers from "
-#~ "external systems to your Inspire "
-#~ "profile</span></br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The following publications have been "
-#~ "successfully assigned to your profile:"
-#~ msgstr "發現以下錯誤"
-
-#~ msgid "Get help!"
-#~ msgstr ""
-
-#~ msgid "<strong> Contact </strong>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please contact our user support in "
-#~ "case you need help or you just "
-#~ "want to suggest some new ideas. We"
-#~ " will get back to you. </br>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<span title=\"It sometimes happens that "
-#~ "somebody's publications are scattered among"
-#~ " two or more profiles for various "
-#~ "reasons\n"
-#~ "(different spelling, change of name, "
-#~ "multiple people with the same name). "
-#~ "You can merge a set of profiles"
-#~ " together.\n"
-#~ "This will assign all the information "
-#~ "(including publications, IDs and citations)"
-#~ " to the profile you choose as a"
-#~ " primary profile.\n"
-#~ "After the merging only the primary "
-#~ "profile will exist in the system "
-#~ "and all others will be automatically "
-#~ "deleted. \"><strong> Merge profiles "
-#~ "</strong><span>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If your or somebody else's publications"
-#~ " in INSPIRE exist in multiple "
-#~ "profiles, you can fix that here. "
-#~ "</br>"
-#~ msgstr ""
-
-#~ msgid "Fatal: Author ID capabilities are disabled on this system."
-#~ msgstr ""
-
 #~ msgid "Fatal: You are not allowed to access this functionality."
 #~ msgstr "您不能使用管理功能。"
 
 #~ msgid "Claim this paper"
 #~ msgstr "加入至用戶"
 
-#~ msgid ""
-#~ "<p>We're sorry. An error occurred while"
-#~ " handling your request. Please find "
-#~ "more information below:</p>"
-#~ msgstr ""
-
-#~ msgid "This page is not accessible directly."
-#~ msgstr ""
-
-#~ msgid "Profile management"
-#~ msgstr ""
-
-#~ msgid "The due date has been updated. New due date: %s"
-#~ msgstr ""
-
-#~ msgid "Copies of %s"
-#~ msgstr ""
-
-#~ msgid "The given barcode <strong>%s</strong> is already in use."
-#~ msgstr ""
-
-#~ msgid "The barcode <strong>%s</strong> was not found"
-#~ msgstr ""
-
-#~ msgid "The copy with barcode <strong>%s</strong> has been deleted."
-#~ msgstr ""
-
-#~ msgid "It was NOT possible to delete the copy with barcode <strong>%s</strong>"
-#~ msgstr ""
-
-#~ msgid "Barcode <strong>%s</strong> not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>status was not modified</strong>."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it is already in use."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated to "
-#~ "<strong>[%s]</strong> with success."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Item <strong>[%s]</strong> updated, but the"
-#~ " <strong>barcode was not modified</strong> "
-#~ "because it was not found (!?)."
-#~ msgstr ""
-
 #~ msgid "Weighted %s keywords:"
 #~ msgstr "已有 %s 記錄引用"
 
-#~ msgid ""
-#~ "The uploaded file is too small "
-#~ "(<%i o) and has therefore not been"
-#~ " considered"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The uploaded file is too big (>%i"
-#~ " o) and has therefore not been "
-#~ "considered"
-#~ msgstr ""
-
-#~ msgid "A file with format '%s' already exists. Please upload another format."
-#~ msgstr ""
-
-#~ msgid "The format %s does not exist for the given version: %s"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been submitted"
-#~ msgstr ""
-
-#~ msgid "Your modifications to record #%i have been cancelled"
-#~ msgstr ""
-
-#~ msgid "Comparison of:"
-#~ msgstr ""
-
 #~ msgid "Revision"
 #~ msgstr "分類"
-
-#~ msgid "Comparing two record revisions"
-#~ msgstr ""
-
-#~ msgid "Failed to create a ticket"
-#~ msgstr ""
-
-#~ msgid "No template could be found for output format %s."
-#~ msgstr ""
-
-#~ msgid "Error when evaluating format element %s with parameters %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Escape mode for format element %s "
-#~ "could not be retrieved. Using default"
-#~ " mode instead."
-#~ msgstr ""
-
-#~ msgid "\"nbMax\" parameter for %s must be an \"int\"."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s."
-#~ msgstr ""
-
-#~ msgid "Format element %s has no function named \"format\"."
-#~ msgstr ""
 
 #~ msgid "Modify Template Attributes"
 #~ msgstr "修改模板屬性"
@@ -16614,89 +16087,20 @@ msgstr "年份"
 #~ msgid "No Record Found for %s."
 #~ msgstr "找不到記錄"
 
-#~ msgid "Tag specification \"%s\" must end with column \":\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Tag specification \"%s\" must start with \"tag\" at line %s."
-#~ msgstr ""
-
-#~ msgid "\"tag\" must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Should be \"tag field_number:\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Invalid tag \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" is outside a tag specification at line %s."
-#~ msgstr ""
-
-#~ msgid "Condition \"%s\" can only have a single separator --- at line %s."
-#~ msgstr ""
-
 #~ msgid "Template \"%s\" does not exist at line %s."
 #~ msgstr "用戶 %s 並不存在。"
-
-#~ msgid "Missing column \":\" after \"default\" in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Default template specification \"%s\" must "
-#~ "start with \"default :\" at line "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid "\"default\" keyword must be lowercase in \"%s\" at line %s."
-#~ msgstr ""
-
-#~ msgid "Line %s could not be understood at line %s."
-#~ msgstr ""
 
 #~ msgid "Output format %s cannot not be read. %s"
 #~ msgstr "輸出格式 %s 屬性"
 
-#~ msgid ""
-#~ "Could not find a name specified in"
-#~ " tag \"<name>\" inside format template "
-#~ "%s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Could not find a description specified"
-#~ " in tag \"<description>\" inside format "
-#~ "template %s."
-#~ msgstr ""
-
 #~ msgid "Format template %s calls undefined element \"%s\"."
 #~ msgstr "格式模板 %s 從屬關係"
-
-#~ msgid ""
-#~ "Format template %s calls unreadable "
-#~ "element \"%s\". Check element file "
-#~ "permissions."
-#~ msgstr ""
-
-#~ msgid "Cannot load element \"%s\" in template %s. Check element code."
-#~ msgstr ""
-
-#~ msgid "Format element %s uses unknown parameter \"%s\" in format template %s."
-#~ msgstr ""
-
-#~ msgid "Could not read format template named %s. %s"
-#~ msgstr ""
 
 #~ msgid "Error in format element %s. %s."
 #~ msgstr "驗證格式元件 %s"
 
 #~ msgid "Format element %s cannot not be read. %s"
 #~ msgstr "格式元件 %s 從屬關係"
-
-#~ msgid ""
-#~ "Cannot write in etc/bibformat dir of "
-#~ "your Invenio installation. Check directory "
-#~ "permission."
-#~ msgstr ""
 
 #~ msgid "Restricted Output Format"
 #~ msgstr "限制輸出格式"
@@ -16752,113 +16156,17 @@ msgstr "年份"
 #~ msgid "Validation of Format Element %s"
 #~ msgstr "驗證格式元件 %s"
 
-#~ msgid "No format specified for validation. Please specify one."
-#~ msgstr ""
-
 #~ msgid "Format Validation"
 #~ msgstr "驗證格式"
 
-#~ msgid "The current taxonomy can be accessed with this URL: %s"
-#~ msgstr ""
-
-#~ msgid "Please upload the RDF file for taxonomy %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "If the expression contains '%', like "
-#~ "'270__a:*%*',                          it will be"
-#~ " replaced by a search string when "
-#~ "the                          knowledge base is "
-#~ "used."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Example 2: Return the institute's name"
-#~ " (100__a) when the                          user"
-#~ " gives its postal code (270__a):"
-#~ "                          Set field to 100__a,"
-#~ " expression to 270__a:*%*."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The left side of the rule (%s) "
-#~ "already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The right side of the rule (%s)"
-#~ " already appears in these knowledge "
-#~ "bases:"
-#~ msgstr ""
-
-#~ msgid "File %s uploaded."
-#~ msgstr ""
-
 #~ msgid "Knowledge Base %s"
 #~ msgstr "知識庫 %s"
-
-#~ msgid "No rights to upload to collection '%s'"
-#~ msgstr ""
-
-#~ msgid "<b>%s documents</b> have been found."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The system is not attempting to "
-#~ "send an email from %s, to %s, "
-#~ "with body %s."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Error in connecting to the SMPT "
-#~ "server waiting %s seconds. Exception is"
-#~ " %s, while sending email from %s "
-#~ "to %s with body %s."
-#~ msgstr ""
-
-#~ msgid "Error while sending an email: %s"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Error while sending an email.\n"
-#~ "Reason: %s\n"
-#~ "Details: %s\n"
-#~ "Sender: \"%s\"\n"
-#~ "Recipient(s): \"%s\"\n"
-#~ "\n"
-#~ "The content of the mail was as follows:\n"
-#~ "%s"
-#~ msgstr ""
-
-#~ msgid "Error in sending email from %s to %s with body %s."
-#~ msgstr ""
 
 #~ msgid "Not Set"
 #~ msgstr "注意"
 
 #~ msgid "never"
 #~ msgstr "轉換"
-
-#~ msgid ""
-#~ "Do you want to touch the OAI "
-#~ "set %s? Note that this will force"
-#~ " all clients to re-harvest the "
-#~ "whole set."
-#~ msgstr ""
-
-#~ msgid "OAI set %s touched."
-#~ msgstr ""
-
-#~ msgid "Name variants"
-#~ msgstr ""
-
-#~ msgid "No Name Variants"
-#~ msgstr ""
-
-#~ msgid "downloaded"
-#~ msgstr ""
 
 #~ msgid "times"
 #~ msgstr "時間"
@@ -16868,9 +16176,6 @@ msgstr "年份"
 
 #~ msgid "No Keywords"
 #~ msgstr "關鍵詞"
-
-#~ msgid "Frequent keywords"
-#~ msgstr ""
 
 #~ msgid "No Subject categories"
 #~ msgstr "共享收藏籃列表"
@@ -16887,17 +16192,8 @@ msgstr "年份"
 #~ msgid "Affiliations"
 #~ msgstr "引用之歷史記錄"
 
-#~ msgid "Frequent co-authors (excluding collaborations)"
-#~ msgstr ""
-
-#~ msgid "No Frequent Co-authors"
-#~ msgstr ""
-
 #~ msgid "Citations%s"
 #~ msgstr "引用之歷史記錄"
-
-#~ msgid "<strong> Publications per year </strong>"
-#~ msgstr ""
 
 #~ msgid "No Publication Graph"
 #~ msgstr "創建日期"
@@ -16908,42 +16204,6 @@ msgstr "年份"
 #~ msgid "No publications available"
 #~ msgstr "沒有可使用的文件種類。"
 
-#~ msgid "Recompute Now!"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid record ID"
-#~ msgstr ""
-
-#~ msgid "%s is an invalid user ID."
-#~ msgstr ""
-
-#~ msgid "Record ID %s is not a number."
-#~ msgstr ""
-
-#~ msgid "%i comments found in total (not shown on this page)"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The size of file \\\"%s\\\" (%s) "
-#~ "is larger than maximum allowed file "
-#~ "size (%s). Select files again."
-#~ msgstr ""
-
-#~ msgid "About your article at %(url)s"
-#~ msgstr ""
-
-#~ msgid "Administrate %(journal_name)s"
-#~ msgstr ""
-
-#~ msgid "Linkbacks%s: %s"
-#~ msgstr ""
-
-#~ msgid "There is no index %s.  Searching for %s in all fields."
-#~ msgstr ""
-
-#~ msgid "Instead searching %s."
-#~ msgstr ""
-
 #~ msgid "Cited by 1 record"
 #~ msgstr "已有 %s 記錄引用"
 
@@ -16953,20 +16213,8 @@ msgstr "年份"
 #~ msgid "%i reviews"
 #~ msgstr "評論"
 
-#~ msgid "%s of"
-#~ msgstr ""
-
-#~ msgid ".. of which self-citations: %s records"
-#~ msgstr ""
-
 #~ msgid "No Papers"
 #~ msgstr "頁:"
-
-#~ msgid "Frequent co-authors"
-#~ msgstr ""
-
-#~ msgid "This is me.  Verify my publication list."
-#~ msgstr ""
 
 #~ msgid "Citations:"
 #~ msgstr "引用之歷史記錄"
@@ -16974,35 +16222,8 @@ msgstr "年份"
 #~ msgid "No Citation Information available"
 #~ msgstr "沒有可使用的文件種類。"
 
-#~ msgid "<p><a href=\"%(url)s\">%(msg)s</a></p>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "For some unknown reason multiple records"
-#~ " matching the specified DOI \"%s\" "
-#~ "have been found."
-#~ msgstr ""
-
-#~ msgid "Found multiple records matching DOI %s"
-#~ msgstr ""
-
 #~ msgid "Discussion"
 #~ msgstr "連線階段"
-
-#~ msgid "Please inform the <a href='mailto%s'>administator</a>"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "for a password reset at %(x_sitename)s\n"
-#~ "for the account \"%(x_email)s\"."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Somebody (possibly you) coming from %(x_ip_address)s has asked\n"
-#~ "to register a new account at %(x_sitename)s\n"
-#~ "for the email address \"%(x_email)s\"."
-#~ msgstr ""
 
 #~ msgid "Your alerts"
 #~ msgstr "警報"
@@ -17022,108 +16243,15 @@ msgstr "年份"
 #~ msgid "Statistics"
 #~ msgstr "狀態"
 
-#~ msgid "Invitation to join \"%s\" group"
-#~ msgstr ""
-
 #~ msgid "Group: %s"
 #~ msgstr "組別: %s"
 
-#~ msgid ""
-#~ "Your e-mail is auto-generated by "
-#~ "the system. Please change your e-mail"
-#~ " from <a href='%s/youraccount/edit?ln=%s'>account "
-#~ "settings</a>."
-#~ msgstr ""
-
-#~ msgid "%s  Personalize, Main page"
-#~ msgstr ""
-
-#~ msgid "Account registration at %s"
-#~ msgstr ""
-
-#~ msgid "This is the table of contents of the %(x_category)s pages."
-#~ msgstr ""
-
 #~ msgid "Page %s Not Found"
 #~ msgstr "找不到 %s 專輯"
-
-#~ msgid ""
-#~ "The task queue is currently running "
-#~ "in automatic mode, and there are "
-#~ "currently %s tasks waiting to be "
-#~ "executed. Your record should be "
-#~ "available within a few minutes and "
-#~ "searchable within an hour or "
-#~ "thereabouts.\n"
-#~ msgstr ""
 
 #~ msgid "The field %s is mandatory."
 #~ msgstr "欄位 %s 不可留空。"
 
 #~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission '%s%s' - Invalid Field "
-#~ "Position Numbers"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to temporary field location"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field at position "
-#~ "%s to position %s. Please ask "
-#~ "Admin to check that a field was"
-#~ " not stranded in a temporary position"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to swap field at position "
-#~ "%s with field at position %s on"
-#~ " page %s of submission %s - "
-#~ "could not move field that was "
-#~ "located at position %s to position "
-#~ "%s from temporary position. Field is "
-#~ "now stranded in temporary position and"
-#~ " must be corrected manually by an "
-#~ "Admin"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s - could not "
-#~ "decrement the position of the fields "
-#~ "below position %s. Tried to recover "
-#~ "- please check that field ordering "
-#~ "is not broken"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Unable to move field at position "
-#~ "%s to position %s on page %s "
-#~ "of submission %s%s - could not "
-#~ "increment the position of the fields "
-#~ "at and below position %s. The "
-#~ "field that was at position %s is"
-#~ " now stranded in a temporary "
-#~ "position."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Moved field from position %s to "
-#~ "position %s on page %s of "
-#~ "submission '%s%s'."
-#~ msgstr ""
-
-#~ msgid "Unable to delete field at position %s from page %s of submission '%s'"
+#~ "Unable to delete field at position %s from page %s of submission '%s'"
 #~ msgstr "不能確定提交頁數數量。"
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,22 @@ all_files  = 1
 build_static = build_npm build_bower build_grunt --path=invenio/base/static/
 sdist_deploy = build_static sdist
 
+[bdist_wheel]
+universal = 1
+
 [compile_catalog]
 directory = invenio/base/translations/
 
-[bdist_wheel]
-universal = 1
+[extract_messages]
+copyright_holder = CERN
+msgid_bugs_address = info@invenio-software.org
+mapping-file = babel.cfg
+output-file = invenio/base/translations/invenio.pot
+
+[init_catalog]
+input-file = invenio/base/translations/invenio.pot
+output-dir = invenio/base/translations/
+
+[update_catalog]
+input-file = invenio/base/translations/invenio.pot
+output-dir = invenio/base/translations/


### PR DESCRIPTION
* FIX Updates PO message catalogues and cleans them of duplicated
  messages.  (closes #3455)

* Adds `setup.py` Babel friendly statements.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>