### PR TITLE
i18n: initial message catalogues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *~
 *.swm
 *.swn
+*.mo
 .coverage
 .eggs
 .kdev4/

--- a/.kwalitee.yml
+++ b/.kwalitee.yml
@@ -86,6 +86,7 @@ components:
 - submit
 - sword
 - tags
+- tests
 - template
 - textminer
 - tickets

--- a/invenio/testsuite/__init__.py
+++ b/invenio/testsuite/__init__.py
@@ -1220,10 +1220,8 @@ def iter_suites(packages=None):
     if packages is None:
         testsuite = ModuleAutoDiscoveryRegistry('testsuite', app=app)
         from invenio import testsuite as testsuite_invenio
-        from invenio.base import testsuite as testsuite_base
         from invenio.celery import testsuite as testsuite_celery
         testsuite.register(testsuite_invenio)
-        testsuite.register(testsuite_base)
         testsuite.register(testsuite_celery)
     else:
         exclude = map(lambda x: x + '.testsuite',

--- a/invenio/translations/af/LC_MESSAGES/messages.po
+++ b/invenio/translations/af/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Afrikaans translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: af <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/ar/LC_MESSAGES/messages.po
+++ b/invenio/translations/ar/LC_MESSAGES/messages.po
@@ -1,0 +1,706 @@
+# Arabic translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: ar <LL@li.org>\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n>=3 "
+"&& n<=10 ? 3 : n>=11 && n<=99 ? 4 : 5)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/bg/LC_MESSAGES/messages.po
+++ b/invenio/translations/bg/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Bulgarian translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: bg <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/ca/LC_MESSAGES/messages.po
+++ b/invenio/translations/ca/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Catalan translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: ca <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/cs/LC_MESSAGES/messages.po
+++ b/invenio/translations/cs/LC_MESSAGES/messages.po
@@ -1,0 +1,706 @@
+# Czech translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: cs <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/de/LC_MESSAGES/messages.po
+++ b/invenio/translations/de/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# German translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: de <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/el/LC_MESSAGES/messages.po
+++ b/invenio/translations/el/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Greek translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: el <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/en/LC_MESSAGES/messages.po
+++ b/invenio/translations/en/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# English translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:15+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/es/LC_MESSAGES/messages.po
+++ b/invenio/translations/es/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Spanish translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/fa/LC_MESSAGES/messages.po
+++ b/invenio/translations/fa/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Persian translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: fa <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/fr/LC_MESSAGES/messages.po
+++ b/invenio/translations/fr/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# French translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:15+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: fr <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/gl/LC_MESSAGES/messages.po
+++ b/invenio/translations/gl/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Galician translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: gl <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/hr/LC_MESSAGES/messages.po
+++ b/invenio/translations/hr/LC_MESSAGES/messages.po
@@ -1,0 +1,706 @@
+# Croatian translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: hr <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/hu/LC_MESSAGES/messages.po
+++ b/invenio/translations/hu/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Hungarian translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: hu <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/invenio.pot
+++ b/invenio/translations/invenio.pot
@@ -1,0 +1,705 @@
+# Translations template for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/it/LC_MESSAGES/messages.po
+++ b/invenio/translations/it/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Italian translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: it <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/ja/LC_MESSAGES/messages.po
+++ b/invenio/translations/ja/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Japanese translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/ka/LC_MESSAGES/messages.po
+++ b/invenio/translations/ka/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Georgian translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: ka <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/lt/LC_MESSAGES/messages.po
+++ b/invenio/translations/lt/LC_MESSAGES/messages.po
@@ -1,0 +1,706 @@
+# Lithuanian translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: lt <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/no/LC_MESSAGES/messages.po
+++ b/invenio/translations/no/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Norwegian Bokmål (Norway) translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: nb_NO <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/pl/LC_MESSAGES/messages.po
+++ b/invenio/translations/pl/LC_MESSAGES/messages.po
@@ -1,0 +1,706 @@
+# Polish translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/pt/LC_MESSAGES/messages.po
+++ b/invenio/translations/pt/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Portuguese translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: pt <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/ro/LC_MESSAGES/messages.po
+++ b/invenio/translations/ro/LC_MESSAGES/messages.po
@@ -1,0 +1,706 @@
+# Romanian translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: ro <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100"
+" < 20)) ? 1 : 2)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/ru/LC_MESSAGES/messages.po
+++ b/invenio/translations/ru/LC_MESSAGES/messages.po
@@ -1,0 +1,706 @@
+# Russian translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: ru <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/rw/LC_MESSAGES/messages.po
+++ b/invenio/translations/rw/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Kinyarwanda translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:17+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: rw <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/sk/LC_MESSAGES/messages.po
+++ b/invenio/translations/sk/LC_MESSAGES/messages.po
@@ -1,0 +1,706 @@
+# Slovak translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:18+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: sk <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/sv/LC_MESSAGES/messages.po
+++ b/invenio/translations/sv/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Swedish translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:18+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: sv <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/uk/LC_MESSAGES/messages.po
+++ b/invenio/translations/uk/LC_MESSAGES/messages.po
@@ -1,0 +1,706 @@
+# Ukrainian translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:18+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: uk <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/zh_CN/LC_MESSAGES/messages.po
+++ b/invenio/translations/zh_CN/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Chinese (Simplified, China) translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:18+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: zh_Hans_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/invenio/translations/zh_TW/LC_MESSAGES/messages.po
+++ b/invenio/translations/zh_TW/LC_MESSAGES/messages.po
@@ -1,0 +1,705 @@
+# Chinese (Traditional, Taiwan) translations for invenio.
+# Copyright (C) 2015 CERN
+# This file is distributed under the same license as the invenio project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio 2.2.0.dev20150901\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-09-09 20:13+0200\n"
+"PO-Revision-Date: 2015-09-09 20:18+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: zh_Hant_TW <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.0\n"
+
+#: invenio/ext/menu.py:36
+msgid "Admin"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:245
+#, python-format
+msgid ""
+"The system is not attempting to send an email from %(x_from)s, to "
+"%(x_to)s, with body %(x_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:267
+#, python-format
+msgid ""
+"Error in sending message.                         Waiting %(sec)s "
+"seconds. Exception is %(exc)s,                         while sending "
+"email from %(sender)s to %(receipient)s                         with body"
+" %(email_body)s."
+msgstr ""
+
+#: invenio/ext/email/__init__.py:285
+#, python-format
+msgid "Error while sending an email: %(x_subject)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:296
+#, python-format
+msgid ""
+"\n"
+"Error while sending an email.\n"
+"Reason: %(x_reason)s\n"
+"Sender: \"%(x_sender)s\"\n"
+"Recipient(s): \"%(x_recipient)s\"\n"
+"\n"
+"The content of the mail was as follows:\n"
+"%(x_body)s"
+msgstr ""
+
+#: invenio/ext/email/__init__.py:304
+#, python-format
+msgid "Error in sending email from %(x_from)s to %(x_to)s with body%(x_body)s."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:90
+#, python-format
+msgid "You are not authorized to use '%(x_login_method)s' login method."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:95
+msgid "You have not yet verified your email address."
+msgstr ""
+
+#: invenio/ext/login/__init__.py:116
+msgid "Authorization failure"
+msgstr ""
+
+#: invenio/ext/login/__init__.py:123
+msgid "Please sign in to continue."
+msgstr ""
+
+#: invenio/ext/script/__init__.py:146
+#, python-format
+msgid ""
+"A newer version of Invenio is available for download. You may want to "
+"visit <a href=\"%(wiki)s\">%()s</a>"
+msgstr ""
+
+#: invenio/ext/script/__init__.py:156
+#, python-format
+msgid "Cannot download or parse release notes from %(release_notes)s"
+msgstr ""
+
+#: invenio/legacy/webpage.py:233 invenio/legacy/webstyle/templates.py:345
+#: invenio/legacy/webstyle/templates.py:382
+#: invenio/legacy/webstyle/templates.py:384
+msgid "Error"
+msgstr ""
+
+#: invenio/legacy/webpage.py:247
+msgid "Warning"
+msgstr ""
+
+#: invenio/legacy/webuser.py:170
+msgid "Database problem"
+msgstr ""
+
+#: invenio/legacy/webuser.py:306
+msgid "user"
+msgstr ""
+
+#: invenio/legacy/webuser.py:308 invenio/legacy/webstyle/templates.py:341
+#: invenio/testsuite/test_utils_date.py:115 invenio/utils/date.py:135
+#: invenio/utils/date.py:162
+msgid "N/A"
+msgstr ""
+
+#: invenio/legacy/webuser.py:562
+msgid "New account on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:564
+msgid "PLEASE ACTIVATE"
+msgstr ""
+
+#: invenio/legacy/webuser.py:565
+msgid "A new account has been created on"
+msgstr ""
+
+#: invenio/legacy/webuser.py:567
+msgid " and is awaiting activation"
+msgstr ""
+
+#: invenio/legacy/webuser.py:569
+msgid "   Username/Email"
+msgstr ""
+
+#: invenio/legacy/webuser.py:570
+msgid "You can approve or reject this account request at"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:393
+msgid "Choose a file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:395
+msgid "Name"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:397
+msgid "Description"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:399
+msgid "Comment"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:401
+msgid "Access"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:555
+msgid ""
+"The file you want to edit is protected against modifications. Your action"
+" has not been applied"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:575
+#, python-format
+msgid ""
+"The uploaded file is too small (<%(x_size)i o) and has therefore not been"
+" considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:580
+#, python-format
+msgid ""
+"The uploaded file is too big (>%(x_size)i o) and has therefore not been "
+"considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:586
+msgid "The uploaded file name is too long and has therefore not been considered"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:598
+msgid ""
+"You have already reached the maximum number of files for this type of "
+"document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:622
+#: invenio/legacy/bibdocfile/managedocfiles.py:632
+#: invenio/legacy/bibdocfile/managedocfiles.py:722
+#, python-format
+msgid "A file named %(x_name)s already exists. Please choose another name."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:643
+#, python-format
+msgid ""
+"A file with format '%(x_name)s' already exists. Please upload another "
+"format."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:651
+#: invenio/legacy/bibdocfile/managedocfiles.py:729
+msgid ""
+"You are not allowed to use dot '.', slash '/', or backslash '\\\\' in "
+"file names. Choose a different name and upload your file again. In "
+"particular, note that you should not include the extension in the "
+"renaming field."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:809
+msgid "Choose how you want to restrict access to this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:848
+msgid "Add new file"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:873
+msgid "You can decide to hide or not previous version(s) of this file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:874
+msgid ""
+"When you revise a file, the additional formats that you might have "
+"previously uploaded are removed, since they no longer up-to-date with the"
+" new file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:875
+msgid ""
+"Alternative formats uploaded for current version of this file will be "
+"removed"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:876
+msgid "Keep previous versions"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:877
+msgid "Cancel"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:878
+msgid "Upload"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:879
+msgid "Uploading..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:880
+msgid "Please wait..."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:893
+#: invenio/legacy/bibdocfile/webinterface.py:397
+msgid "Apply changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:898
+#, python-format
+msgid "Need help revising or adding files to record %(recid)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:900
+#, python-format
+msgid ""
+"Dear Support,\n"
+"I would need help to revise or add a file to record %(recid)s.\n"
+"I have attached the new version to this email.\n"
+"Best regards"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:905
+#, python-format
+msgid ""
+"Having a problem revising a file? Send the revised version to "
+"%(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:908
+#, python-format
+msgid ""
+"Having a problem adding or revising a file? Send the new/revised version "
+"to %(mailto_link)s."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1034
+msgid "revise"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1050
+msgid "delete"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/managedocfiles.py:1093
+msgid "add format"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:185
+msgid "file(s)"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:305
+msgid "Restricted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:310
+msgid "see"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:315
+msgid "previous"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/templates.py:327
+msgid "version"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:100
+#: invenio/legacy/bibdocfile/webinterface.py:135
+msgid "Requested record does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:104
+msgid "Requested record does not seem to have been integrated."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:129
+msgid ""
+"The system has encountered an error in retrieving the list of files for "
+"this document."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:130
+msgid ""
+"The error has been logged and will be taken in consideration as soon as "
+"possible."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:190
+#, python-format
+msgid "The format %(x_form)s does not exist for the given version: %(x_vers)s"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:204
+msgid "This file is restricted: "
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:216
+msgid "An error has happened in trying to stream the request file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:219
+msgid "The requested file is hidden and can not be accessed."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:226
+msgid "Requested file does not seem to exist."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:268
+msgid "An error has happened in trying to retrieve the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:270
+msgid "Not enough information to retrieve the document"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:278
+msgid "An error has happened in trying to retrieving the requested file."
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:326
+msgid "Manage Document Files"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:351
+#, python-format
+msgid "Your modifications to record #%(x_redid)i have been submitted"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:359
+#, python-format
+msgid "Your modifications to record #%(x_num)i have been cancelled"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:368
+msgid "Edit"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:369
+msgid "Edit record"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:398
+msgid "Cancel all changes"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+msgid "Document File Manager"
+msgstr ""
+
+#: invenio/legacy/bibdocfile/webinterface.py:405
+#, python-format
+msgid "Record #%(x_rec)i"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:84
+msgid "Home"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:316
+msgid "This site is also available in the following languages:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:347
+msgid "Internal Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:349
+msgid "Browser"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:371
+msgid "System Error"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:386
+msgid "Traceback"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:419
+msgid "Time"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:420
+msgid "Client"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:422
+msgid "Please send an error report to the administrator."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:423
+msgid "Send error report"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:428
+#, python-format
+msgid "Please contact %(x_name)s quoting the following information:"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:593
+#, python-format
+msgid "Record created %(x_date_creation)s, last modified %(x_date_modification)s"
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:661
+msgid "The server encountered an error while dealing with your request."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:662
+msgid "The system administrators have been alerted."
+msgstr ""
+
+#: invenio/legacy/webstyle/templates.py:663
+#, python-format
+msgid "In case of doubt, please contact %(x_admin_email)s."
+msgstr ""
+
+#: invenio/modules/authors/templates/authors/author_stub.html:25
+msgid ""
+"You tried to access an author module page.\n"
+"    Author module is currently disabled. A new version\n"
+"    is under development and will be released soon."
+msgstr ""
+
+#: invenio/modules/dashboard/user_settings.py:37
+msgid "Dashboard"
+msgstr ""
+
+#: invenio/utils/date.py:223
+msgid "Sun"
+msgstr ""
+
+#: invenio/utils/date.py:224
+msgid "Mon"
+msgstr ""
+
+#: invenio/utils/date.py:225
+msgid "Tue"
+msgstr ""
+
+#: invenio/utils/date.py:226
+msgid "Wed"
+msgstr ""
+
+#: invenio/utils/date.py:227
+msgid "Thu"
+msgstr ""
+
+#: invenio/utils/date.py:228
+msgid "Fri"
+msgstr ""
+
+#: invenio/utils/date.py:229
+msgid "Sat"
+msgstr ""
+
+#: invenio/utils/date.py:231
+msgid "Sunday"
+msgstr ""
+
+#: invenio/utils/date.py:232
+msgid "Monday"
+msgstr ""
+
+#: invenio/utils/date.py:233
+msgid "Tuesday"
+msgstr ""
+
+#: invenio/utils/date.py:234
+msgid "Wednesday"
+msgstr ""
+
+#: invenio/utils/date.py:235
+msgid "Thursday"
+msgstr ""
+
+#: invenio/utils/date.py:236
+msgid "Friday"
+msgstr ""
+
+#: invenio/utils/date.py:237
+msgid "Saturday"
+msgstr ""
+
+#: invenio/utils/date.py:253 invenio/utils/date.py:267
+msgid "Month"
+msgstr ""
+
+#: invenio/utils/date.py:254
+msgid "Jan"
+msgstr ""
+
+#: invenio/utils/date.py:255
+msgid "Feb"
+msgstr ""
+
+#: invenio/utils/date.py:256
+msgid "Mar"
+msgstr ""
+
+#: invenio/utils/date.py:257
+msgid "Apr"
+msgstr ""
+
+#: invenio/utils/date.py:258
+msgid "May"
+msgstr ""
+
+#: invenio/utils/date.py:259
+msgid "Jun"
+msgstr ""
+
+#: invenio/utils/date.py:260
+msgid "Jul"
+msgstr ""
+
+#: invenio/utils/date.py:261
+msgid "Aug"
+msgstr ""
+
+#: invenio/utils/date.py:262
+msgid "Sep"
+msgstr ""
+
+#: invenio/utils/date.py:263
+msgid "Oct"
+msgstr ""
+
+#: invenio/utils/date.py:264
+msgid "Nov"
+msgstr ""
+
+#: invenio/utils/date.py:265
+msgid "Dec"
+msgstr ""
+
+#: invenio/utils/date.py:268
+msgid "January"
+msgstr ""
+
+#: invenio/utils/date.py:269
+msgid "February"
+msgstr ""
+
+#: invenio/utils/date.py:270
+msgid "March"
+msgstr ""
+
+#: invenio/utils/date.py:271
+msgid "April"
+msgstr ""
+
+#: invenio/utils/date.py:272
+msgid "May "
+msgstr ""
+
+#: invenio/utils/date.py:273
+msgid "June"
+msgstr ""
+
+#: invenio/utils/date.py:274
+msgid "July"
+msgstr ""
+
+#: invenio/utils/date.py:275
+msgid "August"
+msgstr ""
+
+#: invenio/utils/date.py:276
+msgid "September"
+msgstr ""
+
+#: invenio/utils/date.py:277
+msgid "October"
+msgstr ""
+
+#: invenio/utils/date.py:278
+msgid "November"
+msgstr ""
+
+#: invenio/utils/date.py:279
+msgid "December"
+msgstr ""
+
+#: invenio/utils/date.py:299
+msgid "Day"
+msgstr ""
+
+#: invenio/utils/date.py:359
+msgid "Year"
+msgstr ""
+
+#: invenio/utils/date.py:553
+msgid "just now"
+msgstr ""
+
+#: invenio/utils/date.py:555
+msgid " seconds ago"
+msgstr ""
+
+#: invenio/utils/date.py:557
+msgid "a minute ago"
+msgstr ""
+
+#: invenio/utils/date.py:559
+msgid " minutes ago"
+msgstr ""
+
+#: invenio/utils/date.py:561
+msgid "an hour ago"
+msgstr ""
+
+#: invenio/utils/date.py:563
+msgid " hours ago"
+msgstr ""
+
+#: invenio/utils/date.py:565
+msgid "Yesterday"
+msgstr ""
+
+#: invenio/utils/date.py:567
+msgid " days ago"
+msgstr ""
+
+#: invenio/utils/date.py:570
+msgid "Last week"
+msgstr ""
+
+#: invenio/utils/date.py:572
+msgid " weeks ago"
+msgstr ""
+
+#: invenio/utils/date.py:575
+msgid "Last month"
+msgstr ""
+
+#: invenio/utils/date.py:577
+msgid " months ago"
+msgstr ""
+
+#: invenio/utils/date.py:579
+msgid "Last year"
+msgstr ""
+
+#: invenio/utils/date.py:581
+msgid " years ago"
+msgstr ""
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,18 +11,18 @@ sdist_deploy = build_static sdist
 universal = 1
 
 [compile_catalog]
-directory = invenio/base/translations/
+directory = invenio/translations/
 
 [extract_messages]
 copyright_holder = CERN
 msgid_bugs_address = info@invenio-software.org
 mapping-file = babel.cfg
-output-file = invenio/base/translations/invenio.pot
+output-file = invenio/translations/invenio.pot
 
 [init_catalog]
-input-file = invenio/base/translations/invenio.pot
-output-dir = invenio/base/translations/
+input-file = invenio/translations/invenio.pot
+output-dir = invenio/translations/
 
 [update_catalog]
-input-file = invenio/base/translations/invenio.pot
-output-dir = invenio/base/translations/
+input-file = invenio/translations/invenio.pot
+output-dir = invenio/translations/


### PR DESCRIPTION
* Creates initial message catalogues after separation of `invenio-base`
  module.  This fixes installation troubles related to `python setup.py
  compile_catalog`.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>