### PR TITLE
BibDocFile: purging extracted text

### DIFF
--- a/modules/bibdocfile/lib/bibdocfile.py
+++ b/modules/bibdocfile/lib/bibdocfile.py
@@ -1839,6 +1839,9 @@ class BibDoc:
                     for flag in CFG_BIBDOCFILE_AVAILABLE_FLAGS:
                         self.more_info.unset_flag(flag, afile.get_format(), afile.get_version())
                     try:
+                        text_file_path = os.path.join(self.basedir, '.text;%i' % afile.get_version())
+                        if os.path.exists(text_file_path):
+                            os.remove(text_file_path)
                         os.remove(afile.get_full_path())
                     except Exception, e:
                         register_exception()


### PR DESCRIPTION
* FIX Purges old extracted text too, when purging a BibDoc.
  (closes #3519)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>