### PR TITLE
installation: add docker setup for developpers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@
 # Use Python-2.7:
 FROM python:2.7-slim
 
+# Args coming from docker-compose
+ARG DEBUG
+
 # Configure Invenio instance:
 ENV INVENIO_WEB_HOST=127.0.0.1
 ENV INVENIO_WEB_INSTANCE=invenio
@@ -39,6 +42,7 @@ ENV INVENIO_REDIS_HOST=redis
 ENV INVENIO_ELASTICSEARCH_HOST=elasticsearch
 ENV INVENIO_RABBITMQ_HOST=rabbitmq
 ENV INVENIO_WORKER_HOST=127.0.0.1
+ENV FLASK_DEBUG=$DEBUG
 
 # Install Invenio web node pre-requisites:
 COPY scripts/provision-web.sh /tmp/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -38,6 +38,7 @@ include MAINTAINERS
 include THANKS
 include Vagrantfile
 include docker-compose.yml
+include docker-compose-dev.yml
 include docs/requirements.txt
 include elasticsearch/Dockerfile
 include nginx/Dockerfile

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -22,6 +22,27 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
+# README
+# ======
+#
+# This docker setup will create a demo site which will be run in debug mode.
+# It authorizes you to develop code locally, and it will automatically update
+# the demo site with your changes.
+#
+# To do so, you need to have a folder named `../modules` (at the same level
+# as the `invenio` directory containing this file). This folder will be
+# in the containers in `/modules`. You can develop a module here and pip
+# install it in your web container
+# (`pip install -Ue /modules/invenio-thingy[all]`).
+#
+# To start this setup, you need to run the following commands:
+# $ docker-compose -f docker-compose-dev.yml build
+# $ docker-compose -f docker-compose-dev.yml up [-d]
+# $ docker-compose -f docker-compose-dev.yml run --rm web /code/scripts/populate-instance.sh
+#
+# Then you can access to containers with
+# $ docker exec -it invenio_web_1 bash
+
 version: "3"
 services:
   web:
@@ -29,7 +50,7 @@ services:
     build:
       context: .
       args:
-        DEBUG: 0
+        DEBUG: 1
     command: /bin/bash -c "invenio run -h 0.0.0.0"
     environment:
       PATH: "/home/invenio/.virtualenvs/invenio/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -48,6 +69,7 @@ services:
       INVENIO_RABBITMQ_HOST: "rabbitmq"
       INVENIO_WORKER_HOST: "127.0.0.1"
     volumes:
+      - ../modules:/modules
       - static:/home/invenio/.virtualenvs/invenio/var/instance/static
     links:
       - postgresql
@@ -56,6 +78,7 @@ services:
       - rabbitmq
     ports:
       - "5000:5000"
+    working_dir: "/modules"
 
   postgresql:
     restart: "always"
@@ -104,7 +127,7 @@ services:
     build:
       context: .
       args:
-        DEBUG: 0
+        DEBUG: 1
     volumes:
       - static:/home/invenio/.virtualenvs/invenio/var/instance/static
     user: invenio

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015, 2016, 2017 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+flask-shell-ipython
+git+https://github.com/remileduc/invenio-flaskdebugtoolbar.git#egg=invenio-flaskdebugtoolbar

--- a/scripts/create-instance.sh
+++ b/scripts/create-instance.sh
@@ -89,6 +89,9 @@ if [ "${INVENIO_WORKER_HOST}" = "" ]; then
     echo "[ERROR] Example: export INVENIO_WORKER_HOST=192.168.50.15"
     exit 1
 fi
+if [ -z "$DEBUG" ]; then
+    DEBUG=0
+fi
 
 # load virtualenvrapper:
 # shellcheck source=/dev/null
@@ -106,12 +109,18 @@ cdvirtualenv
 set -o errexit
 set -o nounset
 
-if [[ "$@" != *"--devel"* ]]; then
+# ideally, when we'll have refactored the setup.py:
+#if [ "$FLASK_DEBUG" != 1 ]; then
+#    pip install invenio[ils]
+#else
+#    pip install invenio[ils,extra]
+#fi
+# For the moment, we use an extra requirements file:
 # sphinxdoc-install-invenio-full-begin
 pip install invenio-app-ils[postgresql,elasticsearch2]
 # sphinxdoc-install-invenio-full-end
-else
-    pip install -r "$scriptpathname/../requirements-devel.txt"
+if [ "$DEBUG" == 1 ]; then
+    pip install -r "$scriptpathname/../requirements-extra.txt"
 fi
 
 # sphinxdoc-customise-instance-begin


### PR DESCRIPTION
- New docker-compose-dev.yml for developpers
- see #3802 

The documentation (at the top of the file) can be copied in antother RST file, but I'm not sure which one... I can add it later

This PR adds 2 files:
- Dockerfile-dev
- docker-compose-dev.yml

These can be used to create a docker dev environment.
We now use the version 3 of the YML of docker-compose...

We use the file `requirements-extra.txt` to install additional modules useful for debugging. In the future, we can just install `invenio[extra]`, see the comment in the `.sh` file.

This is for demo, it is not intended to be merged as is. The goal is to have an easy dev environment. Don't hesitate to provide feedbacks!