### PR TITLE
docs: maintainer email address fix

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,3 @@
 Tibor Simko <tibor.simko@cern.ch> (@tiborsimko)
 Esteban J. G. Gabancho <esteban.gabancho@gmail.com> (@egabancho)
-Jiri Kuncar <jiri.kuncar@cern.h> (@jirikuncar)
+Jiri Kuncar <jiri.kuncar@cern.ch> (@jirikuncar)


### PR DESCRIPTION
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>