### PR TITLE
installation: Elasticsearch 2 in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ redis:
 
 elasticsearch:
   restart: "always"
-  image: elasticsearch
+  image: elasticsearch:2
   ports:
     - "29200:9200"
     - "29300:9300"

--- a/setup.py
+++ b/setup.py
@@ -44,33 +44,33 @@ tests_require = [
     'pytest>=2.8.0',
 ]
 
-invenio_db_version = '>=1.0.0a10,<1.1.0'
+invenio_db_version = '>=1.0.0b3,<1.1.0'
 
 extras_require = {
     'access': [
-        'invenio-access>=1.0.0a8,<1.1.0',
+        'invenio-access>=1.0.0a11,<1.1.0',
     ],
     'accounts': [
-        'invenio-accounts>=1.0.0a13,<1.1.0',
+        'invenio-accounts>=1.0.0b1,<1.1.0',
     ],
     'records': [
         'dojson>=1.2.1',
-        'invenio-pidstore>=1.0.0a9,<1.1.0',
-        'invenio-records>=1.0.0a17,<1.1.0',
-        'invenio-records-ui>=1.0.0a7,<1.1.0',
-        'invenio-records-rest>=1.0.0a15,<1.1.0',
+        'invenio-pidstore>=1.0.0b1,<1.1.0',
+        'invenio-records>=1.0.0b1,<1.1.0',
+        'invenio-records-ui>=1.0.0a8,<1.1.0',
+        'invenio-records-rest>=1.0.0a17,<1.1.0',
     ],
     'search': [
-        'invenio-search>=1.0.0a7,<1.1.0',
+        'invenio-search>=1.0.0a9,<1.1.0',
     ],
     'theme': [
-        'invenio-assets>=1.0.0a5,<1.1.0',
-        'invenio-theme>=1.0.0a13,<1.1.0',
+        'invenio-assets>=1.0.0b4,<1.1.0',
+        'invenio-theme>=1.0.0a14,<1.1.0',
     ],
     'utils': [
-        'invenio-mail>=1.0.0a4,<1.1.0',
-        'invenio-rest>=1.0.0a9,<1.1.0',
-        'invenio-logging>=1.0.0a2,<1.1.0',
+        'invenio-mail>=1.0.0a5,<1.1.0',
+        'invenio-rest>=1.0.0a10,<1.1.0',
+        'invenio-logging>=1.0.0a3,<1.1.0',
     ],
     'mysql': [
         'invenio-db[mysql]' + invenio_db_version,
@@ -116,6 +116,8 @@ setup_requires = [
 
 install_requires = [
     'Flask>=0.11.1',
+    'elasticsearch>=2.0.0,<3.0.0',
+    'elasticsearch-dsl>=2.0.0,<3.0.0',
     'invenio-base>=1.0.0a6,<1.1.0',
     'invenio-celery>=1.0.0a2,<1.1.0',
     'invenio-config>=1.0.0a1,<1.1.0',


### PR DESCRIPTION
* FIX Pins Elasticsearch PyPI dependencies to use version 2 and
  configures Docker to use Elasticsearch version 2 rather than version 5
  for which some of the Invenio packages are not ready yet. This
  harmonises the use of Elasticsearch version 2 for both Docker and
  Vagrant based installation procedures. (closes #3714)

* Increments versions of several Invenio packages.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>