### PR TITLE
Implemented possibility to switch off CFG_WEBSTYLE_REVERSE_PROXY_IPS.

### DIFF
--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -306,12 +306,13 @@ CFG_WEBSTYLE_HTTP_USE_COMPRESSION = 0
 ## CFG_WEBSTYLE_REVERSE_PROXY_IPS -- if you are setting a multinode
 ## environment where an HTTP proxy such as mod_proxy is sitting in
 ## front of the Invenio web application and is forwarding requests to
-## worker nodes, set here the the list of IP addresses of the allowed
-## HTTP proxies. This is needed in order to avoid IP address spoofing
-## when worker nodes are also available on the public Internet and
-## might receive forged HTTP requests. Only HTTP requests coming from
-## the specified IP addresses will be considered as forwarded from a
-## reverse proxy.  E.g. set this to '123.123.123.123'.
+## worker nodes, set here the list of IP addresses of the allowed HTTP
+## proxies. This is needed in order to avoid IP address spoofing when
+## worker nodes are also available on the public Internet and might
+## receive forged HTTP requests. Only HTTP requests coming from the
+## specified IP addresses will be considered as forwarded from a
+## reverse proxy.  E.g. set this to '123.123.123.123'.  If empty, such
+## a check is not performed.
 CFG_WEBSTYLE_REVERSE_PROXY_IPS = 0.0.0.0
 
 ##################################

--- a/config/invenio.conf
+++ b/config/invenio.conf
@@ -312,7 +312,7 @@ CFG_WEBSTYLE_HTTP_USE_COMPRESSION = 0
 ## might receive forged HTTP requests. Only HTTP requests coming from
 ## the specified IP addresses will be considered as forwarded from a
 ## reverse proxy.  E.g. set this to '123.123.123.123'.
-CFG_WEBSTYLE_REVERSE_PROXY_IPS =
+CFG_WEBSTYLE_REVERSE_PROXY_IPS = 0.0.0.0
 
 ##################################
 ## Part 3: WebSearch parameters ##

--- a/modules/webstyle/lib/webinterface_handler_wsgi.py
+++ b/modules/webstyle/lib/webinterface_handler_wsgi.py
@@ -263,7 +263,7 @@ class SimulatedModPythonRequest(object):
                self.__headers_in.get('X-FORWARDED-HOST', '') == \
                urlparse(CFG_SITE_URL)[1]:
             # we are using proxy setup
-            if self.__environ.get('REMOTE_ADDR') in CFG_WEBSTYLE_REVERSE_PROXY_IPS:
+            if not CFG_WEBSTYLE_REVERSE_PROXY_IPS or self.__environ.get('REMOTE_ADDR') in CFG_WEBSTYLE_REVERSE_PROXY_IPS:
                 # we trust this proxy
                 ip_list = self.__headers_in['X-FORWARDED-FOR'].split(',')
                 for ip in ip_list:


### PR DESCRIPTION
In docker context, it is difficult to determine the IP address of the proxy server.  Besides, the whole setup runs behind a firewall.  Thus, this change allows an empty value of CFG_WEBSTYLE_REVERSE_PROXY_IPS which means that this check is not performed.  Invenio is still secure by default because the default value is set to 0.0.0.0.