### PR TITLE
BibIndex: fix computation of records to be indexed

### DIFF
--- a/modules/bibindex/lib/bibindex_engine.py
+++ b/modules/bibindex/lib/bibindex_engine.py
@@ -544,8 +544,10 @@ def find_affected_records_for_index(indexes=None, recIDs=None, force_all_indexes
         res = run_sql("""SELECT bibrec.id,modification_date,''
                          FROM bibrec, hstRECORD
                          WHERE modification_date>%s
+                           AND id_bibrec BETWEEN %s AND %s
                            AND bibrec.id=id_bibrec
-                           AND (SELECT COUNT(*) FROM hstRECORD WHERE id_bibrec=bibrec.id)=1""", (min_last_updated,))
+                           AND (SELECT COUNT(*) FROM hstRECORD WHERE id_bibrec=bibrec.id)=1""",
+                      (recIDs_range[0], recIDs_range[1], min_last_updated,))
         if res:
             recIDs_info.extend(res)
 


### PR DESCRIPTION
- FIX The function find_affected_records_for_index() should
  calculate the affected records based on the `recIDs` argument,
  and not add additional records to the affected ones.

Signed-off-by: Ludmila Marian ludmila.marian@gmail.com
