### PR TITLE
installation: better Docker detection

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -27,13 +27,12 @@ from __future__ import print_function
 import os
 
 import sphinx.environment
-from docutils.utils import get_source_line
 
 
-def _warn_node(self, msg, node):
+def _warn_node(self, msg, *args, **kwargs):
     """Do not warn on external images."""
     if not msg.startswith('nonlocal image URI found:'):
-        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+        _warn_node_old(self, msg, *args, **kwargs)
 
 sphinx.environment.BuildEnvironment.warn_node = _warn_node
 

--- a/scripts/provision-web.sh
+++ b/scripts/provision-web.sh
@@ -188,7 +188,7 @@ main () {
     fi
 
     # call appropriate provisioning functions:
-    if [ -f /.dockerinit ]; then
+    if [ -f /.dockerinit -o -f /.dockerenv ]; then
         # running inside Docker
         provision_web_common_ubuntu_trusty
         provision_web_libpostgresql_ubuntu_trusty

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ extras_require = {
         'invenio-db[postgresql]' + invenio_db_version,
     ],
     'docs': [
-        'Sphinx>=1.3',
+        'Sphinx>=1.4',
     ],
     'tests': tests_require,
 }


### PR DESCRIPTION
* Uses the presence of either `/.dockerenv` or `/.dockerinit` file to
  detect whether the web provisioning script runs inside the Docker
  container. (The `/.dockerinit` file was removed in recent Docker
  versions.)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>