### PR TITLE
Correct link to readthedocs

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -16,4 +16,4 @@ all the needed services such as PostgreSQL, Elasticsearch, Redis, RabbitMQ.
 
 For a detailed walk-through on how to set up your Invenio instance, please see
 our `installation documentation
-<http://invenio/installation.readthedocs.io/index.html>`_.
+<http://invenio.readthedocs.io/en/latest/installation/index.html>`_.


### PR DESCRIPTION
It appears this link wasn't updated when documentation was moved?