### PR TITLE
bibcirculation_dblayer: fix item status return

### DIFF
--- a/modules/bibcirculation/lib/bibcirculation_dblayer.py
+++ b/modules/bibcirculation/lib/bibcirculation_dblayer.py
@@ -2797,7 +2797,7 @@ def get_copies_status(recid):
                   (recid, ))
 
     if res:
-        return res[0]
+        return tuple([element for tupl in res for element in tupl])
     else:
         return None
 


### PR DESCRIPTION
* Fix get_copies_status() to return acually a tuple of _all_ copies
  status instead of only the 1st elements status.

Closes #3840