### PR TITLE
websearch: advanced search and exact match

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -412,12 +412,12 @@ CFG_WEBSTYLE_REVERSE_PROXY_IPS =
 # often during the runtime.  (Note that you may modify them
 # afterwards too, though.)
 
-# CFG_WEBSEARCH_ADVANCED_SEARCH_EXACT_MATCH -- tells if the advanced
-# search should do an exact match or use the parentheses behavior (adds
-# the possibility to do boolean operation in parentheses).
-# Note that the boolean operations can always be done thanks to the form
-# in the UI.
-CFG_WEBSEARCH_ADVANCED_SEARCH_EXACT_MATCH = False
+# CFG_WEBSEARCH_ADVANCED_SEARCH_PREFER_MATCHING_TYPE -- tells if the
+# advanced search engine should prefer the matching type selected by
+# the user rather than the Boolean query typed by the user.
+# Note that the boolean operations can always be done thanks to the
+# form in the UI.
+CFG_WEBSEARCH_ADVANCED_SEARCH_PREFER_MATCHING_TYPE = False
 
 # CFG_WEBSEARCH_SEARCH_CACHE_SIZE -- how many queries we want to
 # cache in memory per one Apache httpd process?  This cache is used

--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -412,6 +412,13 @@ CFG_WEBSTYLE_REVERSE_PROXY_IPS =
 # often during the runtime.  (Note that you may modify them
 # afterwards too, though.)
 
+# CFG_WEBSEARCH_ADVANCED_SEARCH_EXACT_MATCH -- tells if the advanced
+# search should do an exact match or use the parentheses behavior (adds
+# the possibility to do boolean operation in parentheses).
+# Note that the boolean operations can always be done thanks to the form
+# in the UI.
+CFG_WEBSEARCH_ADVANCED_SEARCH_EXACT_MATCH = False
+
 # CFG_WEBSEARCH_SEARCH_CACHE_SIZE -- how many queries we want to
 # cache in memory per one Apache httpd process?  This cache is used
 # mainly for "next/previous page" functionality, but it caches also

--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -57,7 +57,6 @@ from invenio.config import \
      CFG_SCOAP3_SITE, \
      CFG_OAI_ID_FIELD, \
      CFG_WEBCOMMENT_ALLOW_REVIEWS, \
-     CFG_WEBSEARCH_ADVANCED_SEARCH_EXACT_MATCH, \
      CFG_WEBSEARCH_CALL_BIBFORMAT, \
      CFG_WEBSEARCH_CREATE_SIMILARLY_NAMED_AUTHORS_LINK_BOX, \
      CFG_WEBSEARCH_FIELDS_CONVERT, \
@@ -91,6 +90,11 @@ from invenio.config import \
      CFG_BASE_URL, \
      CFG_WEBSEARCH_MAX_RECORDS_REFERSTO, \
      CFG_WEBSEARCH_MAX_RECORDS_CITEDBY
+
+try:
+    from invenio.config import CFG_WEBSEARCH_ADVANCED_SEARCH_PREFER_MATCHING_TYPE
+except ImportError:
+    CFG_WEBSEARCH_ADVANCED_SEARCH_PREFER_MATCHING_TYPE = False
 
 from invenio.search_engine_config import \
      InvenioWebSearchUnknownCollectionError, \
@@ -6159,7 +6163,7 @@ def prs_advanced_search(results_in_any_collection, kwargs=None, req=None, of=Non
     len_results_p1 = 0
     len_results_p2 = 0
     len_results_p3 = 0
-    if CFG_WEBSEARCH_ADVANCED_SEARCH_EXACT_MATCH:
+    if CFG_WEBSEARCH_ADVANCED_SEARCH_PREFER_MATCHING_TYPE:
         search_function = search_pattern
     else:
         search_function = search_pattern_parenthesised

--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -57,6 +57,7 @@ from invenio.config import \
      CFG_SCOAP3_SITE, \
      CFG_OAI_ID_FIELD, \
      CFG_WEBCOMMENT_ALLOW_REVIEWS, \
+     CFG_WEBSEARCH_ADVANCED_SEARCH_EXACT_MATCH, \
      CFG_WEBSEARCH_CALL_BIBFORMAT, \
      CFG_WEBSEARCH_CREATE_SIMILARLY_NAMED_AUTHORS_LINK_BOX, \
      CFG_WEBSEARCH_FIELDS_CONVERT, \
@@ -6158,8 +6159,13 @@ def prs_advanced_search(results_in_any_collection, kwargs=None, req=None, of=Non
     len_results_p1 = 0
     len_results_p2 = 0
     len_results_p3 = 0
+    if CFG_WEBSEARCH_ADVANCED_SEARCH_EXACT_MATCH:
+        search_function = search_pattern
+    else:
+        search_function = search_pattern_parenthesised
+
     try:
-        results_in_any_collection.union_update(search_pattern_parenthesised(req, p1, f1, m1, ap=ap, of=of, verbose=verbose, ln=ln, wl=wl))
+        results_in_any_collection.union_update(search_function(req, p1, f1, m1, ap=ap, of=of, verbose=verbose, ln=ln, wl=wl))
         len_results_p1 = len(results_in_any_collection)
         if len_results_p1 == 0:
             if of.startswith("h"):
@@ -6171,7 +6177,7 @@ def prs_advanced_search(results_in_any_collection, kwargs=None, req=None, of=Non
                 print_records_epilogue(req, of)
             return page_end(req, of, ln, em)
         if p2:
-            results_tmp = search_pattern_parenthesised(req, p2, f2, m2, ap=ap, of=of, verbose=verbose, ln=ln, wl=wl)
+            results_tmp = search_function(req, p2, f2, m2, ap=ap, of=of, verbose=verbose, ln=ln, wl=wl)
             len_results_p2 = len(results_tmp)
             if op1 == "a": # add
                 results_in_any_collection.intersection_update(results_tmp)
@@ -6199,7 +6205,7 @@ def prs_advanced_search(results_in_any_collection, kwargs=None, req=None, of=Non
                     print_records_prologue(req, of)
                     print_records_epilogue(req, of)
         if p3:
-            results_tmp = search_pattern_parenthesised(req, p3, f3, m3, ap=ap, of=of, verbose=verbose, ln=ln, wl=wl)
+            results_tmp = search_function(req, p3, f3, m3, ap=ap, of=of, verbose=verbose, ln=ln, wl=wl)
             len_results_p3 = len(results_tmp)
             if op2 == "a": # add
                 results_in_any_collection.intersection_update(results_tmp)


### PR DESCRIPTION
Actually, when we do an advanced search, it doesn't really do an exact search even if we select the _"exact match"_. In fact, if we have parentheses with several words in it, it will try to parse it as a logical statement, like `(foo OR bar)`

Thus, if we have an author with a strange name like `organization (foo, bar)` and we do an exact search on it, we won't found any records. While doing the same search surrounded by quotes to force the exact search will work.

here, I propose to add a config variable to configure the advanced search. So, if `CFG_WEBSEARCH_ADVANCED_SEARCH_EXACT_MATCH` is `True`, it will use the default search function and not try to parse the parentheses.
