### PR TITLE
invenio: disable Talisman session_cookie_secure

### DIFF
--- a/scripts/instance.cfg
+++ b/scripts/instance.cfg
@@ -31,3 +31,4 @@ OAISERVER_ID_PREFIX='oai:{{ environ('INVENIO_WEB_INSTANCE') }}:recid/'
 # Default Secure Headers
 APP_DEFAULT_SECURE_HEADERS = INVENIO_APP_APP_DEFAULT_SECURE_HEADERS
 APP_DEFAULT_SECURE_HEADERS['force_https'] = False
+APP_DEFAULT_SECURE_HEADERS['session_cookie_secure'] = False


### PR DESCRIPTION
* Disable Talisman session_cookie_secure to be able to login
  without HTTPS. (closes #3815)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>