### PR TITLE
Fixed broken encryptedtype imports

### DIFF
--- a/invenio/modules/oauth2server/models.py
+++ b/invenio/modules/oauth2server/models.py
@@ -33,7 +33,8 @@ from invenio.ext.sqlalchemy import db
 import six
 
 from sqlalchemy_utils.types import URLType
-from sqlalchemy_utils.types.encrypted import AesEngine, EncryptedType
+from sqlalchemy_utils import EncryptedType
+from sqlalchemy_utils.types.encrypted.encrypted_type import AesEngine
 
 from werkzeug.security import gen_salt
 


### PR DESCRIPTION
As per http://sqlalchemy-utils.readthedocs.io/en/latest/data_types.html#module-sqlalchemy_utils.types.encrypted.encrypted_type