### PR TITLE
installation: fix of nginx host header

### DIFF
--- a/nginx/invenio3.conf
+++ b/nginx/invenio3.conf
@@ -10,7 +10,7 @@ server {
 
     location / {
         proxy_pass http://web:5000;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }


### PR DESCRIPTION
* Updates the ``Host`` header value in order to use ``$http_host`` variable which also contains the port that the browser is sending.

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>