### PR TITLE
installation: migration from `bower` to `npm`

### DIFF
--- a/docs/configuration/overlay.rst
+++ b/docs/configuration/overlay.rst
@@ -21,6 +21,11 @@
  How to create an Invenio overlay
 ==================================
 
+.. admonition:: CAVEAT LECTOR
+
+   The following overlay guide was written for Invenio v2.0 release series. It
+   is to be updated for Invenio v3.0.x
+
 .. admonition:: TODO
 
     The following items are still missing from this document, feel free to

--- a/docs/installation/installation-detailed.rst
+++ b/docs/installation/installation-detailed.rst
@@ -146,7 +146,7 @@ First, some useful system tools are installed:
    :literal:
 
 Second, an external Node.js package repository is enabled. We'll be needing to
-install and run Bower on the web node later. The Node.js repository is enabled
+install and run Npm on the web node later. The Node.js repository is enabled
 as follows:
 
 * on Ubuntu 14.04 LTS (Trusty Tahr):
@@ -197,14 +197,14 @@ install corresponding libraries too:
    :end-before: # sphinxdoc-install-web-libpostgresql-centos7-end
    :literal:
 
-Fourth, now that Node.js is installed, we can proceed with installing Bower and
+Fourth, now that Node.js is installed, we can proceed with installing Npm and
 associated CSS/JS filter tools. Let's do it globally:
 
 * on either of the operating systems:
 
 .. include:: ../../scripts/provision-web.sh
-   :start-after: # sphinxdoc-install-bower-and-css-js-filters-begin
-   :end-before: # sphinxdoc-install-bower-and-css-js-filters-end
+   :start-after: # sphinxdoc-install-npm-and-css-js-filters-begin
+   :end-before: # sphinxdoc-install-npm-and-css-js-filters-end
    :literal:
 
 Finally, we'll install Python virtual environment wrapper tools and activate
@@ -430,12 +430,12 @@ multi-server environment:
    :end-before: # sphinxdoc-customise-instance-end
    :literal:
 
-In the instance folder, we run Bower to install any JavaScript libraries that
+In the instance folder, we run Npm to install any JavaScript libraries that
 Invenio needs:
 
 .. include:: ../../scripts/install.sh
-   :start-after: # sphinxdoc-run-bower-begin
-   :end-before: # sphinxdoc-run-bower-end
+   :start-after: # sphinxdoc-run-npm-begin
+   :end-before: # sphinxdoc-run-npm-end
    :literal:
 
 We can now collect and build CSS/JS assets of our Invenio instance:

--- a/docs/technology/docker.rst
+++ b/docs/technology/docker.rst
@@ -130,7 +130,7 @@ Code changes and live reloading
     you are using one of these setups, you have to restart the Docker
     containers to reload the code and templates.
 
-As long as you do not add new requirements (python and bower) and only change
+As long as you do not add new requirements (python and npm) and only change
 files inside the `invenio` package, it is not required to rebuild the docker
 images. Code changes are mirrored to the containers. If Flask supports it, on
 your system it will automatically reload the application when changes are

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -127,14 +127,14 @@ echo "BROKER_URL='redis://${INVENIO_REDIS_HOST}:6379/0'" >> ../var/${INVENIO_WEB
 echo "CELERY_RESULT_BACKEND='redis://${INVENIO_REDIS_HOST}:6379/1'" >> ../var/${INVENIO_WEB_INSTANCE}-instance/${INVENIO_WEB_INSTANCE}.cfg
 # sphinxdoc-customise-instance-end
 
-# sphinxdoc-run-bower-begin
+# sphinxdoc-run-npm-begin
 cd ${INVENIO_WEB_INSTANCE}
 pip install ipaddr # FIXME this seems explicitly needed on Python-2.7
-python manage.py bower
-cdvirtualenv var/${INVENIO_WEB_INSTANCE}-instance/
-CI=true bower install
+python manage.py npm
+cdvirtualenv var/${INVENIO_WEB_INSTANCE}-instance/static
+CI=true npm install
 cd -
-# sphinxdoc-run-bower-end
+# sphinxdoc-run-npm-end
 
 # sphinxdoc-collect-and-build-assets-begin
 python manage.py collect -v

--- a/scripts/provision-web.sh
+++ b/scripts/provision-web.sh
@@ -107,12 +107,12 @@ provision_web_libpostgresql_centos7 () {
     # sphinxdoc-install-web-libpostgresql-centos7-end
 }
 
-setup_bower_and_css_js_filters () {
+setup_npm_and_css_js_filters () {
 
-    # sphinxdoc-install-bower-and-css-js-filters-begin
-    sudo su -c "npm install -g bower"
+    # sphinxdoc-install-npm-and-css-js-filters-begin
+    sudo su -c "npm install -g npm"
     sudo su -c "npm install -g node-sass clean-css requirejs uglify-js"
-    # sphinxdoc-install-bower-and-css-js-filters-end
+    # sphinxdoc-install-npm-and-css-js-filters-end
 
 }
 
@@ -176,7 +176,7 @@ main () {
     fi
 
     # finish with common setups:
-    setup_bower_and_css_js_filters
+    setup_npm_and_css_js_filters
     setup_virtualenvwrapper
 
 }


### PR DESCRIPTION
* BETTER Amends installation scripts and instructions to use `npm`
  instead of `bower`. (closes #3568)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>