### PR TITLE
installation: use of `/usr/sbin/service`

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -262,7 +262,7 @@ Contents
       $ sudo -u www-data /opt/invenio/bin/inveniocfg --create-tables
       $ sudo -u www-data /opt/invenio/bin/inveniocfg --load-webstat-conf
       $ sudo -u www-data /opt/invenio/bin/inveniocfg --create-apache-conf
-      $ sudo /etc/init.d/apache2 restart
+      $ sudo /usr/sbin/service apache2 restart
       $ sudo -u www-data /opt/invenio/bin/inveniocfg --create-demo-site
       $ sudo -u www-data /opt/invenio/bin/inveniocfg --load-demo-records
       $ sudo -u www-data /opt/invenio/bin/inveniocfg --run-unit-tests
@@ -634,7 +634,7 @@ Contents
           processes are not fully thread safe yet.  This may change in
           the future.
 
-      $ sudo /etc/init.d/apache2 restart
+      $ sudo /usr/sbin/service apache2 restart
 
           Please ask your webserver administrator to restart the
           Apache server after the above "httpd.conf" changes.

--- a/scripts/create-instance.sh
+++ b/scripts/create-instance.sh
@@ -112,7 +112,7 @@ create_apache_vhost_ubuntu_precise () {
     sudo /usr/sbin/a2enmod ssl
     sudo /usr/sbin/a2enmod version || echo "[WARNING] Ignoring 'a2enmod version' command; hoping IfVersion is built-in."
     sudo /usr/sbin/a2enmod xsendfile
-    sudo /etc/init.d/apache2 restart
+    sudo /usr/sbin/service apache2 restart
 }
 
 create_apache_vhost_centos6 () {
@@ -202,11 +202,11 @@ create_apache_configuration () {
 }
 
 restart_apache_ubuntu_precise () {
-    $sudo /etc/init.d/apache2 restart
+    $sudo /usr/sbin/service apache2 restart
 }
 
 restart_apache_centos6 () {
-    $sudo /etc/init.d/httpd restart
+    $sudo /sbin/service httpd restart
 }
 
 main () {

--- a/scripts/drop-instance.sh
+++ b/scripts/drop-instance.sh
@@ -74,19 +74,19 @@ fi
 
 
 start_apache_ubuntu_precise () {
-    $sudo /etc/init.d/apache2 start
+    $sudo /usr/sbin/service apache2 start
 }
 
 stop_apache_ubuntu_precise () {
-    $sudo /etc/init.d/apache2 stop
+    $sudo /usr/sbin/service apache2 stop
 }
 
 start_apache_centos6 () {
-    $sudo /etc/init.d/httpd start
+    $sudo /sbin/service httpd start
 }
 
 stop_apache_centos6 () {
-    $sudo /etc/init.d/httpd stop
+    $sudo /sbin/service httpd stop
 }
 
 drop_apache_vhost_ubuntu_precise () {

--- a/scripts/populate-instance.sh
+++ b/scripts/populate-instance.sh
@@ -63,19 +63,19 @@ apache_wsgi_restart () {
 }
 
 start_apache_ubuntu_precise () {
-    $sudo /etc/init.d/apache2 start
+    $sudo /usr/sbin/service apache2 start
 }
 
 stop_apache_ubuntu_precise () {
-    $sudo /etc/init.d/apache2 stop
+    $sudo /usr/sbin/service apache2 stop
 }
 
 start_apache_centos6 () {
-    $sudo /etc/init.d/httpd start
+    $sudo /sbin/service httpd start
 }
 
 stop_apache_centos6 () {
-    $sudo /etc/init.d/httpd stop
+    $sudo /sbin/service httpd stop
 }
 
 main () {

--- a/scripts/provision-mysql.sh
+++ b/scripts/provision-mysql.sh
@@ -100,13 +100,13 @@ provision_mysql_centos6 () {
     fi
 
     # save new firewall rules to survive reboot:
-    sudo /etc/init.d/iptables save
+    sudo /sbin/service iptables save
 
     # enable MySQL upon reboot:
     sudo /sbin/chkconfig mysqld on
 
     # restart MySQL server:
-    sudo /etc/init.d/mysqld restart
+    sudo /sbin/service mysqld restart
 
 }
 

--- a/scripts/provision-web.sh
+++ b/scripts/provision-web.sh
@@ -173,7 +173,7 @@ provision_web_centos6 () {
     fi
 
     # save new firewall rules to survive reboot:
-    sudo /etc/init.d/iptables save
+    sudo /sbin/service iptables save
 
     # enable Apache upon reboot:
     sudo /sbin/chkconfig httpd on


### PR DESCRIPTION
* BETTER Uses `/usr/sbin/service foo` consistently everywhere to restart
  daemons instead of deprecated `/etc/init.d/foo`.

* This fixes some troubles seen on Travis CI in higher `maint-1.2`
  branches.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>