### PR TITLE
docker: rabbitmq port exposure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ web:
     - elasticsearch
     - rabbitmq
   ports:
-    - "5000:5000"
+    - "127.0.0.1:5000:5000"
 
 postgresql:
   image: postgres
@@ -68,10 +68,11 @@ redis:
 elasticsearch:
   image: elasticsearch
   ports:
-    - "29200:9200"
-    - "29300:9300"
+    - "127.0.0.1:29200:9200"
+    - "127.0.0.1:29300:9300"
 
 rabbitmq:
   image: rabbitmq
   ports:
-    - "25672:5672"
+    - "127.0.0.1:24369:4369"
+    - "127.0.0.1:45672:25672"


### PR DESCRIPTION
* Amends RabbitMQ Docker container's port exposure to use the higher
   port (by adding 20000 to the usual port), so that one can run
   docker-based installation alongside OS-based installation without
   having to shutting down any locally installed system services.
    
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
