### PR TITLE
installation: fix entry_points for pip7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -269,7 +269,7 @@ setup(
             'plotextractor = invenio.utils.scripts.plotextractor:main',
             # Legacy
             'alertengine = invenio.legacy.webalert.scripts.alertengine:main',
-            'batchuploader = invenio.legacy.bibupload.scripts.batchuploader',
+            'batchuploader = invenio.legacy.bibupload.scripts.batchuploader:main',
             'bibcheck = invenio.legacy.bibcheck.scripts.bibcheck:main',
             'bibcircd = invenio.legacy.bibcirculation.scripts.bibcircd:main',
             'bibauthorid = '


### PR DESCRIPTION
Fixes the `entry_point` as pip 7.x expects a function and not a module.