### PR TITLE
inveniogc: tempdir deletion

### DIFF
--- a/modules/websession/lib/inveniogc.py
+++ b/modules/websession/lib/inveniogc.py
@@ -177,15 +177,15 @@ def clean_tempfiles():
             % (CFG_TMPDIR, CFG_TMPSHAREDDIR, \
                CFG_MAX_ATIME_RM_BIBDOC, vstr))
 
-    write_message("- deleting old temporary WebSubmit icons")
+    write_message("- deleting old temporary WebSubmit icon dirs")
     gc_exec_command('find %s %s -name "websubmit_icon_creator_*"'
-        ' -atime +%s -exec rm %s -f {} \;' \
+        ' -atime +%s -exec rm %s -rf {} \;' \
             % (CFG_TMPDIR, CFG_TMPSHAREDDIR, \
                CFG_MAX_ATIME_RM_ICON, vstr))
 
-    write_message("- deleting old temporary WebSubmit stamps")
+    write_message("- deleting old temporary WebSubmit stamp dirs")
     gc_exec_command('find %s %s -name "websubmit_file_stamper_*"'
-        ' -atime +%s -exec rm %s -f {} \;' \
+        ' -atime +%s -exec rm %s -rf {} \;' \
             % (CFG_TMPDIR, CFG_TMPSHAREDDIR, \
                CFG_MAX_ATIME_RM_STAMP, vstr))
 


### PR DESCRIPTION
FIX websubmit_icon_creator and  websubmit_file_stamper create tempdirs
instead of files thus deletion has to be recursive.

Addresses #3556

Signed-off-by: Alexander Wagner alexander.wagner@desy.de
