### PR TITLE
base: fix "error(html_safe)" flash messages

### DIFF
--- a/invenio/base/templates/_macros.html
+++ b/invenio/base/templates/_macros.html
@@ -23,7 +23,8 @@
     category_filter=['', 'info', 'danger', 'error', 'warning', 'success',
     '(html_safe)', 'info(html_safe)', 'danger(html_safe)', 'error(html_safe)',
     'warning(html_safe)', 'success(html_safe)']) %}
-    {% set category = 'danger' if category == 'error' or category == 'error(html_safe)' else category %}
+    {% set category = 'danger' if category == 'error'
+    else 'danger(html_safe)' if category == 'error(html_safe)' else category %}
       <div class="alert alert-{{ category[:-('(html_safe)'|length)] if category.endswith('(html_safe)') else category }}">
         <a class="close" data-dismiss="alert" href="#">&times;</a>
         {% if category.endswith('(html_safe)') %}

--- a/invenio/base/testsuite/test_apps/__init__.py
+++ b/invenio/base/testsuite/test_apps/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Test Applications."""

--- a/invenio/base/testsuite/test_apps/flash_msg/__init__.py
+++ b/invenio/base/testsuite/test_apps/flash_msg/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Application used by test_flash_security test."""

--- a/invenio/base/testsuite/test_apps/flash_msg/views.py
+++ b/invenio/base/testsuite/test_apps/flash_msg/views.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Test Application for displaying flash messages on base page."""
+
+from flask import Blueprint, flash, render_template
+
+from invenio.base.decorators import wash_arguments
+
+
+blueprint = Blueprint('flash_msg', __name__, url_prefix='/flash_msg',
+                      template_folder='templates', static_folder='static')
+
+
+@blueprint.route('/')
+@wash_arguments({"context": (unicode, ""), "message": (unicode, None)})
+def index(context, message=None):
+    """Print the given message string as a flash message."""
+    flash(message, context)
+    return render_template("page.html")

--- a/invenio/base/testsuite/test_flash_security.py
+++ b/invenio/base/testsuite/test_flash_security.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Unit tests for the inveniomanage script."""
+
+from flask import escape, url_for
+
+from invenio.testsuite import InvenioTestCase, make_test_suite, \
+    run_test_suite
+
+
+class FlashMessageSecurityTest(InvenioTestCase):
+    """Test base views."""
+
+    @property
+    def config(self):
+        # add the test flask application to loaded packages
+        cfg = super(FlashMessageSecurityTest, self).config
+        cfg['PACKAGES'] = [
+            'invenio.base.testsuite.test_apps.flash_msg',
+            'invenio.base',
+        ]
+        return cfg
+
+    def test_flash_message_escaping(self):
+        """Test that flash messages are escaped by default."""
+
+        flash_contexts = ['', 'info', 'danger', 'error', 'warning', 'success']
+        safe_flash_contexts = [context + '(html_safe)' for context in
+                               flash_contexts]
+
+        message = 'this is an <script>alert(1)</script>'
+        escaped_message = str(escape('<script>alert(1)</script>'))
+
+        for context in flash_contexts:
+            # test non safe contexts
+            response = self.client.get(url_for('flash_msg.index', message=message,
+                                               context=context))
+            self.assertTrue(escaped_message in response.data,
+                            'flash message should have been escaped for ' +
+                            'context "{}"'.format(context))
+
+        for context in safe_flash_contexts:
+            # test safe contexts
+            response = self.client.get(url_for('flash_msg.index', message=message,
+                                               context=context))
+            self.assertTrue(message in response.data,
+                            'flash message should not have been escaped for ' +
+                            'context "{}"'.format(context))
+
+TEST_SUITE = make_test_suite(FlashMessageSecurityTest)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
* FIX Fixes display of flash messages which use "error(html_safe)"
  context. They were escaped despite the "(html_safe)".
* Adds tests for standard flash message escaping.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>