### PR TITLE
WebSearch: fix the order of prev and next links

### DIFF
--- a/modules/websearch/lib/websearch_templates.py
+++ b/modules/websearch/lib/websearch_templates.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is part of Invenio.
-# Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
+# Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -4022,7 +4022,7 @@ class Template:
 
         # let's calculate lenght of recID's collection
         if record_found:
-            recIDs = coll_recID[::-1]
+            recIDs = coll_recID
             totalrec = len(recIDs)
         # search for a specific record having not done any search before
         else:


### PR DESCRIPTION
* FIX Fixes the order of search results when computing the
  next and previous search links on the record page by not
  reversing the initial search results.

Signed-off-by: Ludmila Marian <ludmila.marian@gmail.com>