### PR TITLE
docker: removal of catalog compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,6 @@ COPY . /code
 #  - clean up
 RUN pip install --editable .[$REXTRAS] && \
     (python -O -m compileall . || true) && \
-    python setup.py compile_catalog && \
     rm -rf /tmp/* /var/tmp/* /var/lib/{cache,log}/ /root/.cache/*
 
 


### PR DESCRIPTION
* FIX Removes "python setup.py compile_catalog" from Dockerfile as
  catalogs were removed in commit 07b2bb0.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>