### PR TITLE
Merge branch 'maint-1.1' into maint-1.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,160 @@ releases.  For more information about the current release, please
 consult RELEASE-NOTES.  For more information about changes, please
 consult ChangeLog.
 
+Invenio v1.1.7 -- released 2016-11-20
+--------------------------------------
+
+New features
+~~~~~~~~~~~~
+
++ installation
+
+  - Initial release of kickstart installations scripts. Ported from
+    the old `tiborsimko/invenio-devscripts` repository of helper
+    scripts and adapted to resemble Invenio 3 kickstart installation
+    scripts. Tested on Ubuntu 12.04 and CentOS 6.
+
+Improved features
+~~~~~~~~~~~~~~~~~
+
++ I18N
+
+  - Updates Slovak translation from Transifex.
+  - Updates German, French, Slovak and Spanish translations from
+    Transifex.
+  - Updates Catalan, French, German, Italian, Russian, Slovak, and
+    Spanish translations from Transifex.
+  - Completes Italian translation.
+
++ installation
+
+  - Installation scripts now support Ubuntu 14.04 LTS.
+  - Uses `/usr/sbin/service foo` consistently everywhere to restart
+    daemons instead of deprecated `/etc/init.d/foo`.
+  - Pinned specific JSON-js and Mediaelement versions instead of using
+    the latest master branch commits. (#11)
+
++ urlutils
+
+  - Uses `md5` from `hashlib` when available. (#3382)
+
+Bug fixes
+~~~~~~~~~
+
++ BibDocFile
+
+  - Purges old extracted text too, when purging a BibDoc. (#3519)
+
++ BibSched
+
+  - Makes `recid` argument optional in tasklet `bst_create_icons`.
+    (#2192)
+
++ OAIHarvest
+
+  - Fixes the parsing of resumptiontoken in incoming OAI-PMH XML which
+    could fail when the resumptiontoken was empty.
+
++ OAIRepository
+
+  - Fixes default configuration of CFG_OAI_METADATA_FORMATS, correctly
+    assigning the XSD and XML namespace to the corresponding metadata
+    prefix.
+
++ WebAccess
+
+  - Improves the WebAccess FireRole documentation by providing
+    corrected example on how to use groups in FireRole definitions.
+    (#3107) (#3225)
+
++ WebSearch
+
+  - Fixes asynchronous external collection getter tests following the
+    update of the Invenio project web site.
+
++ WebSession
+
+  - Removes pending groups from user info object.  (#3526)
+
++ bibupload
+
+  - In case of replicating datasets between instances by means of OAI
+    harvesting it is plausible to check for external OAI-IDs not only
+    in the field specified by CFG_BIBUPLOAD_EXTERNAL_OAIID_TAG but
+    also in CFG_OAI_ID_FIELD. (#2812) (PR #2816)
+
++ global
+
+  - Silences most MySQL UTF-8 warnings related to inserting into and
+    updating BLOB table columns.
+
++ installation
+
+  - Amends canonical location of py-editdist and pyRXP packages,
+    fixing the installation problem.
+  - Amends installation procedures to download necessary jQuery
+    plugins from Invenio-hosted web site, fixing problems with non-
+    existing Google Code pages. (#3620)
+  - Fixes Apache virtual host configuration generation on CentOS 6.
+
++ inveniogc
+
+  - Fixes garbage collection of temporary directories created by
+    websubmit_icon_creator and websubmit_file_stamper. (#3556) (PR
+    #3558)
+
+Invenio v1.0.10 -- released 2016-11-09
+--------------------------------------
+
+New features
+~~~~~~~~~~~~
+
++ installation
+
+  - Initial release of kickstart installations scripts. Ported from
+    the old `tiborsimko/invenio-devscripts` repository of helper
+    scripts and adapted to resemble Invenio 3 kickstart installation
+    scripts. Tested on Ubuntu 12.04 and CentOS 6.
+
+Improved features
+~~~~~~~~~~~~~~~~~
+
++ I18N
+
+  - Updates Catalan, French, German, Italian, Russian, Slovak, and
+    Spanish translations from Transifex.
+
++ installation
+
+  - Installation scripts now support Ubuntu 14.04 LTS.
+  - Uses `/usr/sbin/service foo` consistently everywhere to restart
+    daemons instead of deprecated `/etc/init.d/foo`.
+
+Bug fixes
+~~~~~~~~~
+
++ WebAccess
+
+  - Improves the WebAccess FireRole documentation by providing
+    corrected example on how to use groups in FireRole definitions.
+    (#3107) (#3225)
+
++ WebSearch
+
+  - Fixes asynchronous external collection getter tests following the
+    update of the Invenio project web site.
+
++ global
+
+  - Silences most MySQL UTF-8 warnings related to inserting into and
+    updating BLOB table columns.
+
++ installation
+
+  - Amends canonical location of py-editdist and pyRXP packages,
+    fixing the installation problem.
+  - Fixes Apache virtual host configuration generation on CentOS 6.
+
 Invenio v1.2.1 -- released 2015-05-21
 -------------------------------------
 

--- a/modules/bibdocfile/lib/bibdocfile.py
+++ b/modules/bibdocfile/lib/bibdocfile.py
@@ -2130,6 +2130,9 @@ class BibDoc(object):
                     for flag in CFG_BIBDOCFILE_AVAILABLE_FLAGS:
                         self.more_info.unset_flag(flag, afile.get_format(), afile.get_version())
                     try:
+                        text_file_path = os.path.join(self.basedir, '.text;%i' % afile.get_version())
+                        if os.path.exists(text_file_path):
+                            os.remove(text_file_path)
                         os.remove(afile.get_full_path())
                     except Exception, dummy:
                         register_exception()

--- a/modules/bibupload/lib/bibupload.py
+++ b/modules/bibupload/lib/bibupload.py
@@ -935,6 +935,14 @@ def find_records_from_extoaiid(extoaiid, extoaisrc=None):
                     write_message('WARNING: Found recid %s for extoaiid="%s" that doesn\'t specify any provenance, while input record does.' % (id_bibrec, extoaiid), stream=sys.stderr)
                 if extoaisrc is None:
                     write_message('WARNING: Found recid %s for extoaiid="%s" that specify a provenance (%s), while input record does not have a provenance.' % (id_bibrec, extoaiid, this_extoaisrc), stream=sys.stderr)
+
+    if len(ret) == 0:
+        # no oaiid in CFG_BIBUPLOAD_EXTERNAL_OAIID_TAG. Check if we have one
+        # in the locally used CFG_OAI_ID_FIELD that matches. This can happen
+        # if oai harvesting is used to duplicate records.
+        recid = find_record_from_oaiid(extoaiid)
+        if recid is not None:
+            ret.add(recid)
     return ret
 
 def find_record_from_oaiid(oaiid):
@@ -2994,7 +3002,7 @@ def task_run_core():
     return not stat['nb_errors'] >= 1
 
 def log_record_uploading(oai_rec_id, task_id, bibrec_id, insertion_db, pretend=False):
-    if oai_rec_id != "" and oai_rec_id != None:
+    if oai_rec_id != "" and oai_rec_id is not None:
         query = """UPDATE oaiHARVESTLOG SET date_inserted=NOW(), inserted_to_db=%s, id_bibrec=%s WHERE oai_id = %s AND bibupload_task_id = %s ORDER BY date_harvested LIMIT 1"""
         if not pretend:
             run_sql(query, (str(insertion_db), str(bibrec_id), str(oai_rec_id), str(task_id), ))

--- a/modules/miscutil/lib/urlutils.py
+++ b/modules/miscutil/lib/urlutils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013 CERN.
+# Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as

--- a/modules/websession/lib/inveniogc.py
+++ b/modules/websession/lib/inveniogc.py
@@ -1,7 +1,7 @@
 # -*- mode: python; coding: utf-8; -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2007, 2008, 2010, 2011, 2012 CERN.
+# Copyright (C) 2007, 2008, 2010, 2011, 2012, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -172,16 +172,16 @@ def clean_tempfiles():
             % (CFG_TMPDIR, CFG_TMPSHAREDDIR, \
                CFG_MAX_ATIME_RM_BIBDOC, vstr))
 
-    write_message("- deleting old temporary WebSubmit icons")
+    write_message("- deleting old temporary WebSubmit icon dirs")
     gc_exec_command('find %s %s -name "websubmit_icon_creator_*"'
-        ' -atime +%s -exec rm %s -f {} \;' \
+        ' -atime +%s -exec rm %s -rf {} \;' \
             % (CFG_TMPDIR, CFG_TMPSHAREDDIR, \
                CFG_MAX_ATIME_RM_ICON, vstr))
 
     if not CFG_INSPIRE_SITE:
-        write_message("- deleting old temporary WebSubmit stamps")
+        write_message("- deleting old temporary WebSubmit stamp dirs")
         gc_exec_command('find %s %s -name "websubmit_file_stamper_*"'
-            ' -atime +%s -exec rm %s -f {} \;' \
+            ' -atime +%s -exec rm %s -rf {} \;' \
                 % (CFG_TMPDIR, CFG_TMPSHAREDDIR, \
                 CFG_MAX_ATIME_RM_STAMP, vstr))
 


### PR DESCRIPTION
@aw-bib Please note that your OAI matching fix for `maint-1.1` may need some adaptation in `maint-1.21 due to the presence of `CFG_BIBUPLOAD_MATCH_DELETED_RECORDS` that was absent in `maint-1.1`. Please check how I merged the feature and, if you have an Invenio 1.2 installation, please verify the behaviour on your concrete use case, as there are no integration tests for this feature...