### PR TITLE
global: assets loaded from their CDN

### DIFF
--- a/invenio/base/bundles.py
+++ b/invenio/base/bundles.py
@@ -114,7 +114,7 @@ jquery = Bundle(
         "jquery.treeview": "latest",  # orphan, to be replaced by jqTree
         "json2": "latest",  # orphan
         "hogan": "~3",
-        "MathJax": "~2.4",  # orphan
+        "MathJax": "~2.5",  # orphan
         "swfobject": "latest",  # orphan
         "typeahead.js": "latest",
         "uploadify": "latest"  # orphan

--- a/invenio/base/templates/base/scripts_base.html
+++ b/invenio/base/templates/base/scripts_base.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -20,9 +20,12 @@
 
 {%- for bundle in get_bundle('js') %}
   {%- if config.get("DEBUG") %}
-  <!-- {{ bundle.weight }}: {{ bundle.output }} -->
+    <!-- {{ bundle.weight }}: {{ bundle.output }} -->
   {%- endif %}
   {%- assets bundle %}
-  <script type="text/javascript" src="{{ EXTRA.static_url_path }}{{ ASSET_URL }}"></script>
+    {%- for cdn_url in bundle.externals %}
+      <script type="text/javascript" src="{{ cdn_url }}"></script>
+    {%- endfor %}
+      <script type="text/javascript" src="{{ EXTRA.static_url_path }}{{ ASSET_URL }}"></script>
   {%- endassets %}
-{%- endfor %}
+{%- endfor -%}

--- a/invenio/ext/assets/commands.py
+++ b/invenio/ext/assets/commands.py
@@ -20,12 +20,15 @@
 
 import argparse
 import os
-import pkg_resources
 import warnings
 
 from flask import current_app, json
+
 from flask_assets import ManageAssets
+
 from flask_script import Command, Option
+
+import pkg_resources
 
 from .registry import bundles
 
@@ -92,7 +95,12 @@ class BowerCommand(Command):
         for pkg, bundle in bundles:
             if bundle.bower:
                 current_app.logger.debug((pkg, bundle.bower))
-            output['dependencies'].update(bundle.bower)
+                externals = list(bundle.externals)
+                for library, version in bundle.bower.items():
+                    if not isinstance(version, basestring):
+                        output['dependencies'][library] = version[1]
+                    elif version not in externals:
+                        output['dependencies'][library] = version
 
         # Remove together with override kwarg, and Option object.
         if override:

--- a/invenio/ext/assets/wrappers.py
+++ b/invenio/ext/assets/wrappers.py
@@ -21,12 +21,17 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import os
+
 from flask import current_app
+
 from flask_assets import Bundle as BundleBase
+
 from flask_registry import ModuleAutoDiscoveryRegistry
-from werkzeug.utils import import_string
-from webassets.filter.requirejs import RequireJSFilter as RequireJSFilterBase
+
 from webassets.filter import ExternalTool
+from webassets.filter.requirejs import RequireJSFilter as RequireJSFilterBase
+
+from werkzeug.utils import import_string
 
 
 class Bundle(BundleBase):
@@ -37,7 +42,9 @@ class Bundle(BundleBase):
     The name is only used for the requirements from the templates and the
     weight does the bundle ordering.
 
-    The bower dependencies are used to generate a bower.json file.
+    The bower dependencies are used to generate a bower.json file. If a bower
+    dependency is a URL (formatted like this: `//code.jquery.com/jquery.js`)
+    then it won't be managed by bower but it will be used directly instead.
     """
 
     def __init__(self, *contents, **options):
@@ -65,6 +72,15 @@ class Bundle(BundleBase):
             if f.name in filters:
                 return True
         return False
+
+    @property
+    def externals(self):
+        """List of dependencies that should loaded using external URLs."""
+        for library, version in self.bower.items():
+            if not isinstance(version, basestring):
+                yield version[0]
+            elif version.startswith(r"//"):
+                yield version
 
 
 class BundlesAutoDiscoveryRegistry(ModuleAutoDiscoveryRegistry):


### PR DESCRIPTION
Some libraries like MathJax or jQuery are very common, sometimes hard to bundle, and may be loaded from their CDN.

**Example**

How to load MathJax and jQuery from their CDNs.

```python
# my-overlay/base/bundles.py
from invenio.base.bundles import jquery as _jquery

_jquery.bower["MathJax"] = "~2.5"
_jquery.bower["jquery"] = ("//code.jquery.com/jquery-1.11.3.min.js", "~1.11")
```

```javascript
// my-overlay/base/static/js/my-overlay-settings.js
require.config({
    paths: {
        jquery: ["//code.jquery.com/jquery-1.11.3.min.js",
                 "vendors/jquery/dist/jquery.min"],
        // ...
```

```javascript
// my-overlay/base/static/js/build.js
({
    // ...
    mainConfigFile: ["./settings.js", "my-overlay-settings.js"],
    paths: {
        "jquery": "empty:"
    }
})
```

**Result**

Bower.json will have `jquery` but not `MathJax`.

```json
{
    "dependencies": {
        "jquery": "~1.11"
    }
}
```

The HTML output will get a smaller `gen/jquery.js` file but two extra HTTP requests. If you're lucky they already live in the cache of the browser.

```html
<!-- 0: almond.js -->
<script type="text/javascript" src="/vendors/almond/almond.js"></script>
<script type="text/javascript" src="/js/settings.js"></script>
<script type="text/javascript" src="/js/my-optional-overlay-settings.js"></script>
<!-- 10: jquery.js -->
<script type="text/javascript" src="//code.jquery.com/jquery-1.11.3.min.js"></script>
<script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
<script type="text/javascript" src="/gen/jquery.js?76c94765"></script>
<!-- ... -->
```