### PR TITLE
rename cython to Cython in provision_web_centos6

### DIFF
--- a/scripts/provision-web.sh
+++ b/scripts/provision-web.sh
@@ -206,7 +206,7 @@ provision_web_centos6 () {
     $sudo yum install -y \
          automake \
          curl \
-         cython \
+         Cython \
          file \
          freetype-devel \
          gcc \


### PR DESCRIPTION
At least in epel for EL6, "Cython" should be capitalized.