### PR TITLE
docker: fix installation instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -48,6 +48,7 @@ RUN yum update -y && \
                    redis \
                    sendmail \
                    sudo \
+                   supervisor \
                    texlive \
                    unzip \
                    w3m \
@@ -56,11 +57,7 @@ RUN yum update -y && \
 
 # Installing Python prerequisites:
 ADD requirements.txt /tmp/requirements.txt
-ADD requirements-extras.txt /tmp/requirements-extras.txt
-RUN pip install --upgrade distribute && \
-    pip install supervisor && \
-    pip install -r /tmp/requirements.txt && \
-    pip install -r /tmp/requirements-extras.txt
+RUN pip install -r /tmp/requirements.txt
 
 # Run container as `apache` user, with forced UID of 1000, which
 # should match current host user in most situations:

--- a/INSTALL
+++ b/INSTALL
@@ -192,7 +192,6 @@ Contents
         Python dependencies, then you can run:
 
           $ sudo pip install -r requirements.txt
-          $ sudo pip install -r requirements-extras.txt
 
         to install all manadatory, recommended, and optional packages
         mentioned above.


### PR DESCRIPTION
* FIX Fixes Docker build instructions by updating `pip` statements regarding
  `supervisor` and by removing remaining references to nowadays removed
  requirements extras list.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>