### PR TITLE
search: intbitset could be None

### DIFF
--- a/invenio/legacy/search_engine/__init__.py
+++ b/invenio/legacy/search_engine/__init__.py
@@ -3101,6 +3101,8 @@ def get_records_that_can_be_displayed(user_info,
     """
     Return records that can be displayed.
     """
+    if hitset_in_any_collection is None:
+        hitset_in_any_collection = intbitset()
     records_that_can_be_displayed = intbitset()
 
     if colls is None:


### PR DESCRIPTION
**What I did**

I was visiting a collection page, e.g. `/search?cc=Photo&ln=en`

**What happened**
```
Traceback (most recent call last):
  File "/home/invenio/.virtualenvs/maint-2.0/lib/python2.7/site-packages/Flask-0.10.1-py2.7.egg/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/code/invenio/invenio/ext/legacy/__init__.py", line 128, in __call__
    response = self.app.handle_exception(e)
  File "/home/invenio/.virtualenvs/maint-2.0/lib/python2.7/site-packages/Flask_RESTful-0.3.4-py2.7.egg/flask_restful/__init__.py", line 270, in error_router
    return original_handler(e)
  File "/home/invenio/.virtualenvs/maint-2.0/lib/python2.7/site-packages/Flask-0.10.1-py2.7.egg/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/code/invenio/invenio/ext/legacy/__init__.py", line 124, in __call__
    response = self.app.full_dispatch_request()
  File "/home/invenio/.virtualenvs/maint-2.0/lib/python2.7/site-packages/Flask-0.10.1-py2.7.egg/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/invenio/.virtualenvs/maint-2.0/lib/python2.7/site-packages/Flask_RESTful-0.3.4-py2.7.egg/flask_restful/__init__.py", line 270, in error_router
    return original_handler(e)
  File "/code/invenio/invenio/base/wrappers.py", line 125, in handle_user_exception
    return super(Flask, self).handle_user_exception(e)
  File "/home/invenio/.virtualenvs/maint-2.0/lib/python2.7/site-packages/Flask-0.10.1-py2.7.egg/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/invenio/.virtualenvs/maint-2.0/lib/python2.7/site-packages/Flask-0.10.1-py2.7.egg/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/invenio/.virtualenvs/maint-2.0/lib/python2.7/site-packages/Flask-0.10.1-py2.7.egg/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/code/invenio/invenio/base/decorators.py", line 203, in decorator
    return f(*args, **argd)
  File "/code/invenio/invenio/modules/search/views/search.py", line 149, in decorated
    return method(collection, *args, **kwargs)
  File "/code/invenio/invenio/modules/search/views/search.py", line 465, in search
    records=len(get_current_user_records_that_can_be_displayed(qid)),
  File "/code/invenio/invenio/modules/search/facet_builders.py", line 59, in get_current_user_records_that_can_be_displayed
    return get_records_for_user(qid, current_user.get_id())
  File "/home/invenio/.virtualenvs/maint-2.0/lib/python2.7/site-packages/Flask_Cache-0.13.1-py2.7.egg/flask_cache/__init__.py", line 537, in decorated_function
    rv = f(*args, **kwargs)
  File "/code/invenio/invenio/modules/search/facet_builders.py", line 57, in get_records_for_user
    cc)
  File "/code/invenio/invenio/legacy/search_engine/__init__.py", line 3138, in get_records_that_can_be_displayed
    records_that_can_be_displayed = hitset_in_any_collection - (notpermitted_recids - permitted_recids)
TypeError: Argument 'self' must not be None
```

**What was expected**
Unicorns and :rainbow:!