### PR TITLE
WIP docker: splits the invenio dockerfile

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -1,0 +1,98 @@
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+###############################################################################
+## 1. Base (stable)                                                          ##
+###############################################################################
+
+FROM python:2.7-slim
+MAINTAINER CERN <info@invenio-software.org>
+
+# expose the right port
+EXPOSE 28080
+
+# add invenio user
+RUN useradd --home-dir /home/invenio --create-home --shell /bin/bash --uid 1000 invenio
+
+# iojs, detects distribution and adds the right repo
+RUN apt-get update && \
+    apt-get -qy install --fix-missing --no-install-recommends \
+        curl \
+        && \
+    curl -sL https://deb.nodesource.com/setup_iojs_2.x | bash -
+
+#  - package cache updates
+#  - install requirements from repos
+#  - clean up
+#  - install python requirements
+#  - install iojs requirements
+RUN apt-get update && \
+    apt-get -qy upgrade --fix-missing --no-install-recommends && \
+    apt-get -qy install --fix-missing --no-install-recommends \
+        gcc \
+        git \
+        iojs \
+        libffi-dev \
+        libjpeg-dev \
+        liblzma-dev \
+        libmysqlclient-dev \
+        libssl-dev \
+        libxslt-dev \
+        mysql-client \
+        poppler-utils \
+        sudo \
+        vim-tiny \
+        && \
+    apt-get clean autoclean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/{apt,dpkg}/ && \
+    (find /usr/share/doc -depth -type f ! -name copyright -delete || true) && \
+    (find /usr/share/doc -empty -delete || true) && \
+    rm -rf /usr/share/man/* /usr/share/groff/* /usr/share/info/* && \
+    ln -s /usr/bin/vim.tiny /usr/bin/vim && \
+    pip install --upgrade pip && \
+    pip install ipdb \
+        ipython \
+        mock \
+        unittest2 \
+        watchdog \
+        && \
+    npm update && \
+    npm install --silent -g bower less clean-css uglify-js requirejs
+
+
+# global environment variables:
+#  - docker specific paths for Invenio
+ENV INVENIOBASE_INSTANCE_PATH="/opt/invenio/instance" \
+    INVENIOBASE_STATIC_FOLDER="/opt/invenio_static"
+
+RUN mkdir -p $INVENIOBASE_INSTANCE_PATH && \
+    mkdir -p $INVENIOBASE_STATIC_FOLDER && \
+    chown -R invenio:invenio /opt/
+
+COPY ./scripts /src/scripts
+
+# add volumes
+# do this AFTER `chown`, otherwise directory permissions are not preserved
+VOLUME ["/tmp", "/opt/invenio"]
+
+# install init scripts
+ENTRYPOINT ["/src/scripts/docker_boot.sh"]
+
+# default to bash
+CMD ["bash"]
+

--- a/docker-base/scripts/docker_boot.sh
+++ b/docker-base/scripts/docker_boot.sh
@@ -28,12 +28,12 @@
 
 
 # location of the folder that gets shared between containers
-CFG_SHARED_FOLDER=/home/invenio
+export CFG_SHARED_FOLDER=${CFG_SHARED_FOLDER:=/opt/invenio}
+export CFG_STATIC_FOLDER=${INVENIOBASE_STATIC_FOLDER:=/opt/invenio_static}
 
 CFG_MARKER_LOCK=$CFG_SHARED_FOLDER/boot.lock
 CFG_MARKER_DONE=$CFG_SHARED_FOLDER/boot.initialized
 CFG_MARKER_RUNNING=$CFG_SHARED_FOLDER/boot.running
-
 # echo function for stderr
 echoerr() { echo "$@" 1>&2; }
 
@@ -109,10 +109,9 @@ wait_for_services() {
 init() {
     # prepare bower installation
     # bower is not able to handle absolute paths very well
-    mkdir -p $CFG_SHARED_FOLDER/static/vendors
-    ln -s $CFG_SHARED_FOLDER/static/vendors bower_components
+    mkdir -p $CFG_STATIC_FOLDER/vendors
+    ln -s $CFG_STATIC_FOLDER/vendors bower_components
     rm .bowerrc
-
 
     # set some additional configs to be in sync with the docker-compose
     # setup. do this before the dev setup, because it sets some paths to
@@ -128,22 +127,22 @@ init() {
 CFG_SITE_URL = u'http://localhost:28080'
 CFG_SITE_SECURE_URL = u'http://localhost:28080'
 
-CFG_BATCHUPLOADER_DAEMON_DIR = u'/home/invenio/var/batchupload'
-CFG_BIBDOCFILE_FILEDIR = u'/home/invenio/var/data/files'
-CFG_BIBEDIT_CACHEDIR = u'/home/invenio/var/tmp-shared/bibedit-cache'
-CFG_BIBSCHED_LOGDIR = u'/home/invenio/var/log/bibsched'
+CFG_BATCHUPLOADER_DAEMON_DIR = u'/opt/invenio/var/batchupload'
+CFG_BIBDOCFILE_FILEDIR = u'/opt/invenio/var/data/files'
+CFG_BIBEDIT_CACHEDIR = u'/opt/invenio/var/tmp-shared/bibedit-cache'
+CFG_BIBSCHED_LOGDIR = u'/opt/invenio/var/log/bibsched'
 CFG_BINDIR = u'/usr/local/bin'
-CFG_CACHEDIR = u'/home/invenio/var/cache'
-CFG_ETCDIR = u'/home/invenio/etc'
-CFG_LOCALEDIR = u'/home/invenio/share/locale'
-CFG_LOGDIR = u'/home/invenio/var/log'
+CFG_CACHEDIR = u'/opt/invenio/var/cache'
+CFG_ETCDIR = u'/opt/invenio/etc'
+CFG_LOCALEDIR = u'/opt/invenio/share/locale'
+CFG_LOGDIR = u'/opt/invenio/var/log'
 CFG_PYLIBDIR = u'/usr/local/lib/python2.7'
-CFG_RUNDIR = u'/home/invenio/var/run'
+CFG_RUNDIR = u'/opt/invenio/var/run'
 CFG_TMPDIR = u'/tmp/invenio-`hostname`'
-CFG_TMPSHAREDDIR = u'/home/invenio/var/tmp-shared'
-CFG_WEBDIR = u'/home/invenio/var/www'
+CFG_TMPSHAREDDIR = u'/opt/invenio/var/tmp-shared'
+CFG_WEBDIR = u'/opt/invenio/var/www'
 
-DEPOSIT_STORAGEDIR = u'/home/invenio/var/data/deposit/storage'
+DEPOSIT_STORAGEDIR = u'/opt/invenio/var/data/deposit/storage'
 EOF
 
     # additional config through hook
@@ -155,11 +154,12 @@ EOF
     fi
 
     # load dev config
-    /code/scripts/setup_devmode.sh
-
+    /src/scripts/setup_devmode.sh
 
     # final shot
+    echo "inveniomanage database init"
     inveniomanage database init --user=root --password=mysecretpassword --yes-i-know
+    echo "inveniomanage database create"
     inveniomanage database create
 }
 
@@ -181,7 +181,7 @@ wait_for_services
         touch $CFG_MARKER_RUNNING
 
         init
-
+        echo "init done"
 
         # remember that we reached this point
         touch $CFG_MARKER_DONE

--- a/docker-base/scripts/setup_devmode.sh
+++ b/docker-base/scripts/setup_devmode.sh
@@ -44,9 +44,10 @@ CFG_TMPDIR = u'/tmp'
 COLLECT_STORAGE = u'flask_collect.storage.link'
 EOF
 
+echo "inveniomanage bower/collect/assets"
 # fetch and build assets
 inveniomanage bower -i bower-base.json > bower.json
-bower install --silent
+bower install --quiet
 inveniomanage collect > /dev/null
 inveniomanage assets build
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -34,11 +34,9 @@ web:
     - ES_HOSTS=['es']
     - INVENIO_APP_CONFIG_ENVS=ASSETS_DEBUG,BROKER_URL,CELERY_RESULT_BACKEND,CACHE_REDIS_HOST,CFG_DATABASE_HOST,CFG_REDIS_HOSTS,DEBUG,DEBUG_TB_INTERCEPT_REDIRECTS,ES_HOSTS
   volumes:
-    - ./invenio:/code/invenio:ro
-    - ./docs:/code/docs:rw
-    - ./scripts:/code/scripts:ro
-    - /code/invenio
-  read_only: true
+    - ./invenio:/src/invenio/invenio:ro
+    - ./docs:/src/invenio/docs:rw
+    - ./scripts:/src/invenio/scripts:ro
   links:
     - elasticsearch:es
     - mysql:db
@@ -60,7 +58,6 @@ worker:
     - INVENIO_APP_CONFIG_ENVS=ASSETS_DEBUG,BROKER_URL,CELERY_RESULT_BACKEND,CACHE_REDIS_HOST,CFG_DATABASE_HOST,CFG_REDIS_HOSTS,DEBUG,DEBUG_TB_INTERCEPT_REDIRECTS,ES_HOSTS
   volumes_from:
     - web
-  read_only: true
   links:
     - elasticsearch:es
     - mysql:db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ web:
     - "CFG_REDIS_HOSTS={'default': [{'db': 0, 'host': 'cache', 'port': 6379}]}"
     - ES_HOSTS=['es']
     - INVENIO_APP_CONFIG_ENVS=BROKER_URL,CELERY_RESULT_BACKEND,CACHE_REDIS_HOST,CFG_DATABASE_HOST,CFG_REDIS_HOSTS,ES_HOSTS
+  volumes:
+    - /opt/invenio_static
   read_only: true
   links:
     - elasticsearch:es


### PR DESCRIPTION
* BETTER Splits the invenio dockerfiles in one generic without code
  and a dockerfile for a basic Invenio installation.

* Moves the invenio files from `/home/invenio` to `/opt/invenio`
  and the static files (bower) to `/opt/invenio_static`.

* Moves all code and also packages that get installed in editable mode
  from `/code` to `/src`

* Installs vim-tiny and adds a symlink it to vim.

* Outputs more information at creation time and bower install.

* Adds `libjpeg-dev` for the pillow jpeg support.

Signed-off-by: David Zerulla <ddaze@outlook.de>