### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/ABOUT-NLS
+++ b/ABOUT-NLS
@@ -114,7 +114,7 @@ the procedure below:
     ``make``.  End of note to developers.)
 
   - Please contribute your translation by emailing the file to
-    <info@invenio-software.org>.  You help is greatly appreciated and
+    <info@inveniosoftware.org>.  You help is greatly appreciated and
     will be properly credited in the THANKS file.
 
 See also the GNU gettext manual, especially the chapters 5, 6 and 11.

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,7 +27,7 @@ Authors
 Invenio is being co-developed by an international collaboration
 comprising institutes such as CERN, DESY, EPFL, FNAL, SLAC.
 
-You can contact us at <info@invenio-software.org>.
+You can contact us at <info@inveniosoftware.org>.
 
 Active contributors:
 

--- a/README.rst
+++ b/README.rst
@@ -107,8 +107,8 @@ more information.
 Happy hacking and thanks for flying Invenio.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   Github: http://github.com/inveniosoftware
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -26,8 +26,8 @@ Documentation
 Happy hacking and thanks for flying Invenio.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/docs/configuration/overlay.rst
+++ b/docs/configuration/overlay.rst
@@ -127,9 +127,9 @@ it later on. Here is its minimal content.
     setup(
         name="My Overlay",
         version="0.1.dev0",
-        url="http://invenio-software.org/",
+        url="http://inveniosoftware.org/",
         author="Invenio Software",
-        author_email="invenio@invenio-software.org",
+        author_email="invenio@inveniosoftware.org",
         description="My first overlay",
         packages=packages,
         install_requires=[

--- a/docs/introduction/demo.rst
+++ b/docs/introduction/demo.rst
@@ -24,7 +24,7 @@ order to see it in action:
 Demo Sites
 ----------
 
-`Atlantis Institute of Fictive Science <http://demo.invenio-software.org/>`_
+`Atlantis Institute of Fictive Science <http://demo.inveniosoftware.org/>`_
     *running Invenio 1.2.1, released 2015-05-21*
 
     Atlantis Institute of Fictive Science is an official demo site of

--- a/docs/technology/git.rst
+++ b/docs/technology/git.rst
@@ -72,7 +72,7 @@ This is how to set up your private repo (on your laptop).
 .. code-block:: console
 
     $ cd ~/src
-    $ git clone http://invenio-software.org/repo/invenio.git
+    $ git clone http://inveniosoftware.org/repo/invenio.git
 
 
 S3. Backuping your private repo (only developers at CERN)
@@ -159,7 +159,7 @@ S6. Making your public repo visible on the Web
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Please contact Joe Bloggs in order to make your public repo visible on
-Invenio's `repo web interface <http://invenio-software.org/repo/>`_.
+Invenio's `repo web interface <http://inveniosoftware.org/repo/>`_.
 
 S7. Using remote repository locally
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ directory = invenio/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio/translations/messages.pot
 

--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,7 @@ setup(
     keywords='Invenio digital library framework',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio',
     packages=packages,
     zip_safe=False,


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>