### PR TITLE
WebSession: excluding pending groups

### DIFF
--- a/modules/websession/lib/webgroup_dblayer.py
+++ b/modules/websession/lib/webgroup_dblayer.py
@@ -117,7 +117,8 @@ def get_groups(uid):
     query = """SELECT g.id, g.name
                FROM usergroup g, user_usergroup ug
                WHERE ug.id_user=%s AND
-                     ug.id_usergroup=g.id
+                     ug.id_usergroup=g.id AND
+                     ug.user_status<>'P'
             """
     res = run_sql(query, (uid, ))
     res = list(res)


### PR DESCRIPTION
* FIX Removes pending groups from user info object.  (closes #3526)

Reported-by: Bessem Aamira <bessemamira@gmail.com>
Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>