### PR TITLE
babel: fallback to NullTranslations

### DIFF
--- a/invenio/ext/babel/__init__.py
+++ b/invenio/ext/babel/__init__.py
@@ -47,13 +47,13 @@ def set_locale(ln):
 
 def get_translation(locale):
     """Generate translation for given language."""
-    translations = None
+    translations = support.Translations.load(None, [locale])
     # NOTE that packages have to be loaded in reversed order!
     for plugin in reversed(current_app.extensions['registry']['packages']):
         if not pkg_resources.resource_isdir(plugin, 'translations'):
             continue
         dirname = pkg_resources.resource_filename(plugin, 'translations')
-        if translations is None:
+        if not hasattr(translations, 'merge'):
             translations = support.Translations.load(dirname, [locale])
         else:
             try:

--- a/invenio/modules/knowledge/testsuite/test_knowledge_restful.py
+++ b/invenio/modules/knowledge/testsuite/test_knowledge_restful.py
@@ -172,13 +172,7 @@ class TestKnowledgeRestfulAPI(APITestCase):
             user_id=1,
         )
 
-        answer = get_answer.json
-
-        expected_result = dict(
-            status=404,
-        )
-
-        assert answer['status'] == expected_result['status']
+        assert get_answer.status_code == 404
 
     def test_get_knwkb_mappings(self):
         """Test the return of list of mappings."""

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,9 @@ install_requires = [
     "MySQL-python>=1.2.5",
     "numpy>=1.7",
     "nydus>=0.10.8",
+    # FIXME new oauthlib release after 0.7.2 has some compatible problems with
+    # the used Flask-Oauthlib version.
+    "oauthlib==0.7.2",
     # pyparsing>=2.0.2 has a new api and is not compatible yet
     "pyparsing>=2.0.1,<2.0.2",
     "python-twitter>=2.0",


### PR DESCRIPTION
* BETTER Improves translations lookup fallback when no compiled catalog
  is found.

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>

--
cc @hachreak 