### PR TITLE
installation: latest base package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,9 +99,10 @@ Public Licence (GPL).  It is provided on an "as is" basis, in the hope
 that it will be useful, but without any warranty.  There is a
 possibility to get commercial support in case of interest.
 
-Invenio runs on Unix-like systems and requires MySQL database server
-and Apache/Python web application server.  Please consult the INSTALL
-file for more information.
+Invenio runs on Unix-like systems and requires Python/Flask web application
+server, MySQL, PostgreSQL or SQLite database server, Elasticsearch for
+information retrieval and Redis for caching. Please consult the INSTALL file for
+more information.
 
 Happy hacking and thanks for flying Invenio.
 

--- a/docs/installation/installation-detailed.rst
+++ b/docs/installation/installation-detailed.rst
@@ -421,9 +421,17 @@ We can now create a new Invenio instance:
    :end-before: # sphinxdoc-create-instance-end
    :literal:
 
+We can now install the newly created instance by means of provided ``setup.py``
+script:
+
+.. include:: ../../scripts/install.sh
+   :start-after: # sphinxdoc-install-instance-begin
+   :end-before: # sphinxdoc-install-instance-end
+   :literal:
+
 Let's briefly customise our instance with respect to the location of the
-database server, the Redis server, and all the other dependent services in our
-multi-server environment:
+database server, the Redis server, the Elasticsearch server, and all the other
+dependent services in our multi-server environment:
 
 .. include:: ../../scripts/install.sh
    :start-after: # sphinxdoc-customise-instance-begin

--- a/scripts/provision-postgresql.sh
+++ b/scripts/provision-postgresql.sh
@@ -76,6 +76,13 @@ provision_postgresql_ubuntu_trusty () {
             sudo tee -a /etc/postgresql/9.3/main/pg_hba.conf
     fi
 
+    # grant database creation rights via SQLAlchemy-Utils:
+    if ! sudo grep -q host.*template1.*${INVENIO_POSTGRESQL_DBUSER} \
+         /etc/postgresql/9.3/main/pg_hba.conf; then
+        echo "host template1 ${INVENIO_POSTGRESQL_DBUSER} ${INVENIO_WEB_HOST}/32 md5" | \
+            sudo tee -a /etc/postgresql/9.3/main/pg_hba.conf
+    fi
+
     # restart PostgreSQL server:
     sudo /etc/init.d/postgresql restart
     # sphinxdoc-install-postgresql-trusty-end
@@ -107,6 +114,13 @@ provision_postgresql_centos7 () {
     if ! sudo grep -q host.*${INVENIO_POSTGRESQL_DBNAME}.*${INVENIO_POSTGRESQL_DBUSER} \
          /var/lib/pgsql/data/pg_hba.conf; then
         echo "host ${INVENIO_POSTGRESQL_DBNAME} ${INVENIO_POSTGRESQL_DBUSER} ${INVENIO_WEB_HOST}/32 md5" | \
+            sudo tee -a /var/lib/pgsql/data/pg_hba.conf
+    fi
+
+    # grant database creation rights via SQLAlchemy-Utils:
+    if ! sudo grep -q host.*template1.*${INVENIO_POSTGRESQL_DBUSER} \
+         /var/lib/pgsql/data/pg_hba.conf; then
+        echo "host template1 ${INVENIO_POSTGRESQL_DBUSER} ${INVENIO_WEB_HOST}/32 md5" | \
             sudo tee -a /var/lib/pgsql/data/pg_hba.conf
     fi
 

--- a/setup.py
+++ b/setup.py
@@ -44,16 +44,19 @@ tests_require = [
     'pytest>=2.8.0',
 ]
 
-invenio_db_version = '>=1.0.0a5,<1.1.0'
+invenio_db_version = '>=1.0.0a7,<1.1.0'
 
 extras_require = {
+    'access': [
+        'invenio-access>=1.0.0a2,<1.1.0',
+    ],
     'accounts': [
         'invenio-accounts>=1.0.0a2,<1.1.0',
     ],
     'records': [
         'invenio-pidstore>=1.0.0a1,<1.1.0',
-        'invenio-records>=1.0.0a3,<1.1.0',
-        'invenio-records-ui>=1.0.0a1,<1.1.0',
+        'invenio-records>=1.0.0a8,<1.1.0',
+        'invenio-records-ui>=1.0.0a4,<1.1.0',
         'invenio-records-rest>=1.0.0a2,<1.1.0',
     ],
     'search': [
@@ -61,7 +64,7 @@ extras_require = {
     ],
     'theme': [
         'invenio-assets>=1.0.0a1,<1.1.0',
-        'invenio-theme>=1.0.0a3,<1.1.0',
+        'invenio-theme>=1.0.0a6,<1.1.0',
     ],
     'utils': [
         'invenio-mail>=1.0.0a1,<1.1.0',
@@ -86,7 +89,7 @@ extras_require = {
 #
 aliases = {
     'minimal': ['accounts', 'theme', 'utils', ],
-    'full': ['accounts', 'records', 'search', 'theme', 'utils'],
+    'full': ['access', 'accounts', 'records', 'search', 'theme', 'utils'],
 }
 
 for name, requires in aliases.items():


### PR DESCRIPTION
* BETTER Amends installation scripts and documentation to use the
  recently released `Invenio-Base` package where `manage.py` was removed
  in profit of `setup.py`. (closes #3572)

* Amends README file to mention PostgreSQL and SQLite alongsite MySQL in
  the list of supported databases.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>