### PR TITLE
Bibuplaod: add CFG parameter for  DOI checking

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Active contributors:
 * Øystein Blixhavn <oystein@blixhavn.no>
 * Pedro Gaudencio <pmgaudencio@gmail.com>
 * Petros Ioannidis <petros.ioannidis@cern.ch>
+* Robert Thiele <robert.thiele@desy.de>
 * Roman Chyla <roman.chyla@cern.ch>
 * Samuele Kaplun <samuele.kaplun@cern.ch>
 * Sebastian Witowski <sebastian.witowski@cern.ch>

--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -1942,6 +1942,10 @@ CFG_BATCHUPLOADER_WEB_ROBOT_RIGHTS = {
 # By default all DOIs are excluded
 CFG_BIBUPLOAD_INTERNAL_DOI_PATTERN = [^\w\W]
 
+# CFG_BIBPLOAD_CHECK_DOI -- do we want to check for 
+# DOI uniqueness during upload jobs? (True/False)
+CFG_BIBUPLOAD_DOI_CHECKING = True
+
 ####################################
 # Part 18: BibCatalog parameters ##
 ####################################

--- a/modules/bibupload/lib/bibupload.py
+++ b/modules/bibupload/lib/bibupload.py
@@ -1212,27 +1212,33 @@ def check_record_doi_is_unique(rec_id, record):
     Return (boolean, msg) where 'boolean' would be True if the DOI is
     unique.
     """
-    record_dois = record_extract_dois(record)
-    if record_dois:
-        matching_recids = set()
-        for record_doi in record_dois:
-            possible_recid = find_record_from_doi(record_doi)
-            if possible_recid:
-                matching_recids.add(possible_recid)
-        if len(matching_recids) > 1:
-            # Oops, this record refers to DOI existing in multiple records.
-            msg = "   Failed: Multiple records found in the" \
+    try:
+        from invenio.config import CFG_BIBUPLOAD_DOI_CHECKING
+    except:
+        CFG_BIBUPLOAD_DOI_CHECKING = True
+
+    if CFG_BIBUPLOAD_DOI_CHECKING:
+        record_dois = record_extract_dois(record)
+        if record_dois:
+            matching_recids = set()
+            for record_doi in record_dois:
+                possible_recid = find_record_from_doi(record_doi)
+                if possible_recid:
+                    matching_recids.add(possible_recid)
+            if len(matching_recids) > 1:
+                # Oops, this record refers to DOI existing in multiple records.
+                msg = "   Failed: Multiple records found in the" \
                       " database %s that match the DOI(s) in the input" \
                       " MARCXML %s" % (repr(matching_recids), repr(record_dois))
-            return (False, msg)
-        elif len(matching_recids) == 1:
-            matching_recid = matching_recids.pop()
-            if str(matching_recid) != str(rec_id):
-                # Oops, this record refers to DOI existing in a different record.
-                msg = "   Failed: DOI(s) %s found in this record (#%s)" \
+                return (False, msg)
+            elif len(matching_recids) == 1:
+                matching_recid = matching_recids.pop()
+                if str(matching_recid) != str(rec_id):
+                    # Oops, this record refers to DOI existing in a different record.
+                    msg = "   Failed: DOI(s) %s found in this record (#%s)" \
                       " already exist(s) in another other record (#%s)" % \
                       (repr(record_dois), rec_id, matching_recid)
-                return (False, msg)
+                    return (False, msg)
     return (True, "")
 
 ### Insert functions


### PR DESCRIPTION
Add new CFG_BIBUPLOAD_DOI_CHECKING in invenio.conf and bibupload.py
for avoiding the multi DOI checking while the upload. The default
state is not changed. Please configure the new parameter in the
invenio-local.conf.

Addresses inveniosoftware/invenio#3661
