### PR TITLE
dependencies: pin werkzeug (broken imports)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ install_requires = [
     'invenio-celery>=1.1.1,<1.2.0',
     'invenio-config>=1.0.2,<1.1.0',
     'invenio-i18n>=1.1.1,<1.2.0',
+    'Werkzeug>=0.15.0,<1.0.0'
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Pin werkzeug to greater than 0.15 and lower than 1 to fix the broken imports temporarily.