### PR TITLE
installation: node provisioning cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 # Use Python-2.7:
-FROM python:2.7
+FROM python:2.7-slim
 
 # Add Invenio sources to `code` and work there:
 WORKDIR /code

--- a/docs/installation/installation-detailed.rst
+++ b/docs/installation/installation-detailed.rst
@@ -214,14 +214,30 @@ associated CSS/JS filter tools. Let's do it globally:
    :end-before: # sphinxdoc-install-npm-and-css-js-filters-end
    :literal:
 
-Finally, we'll install Python virtual environment wrapper tools and activate
-them in the current user shell process:
+Sixth, we'll install Python virtual environment wrapper tools and activate them
+in the current user shell process:
 
 * on either of the operating systems:
 
 .. include:: ../../scripts/provision-web.sh
    :start-after: # sphinxdoc-install-virtualenvwrapper-begin
    :end-before: # sphinxdoc-install-virtualenvwrapper-end
+   :literal:
+
+Finally, let's clean after ourselves:
+
+* on Ubuntu 14.04 LTS (Trusty Tahr):
+
+.. include:: ../../scripts/provision-web.sh
+   :start-after: # sphinxdoc-install-web-cleanup-trusty-begin
+   :end-before: # sphinxdoc-install-web-cleanup-trusty-end
+   :literal:
+
+* on CentOS7:
+
+.. include:: ../../scripts/provision-web.sh
+   :start-after: # sphinxdoc-install-web-cleanup-centos7-begin
+   :end-before: # sphinxdoc-install-web-cleanup-centos7-end
    :literal:
 
 Database
@@ -268,6 +284,22 @@ the new database:
    :end-before: # sphinxdoc-setup-postgresql-access-end
    :literal:
 
+Finally, let's clean after ourselves:
+
+* on Ubuntu 14.04 LTS (Trusty Tahr):
+
+.. include:: ../../scripts/provision-postgresql.sh
+   :start-after: # sphinxdoc-install-postgresql-cleanup-trusty-begin
+   :end-before: # sphinxdoc-install-postgresql-cleanup-trusty-end
+   :literal:
+
+* on CentOS7:
+
+.. include:: ../../scripts/provision-postgresql.sh
+   :start-after: # sphinxdoc-install-postgresql-cleanup-centos7-begin
+   :end-before: # sphinxdoc-install-postgresql-cleanup-centos7-end
+   :literal:
+
 Redis
 -----
 
@@ -295,6 +327,22 @@ Let's see in detail what the Redis provisioning script does.
 .. include:: ../../scripts/provision-redis.sh
    :start-after: # sphinxdoc-install-redis-centos7-begin
    :end-before: # sphinxdoc-install-redis-centos7-end
+   :literal:
+
+Finally, let's clean after ourselves:
+
+* on Ubuntu 14.04 LTS (Trusty Tahr):
+
+.. include:: ../../scripts/provision-redis.sh
+   :start-after: # sphinxdoc-install-redis-cleanup-trusty-begin
+   :end-before: # sphinxdoc-install-redis-cleanup-trusty-end
+   :literal:
+
+* on CentOS7:
+
+.. include:: ../../scripts/provision-redis.sh
+   :start-after: # sphinxdoc-install-redis-cleanup-centos7-begin
+   :end-before: # sphinxdoc-install-redis-cleanup-centos7-end
    :literal:
 
 Elasticsearch
@@ -328,6 +376,22 @@ Let's see in detail what the Elasticsearch provisioning script does.
    :end-before: # sphinxdoc-install-elasticsearch-centos7-end
    :literal:
 
+Finally, let's clean after ourselves:
+
+* on Ubuntu 14.04 LTS (Trusty Tahr):
+
+.. include:: ../../scripts/provision-elasticsearch.sh
+   :start-after: # sphinxdoc-install-elasticsearch-cleanup-trusty-begin
+   :end-before: # sphinxdoc-install-elasticsearch-cleanup-trusty-end
+   :literal:
+
+* on CentOS7:
+
+.. include:: ../../scripts/provision-elasticsearch.sh
+   :start-after: # sphinxdoc-install-elasticsearch-cleanup-centos7-begin
+   :end-before: # sphinxdoc-install-elasticsearch-cleanup-centos7-end
+   :literal:
+
 RabbitMQ
 --------
 
@@ -355,6 +419,22 @@ Let's see in detail what the RabbitMQ provisioning script does.
 .. include:: ../../scripts/provision-rabbitmq.sh
    :start-after: # sphinxdoc-install-rabbitmq-centos7-begin
    :end-before: # sphinxdoc-install-rabbitmq-centos7-end
+   :literal:
+
+Finally, let's clean after ourselves:
+
+* on Ubuntu 14.04 LTS (Trusty Tahr):
+
+.. include:: ../../scripts/provision-rabbitmq.sh
+   :start-after: # sphinxdoc-install-rabbitmq-cleanup-trusty-begin
+   :end-before: # sphinxdoc-install-rabbitmq-cleanup-trusty-end
+   :literal:
+
+* on CentOS7:
+
+.. include:: ../../scripts/provision-rabbitmq.sh
+   :start-after: # sphinxdoc-install-rabbitmq-cleanup-centos7-begin
+   :end-before: # sphinxdoc-install-rabbitmq-cleanup-centos7-end
    :literal:
 
 Worker
@@ -385,6 +465,22 @@ Let's see in detail what the worker provisioning script does.
 .. include:: ../../scripts/provision-worker.sh
    :start-after: # sphinxdoc-install-worker-centos7-begin
    :end-before: # sphinxdoc-install-worker-centos7-end
+   :literal:
+
+Finally, let's clean after ourselves:
+
+* on Ubuntu 14.04 LTS (Trusty Tahr):
+
+.. include:: ../../scripts/provision-worker.sh
+   :start-after: # sphinxdoc-install-worker-cleanup-trusty-begin
+   :end-before: # sphinxdoc-install-worker-cleanup-trusty-end
+   :literal:
+
+* on CentOS7:
+
+.. include:: ../../scripts/provision-worker.sh
+   :start-after: # sphinxdoc-install-worker-cleanup-centos7-begin
+   :end-before: # sphinxdoc-install-worker-cleanup-centos7-end
    :literal:
 
 Invenio

--- a/scripts/provision-elasticsearch.sh
+++ b/scripts/provision-elasticsearch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -118,6 +118,18 @@ enabled=1" | \
 
 }
 
+cleanup_elasticsearch_ubuntu_trusty () {
+    # sphinxdoc-install-elasticsearch-cleanup-trusty-begin
+    sudo apt-get -y autoremove && sudo apt-get -y clean
+    # sphinxdoc-install-elasticsearch-cleanup-trusty-end
+}
+
+cleanup_elasticsearch_centos7 () {
+    # sphinxdoc-install-elasticsearch-cleanup-centos7-begin
+    sudo yum clean -y all
+    # sphinxdoc-install-elasticsearch-cleanup-centos7-end
+}
+
 main () {
 
     # detect OS distribution and release version:
@@ -136,6 +148,7 @@ main () {
     if [ "$os_distribution" = "Ubuntu" ]; then
         if [ "$os_release" = "14.04" ]; then
             provision_elasticsearch_ubuntu_trusty
+            cleanup_elasticsearch_ubuntu_trusty
         else
             echo "[ERROR] Sorry, unsupported release ${os_release}."
             exit 1
@@ -143,6 +156,7 @@ main () {
     elif [ "$os_distribution" = "CentOS" ]; then
         if [ "$os_release" = "7" ]; then
             provision_elasticsearch_centos7
+            cleanup_elasticsearch_centos7
         else
             echo "[ERROR] Sorry, unsupported release ${os_release}."
             exit 1

--- a/scripts/provision-postgresql.sh
+++ b/scripts/provision-postgresql.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -142,6 +142,18 @@ provision_postgresql_centos7 () {
 
 }
 
+cleanup_postgresql_ubuntu_trusty () {
+    # sphinxdoc-install-postgresql-cleanup-trusty-begin
+    sudo apt-get -y autoremove && sudo apt-get -y clean
+    # sphinxdoc-install-postgresql-cleanup-trusty-end
+}
+
+cleanup_postgresql_centos7 () {
+    # sphinxdoc-install-postgresql-cleanup-centos7-begin
+    sudo yum clean -y all
+    # sphinxdoc-install-postgresql-cleanup-centos7-end
+}
+
 setup_db () {
 
     # sphinxdoc-setup-postgresql-access-begin
@@ -181,6 +193,7 @@ main () {
     if [ "$os_distribution" = "Ubuntu" ]; then
         if [ "$os_release" = "14.04" ]; then
             provision_postgresql_ubuntu_trusty
+            cleanup_postgresql_ubuntu_trusty
         else
             echo "[ERROR] Sorry, unsupported release ${os_release}."
             exit 1
@@ -188,6 +201,7 @@ main () {
     elif [ "$os_distribution" = "CentOS" ]; then
         if [ "$os_release" = "7" ]; then
             provision_postgresql_centos7
+            cleanup_postgresql_centos7
         else
             echo "[ERROR] Sorry, unsupported release ${os_release}."
             exit 1

--- a/scripts/provision-rabbitmq.sh
+++ b/scripts/provision-rabbitmq.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -79,6 +79,18 @@ setup_firewall_redis_centos7 () {
     # sphinxdoc-setup-firewall-redis-centos7-end
 }
 
+cleanup_rabbitmq_ubuntu_trusty () {
+    # sphinxdoc-install-rabbitmq-cleanup-trusty-begin
+    sudo apt-get -y autoremove && sudo apt-get -y clean
+    # sphinxdoc-install-rabbitmq-cleanup-trusty-end
+}
+
+cleanup_rabbitmq_centos7 () {
+    # sphinxdoc-install-rabbitmq-cleanup-centos7-begin
+    sudo yum clean -y all
+    # sphinxdoc-install-rabbitmq-cleanup-centos7-end
+}
+
 main () {
 
     # detect OS distribution and release version:
@@ -97,6 +109,7 @@ main () {
     if [ "$os_distribution" = "Ubuntu" ]; then
         if [ "$os_release" = "14.04" ]; then
             provision_rabbitmq_ubuntu_trusty
+            cleanup_rabbitmq_ubuntu_trusty
         else
             echo "[ERROR] Sorry, unsupported release ${os_release}."
             exit 1
@@ -104,6 +117,7 @@ main () {
     elif [ "$os_distribution" = "CentOS" ]; then
         if [ "$os_release" = "7" ]; then
             provision_rabbitmq_centos7
+            cleanup_rabbitmq_centos7
         else
             echo "[ERROR] Sorry, unsupported release ${os_release}."
             exit 1

--- a/scripts/provision-redis.sh
+++ b/scripts/provision-redis.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -91,6 +91,18 @@ provision_redis_centos7 () {
 
 }
 
+cleanup_redis_ubuntu_trusty () {
+    # sphinxdoc-install-redis-cleanup-trusty-begin
+    sudo apt-get -y autoremove && sudo apt-get -y clean
+    # sphinxdoc-install-redis-cleanup-trusty-end
+}
+
+cleanup_redis_centos7 () {
+    # sphinxdoc-install-redis-cleanup-centos7-begin
+    sudo yum clean -y all
+    # sphinxdoc-install-redis-cleanup-centos7-end
+}
+
 main () {
 
     # detect OS distribution and release version:
@@ -109,6 +121,7 @@ main () {
     if [ "$os_distribution" = "Ubuntu" ]; then
         if [ "$os_release" = "14.04" ]; then
             provision_redis_ubuntu_trusty
+            cleanup_redis_ubuntu_trusty
         else
             echo "[ERROR] Sorry, unsupported release ${os_release}."
             exit 1
@@ -116,6 +129,7 @@ main () {
     elif [ "$os_distribution" = "CentOS" ]; then
         if [ "$os_release" = "7" ]; then
             provision_redis_centos7
+            cleanup_redis_centos7
         else
             echo "[ERROR] Sorry, unsupported release ${os_release}."
             exit 1

--- a/scripts/provision-web.sh
+++ b/scripts/provision-web.sh
@@ -165,6 +165,18 @@ setup_virtualenvwrapper () {
 
 }
 
+cleanup_web_ubuntu_trusty () {
+    # sphinxdoc-install-web-cleanup-trusty-begin
+    $sudo apt-get -y autoremove && $sudo apt-get -y clean
+    # sphinxdoc-install-web-cleanup-trusty-end
+}
+
+cleanup_web_centos7 () {
+    # sphinxdoc-install-web-cleanup-centos7-begin
+    $sudo yum clean -y all
+    # sphinxdoc-install-web-cleanup-centos7-end
+}
+
 main () {
 
     # detect OS distribution and release version:
@@ -184,10 +196,16 @@ main () {
         # running inside Docker
         provision_web_common_ubuntu_trusty
         provision_web_libpostgresql_ubuntu_trusty
+        setup_npm_and_css_js_filters
+        setup_virtualenvwrapper
+        cleanup_web_ubuntu_trusty
     elif [ "$os_distribution" = "Ubuntu" ]; then
         if [ "$os_release" = "14.04" ]; then
             provision_web_common_ubuntu_trusty
             provision_web_libpostgresql_ubuntu_trusty
+            setup_npm_and_css_js_filters
+            setup_virtualenvwrapper
+            cleanup_web_ubuntu_trusty
         else
             echo "[ERROR] Sorry, unsupported release ${os_release}."
             exit 1
@@ -196,6 +214,9 @@ main () {
         if [ "$os_release" = "7" ]; then
             provision_web_common_centos7
             provision_web_libpostgresql_centos7
+            setup_npm_and_css_js_filters
+            setup_virtualenvwrapper
+            cleanup_web_centos7
         else
             echo "[ERROR] Sorry, unsupported release ${os_release}."
             exit 1
@@ -204,10 +225,6 @@ main () {
         echo "[ERROR] Sorry, unsupported distribution ${os_distribution}."
         exit 1
     fi
-
-    # finish with common setups:
-    setup_npm_and_css_js_filters
-    setup_virtualenvwrapper
 
 }
 

--- a/scripts/provision-worker.sh
+++ b/scripts/provision-worker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -44,6 +44,18 @@ provision_worker_centos7 () {
 
 }
 
+cleanup_worker_ubuntu_trusty () {
+    # sphinxdoc-install-worker-cleanup-trusty-begin
+    sudo apt-get -y autoremove && sudo apt-get -y clean
+    # sphinxdoc-install-worker-cleanup-trusty-end
+}
+
+cleanup_worker_centos7 () {
+    # sphinxdoc-install-worker-cleanup-centos7-begin
+    sudo yum clean -y all
+    # sphinxdoc-install-worker-cleanup-centos7-end
+}
+
 main () {
 
     # detect OS distribution and release version:
@@ -62,6 +74,7 @@ main () {
     if [ "$os_distribution" = "Ubuntu" ]; then
         if [ "$os_release" = "14.04" ]; then
             provision_worker_ubuntu_trusty
+            cleanup_worker_ubuntu_trusty
         else
             echo "[ERROR] Sorry, unsupported release ${os_release}."
             exit 1
@@ -69,6 +82,7 @@ main () {
     elif [ "$os_distribution" = "CentOS" ]; then
         if [ "$os_release" = "7" ]; then
             provision_worker_centos7
+            cleanup_worker_centos7
         else
             echo "[ERROR] Sorry, unsupported release ${os_release}."
             exit 1


### PR DESCRIPTION
* Uses slim Python Docker image and cleans locally cached system
  packages that are no longer necessary after provisioning the nodes.
  Helps to reduce the size of virtual machines and of Docker containers.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>