### PR TITLE
installation: docker-machine friendly instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,4 @@ RUN echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
 RUN echo "workon invenio3" >> ~/.bashrc
 
 # Start the Invenio application:
-CMD ["/bin/bash", "-c", "invenio3 --debug run -h 0.0.0.0"]
+CMD ["/bin/bash", "-c", "invenio3 run -h 0.0.0.0"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -37,6 +37,7 @@ include .inveniorc
 include Vagrantfile
 include docker-compose.yml
 include Dockerfile
+include nginx/Dockerfile
 
 include *.rst
 include *.sh
@@ -62,3 +63,4 @@ recursive-include misc *.py
 recursive-include misc *.rst
 recursive-include scripts *.sh
 recursive-include tests *.py
+recursive-include nginx *.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,9 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 web:
+  restart: "always"
   build: .
-  command: /bin/bash -c "invenio3 --debug run -h 0.0.0.0"
+  command: /bin/bash -c "invenio3 run -h 0.0.0.0"
   environment:
     - PATH=/home/invenio/.virtualenvs/invenio3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     - VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python
@@ -41,8 +42,8 @@ web:
     - INVENIO_ELASTICSEARCH_HOST=elasticsearch
     - INVENIO_RABBITMQ_HOST=rabbitmq
     - INVENIO_WORKER_HOST=127.0.0.1
-  volumes:
-    - .:/code
+  volumes_from:
+    - static
   links:
     - postgresql
     - redis
@@ -52,6 +53,7 @@ web:
     - "5000:5000"
 
 postgresql:
+  restart: "always"
   image: postgres
   environment:
     - POSTGRES_USER=invenio3
@@ -61,18 +63,39 @@ postgresql:
     - "25432:5432"
 
 redis:
+  restart: "always"
   image: redis
   ports:
     - "26379:6379"
 
 elasticsearch:
+  restart: "always"
   image: elasticsearch
   ports:
     - "29200:9200"
     - "29300:9300"
 
 rabbitmq:
+  restart: "always"
   image: rabbitmq
   ports:
     - "24369:4369"
     - "45672:25672"
+
+nginx:
+  restart: "always"
+  build: ./nginx
+  ports:
+    - "80:80"
+  volumes_from:
+    - static
+  links:
+    - web
+
+static:
+  restart: "no"
+  build: .
+  volumes:
+    - /home/invenio/.virtualenvs/invenio3/var/invenio3-instance/static
+    - /home/invenio/.virtualenvs/invenio3/src/invenio-theme/invenio_theme/static
+  user: invenio

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+FROM nginx
+RUN rm /etc/nginx/conf.d/default.conf
+ADD invenio3.conf /etc/nginx/conf.d/

--- a/nginx/invenio3.conf
+++ b/nginx/invenio3.conf
@@ -1,0 +1,23 @@
+server {
+
+    listen 80;
+    server_name localhost;
+    charset utf-8;
+
+    location /static {
+        root /home/invenio/.virtualenvs/invenio3/var/invenio3-instance;
+    }
+
+    location / {
+        proxy_pass http://web:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+}

--- a/scripts/start-instance.sh
+++ b/scripts/start-instance.sh
@@ -100,5 +100,5 @@ set -o errexit
 set -o nounset
 
 # sphinxdoc-start-application-begin
-${INVENIO_WEB_INSTANCE} --debug run -h 0.0.0.0 &
+${INVENIO_WEB_INSTANCE} run -h 0.0.0.0 &
 # sphinxdoc-start-application-end


### PR DESCRIPTION
* Amends Docker installations instructions to be both GNU/Linux native
  friendly and remote docker-machine VM friendly. (closes #3595)

* Adds Nginx front-end support for static files.

* Removes `--debug` flag when starting the Invenio instance.

* Adds temporary fix for `SQLAlchemy-Utils` on Ubuntu 14.04 that is
  encountered also on Docker images.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>