### PR TITLE
Fix: allow unrestricted records for guest users

### DIFF
--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -3090,10 +3090,13 @@ def intersect_results_with_collrecs(req, hitset_in_any_collection, colls, of="hb
         policy = CFG_WEBSEARCH_VIEWRESTRCOLL_POLICY.strip().upper()
         # let's get the restricted collections the user has rights to view
         if user_info['guest'] == '1':
-            permitted_restricted_collections = []
-            ## For guest users that are actually authorized to some restricted
-            ## collection (by virtue of the IP address in a FireRole rule)
-            ## we explicitly build the list of permitted_restricted_collections
+            permitted_restricted_collections = user_info.get(
+                'precached_permitted_restricted_collections', [])
+            # For guest users that are actually authorized to some restricted
+            # collection (by virtue of the IP address in a FireRole rule) we
+            # explicitly build the list of permitted_restricted_collections and
+            # we make sure that these are used in the search engine`
+
             for coll in colls:
                 if collection_restricted_p(coll) and (acc_authorize_action(user_info, 'viewrestrcoll', collection=coll)[0] == 0):
                     permitted_restricted_collections.append(coll)

--- a/modules/websession/lib/webuser.py
+++ b/modules/websession/lib/webuser.py
@@ -1390,6 +1390,8 @@ def collect_user_info(req, login_time=False, refresh=False):
                 user_info['precached_viewclaimlink'] = viewclaimlink
                 user_info['precached_usepaperclaim'] = usepaperclaim
                 user_info['precached_usepaperattribution'] = usepaperattribution
+        else: # guest user
+                user_info['precached_permitted_restricted_collections'] = get_permitted_restricted_collections(user_info)
 
     except Exception, e:
         register_exception()


### PR DESCRIPTION
- webuser.py
  Calculate allowed records by
  `get_permitted_restricted_collections(user_info)` for guest users
  also.
- search_engine.py:
  honor `precached_permitted_restricted_collections` for guest users

Addresses #3638
