### PR TITLE
OAIRepository: CFG_OAI_METADATA_FORMATS fix

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -662,8 +662,8 @@ CFG_OAI_SLEEP = 2
 ## CFG_OAI_METADATA_FORMATS -- mapping between accepted metadataPrefixes and
 ## the corresponding output format to use, its schema and its metadataNamespace.
 CFG_OAI_METADATA_FORMATS = {
-    'marcxml': ('XOAIMARC', 'http://www.openarchives.org/OAI/1.1/dc.xsd', 'http://purl.org/dc/elements/1.1/'),
-    'oai_dc': ('XOAIDC', 'http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd', 'http://www.loc.gov/MARC21/slim'),
+    'marcxml': ('XOAIMARC', 'http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd', 'http://www.loc.gov/MARC21/slim'),
+    'oai_dc': ('XOAIDC', 'http://www.openarchives.org/OAI/1.1/dc.xsd', 'http://purl.org/dc/elements/1.1/'),
     }
 
 ## CFG_OAI_FRIENDS -- list of OAI baseURL of friend repositories. See:


### PR DESCRIPTION
* FIX Fixes default configuration of CFG_OAI_METADATA_FORMATS,
  correctly assigning the XSD and XML namespace to the corresponding
  metadata prefix.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>