### PR TITLE
base: fix flash message CSS class bug

### DIFF
--- a/invenio/base/templates/_macros.html
+++ b/invenio/base/templates/_macros.html
@@ -24,7 +24,7 @@
     '(html_safe)', 'info(html_safe)', 'danger(html_safe)', 'error(html_safe)',
     'warning(html_safe)', 'success(html_safe)']) %}
     {% set category = 'danger' if category == 'error' or category == 'error(html_safe)' else category %}
-      <div class="alert alert-{{ category[::11] if category.endswith('(html_safe)') else category }}">
+      <div class="alert alert-{{ category[:-('(html_safe)'|length)] if category.endswith('(html_safe)') else category }}">
         <a class="close" data-dismiss="alert" href="#">&times;</a>
         {% if category.endswith('(html_safe)') %}
             {{ msg|safe }}


### PR DESCRIPTION
* Fix bug introduced by ecb6d6e79282fb555483d3133bf3e61dfeaf2e64.
  CSS class of 'html_safe' flash messages where not displayed
  properly.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>