### PR TITLE
WebSearch: consider sort order when searching

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -1171,6 +1171,8 @@ CFG_BIBINDEX_PERFORM_OCR_ON_DOCNAMES = scan-.*
 # NOTE: for backward compatibility reasons you can set this to a simple
 # regular expression that will directly be used as the unique key of the
 # map, with corresponding value set to ".*" (in order to match any URL)
+# NOTE2: If the value is None, the url mapping the key regex will be used
+# directly
 CFG_BIBINDEX_SPLASH_PAGES = {
     "http://documents\.cern\.ch/setlink\?.*": ".*",
     "http://ilcagenda\.linearcollider\.org/subContributionDisplay\.py\?.*|http://ilcagenda\.linearcollider\.org/contributionDisplay\.py\?.*": "http://ilcagenda\.linearcollider\.org/getFile\.py/access\?.*|http://ilcagenda\.linearcollider\.org/materialDisplay\.py\?.*",

--- a/modules/bibdocfile/lib/bibdocfile_managedocfiles.py
+++ b/modules/bibdocfile/lib/bibdocfile_managedocfiles.py
@@ -599,7 +599,12 @@ def create_file_upload_interface(recid,
                 os.unlink(uploaded_filepath)
                 body += '<script>alert("%s");</script>' % \
                        _("You have already reached the maximum number of files for this type of document").replace('"', '\\"')
-
+            elif '/' in filename or "%" in filename or "\\" in filename:
+                # We forbid usage of a few characters, for the good of
+                # everybody...
+                os.unlink(uploaded_filepath)
+                body += '<script>alert("%s");</script>' % \
+                        _("You are not allowed to use dot slash '/', percent '%' or backslash '\\\\' in file names. Please, rename the file and upload it again.").replace('"', '\\"')
             else:
                 # Prepare to move file to
                 # working_dir/files/updated/doctype/bibdocname/
@@ -645,13 +650,13 @@ def create_file_upload_interface(recid,
                     body += '<script>alert("%s");</script>' % \
                            (_("A file with format '%s' already exists. Please upload another format.") % \
                             extension).replace('"', '\\"')
-                elif '.' in file_rename  or '/' in file_rename or "\\" in file_rename or \
+                elif '.' in file_rename  or '/' in file_rename or "%" in file_rename or "\\" in file_rename or \
                          not os.path.abspath(new_uploaded_filepath).startswith(os.path.join(working_dir, 'files', 'updated')):
                     # We forbid usage of a few characters, for the good of
                     # everybody...
                     os.unlink(uploaded_filepath)
                     body += '<script>alert("%s");</script>' % \
-                           _("You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file names. Choose a different name and upload your file again. In particular, note that you should not include the extension in the renaming field.").replace('"', '\\"')
+                           _("You are not allowed to use dot '.', slash '/', percent '%' or backslash '\\\\' in file names. Choose a different name and upload your file again. In particular, note that you should not include the extension in the renaming field.").replace('"', '\\"')
                 else:
                     # No conflict with file name
 
@@ -747,11 +752,11 @@ def create_file_upload_interface(recid,
                        (_("A file named %s already exists. Please choose another name.") % \
                         file_rename).replace('"', '\\"')
             elif file_rename != file_target and \
-                     ('.' in file_rename or '/' in file_rename or "\\" in file_rename):
+                     ('.' in file_rename or '/' in file_rename or '%' in file_rename or "\\" in file_rename):
                     # We forbid usage of a few characters, for the good of
                     # everybody...
                 body += '<script>alert("%s");</script>' % \
-                        _("You are not allowed to use dot '.', slash '/', or backslash '\\\\' in file names. Choose a different name and upload your file again. In particular, note that you should not include the extension in the renaming field.").replace('"', '\\"')
+                        _("You are not allowed to use dot '.', slash '/', percent '%' or backslash '\\\\' in file names. Choose a different name and upload your file again. In particular, note that you should not include the extension in the renaming field.").replace('"', '\\"')
             else:
                 # Log
                 log_action(working_dir, file_action, file_target,

--- a/modules/bibformat/lib/elements/bfe_edit_record.py
+++ b/modules/bibformat/lib/elements/bfe_edit_record.py
@@ -36,7 +36,7 @@ def format_element(bfo, style):
     out = ""
 
     user_info = bfo.user_info
-    if user_can_edit_record_collection(user_info, bfo.recID):
+    if user_can_edit_record_collection(user_info, int(bfo.recID)):
         linkattrd = {}
         if style != '':
             linkattrd['style'] = style

--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -4677,8 +4677,8 @@ def print_records(req, recIDs, jrec=1, rg=CFG_WEBSEARCH_DEF_RECORDS_IN_GROUPS, f
 
                     link_ln = ''
 
-                    if ln != CFG_SITE_LANG:
-                        link_ln = '?ln=%s' % ln
+                    if 'ln' in req.form:
+                        link_ln = "?ln={0}".format(ln)
 
                     recid_to_display = recid  # Record ID used to build the URL.
                     if CFG_WEBSEARCH_USE_ALEPH_SYSNOS:

--- a/modules/websearch/lib/search_engine.py
+++ b/modules/websearch/lib/search_engine.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is part of Invenio.
-# Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014 CERN.
+# Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -4247,7 +4247,7 @@ def sort_records(req, recIDs, sort_field='', sort_order='d', sort_pattern='', ve
         else:
             if of.startswith('h'):
                 write_warning(_("Sorry, %s does not seem to be a valid sort option. The records will not be sorted.") % cgi.escape(error_field), "Error", req=req)
-            return slice_records(recIDs, jrec, rg)
+            return sort_records_latest(recIDs, jrec, rg, sort_order)
     elif tags:
         for sort_method in sorting_methods:
             definition = sorting_methods[sort_method]
@@ -4259,7 +4259,7 @@ def sort_records(req, recIDs, sort_field='', sort_order='d', sort_pattern='', ve
         #we do not have this sort_field in BibSort tables -> do the old fashion sorting
         return sort_records_bibxxx(req, recIDs, tags, sort_field, sort_order, sort_pattern, verbose, of, ln, rg, jrec)
     else:
-        return slice_records(recIDs, jrec, rg)
+        return sort_records_latest(recIDs, jrec, rg, sort_order)
 
 
 def sort_records_bibsort(req, recIDs, sort_method, sort_field='', sort_order='d', verbose=0, of='hb', ln=CFG_SITE_LANG, rg=None, jrec=1, sort_or_rank='s', sorting_methods=SORTING_METHODS):
@@ -4372,12 +4372,12 @@ def sort_records_bibxxx(req, recIDs, tags, sort_field='', sort_order='d', sort_p
 
     ## check arguments:
     if not sort_field:
-        return slice_records(recIDs, jrec, rg)
+        return sort_records_latest(recIDs, jrec, rg, sort_order)
 
     if len(recIDs) > CFG_WEBSEARCH_NB_RECORDS_TO_SORT:
         if of.startswith('h'):
             write_warning(_("Sorry, sorting is allowed on sets of up to %d records only. Using default sort order.") % CFG_WEBSEARCH_NB_RECORDS_TO_SORT, "Warning", req=req)
-        return slice_records(recIDs, jrec, rg)
+        return sort_records_latest(recIDs, jrec, rg, sort_order)
 
     recIDs_dict = {}
     recIDs_out = []
@@ -4389,7 +4389,7 @@ def sort_records_bibxxx(req, recIDs, tags, sort_field='', sort_order='d', sort_p
         if error_field:
             if of.startswith('h'):
                 write_warning(_("Sorry, %s does not seem to be a valid sort option. The records will not be sorted.") % cgi.escape(error_field), "Error", req=req)
-            return slice_records(recIDs, jrec, rg)
+            return sort_records_latest(recIDs, jrec, rg, sort_order)
 
     if verbose >= 3 and of.startswith('h'):
         write_warning("Sorting by tags %s." % cgi.escape(repr(tags)), req=req)

--- a/modules/websession/lib/webuser.py
+++ b/modules/websession/lib/webuser.py
@@ -138,7 +138,8 @@ def page_not_authorized(req, referer='', uid='', text='', navtrail='', ln=CFG_SI
                 if text:
                     body = text
                 else:
-                    body = "%s %s" % (CFG_WEBACCESS_WARNING_MSGS[9] % cgi.escape(res[0][0]),
+                    message_index = 1 if CFG_ACCESS_CONTROL_LEVEL_ACCOUNTS == 0 else 9
+                    body = "%s %s" % (CFG_WEBACCESS_WARNING_MSGS[message_index] % cgi.escape(res[0][0]),
                                       ("%s %s" % (CFG_WEBACCESS_MSGS[0] % urllib.quote(referer), CFG_WEBACCESS_MSGS[1])))
             else:
                 if text:

--- a/modules/websubmit/lib/websubmit_file_converter.py
+++ b/modules/websubmit/lib/websubmit_file_converter.py
@@ -138,6 +138,8 @@ def get_conversion_map():
         '.hocr': {},
         '.pdf;pdfa': {},
         '.asc': {},
+        '.vtt': {},
+        '.srt': {},
     }
     if CFG_PATH_GZIP:
         ret['.ps']['.ps.gz'] = (gzip, {})
@@ -186,6 +188,9 @@ def get_conversion_map():
     ret['.html']['.txt'] = (html2text, {})
     ret['.htm']['.txt'] = (html2text, {})
     ret['.xml']['.txt'] = (html2text, {})
+    # Subtitle files
+    ret['.vtt']['.txt'] = (txt2text, {})
+    ret['.srt']['.txt'] = (txt2text, {})
     if CFG_PATH_TIFF2PDF:
         ret['.tiff']['.pdf'] = (tiff2pdf, {})
         ret['.tif']['.pdf'] = (tiff2pdf, {})


### PR DESCRIPTION
* FIX Takes into account the sort order when searching, even if
   no specific sort or rank method is used. (PR #3564)

* Issue introduced in e49a1368bb0e4159b3a43b508140db120c2e8e82.

Signed-off-by: Ludmila Marian <ludmila.marian@gmail.com>
