### PR TITLE
docs: Fix link to COPYING in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@
         :target: https://pypi.python.org/pypi/invenio
 
 .. image:: https://img.shields.io/github/license/inveniosoftware/invenio.svg
-        :target: https://github.com/inveniosoftware/invenio/blob/master/LICENSE
+        :target: https://github.com/inveniosoftware/invenio/blob/master/COPYING
 
 .. image:: https://badges.gitter.im/Join%20Chat.svg
     :target: https://gitter.im/inveniosoftware/invenio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge


### PR DESCRIPTION
- Remove link to non-existing `LICENSE` file and replace with correct
  link (Closes #3682)

Signed-off-by: Achintya Rao <achintya.rao@cern.ch>