### PR TITLE
docs: update list of modules

### DIFF
--- a/docs/documentation/bundles/alpha.rst
+++ b/docs/documentation/bundles/alpha.rst
@@ -12,15 +12,33 @@ to change prior to final release and in most cases are missing documentation.
 
 - `invenio-accounts-rest <https://invenio-accounts-rest.readthedocs.io>`_
     - REST APIs for account management.
+- `invenio-app-rdm <https://inveniordm.docs.cern.ch>`_
+    - Research Data Management (RDM) flavour of Invenio
+- `invenio-app-ils <https://invenio-app-ils.readthedocs.io>`_
+    - Integrated Library System (ILS) flavour of Invenio.
+- `invenio-banners <https://invenio-banners.readthedocs.io>`_
+    - Create and show banners with useful messages to users.
 - `invenio-charts-js <https://invenio-charts-js.readthedocs.io>`_
     - AngularJS application for producing charts.
+- `invenio-circulation <https://invenio-circulation.readthedocs.io>`_
+    - Library circulation module for Invenio.
+- `invenio-cli <https://inveniordm.docs.cern.ch/reference/cli/>`_
+    - CLI module for Invenio
+- `invenio-communities <https://invenio-communities.readthedocs.io>`_
+    - Invenio communities module.
 - `invenio-csl-js <https://invenio-csl-js.readthedocs.io>`_
     - AngularJS application for rendering citation strings via the records
       REST API and the CSL REST API.
 - `invenio-csl-rest <https://invenio-csl-rest.readthedocs.io>`_
     - REST API for retrieving Citation Style Language (CSL) style files.
+- `invenio-drafts-resources <https://invenio-drafts-resources.readthedocs.io>`_
+    - Submission/deposit module for Invenio.
 - `invenio-github <https://invenio-github.readthedocs.io>`_
     - GitHub integration with automatic archiving of new releases in Invenio.
+- `invenio-migrator <https://invenio-migrator.readthedocs.io>`_
+    - Utilities for migrating past Invenio versions to Invenio 3.0.
+- `invenio-oaiharvester <https://invenio-oaiharvester.readthedocs.io>`_
+    - Invenio module for OAI-PMH metadata harvesting between repositories.
 - `invenio-openaire <https://invenio-openaire.readthedocs.io>`_
     - Integration with OpenAIRE, including support for harvesting Open Funder
       Regsitry and the OpenAIRE grants database, as well as REST APIs for
@@ -37,6 +55,16 @@ to change prior to final release and in most cases are missing documentation.
 - `invenio-query-parser <https://invenio-query-parser.readthedocs.io>`_
     - Invenio v1 compatible query parser for Invenio v3. Note the module is GPL
       licensed due to a GPL-licensed dependency.
+- `invenio-records-editor <https://invenio-records-editor.readthedocs.io>`_
+    - Record editor for Invenio (Python part).
+- `invenio-records-editor-js <https://invenio-records-editor-js.readthedocs.io>`_
+    - Record editor for Invenio (JavaScript part).
+- `invenio-records-permissions <https://invenio-records-permissions.readthedocs.io>`_
+    - Permissions for Invenio's records REST API.
+- `invenio-records-resources <https://invenio-records-resources.readthedocs.io>`_
+    - Records REST APIs for Invenio.
+- `invenio-rdm-records <https://invenio-rdm-records.readthedocs.io>`_
+    - DataCite-based data model for InvenioRDM flavour.
 - `invenio-s3 <https://invenio-s3.readthedocs.io>`_
     - Support for the S3 storage protocol in Invenio.
 - `invenio-saml <https://invenio-saml.readthedocs.io>`_
@@ -51,6 +79,12 @@ to change prior to final release and in most cases are missing documentation.
       services.
 - `invenio-xrootd <https://invenio-xrootd.readthedocs.io>`_
     - Support for the storage protocol XRootD in Invenio.
+- `react-invenio-app-ils <https://react-invenio-app-ils.readthedocs.io>`_
+    - Single Page App built with React for InvenioILS.
+- `react-invenio-deposit <https://react-invenio-deposit.readthedocs.io>`_
+    - React application for Invenio deposit forms.
+- `react-invenio-forms <https://react-invenio-forms.readthedocs.io>`_
+    - React component library for Formik components.
 - `react-searchkit <https://invenio-react-searchkit.readthedocs.io>`_
     - Modular React library for implementing search interfaces on top of
       Invenio, Elasticsearch or other search APIs. Replacement for

--- a/docs/documentation/bundles/documentation.rst
+++ b/docs/documentation/bundles/documentation.rst
@@ -1,0 +1,10 @@
+Documentation modules
+---------------------
+These modules include the documentation for Invenio products.
+
+Included modules:
+
+- `docs-invenio-ils <https://invenioils.docs.cern.ch>`_
+    - InvenioILS documentation
+- `docs-invneio-rdm <https://inveniordm.docs.cern.ch>`_
+    - InvenioRDM documentation

--- a/docs/documentation/bundles/index.rst
+++ b/docs/documentation/bundles/index.rst
@@ -30,6 +30,7 @@ Each module has a separate documentation which you can find linked below.
    alpha
    utilities
    scaffolding
+   documentation
 
 
 Notes on license

--- a/docs/documentation/bundles/scaffolding.rst
+++ b/docs/documentation/bundles/scaffolding.rst
@@ -6,6 +6,8 @@ Following modules provide templates for getting started with Invenio:
     - Template for new Invenio instances.
 - `cookiecutter-invenio-module <https://github.com/inveniosoftware/cookiecutter-invenio-module>`_
     - Template for a reusable Invenio module.
+- `cookiecutter-invenio-rdm <https://github.com/inveniosoftware/cookiecutter-invenio-rdm>`_
+    - Cookiecutter template for a new Invenio RDM instance.
 
 Discontinued:
 

--- a/docs/documentation/bundles/utilities.rst
+++ b/docs/documentation/bundles/utilities.rst
@@ -5,6 +5,10 @@ Above Invenio modules dependent on a number of smaller utility libraries we
 have developed to take care of e.g. identifier normalization, DataCite/Dublin
 Core metadata generation, testing and citation formatting.
 
+- `babel-edtf <https://babel-edtf.readthedocs.io>`_
+    - Localization for EDTF (Extended Date Time Format) date strings.
+- `base32-lib <https://base32-lib.readthedocs.io>`_
+    - Library to generate, encode and decode random base32 strings.
 - `citeproc-py-styles <https://citeproc-py-styles.readthedocs.io>`_
     - Citation Style Language (CSL) style files packaged as a Python module
 - `datacite <https://datacite.readthedocs.io>`_
@@ -14,24 +18,44 @@ Core metadata generation, testing and citation formatting.
     - Python library for generating Dublin Core XML from Python dictionaries.
 - `dictdiffer <https://dictdiffer.readthedocs.io>`_
     - Python library for diffing/patching/merging JSON documents.
+- `docker-services-cli <https://docker-services-cli.readthedocs.io>`_
+    - Infrastructure services for local and CI tests.
 - `dojson <https://dojson.readthedocs.io>`_
     - JSON to JSON rule-based transformation library.
+- `domapping <https://domapping.readthedocs.io/en/latest/>`_
+    - Package generating elasticsearch mapping from jsonschemas.
+- `doschema <https://doschema.readthedocs.io/en/latest/>`_
+    - Utilities to work with JSON Schemas.
 - `flask-breadcrumbs <https://flask-breadcrumbs.readthedocs.io>`_
     - Flask extension for managing breadcrumbs in web applications.
 - `flask-celeryext <https://flask-celeryext.readthedocs.io>`_
     - Celery integration for Flask.
+- `flask-cli <https://flask-cli.readthedocs.io>`_
+    - Flask-CLI is a backport of Flask 1.0's new click integration to Flask.
 - `flask-iiif <https://flask-iiif.readthedocs.io>`_
     - IIIF server for Flask.
+- `flask-kvsessions <https://pythonhosted.org/Flask-KVSession/>`_
+    - A drop-in replacement for Flask's session handling using server-side sessions.
 - `flask-menu <https://flask-menu.readthedocs.io>`_
     - Menu generation support for Flask.
+- `flask-resources <https://flask-resources.readthedocs.io>`_
+    - REST APIs for Flask
 - `flask-sitemap <https://flask-sitemap.readthedocs.io>`_
     - Sitemaps XML generation for Flask.
+- `flask-sso <https://flask-sso.readthedocs.io>`_
+    - Flask Single-Sign-On Extension
 - `flask-webpack <https://flask-webpack.readthedocs.io>`_
     - Webpack integration for Flask.
+- `helm-invenio <https://helm-invenio.readthedocs.io>`_
+    - Helm charts for deploying an Invenio instance
 - `idutils <https://idutils.readthedocs.io>`_
     - Persistent identifier validation, identification and normalization.
+- `intbitset <https://intbitset.readthedocs.io>`_
+    - Python C-based extension implementing fast integer bit sets
 - `jsonresolver <https://jsonresolver.readthedocs.io>`_
     - JSONRef resolver with support for local plugins.
+- `marshmallow-utils <https://marshmallow-utils.readthedocs.io>`_
+    - Utilities for Marshmallow.
 - `pynpm <https://pynpm.readthedocs.io>`_
     - NPM integration for Python.
 - `pywebpack <https://pywebpack.readthedocs.io>`_


### PR DESCRIPTION
Closes #4058 

**Notes**:

- Some modules like `.github`, `automation-tools`, etc. have been left out since they are utility modules to manage Invenio, but not Invenio modules *per se* or CERN specific (e.g. `cernservicexml`).
- RDM modules are all included in `alpha.rst`.
- Utility modules are in `utilities.rst` even if they are in alpha state, because this was the pattern with others like `citeproc-py-styles`.
- Some modules (e.g. babel-edtf) have their docs page broken (not built?)
    - https://babel-edtf.readthedocs.io
    - https://helm-invenio.readthedocs.io
    - https://invenio-banners.readthedocs.io
    - https://invenio-cli.readthedocs.io/en/latest/ Should just point to https://inveniordm.docs.cern.ch/reference/cli/
    - https://invenio-records-editor.readthedocs.io
    - https://invenio-records-editor-js.readthedocs.io
    - https://react-invenio-app-ils.readthedocs.io
    - https://react-invenio-deposit.readthedocs.io
    - https://react-invenio-forms.readthedocs.io
- Repos **not included because they are empty**:
    - https://github.com/inveniosoftware/invenio-accessrequests
    - https://github.com/inveniosoftware/invenio-exporter
    - https://github.com/inveniosoftware/invenio-sitemap
- Repos **not included because they are not released**:
    - invenio-files-processor
    - invenio-index-migrator
    - invenio-swh
    - invenio-vocabularies