### PR TITLE
dependencies: pin werkzeug (broken imports)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,10 @@ cache:
 
 env:
   global:
-    - ES2_DOWNLOAD_URL="https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.2/elasticsearch-2.4.2.tar.gz"
     - ES5_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.4.tar.gz"
     - ES6_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.2.tar.gz"
     - ES_HOST=127.0.0.1
   matrix:
-    # ES2 + SQLite
-    - REQUIREMENTS=lowest EXTRAS=all,sqlite,elasticsearch2 SQLALCHEMY_DATABASE_URI="sqlite:///test.db" ES_URL=$ES2_DOWNLOAD_URL
     # ES5 + MySQL
     - REQUIREMENTS=lowest EXTRAS=all,mysql,elasticsearch5 SQLALCHEMY_DATABASE_URI="mysql+pymysql://travis@localhost:3306/invenio" ES_URL=$ES5_DOWNLOAD_URL
     # ES5 + PostgreSQL

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -331,7 +331,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/2.7/', None),
     'sqlalchemy': ('http://docs.sqlalchemy.org/en/latest/', None),
     'webassets': ('https://webassets.readthedocs.io/en/latest/', None),
-    'werkzeug': ('http://werkzeug.pocoo.org/docs/', None),
+    'werkzeug': ('http://werkzeug.pocoo.org/docs/en/0.16.x/', None),
 }
 
 # Autodoc configuraton.

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -1,6 +1,6 @@
 ..
     This file is part of Invenio.
-    Copyright (C) 2018 CERN.
+    Copyright (C) 2018-2020 CERN.
 
     Invenio is free software; you can redistribute it and/or modify it
     under the terms of the MIT License; see LICENSE file for more details.
@@ -17,6 +17,7 @@ are here for the interested.
     :name: mastertoc
 
     maintenance-policy
+    v3.1.2
     v3.1.1
     v3.1.0
     v3.0.2

--- a/docs/releases/v3.1.2.rst
+++ b/docs/releases/v3.1.2.rst
@@ -1,0 +1,22 @@
+..
+    This file is part of Invenio.
+    Copyright (C) 2020 CERN.
+
+    Invenio is free software; you can redistribute it and/or modify it
+    under the terms of the MIT License; see LICENSE file for more details.
+
+Version 3.1.2
+=============
+
+*Released 2020-02-11*
+
+Invenio v3.1.2 fixes issues with an incompatibility of the recent released
+Werkzeug v1.0
+
+Maintenance policy
+------------------
+
+Invenio v3.1 will be supported with bug and security fixes until the release of
+Invenio v3.3 and minimum until 2020-03-31.
+
+See our :ref:`maintenance-policy`.

--- a/invenio/version.py
+++ b/invenio/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "3.1.1"
+__version__ = "3.1.2"

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ install_requires = [
     'invenio-celery>=1.0.1,<1.1.0',
     'invenio-config>=1.0.1,<1.1.0',
     'invenio-i18n>=1.1.1,<1.2.0',
+    'Werkzeug>=0.15.0,<1.0.0'
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Pin werkzeug to greater than 0.15 and lower than 1 to fix the broken imports temporarily.