### PR TITLE
oaiharvest : Lastrun date return an empty string

### DIFF
--- a/modules/oaiharvest/lib/oai_harvest_dblayer.py
+++ b/modules/oaiharvest/lib/oai_harvest_dblayer.py
@@ -227,7 +227,7 @@ def get_oai_src(params={}):
     if res:
         for result in res:
             for key, value in result.iteritems():
-                if value is None:
+                if value is None and key !="lastrun":
                     if key == "arguments":
                         value = {}
                     else:


### PR DESCRIPTION
oaiharvest : Set the lastrun date variables value to None if the oai was never harvest ,  without the lastrun variable will return an empty string ""  which will generate   an error here https://github.com/inveniosoftware/invenio/blob/legacy/modules/oaiharvest/lib/oai_harvest_utils.py#L171 when running oaiharvest against a new oai for the first time.