### PR TITLE
elasticsearch: virtualenv support

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ web: inveniomanage runserver
 cache: redis-server
 worker: celery worker --purge -E -A invenio_celery.celery --loglevel=DEBUG --workdir=$VIRTUAL_ENV
 workermon: flower --broker=redis://localhost:6379/1
-indexer: elasticsearch --config=elasticsearch.yml
+indexer: elasticsearch --config=elasticsearch.yml --path.data="$VIRTUAL_ENV/var/data/elasticsearch"  --path.logs="$VIRTUAL_ENV/var/log/elasticsearch"


### PR DESCRIPTION
* BETTER When developing and using honcho to start elasticsearch, executes
  elasticsearch by storing indexes and logs within the local virtual
  environment.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>