### PR TITLE
WebSearch: fix async getter tests

### DIFF
--- a/modules/websearch/lib/websearch_external_collections_getter_tests.py
+++ b/modules/websearch/lib/websearch_external_collections_getter_tests.py
@@ -39,7 +39,7 @@ class AsyncDownloadTest(unittest.TestCase):
         ##   - test 1 bad IP: 1.2.3.4
         ## Return the list of errors.
         checks = [
-            {'url': 'http://invenio-software.org', 'content': 'About Invenio'},
+            {'url': 'http://invenio-software.org', 'content': 'Invenio'},
             {'url': 'http://rjfreijoiregjreoijgoirg.fr'},
             {'url': 'http://1.2.3.4/'} ]
 


### PR DESCRIPTION
* FIX Fixes asynchronous external collection getter tests following the
  update of the Invenio project web site.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>