### PR TITLE
global: optional groups field for users logged in

### DIFF
--- a/invenio/ext/login/legacy_user.py
+++ b/invenio/ext/login/legacy_user.py
@@ -157,7 +157,7 @@ class UserInfo(CombinedMultiDict, UserMixin):
             data['email'] = user.email or ''
             data['note'] = user.note or ''
             data['group'] = map(lambda x: x.group.name,
-                                user.groups or [])
+                                getattr(user, 'groups', []))
             data.update(user.settings or {})
             data['settings'] = user.settings or {}
             data['guest'] = str(int(user.guest))  # '1' or '0'


### PR DESCRIPTION
* Sets group list on logged in user as not mandatory field.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>