### PR TITLE
WebSession: silencing MySQL UTF-8 warnings

### DIFF
--- a/modules/websession/lib/session.py
+++ b/modules/websession/lib/session.py
@@ -239,7 +239,7 @@ class InvenioSession(dict):
                     %s
                 ) ON DUPLICATE KEY UPDATE
                     session_expiry=%s,
-                    session_object=%s,
+                    session_object=_binary %s,
                     uid=%s
             """, (session_key, session_expiry, session_object, uid,
                 session_expiry, session_object, uid))


### PR DESCRIPTION
* Silences one more MySQL UTF-8 warnings related to session object
  updating.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>