### PR TITLE
BibIndex: native fulltext index textification

### DIFF
--- a/modules/bibindex/lib/tokenizers/BibIndexFulltextTokenizer.py
+++ b/modules/bibindex/lib/tokenizers/BibIndexFulltextTokenizer.py
@@ -121,6 +121,8 @@ class BibIndexFulltextTokenizer(BibIndexDefaultTokenizer):
                 else:
                     text = ""
                     if hasattr(bibdoc, "get_text"):
+                     #Textify Doc Before getting Text
+                        bibdoc.extract_text()
                         text = bibdoc.get_text()
                     return self.tokenize_for_words_default(text)
             else:


### PR DESCRIPTION
* FIX Enables native fulltext indexing by explicitly extracting text when using the BibDoc
  interface. (closes #3708) (closes #3690), (closes #2576)