### PR TITLE
 Crossrefutils: Configuraion variable for crossref2marcxml.xsl

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -2462,6 +2462,9 @@ CFG_CROSSREF_PASSWORD =
 ## CFG_CROSSREF_EMAIL -- crossref query services email
 CFG_CROSSREF_EMAIL =
 
+## CFG_CROSSREF_2MARC  -- filename in CFG_ETCDIR for crossref
+CFG_CROSSREF_2MARC = crossref2marcxml.xsl
+
 #####################################
 ## Part 32: WebLinkback parameters ##
 #####################################

--- a/modules/bibconvert/etc/crossref2marcxml.xsl
+++ b/modules/bibconvert/etc/crossref2marcxml.xsl
@@ -20,10 +20,7 @@
       <!-- checking different types of documents -->
       <xsl:when test="$doi[@type='journal_article']">
         <datafield tag="980" ind1=" " ind2=" ">
-          <subfield code="a"><xsl:text>Published</xsl:text></subfield>
-        </datafield>
-        <datafield tag="980" ind1=" " ind2=" ">
-          <subfield code="a"><xsl:text>citeable</xsl:text></subfield>
+          <subfield code="a"><xsl:text>ARTICLE</xsl:text></subfield>
         </datafield>
       </xsl:when>
       <xsl:when test="$doi[@type='conference_paper']">
@@ -208,9 +205,5 @@
         <xsl:with-param name="title" select="./crossref:query/crossref:article_title"/>
       </xsl:call-template>
     </xsl:if>
-    <!-- Adding 980__$aHEP field to every record -->
-    <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a"><xsl:text>HEP</xsl:text></subfield>
-    </datafield>
   </xsl:template>
 </xsl:stylesheet>

--- a/modules/miscutil/lib/crossrefutils.py
+++ b/modules/miscutil/lib/crossrefutils.py
@@ -27,7 +27,7 @@ from xml.dom.minidom import parse
 from time import sleep
 
 from invenio.config import CFG_ETCDIR, CFG_CROSSREF_USERNAME, \
- CFG_CROSSREF_PASSWORD, CFG_CROSSREF_EMAIL
+ CFG_CROSSREF_PASSWORD, CFG_CROSSREF_EMAIL, CFG_CROSSREF_2MARC
 from invenio.bibconvert_xslt_engine import convert
 from invenio.bibrecord import record_get_field_value
 from invenio.urlutils import make_invenio_opener
@@ -82,7 +82,7 @@ def get_marcxml_for_doi(doi):
     # from bibconvert_xslt_engine file
     # Seting the path to xsl template
     xsl_crossref2marc_config = "%s/bibconvert/config/%s" % \
-    (CFG_ETCDIR, "crossref2marcxml.xsl")
+    (CFG_ETCDIR, CFG_CROSSREF_2MARC)
 
     output = convert(xmltext=content, \
                     template_filename=xsl_crossref2marc_config)


### PR DESCRIPTION
- configutaion changes in crossref2marcxml.xsl and crossrefutils.py
- change in crossref2marcxml.xsl for linking templates in /opt/invenio/etc/bibedit/record_templates/
- new variable CFG_CROSSREF_2MARC in invenio.conf for crossref2marcxml.xsl
- change in crossrefutils.py for new variable
- final commit after cleaning logs
  
  Signed-off-by: Nalin Chhibber nalin.chhibber@gmail.com
  Acked-by: Javier Martin Montull javier.martin.montull@cern.ch
