### PR TITLE
BibCirculation: reset ILL overdue_letter_number

### DIFF
--- a/modules/bibcirculation/lib/bibcirculation_dblayer.py
+++ b/modules/bibcirculation/lib/bibcirculation_dblayer.py
@@ -2700,6 +2700,11 @@ def get_purchase_request_borrower_details(ill_request_id):
     else:
         return None
 
+def update_ill_request_letter_number(ill_request_id, overdue_letter_number):
+    query = ('UPDATE crcILLREQUEST set overdue_letter_number={0} '
+             'where id="{1}"')
+    run_sql(query.format(overdue_letter_number, ill_request_id))
+
 def update_ill_request(ill_request_id, library_id, request_date,
                        expected_date, arrival_date, due_date, return_date,
                        status, cost, barcode, library_notes):


### PR DESCRIPTION
- A ILL is currently extended by manually updating the _due_date_ of
  that ILL, this leads to the following issue:
  A user receives an ILL recall letter, therefore gets the ILL extended
  at the library.
  The next ILL recall letter will be of the second category, since the
  _overdue_letter_number_ never gets reseted.
- Introduces the new function _update_ill_request_letter_number_
- Changes the _overdue_letter_number_ in case the updated due_date is a
  later date than the current due_date in
  _ill_request_details_step2_.

Signed-off-by: Martin Vesper martin.vesper@cern.ch
