### PR TITLE
installation: PyPI packages in kickstart scripts

### DIFF
--- a/.inveniorc
+++ b/.inveniorc
@@ -21,7 +21,7 @@ export INVENIO_WORKER_HOST=192.168.50.15
 # Now you can use kickstart scripts, for example:
 #
 # vagrant up
-# vagrant ssh web -c 'source .inveniorc && /vagrant/scripts/create-instance.sh --devel'
+# vagrant ssh web -c 'source .inveniorc && /vagrant/scripts/create-instance.sh'
 # vagrant ssh web -c 'source .inveniorc && nohup /vagrant/scripts/start-instance.sh'
 # vagrant ssh web -c 'source .inveniorc && /vagrant/scripts/populate-instance.sh'
 # firefox http://192.168.50.10/records/1

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV INVENIO_RABBITMQ_HOST=rabbitmq
 ENV INVENIO_WORKER_HOST=127.0.0.1
 
 # Create Invenio instance:
-RUN /code/scripts/create-instance.sh --devel
+RUN /code/scripts/create-instance.sh
 
 # Make given VENV default:
 ENV PATH=/home/invenio/.virtualenvs/invenio3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,20 +1,19 @@
 Installation
 ============
 
-The best way to get Invenio up running immediately is using our provided
-Docker image:
+The best way to get an Invenio demo instance up and running immediately is by
+using Docker or Vagrant, for example:
 
 .. code-block:: console
 
-   $ pip install invenio[minimal]
-   $ inveniomanage instance create mysite
-   $ cd mysite
    $ docker-compose build
-   $ docker-compose up
+   $ docker-compose up -d
+   $ docker-compose run --rm web ./scripts/populate-instance.sh
+   $ firefox http://127.0.0.1/records/1
 
-This will start an Invenio instance with all the related services you need such
-as PostgreSQL, ElasticSearch, Redis, RabbitMQ.
+This will start an Invenio demo instance containing several example records and
+all the needed services such as PostgreSQL, Elasticsearch, Redis, RabbitMQ.
 
-For a detailed walk-through on how to setup your instance on Invenio, see `our
-documentation
-<http://pythonhosted.org/invenio/installation/installation-detailed.html>`_.
+For a detailed walk-through on how to set up your Invenio instance, please see
+our `installation documentation
+<http://pythonhosted.org/invenio/installation/index.html>`_.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@
 # Invenio demo site by running:
 #
 # $ vagrant up
-# $ vagrant ssh web -c 'source .inveniorc && /vagrant/scripts/create-instance.sh --devel'
+# $ vagrant ssh web -c 'source .inveniorc && /vagrant/scripts/create-instance.sh'
 # $ vagrant ssh web -c 'source .inveniorc && nohup /vagrant/scripts/start-instance.sh'
 # $ vagrant ssh web -c 'source .inveniorc && /vagrant/scripts/populate-instance.sh'
 # $ firefox http://192.168.50.10/records/1

--- a/docs/architecture/system-overview.rst
+++ b/docs/architecture/system-overview.rst
@@ -1,5 +1,5 @@
 .. This file is part of Invenio
-   Copyright (C) 2015 CERN.
+   Copyright (C) 2015, 2016 CERN.
 
    Invenio is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License as
@@ -25,7 +25,7 @@ Invenio v3.x
 .. admonition:: CAVEAT LECTOR
 
    Invenio v3.0 alpha is a bleeding-edge developer preview version that is
-   scheduled for public release in Q1/2016.
+   scheduled for public release in Q3/2016.
 
 Invenio v3.0 build on top of `Flask`_ web development framework, using `Jinja2`_
 template engine, `SQLAlchemy`_ Object Relational Mapper, `JSONSchema`_ data
@@ -35,9 +35,9 @@ information retrieval.
 .. _Flask: http://flask.pocoo.org/
 .. _Jinja2: http://jinja.pocoo.org/docs/
 .. _SQLAlchemy: http://www.sqlalchemy.org/
-.. _JSONSchema: http://json-schema.org/ 
+.. _JSONSchema: http://json-schema.org/
 .. _PostgreSQL: http://www.postgresql.org/
-.. _Elasticsearch: https://www.elastic.co/products/elasticsearch 
+.. _Elasticsearch: https://www.elastic.co/products/elasticsearch
 
 Invenio's architecture is modular. The code base is split into more than 50
 independent components that are `released independently on PyPI

--- a/docs/installation/installation-detailed.rst
+++ b/docs/installation/installation-detailed.rst
@@ -23,7 +23,7 @@ Detailed installation guide
 .. admonition:: CAVEAT LECTOR
 
    Invenio v3.0 alpha is a bleeding-edge developer preview version that is
-   scheduled for public release in Q1/2016.
+   scheduled for public release in Q3/2016.
 
 Introduction
 ------------
@@ -515,8 +515,15 @@ following scripts:
 
    source .inveniorc
    ./scripts/create-instance.sh
-   ./scripts/populate-instance.sh
    ./scripts/start-instance.sh
+   ./scripts/populate-instance.sh
+
+.. note::
+
+   If you want to install the very-bleeding-edge Invenio packages from GitHub,
+   you can run the ``create-instance.sh`` script with the ``--devel`` argument::
+
+     ./scripts/create-instance.sh --devel
 
 Let’s see in detail about every Invenio installation step.
 
@@ -539,11 +546,6 @@ PyPI:
    :start-after: # sphinxdoc-install-invenio-full-begin
    :end-before: # sphinxdoc-install-invenio-full-end
    :literal:
-
-Alternatively, if you want to install the very-bleeding-edge Invenio packages
-from GitHub, you can run the following in the Invenio source code directory::
-
-  pip install -r requirements-devel.txt
 
 We can now create a new Invenio instance:
 

--- a/docs/installation/installation-quick.rst
+++ b/docs/installation/installation-quick.rst
@@ -34,7 +34,7 @@ Using Vagrant
 You can get Invenio v3.0 demo site up and running using Vagrant::
 
   vagrant up
-  vagrant ssh web -c 'source .inveniorc && /vagrant/scripts/create-instance.sh --devel'
+  vagrant ssh web -c 'source .inveniorc && /vagrant/scripts/create-instance.sh'
   vagrant ssh web -c 'source .inveniorc && nohup /vagrant/scripts/start-instance.sh'
   vagrant ssh web -c 'source .inveniorc && /vagrant/scripts/populate-instance.sh'
   firefox http://192.168.50.10/records/1
@@ -53,7 +53,7 @@ installation scripts manually::
   scripts/provision-redis.sh
   scripts/provision-rabbitmq.sh
   scripts/provision-worker.sh
-  scripts/create-instance.sh --devel
+  scripts/create-instance.sh
   scripts/start-instance.sh
   scripts/populate-instance.sh
   firefox http://192.168.50.10/records/1

--- a/docs/introduction/releases.rst
+++ b/docs/introduction/releases.rst
@@ -1,5 +1,5 @@
 ..  This file is part of Invenio
-    Copyright (C) 2015 CERN.
+    Copyright (C) 2015, 2016 CERN.
 
     Invenio is free software; you can redistribute it and/or
     modify it under the terms of the GNU General Public License as
@@ -79,7 +79,7 @@ Invenio v3.x
 *Not released yet; however a developer preview is available on GitHub.*
 
 Invenio v3.0 will be released when the Invenio code base is fully split into a
-set of standalone independent Python packages. *(ETA: Q1/2016)*
+set of standalone independent Python packages. *(ETA: Q3/2016)*
 
 Invenio v2.x
 ------------
@@ -183,4 +183,3 @@ Released versions include:
 * `v0.1.1 <https://github.com/inveniosoftware/invenio/releases/tag/v0.1.1>`_ - released 2003-12-19
 * `v0.1.0 <https://github.com/inveniosoftware/invenio/releases/tag/v0.1.0>`_ - released 2003-12-04
 * `v0.0.9 <https://github.com/inveniosoftware/invenio/releases/tag/v0.0.9>`_ - released 2002-08-01
-

--- a/scripts/create-instance.sh
+++ b/scripts/create-instance.sh
@@ -124,11 +124,14 @@ fi
 inveniomanage instance create ${INVENIO_WEB_INSTANCE}
 # sphinxdoc-create-instance-end
 
+if [[ "$@" != *"--devel"* ]]; then
 # sphinxdoc-install-instance-begin
 cd ${INVENIO_WEB_INSTANCE}
 pip install -e .
-pip install -r requirements-devel.txt
 # sphinxdoc-install-instance-end
+else
+    pip install -r requirements-devel.txt
+fi
 
 # sphinxdoc-customise-instance-begin
 mkdir -p ../../var/${INVENIO_WEB_INSTANCE}-instance/

--- a/setup.py
+++ b/setup.py
@@ -44,33 +44,33 @@ tests_require = [
     'pytest>=2.8.0',
 ]
 
-invenio_db_version = '>=1.0.0a7,<1.1.0'
+invenio_db_version = '>=1.0.0a10,<1.1.0'
 
 extras_require = {
     'access': [
-        'invenio-access>=1.0.0a2,<1.1.0',
+        'invenio-access>=1.0.0a8,<1.1.0',
     ],
     'accounts': [
-        'invenio-accounts>=1.0.0a2,<1.1.0',
+        'invenio-accounts>=1.0.0a13,<1.1.0',
     ],
     'records': [
-        'dojson>=0.4.0',
-        'invenio-pidstore>=1.0.0a1,<1.1.0',
-        'invenio-records>=1.0.0a8,<1.1.0',
-        'invenio-records-ui>=1.0.0a4,<1.1.0',
-        'invenio-records-rest>=1.0.0a2,<1.1.0',
+        'dojson>=1.2.1',
+        'invenio-pidstore>=1.0.0a9,<1.1.0',
+        'invenio-records>=1.0.0a17,<1.1.0',
+        'invenio-records-ui>=1.0.0a7,<1.1.0',
+        'invenio-records-rest>=1.0.0a15,<1.1.0',
     ],
     'search': [
-        'invenio-search>=1.0.0a1,<1.1.0',
+        'invenio-search>=1.0.0a7,<1.1.0',
     ],
     'theme': [
-        'invenio-assets>=1.0.0a1,<1.1.0',
-        'invenio-theme>=1.0.0a6,<1.1.0',
+        'invenio-assets>=1.0.0a5,<1.1.0',
+        'invenio-theme>=1.0.0a13,<1.1.0',
     ],
     'utils': [
-        'invenio-mail>=1.0.0a1,<1.1.0',
-        'invenio-rest>=1.0.0a2,<1.1.0',
-        'invenio-logging>=1.0.0a1,<1.1.0',
+        'invenio-mail>=1.0.0a4,<1.1.0',
+        'invenio-rest>=1.0.0a9,<1.1.0',
+        'invenio-logging>=1.0.0a2,<1.1.0',
     ],
     'mysql': [
         'invenio-db[mysql]' + invenio_db_version,


### PR DESCRIPTION
* The example installation procedures now use Invenio PyPI packages
  instead of GitHub bleeding-edge versions. (In other words,
  ``scripts/create-instance.sh`` does not use ``--devel`` argument by
  default anymore.)

* Increases minimal versions of required Invenio PyPI packages to the
  latest recommended versions.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>