### PR TITLE
installation: addition of `Invenio-Search` module

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,6 +42,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "web" do |web|
     web.vm.box = OS
+    web.vm.hostname = 'web'
     web.vm.provision "file", source: ".inveniorc", destination: ".inveniorc"
     web.vm.provision "shell", inline: "source .inveniorc && /vagrant/scripts/provision-web.sh", privileged: false
     web.vm.network "forwarded_port", guest: 5000, host: 5000
@@ -50,6 +51,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "postgresql" do |postgresql|
     postgresql.vm.box = OS
+    postgresql.vm.hostname = 'postgresql'
     postgresql.vm.provision "file", source: ".inveniorc", destination: ".inveniorc"
     postgresql.vm.provision "shell", inline: "source .inveniorc && /vagrant/scripts/provision-postgresql.sh", privileged: false
     postgresql.vm.network "private_network", ip: ENV.fetch('INVENIO_POSTGRESQL_HOST','192.168.50.11')
@@ -57,6 +59,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "redis" do |redis|
     redis.vm.box = OS
+    redis.vm.hostname = 'redis'
     redis.vm.provision "file", source: ".inveniorc", destination: ".inveniorc"
     redis.vm.provision "shell", inline: "source .inveniorc && /vagrant/scripts/provision-redis.sh", privileged: false
     redis.vm.network "private_network", ip: ENV.fetch('INVENIO_REDIS_HOST','192.168.50.12')
@@ -64,6 +67,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "elasticsearch" do |elasticsearch|
     elasticsearch.vm.box = OS
+    elasticsearch.vm.hostname = 'elasticsearch'
     elasticsearch.vm.provision "file", source: ".inveniorc", destination: ".inveniorc"
     elasticsearch.vm.provision "shell", inline: "source .inveniorc && /vagrant/scripts/provision-elasticsearch.sh", privileged: false
     elasticsearch.vm.network "private_network", ip: ENV.fetch('INVENIO_ELASTICSEARCH_HOST','192.168.50.13')
@@ -71,6 +75,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "rabbitmq" do |rabbitmq|
     rabbitmq.vm.box = OS
+    rabbitmq.vm.hostname = 'rabbitmq'
     rabbitmq.vm.provision "file", source: ".inveniorc", destination: ".inveniorc"
     rabbitmq.vm.provision "shell", inline: "source .inveniorc && /vagrant/scripts/provision-rabbitmq.sh", privileged: false
     rabbitmq.vm.network "private_network", ip: ENV.fetch('INVENIO_RABBITMQ_HOST','192.168.50.14')
@@ -78,6 +83,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "worker" do |worker|
     worker.vm.box = OS
+    worker.vm.hostname = 'worker'
     worker.vm.provision "file", source: ".inveniorc", destination: ".inveniorc"
     worker.vm.provision "shell", inline: "source .inveniorc && /vagrant/scripts/provision-worker.sh", privileged: false
     worker.vm.network "private_network", ip: ENV.fetch('INVENIO_WORKER_HOST','192.168.50.15')

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -104,9 +104,11 @@ set -o errexit
 set -o nounset
 
 # sphinxdoc-install-invenio-full-begin
-# FIXME we need to install PostgreSQL DB connect option explicitly
-# (for Invenio versions less than v3.0.0a3)
-pip install invenio-db[postgresql]
+# FIXME needed for invenio-search
+pip install requests
+# FIXME next two commands needed only for invenio<v3.0.0a3
+pip install invenio-db[postgresql] --pre
+pip install invenio-search --pre
 # now we can install full Invenio:
 pip install invenio[full] --pre
 # sphinxdoc-install-invenio-full-end
@@ -124,6 +126,9 @@ echo "# Redis" >> ../var/${INVENIO_WEB_INSTANCE}-instance/${INVENIO_WEB_INSTANCE
 echo "CACHE_REDIS_HOST='${INVENIO_REDIS_HOST}'" >> ../var/${INVENIO_WEB_INSTANCE}-instance/${INVENIO_WEB_INSTANCE}.cfg
 echo "BROKER_URL='redis://${INVENIO_REDIS_HOST}:6379/0'" >> ../var/${INVENIO_WEB_INSTANCE}-instance/${INVENIO_WEB_INSTANCE}.cfg
 echo "CELERY_RESULT_BACKEND='redis://${INVENIO_REDIS_HOST}:6379/1'" >> ../var/${INVENIO_WEB_INSTANCE}-instance/${INVENIO_WEB_INSTANCE}.cfg
+echo "" >> ../var/${INVENIO_WEB_INSTANCE}-instance/${INVENIO_WEB_INSTANCE}.cfg
+echo "# Elasticsearch" >> ../var/${INVENIO_WEB_INSTANCE}-instance/${INVENIO_WEB_INSTANCE}.cfg
+echo "SEARCH_ELASTIC_HOSTS='${INVENIO_ELASTICSEARCH_HOST}'" >> ../var/${INVENIO_WEB_INSTANCE}-instance/${INVENIO_WEB_INSTANCE}.cfg
 # sphinxdoc-customise-instance-end
 
 # sphinxdoc-run-npm-begin

--- a/scripts/provision-elasticsearch.sh
+++ b/scripts/provision-elasticsearch.sh
@@ -53,7 +53,18 @@ provision_elasticsearch_ubuntu_trusty () {
     sudo DEBIAN_FRONTEND=noninteractive apt-get -y install \
          elasticsearch \
          openjdk-7-jre
+
+    # allow network connections:
+    if ! sudo grep -q "network.host: ${INVENIO_ELASTICSEARCH_HOST}" \
+         /etc/elasticsearch/elasticsearch.yml; then
+        echo "network.host: ${INVENIO_ELASTICSEARCH_HOST}" | \
+            sudo tee -a /etc/elasticsearch/elasticsearch.yml
+    fi
+
+    # enable Elasticsearch upon reboot:
     sudo update-rc.d elasticsearch defaults 95 10
+
+    # start Elasticsearch:
     sudo /etc/init.d/elasticsearch restart
     # sphinxdoc-install-elasticsearch-trusty-end
 
@@ -84,8 +95,11 @@ enabled=1" | \
          java
 
     # allow network connections:
-    echo "network.host: ${INVENIO_ELASTICSEARCH_HOST}" | \
-        sudo tee -a /etc/elasticsearch/elasticsearch.yml
+    if ! sudo grep -q "network.host: ${INVENIO_ELASTICSEARCH_HOST}" \
+         /etc/elasticsearch/elasticsearch.yml; then
+        echo "network.host: ${INVENIO_ELASTICSEARCH_HOST}" | \
+            sudo tee -a /etc/elasticsearch/elasticsearch.yml
+    fi
 
     # open firewall ports:
     if firewall-cmd --state | grep -q running; then

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,9 @@ extras_require = {
         'invenio-records-ui>=1.0.0a1,<1.1.0',
         'invenio-records-rest>=1.0.0a2,<1.1.0',
     ],
+    'search': [
+        'invenio-search>=1.0.0a1,<1.1.0',
+    ],
     'theme': [
         'invenio-assets>=1.0.0a1,<1.1.0',
         'invenio-theme>=1.0.0a3,<1.1.0',
@@ -83,7 +86,7 @@ extras_require = {
 #
 aliases = {
     'minimal': ['accounts', 'theme', 'utils', ],
-    'full': ['accounts', 'records', 'theme', 'utils', ],
+    'full': ['accounts', 'records', 'search', 'theme', 'utils'],
 }
 
 for name, requires in aliases.items():


### PR DESCRIPTION
* BETTER Amends installation scripts and documentation to use the
  recently released `Invenio-Search` module providing record indexing in
  Elasticsearch.

* Completes Elasticsearch host provisioning script to allow network
  connections.

* Gives all Vagrant boxes explicit names to ease orientation.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>