### PR TITLE
docs: new maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,3 @@
 Tibor Simko <tibor.simko@cern.ch> (@tiborsimko)
 Esteban J. G. Gabancho <esteban.gabancho@gmail.com> (@egabancho)
+Jiri Kuncar <jiri.kuncar@cern.h> (@jirikuncar)


### PR DESCRIPTION
Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>