### PR TITLE
BibCatalog: no email tests when no SMTP server

### DIFF
--- a/modules/bibcatalog/lib/bibcatalog_system_email_unit_tests.py
+++ b/modules/bibcatalog/lib/bibcatalog_system_email_unit_tests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2008, 2009, 2010, 2011, 2013 CERN.
+# Copyright (C) 2008, 2009, 2010, 2011, 2013, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -22,61 +22,66 @@
 
 from invenio.testutils import InvenioTestCase
 
-from invenio.config import CFG_SITE_SUPPORT_EMAIL
+from invenio.config import CFG_SITE_SUPPORT_EMAIL, CFG_MISCUTIL_SMTP_PORT
 from invenio.testutils import make_test_suite, run_test_suite
 from invenio import bibcatalog_system_email
 
 
-class BibCatalogSystemEmailTest(InvenioTestCase):
-    """Testing of BibCatalog."""
+if CFG_MISCUTIL_SMTP_PORT:
+    class BibCatalogSystemEmailTest(InvenioTestCase):
+        """Testing of BibCatalog."""
 
-    def setUp(self):
-        self.email = bibcatalog_system_email.BibCatalogSystemEmail()
-        bibcatalog_system_email.CFG_BIBCATALOG_SYSTEM_TICKETS_EMAIL = CFG_SITE_SUPPORT_EMAIL
-        bibcatalog_system_email.CFG_BIBCATALOG_SYSTEM = 'EMAIL'
+        def setUp(self):
+            self.email = bibcatalog_system_email.BibCatalogSystemEmail()
+            bibcatalog_system_email.CFG_BIBCATALOG_SYSTEM_TICKETS_EMAIL = CFG_SITE_SUPPORT_EMAIL
+            bibcatalog_system_email.CFG_BIBCATALOG_SYSTEM = 'EMAIL'
+            pass
+
+        def tearDown(self):
+            pass
+
+
+        def test_email_ticket_search_exception_not_implemented(self):
+            """bibcatalog_system_email - execution raises NotImplementedError exception"""
+
+            self.assertRaises(NotImplementedError, self.email.ticket_search, 1)
+
+
+        def test_ticket_submit_via_email(self):
+            """bibcatalog_system_email - test creating ticket via email"""
+
+            # TODO: our return values are ticket id or none; check both cases
+            self.assertTrue(self.email.ticket_submit(subject="Issue with RT", text="The RT system is not as good as the email ticketing", owner='eduardo', priority=3, queue='TEST', requestor='Joeb', recordid=100))
+
+        def test_ticket_comment_via_email(self):
+            """bibcatalog_system_email - test commention on ticket via email"""
+
+            self.assertTrue(self.email.ticket_comment(uid=1, ticketid='d834bnklca', comment='Eduardo is commenting on ticket blah, blah, blah'))
+
+        def test_ticket_assign_via_email(self):
+            """bibcatalog_system_email - test commention on ticket via email"""
+
+            self.assertTrue(self.email.ticket_assign(uid=1, ticketid='d834bnklca', to_user='jrbl'))
+
+        def test_ticket_set_attribute_via_email(self):
+            """bibcatalog_system_email - test setting attribute on ticket via email"""
+
+            self.assertTrue(self.email.ticket_set_attribute(uid=1, ticketid='d834bnklca', attribute='priority', new_value='1'))
+
+        def test_ckeck_system(self):
+            """bibcatalog_system_email - check_system returns true if succesfull, a message otherwise"""
+
+            self.assertEqual(self.email.check_system(), '')
+
+
+        def test_ticket_get_info(self):
+            """bibcatalog_system_email - ticket_get_info raises NotImplementedError exception"""
+
+            self.assertRaises(NotImplementedError, self.email.ticket_get_info, uid=1, ticketid=0)
+else:
+    # SMTP server is not available. let's skip this test
+    class BibCatalogSystemEmailTest(InvenioTestCase):
         pass
-
-    def tearDown(self):
-        pass
-
-
-    def test_email_ticket_search_exception_not_implemented(self):
-        """bibcatalog_system_email - execution raises NotImplementedError exception"""
-
-        self.assertRaises(NotImplementedError, self.email.ticket_search, 1)
-
-
-    def test_ticket_submit_via_email(self):
-        """bibcatalog_system_email - test creating ticket via email"""
-
-        # TODO: our return values are ticket id or none; check both cases
-        self.assertTrue(self.email.ticket_submit(subject="Issue with RT", text="The RT system is not as good as the email ticketing", owner='eduardo', priority=3, queue='TEST', requestor='Joeb', recordid=100))
-
-    def test_ticket_comment_via_email(self):
-        """bibcatalog_system_email - test commention on ticket via email"""
-
-        self.assertTrue(self.email.ticket_comment(uid=1, ticketid='d834bnklca', comment='Eduardo is commenting on ticket blah, blah, blah'))
-
-    def test_ticket_assign_via_email(self):
-        """bibcatalog_system_email - test commention on ticket via email"""
-
-        self.assertTrue(self.email.ticket_assign(uid=1, ticketid='d834bnklca', to_user='jrbl'))
-
-    def test_ticket_set_attribute_via_email(self):
-        """bibcatalog_system_email - test setting attribute on ticket via email"""
-
-        self.assertTrue(self.email.ticket_set_attribute(uid=1, ticketid='d834bnklca', attribute='priority', new_value='1'))
-
-    def test_ckeck_system(self):
-        """bibcatalog_system_email - check_system returns true if succesfull, a message otherwise"""
-
-        self.assertEqual(self.email.check_system(), '')
-
-
-    def test_ticket_get_info(self):
-        """bibcatalog_system_email - ticket_get_info raises NotImplementedError exception"""
-
-        self.assertRaises(NotImplementedError, self.email.ticket_get_info, uid=1, ticketid=0)
 
 
 

--- a/scripts/provision-web.sh
+++ b/scripts/provision-web.sh
@@ -89,6 +89,7 @@ provision_web_ubuntu_precise () {
           pylint \
           python-dev \
           python-gnuplot \
+          python-h5py \
           python-libxml2 \
           python-libxslt1 \
           python-nose \
@@ -130,6 +131,7 @@ provision_web_centos6 () {
          gettext-devel \
          git \
          gnuplot-py \
+         h5py \
          hdf5-devel \
          ipython \
          libffi-devel \


### PR DESCRIPTION
* Skips running email test suite when the SMTP server is not available.
   Fixes four failed tests on Travis CI.
    
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>