### PR TITLE
docs: process principle improvements and anchors

### DIFF
--- a/docs/processes/developing.rst
+++ b/docs/processes/developing.rst
@@ -29,9 +29,15 @@
 Developing principles
 =====================
 
+.. _contributing-documentation:
+
 1. **Contributing documentation?** ReST and Sphinx. Contribute as code.
 
+.. _contributing-i18n-translations:
+
 2. **Contributing I18N translations?** GNU gettext. See :ref:`i18n`.
+
+.. _contributing-code:
 
 3. **Contributing code?**
 
@@ -60,6 +66,8 @@ Developing principles
    vi. Follow egoless programming principles. See :ref:`code-of-conduct`.
 
    vii. Read the following contributing guide and developer guidelines.
+
+.. _contributing-guide:
 
 Contributing guide
 ==================

--- a/docs/processes/integrating.rst
+++ b/docs/processes/integrating.rst
@@ -29,20 +29,34 @@
 Integrating principles
 ======================
 
-1. **Beware of inter-module relations.** Changing API? Perhaps this pull request
-   may break other modules.
+.. _check-it-from-the-helicopter:
 
-2. **Beware of inter-service relations.** Seems service specific? Perhaps this
-   pull request does not fit the needs of other Invenio services.
-
-3. **Check the signature karma.** If it ain’t signed, it ain’t finished.
-
-4. **Check the counter-signature karma.** If it ain’t counter-signed, it ain’t
-   finished. (i) "Reviewed-by" commit signatures. (ii) ":shipit:" PR signatures.
-   (iii) Cross-team signatures.
-
-5. **Check it from the helicopter.** If it ain’t green, it ain’t finished. If it
+1. **Check it from the helicopter.** If it ain’t green, it ain’t finished. If it
    ain’t understandable, it ain’t documented.
 
-6. **Check its neighbourhoods.** If it changes pre-existing tests, beware of
-   compatibility. If it removes API-like functions, check outside usage.
+.. _beware-of-inter-module-relations:
+
+2. **Beware of inter-module relations.** Changing API? Perhaps this pull request
+   may break other modules. Check outside usage. Check the presence of
+   ``versionadded``, ``versionmodified``, ``deprecated`` docstring directives.
+
+.. _beware-of-inter-service-relations:
+
+3. **Beware of inter-service relations.** Changing pre-existing tests? Perhaps
+   this pull request does not fit the needs of other Invenio services.
+
+.. _check-the-signature-karma:
+
+4. **Check the signature karma.** If it ain’t signed, it ain’t finished.
+
+.. _check-the-counter-signature-karma:
+
+5. **Check the counter-signature karma.** If it ain’t counter-signed, it ain’t
+   finished. Check for "Reviewed-by" commit signatures. Check for "LGTM" or
+   ":shipit:" pull request signatures.
+
+.. _avoid-self-merges:
+
+6. **Avoid self merges.** Each pull request should be seen by another pair of
+   eyes. Was it authored and reviewed by two different persons? Good. Were the
+   two different persons coming from two different service teams? Better.

--- a/docs/processes/releasing.rst
+++ b/docs/processes/releasing.rst
@@ -29,30 +29,67 @@
 Releasing principles
 ====================
 
+.. _cross-check-ci-green-lights:
+
 1. **Cross-check CI green lights.** Are all Travis builds green? Is nightly
    Jenkins build green?
 
+.. _cross-check-read-the-docs-documentation-builds:
+
 2. **Cross-check Read The Docs documentation builds.** Are docs building fine?
+   Is this check done as part of the continuous integration? If not, add it.
+
+.. _cross-check-demo-site-builds:
 
 3. **Cross-check demo site builds.** Is demo site working?
 
-4. **check-manifest** Are all files included in the release?
+.. _check-manifest:
+
+4. **check-manifest** Are all files included in the release? Is this check done
+   as part of the continuous integration? If not, add it.
+
+.. _check-author-list:
 
 5. **Check author list.** Are all committers listed in AUTHORS file? Use
-   ``kwalitee check authors``. Add newcomers.
+   ``kwalitee check authors``. Add newcomers. Is this check done as part of the
+   continuous integration? If not, add it.
+
+.. _update-i18n-message-catalogs:
 
 6. **Update I18N message catalogs.**
 
-7. **Update version number. Generate release notes.** Use `kwalitee prepare
-   release v1.1.0..` to generate release notes.
+.. _update_version_number:
 
-8. **Push a pre-release to testpypi.** Try a test install from there.
+7. **Update version number.** Stick to `semantic versioning
+   <http://semver.org/>`_.
 
-9. **Tag it. Push it. Bump it.** Sign the tag with your GnuPG key. Don't forget
-   the post-release version bump.
+.. _generate-release-notes:
 
-10. **Add release notes on GitHub. Tweet it. Post it.** Make publicity for
+8. **Generate release notes.** Use `kwalitee prepare release v1.1.0..` to
+   generate release notes. Use empty commits with "AMENDS" to amend wrong past
+   messages before releasing.
+
+.. _push-pre-release-to-testpypi:
+
+9. **Push a pre-release to testpypi.** Try a test install from there.
+
+.. _tag-it-push-it-:
+
+10. **Tag it. Push it.** Sign the tag with your GnuPG key. Push it to PyPI. Is
+    the PyPI deployment done automatically as part of the continuous
+    integration? If not, add it.
+
+.. _bump-it:
+
+11. **Bump it.** Don't forget the issue the pull request with a post-release
+    version bump. Use ``.devYYYYMMDD`` suffix.
+
+.. _add-release-notes-on-github-tweet-it-post-it:
+
+12. **Add release notes on GitHub. Tweet it. Post it.** Make publicity for
     production-ready releases. This is not automated yet.
+
+.. _structured-release-notes:
 
 Structured release notes
 ========================
@@ -80,4 +117,4 @@ the following labels:
 | (missing)    | (developers only)        |
 +--------------+--------------------------+
 
-For more, see kwalitee.
+For more, see `kwalitee <http://kwalitee.readthedocs.io/>`_.

--- a/docs/processes/reporting.rst
+++ b/docs/processes/reporting.rst
@@ -32,29 +32,45 @@ Reporting principles
 Have you encountered a bug or do you have a new feature request? Here are a few
 tips on our issue reporting practices.
 
+.. _if-it-aint-on-github-it-does-not-exist:
+
 1. **If it ain’t on GitHub, it does not exist.** Please document every bug or
    every feature request on GitHub in respected repositories.
+
+.. _found-security-issue-alert-use-privately:
 
 2. **Found security issue? Alert us privately.** If you find a security issue
    that has a possible dangerous exploit, please alert us privately at
    ``<info@inveniosoftware.org>``. This will allow us to distribute a security
    patch before potential attackers look at the issue.
 
+.. _check-existing-issues-before-submitting:
+
 3. **Check existing issues before submitting.** Please check opened or closed
    issued before submitting. Somebody else might have had the same issue as you.
 
+.. _describe-concrete-steps-how-to-reproduce-a-problem:
+
 4. **Describe concrete steps how to reproduce a problem.** Which version you
    used? What you did? What was the outcome? What you expected instead?
+
+.. _submit-a-use-case-submit-a-test-case-code:
 
 5. **Submit a use case. Submit a test case code.** Please clarify the use case
    in mind with as much explicit detail as necessary. Other Invenio instances
    may have different implicit assumptions than you.
 
+.. _get-involved-comment-ad-advise-on-other-issues:
+
 6. **Get involved! Comment and advise on other issues.** Help the community and
    see your responsibilites widen.
 
+.. _join-invenio-chat-room:
+
 7. **Join Invenio chat room.** Sometimes a quick chat may be better than long
    GitHub issue.
+
+.. _watch-notifications-in-interested-repositories:
 
 9. **Watch notifications in interested repositories.** Subscribe to GitHub
    notifications to stay up-to-date on what is going on.

--- a/docs/processes/reviewing.rst
+++ b/docs/processes/reviewing.rst
@@ -29,14 +29,24 @@
 Reviewing principles
 ====================
 
+.. _every-pr-should-preserve-or-increase-code-coverage:
+
 1. **Every PR should preserve or increase code coverage.** If it ain’t green, it
    ain’t finished.
 
-2. **Check it as a black box. Input, magic, output.** If it ain’t documented, it
-   ain’t finished.
+.. _check-it-as-a-black-box:
 
-3. **Check it as a white box. Implementation details.** If it ain’t styled, it
-   ain’t finished.
+2. **Check it as a black box.** Check the overall picture of input, "something
+   happens", output chain. If it ain’t documented, it ain’t finished.
 
-4. **Check it as a release news. Commit messages.** If it does not announce
-   anything, it may not be finished.
+.. _check-it-as-a-white-box:
+
+3. **Check it as a white box.** Check implementation details of
+   "something-happens". If it ain’t styled, it ain’t finished.
+
+.. _check-it-as-a-release-news:
+
+4. **Check it as a release news.** Check commit messages. Are they
+   understandable? Do they use FIX or BETTER labels? If a commit does not
+   announce anything, it may not be finished. See
+   :ref:`structured-release-notes`.

--- a/docs/processes/sprinting.rst
+++ b/docs/processes/sprinting.rst
@@ -29,6 +29,8 @@
 Sprinting principles
 ====================
 
+.. _before-planning-sprint-do-your-homework:
+
 1. **Before planning a sprint, do your homework.** Start by drafting initial
    thoughts about high-level requirements and use cases in an RFC. Be specific.
 
@@ -38,29 +40,52 @@ Sprinting principles
    iv. High-level architecture
    v. High-level API
 
+.. _discuss-with-various-invenio-services-and-experts:
+
 2. **Discuss with various Invenio services and experts.** Check for other
    similar use cases and synergies. Use the community. Seek expert opinions.
+
+.. _establish-a-cross-service-team:
 
 3. **Establish a cross-service team.** "Alone we can do so little; together we
    can do so much." --Helen Keller
 
-4. **Establish a backlog of tasks.** List everything that needs to be done. Keep
+.. _start-with-a-kick-off-meeting:
+
+4. **Start with a kick-off meeting.** Invite all sprint team members to kick off
+   the sprint and plan its details collectively. Invite related technology
+   experts to provide input to estimated tasks. Invite related service managers
+   to help making sure the use cases were well understood.
+
+.. _establish-a-backlog-of-tasks:
+
+5. **Establish a backlog of tasks.** List everything that needs to be done. Keep
    it short. Use GitHub "Sprint-Foo" labels or milestones.
 
-5. **Keep it manageable.** Plan no more than a two-week sprint. Break up longer
+.. _keep-it-manageable:
+
+6. **Keep it manageable.** Plan no more than a two-week sprint. Break up longer
    sprints into manageable two-week chunks. Beware of attention span.
    Prioritise.
 
-6. **Act.** Trying our best to finish all tasks in time? "No. Try not. Do. Or do
+.. _act:
+
+7. **Act.** Trying our best to finish all tasks in time? "No. Try not. Do. Or do
    not. There is no try." (--Master Yoda)
 
-7. **Hold very short daily stand-up meetings.** What has everyone done since
+.. _hold-very-short-daily-stand-up-meetings:
+
+8. **Hold very short daily stand-up meetings.** What has everyone done since
    yesterday? Is anyone blocked by anything? What is everyone going to do next?
 
-8. **Once over, review achievements.** Did everything go as planned? Were you
+.. _once-over-review-achievements:
+
+9. **Once over, review achievements.** Did everything go as planned? Were you
    too optimistic or too pessimistic regarding backlog and time planning? What
    have we learned?
 
-9. **Finish by releasing the packages and deploying the features.** Close
-   sprints by releasing the software and deploying the features on concerned
-   services --- production or sandbox.
+.. _finish-by-releasing-packages-and-deploying-features:
+
+10. **Finish by releasing packages and deploying features.** Close sprints by
+    releasing the software and deploying the features on concerned services ---
+    production or sandbox.

--- a/docs/processes/triaging.rst
+++ b/docs/processes/triaging.rst
@@ -39,28 +39,44 @@ members make sure of the big picture, cross-consider issues and tasks among
 interested services, help to note down, understand, prioritise, and follow-upon
 them.
 
+.. _every-issue-should-have-an-assignee:
+
 1. **Every issue should have an assignee.** Issues without assignees are sad and
    likely to remain so. Each issue should have a driving force behind it.
+
+.. _every-issue-should-have-a-milestone:
 
 2. **Every issue should have a milestone.** Issues without milestones are sad
    and likely to remain unaddressed.
 
+.. _use-additional-type-and-priority-labels:
+
 3. **Use additional type and priority labels.** Helps to find related issues out
    quickly.
 
-4. **Use additional service labels to provide overview.** Helps to distinguish
-   which issues are of utmost importance to which services. Helps to keep a
-   service-oriented dashboard.
+.. _use-additional-service-labels:
+
+4. **Use additional service labels.** Helps to distinguish which issues are of
+   utmost importance to which services. Helps to keep a service-oriented
+   dashboard overview.
+
+.. _silent-since-a-month-ping-responsible:
 
 5. **Silent since a month? Ping responsible.** An issue shouldn't be opened
    without update for more than a month.
 
+.. _nobody-in-sight-to-work-on-this-discuss-and-triage:
+
 6. **Nobody in sight to work on this? Discuss and triage.** The triage team
    should take action if there is no natural candidate to work on an issue.
 
-7. **No time to realistically tackle this? “Someday” or close.** We don't want
-   to have thousands of open issues. Issues from the someday open or closed pool
-   can be revived later, should realistic manpower be found.
+.. _no-time-to-realistically-tackle-this-use-someday-or-close:
+
+7. **No time to realistically tackle this? Use "Someday" or close.** We don't
+   want to have thousands of open issues. Issues from the someday open or closed
+   pool can be revived later, should realistic manpower be found.
+
+.. _no-reply-ping-inveniosoftware-triagers:
 
 8. **No reply? Ping @inveniosoftware/triagers** The triage team should take
    action if there is no update on an issues for more than a month.


### PR DESCRIPTION
* Improves verbiage of several process principles, such as avoiding
  self-merges or starting sprints with kick-off meetings. (closes #3659)

* Adds anchors to all process principles to make them easily citeable.
  Example: `/processes/integrating.html#avoid-self-merges`.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>