### PR TITLE
docker: adds missing Pillow system dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN apt-get update && \
         gcc \
         git \
         libffi-dev \
+        libfreetype6-dev \
+        libjpeg-dev \
         libmysqlclient-dev \
         libssl-dev \
         libxslt-dev \


### PR DESCRIPTION
* FIX Adds missing Pillow-related system dependencies to Docker build
  instructions.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>