### PR TITLE
Nodejs and bower changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,24 +31,25 @@ RUN useradd --home-dir /home/invenio --create-home --shell /bin/bash --uid 1000 
 # set work dir
 WORKDIR /code
 
-# iojs, detects distribution and adds the right repo
+# nodejs, detects distribution and adds the right repo
 RUN apt-get update && \
     apt-get -qy install --fix-missing --no-install-recommends \
         curl \
         && \
-    curl -sL https://deb.nodesource.com/setup_iojs_2.x | bash -
+    curl -sL https://deb.nodesource.com/setup_4.x | bash -
 
 #  - package cache updates
 #  - install requirements from repos
 #  - clean up
 #  - install python requirements
-#  - install iojs requirements
+#  - install nodejs requirements
 RUN apt-get update && \
     apt-get -qy upgrade --fix-missing --no-install-recommends && \
     apt-get -qy install --fix-missing --no-install-recommends \
+        cython \
         gcc \
         git \
-        iojs \
+        nodejs \
         libffi-dev \
         libfreetype6-dev \
         libjpeg-dev \

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -48,16 +48,16 @@ refer to it as ``$MYSQL_ROOT``.
 
     $ sudo apt-get install mysql-server
 
-Io.js
-+++++
+Node.js
++++++++
 
-`io.js <http://iojs.org/>`_ and `npm <https://www.npmjs.org/>`_ can be
-installed using io.js's script.
+`Node.js <http://nodejs.org/>`_ and `npm <https://www.npmjs.org/>`_ can be
+installed using nodesource's script.
 
 .. code-block:: console
 
-    $ curl -sL https://deb.nodesource.com/setup_iojs_2.x | sudo bash -
-    $ sudo apt-get install iojs
+    $ curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
+    $ sudo apt-get install nodejs
 
 Centos / RHEL
 ~~~~~~~~~~~~~
@@ -109,10 +109,10 @@ parameter to rpm.
     $ sudo mysql_secure_installation
     # follow the instructions
 
-Io.js / Node.js
-+++++++++++++++
+Node.js
++++++++
 
-Io.js or Node.js require a bit more manual work to install it from the sources.
+Node.js require a bit more manual work to install it from the sources.
 We are following the tutorial: `digital ocean: tutorial on how to install
 node.js on centos
 <https://www.digitalocean.com/community/tutorials/how-to-install-and-run-a-node-js-app-on-centos-6-4-64bit>`_

--- a/docs/configuration/overlay.rst
+++ b/docs/configuration/overlay.rst
@@ -53,7 +53,7 @@ The global setup
 ----------------
 
 Some softwares and libraries are required to work on your overlay. It's mostly
-Python, MySQL, Redis as well as XML, XSLT and graphical libraries. Io.js is
+Python, MySQL, Redis as well as XML, XSLT and graphical libraries. Node.js is
 solely required for development purposes.
 
 .. code-block:: console
@@ -73,9 +73,9 @@ solely required for development purposes.
     # Install MySQL server, and keep the root password somewhere safe.
     $ sudo apt-get install mysql-server
 
-    # Install io.js
-    $ curl -sL https://deb.nodesource.com/setup_iojs_2.x | sudo bash -
-    $ sudo apt-get install iojs
+    # Install node.js
+    $ curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
+    $ sudo apt-get install nodejs
 
 The virtual environment
 -----------------------
@@ -457,7 +457,7 @@ Before deploying anything, we need to locally prepare the python package to be
 installed. Thanks to our ``setup.py`` file, it's very simple.
 
 Beforehand, we have to generate the static assets into our static folder. By
-doing so, it's not required to install anything related to io.js on your
+doing so, it's not required to install anything related to node.js on your
 server (no ``bower``, ``less``, ``uglifyjs``, etc.).
 
 .. code-block:: python

--- a/docs/configuration/overlay.rst
+++ b/docs/configuration/overlay.rst
@@ -250,17 +250,16 @@ configured using two files:
 - `.bowerrc`: tells where the assets are downloaded
 - `bower.json`: lists the dependencies to be downloaded
 
-.. code-block:: json
-
-    {
-        "directory": "myoverlay/base/static/vendors"
-    }
-
-The ``bower.json`` can be automagically generated.
+The ``bower.json`` can be automagically generated through the `inveniomanage`
+command. However, we will have to tell `bower` the path we want the libraries
+downloaded to. In most cases, it will be in the instance directory under the
+`static/vendors` path.
 
 .. code-block:: console
 
     $ sudo su -c "npm install -g bower less clean-css requirejs uglify-js"
+    (myoverlay)$ cdvirtualenv var/invenio.base-instance
+    (myoverlay)$ echo '{"directory": "static/vendors"}' > .bowerrc
     (myoverlay)$ inveniomanage bower > bower.json
     (myoverlay)$ bower install
 


### PR DESCRIPTION
The `.bowerrc` file shouldn't live in the overlay as it is meant to be installed as a package too. In the meantime, invenio can safely use nodejs-4.x the son of io.js and node.js pre-Node.js foundation.