### PR TITLE
docs: add Linux development environment setup guides

### DIFF
--- a/docs/getting-started/development-environment.rst
+++ b/docs/getting-started/development-environment.rst
@@ -180,238 +180,446 @@ See https://docs.docker.com/docker-for-mac/#resources.
 Typically this is necessary if services are not running or
 images are having problems building.
 
-Ubuntu
-~~~~~~
+Linux
+~~~~~
 
-System setup guide for Ubuntu.
+This section covers setting up a Linux system for Invenio development.
+Instructions are provided for Debian/Ubuntu, NixOS, Alpine Linux, and
+Arch Linux. Install the system packages for your distribution, then follow
+the `Shared setup (all distributions)`_ section.
 
-**General tools/packages useful during development:**
+Debian / Ubuntu
+^^^^^^^^^^^^^^^
 
-.. code-block:: sh
+Tested on Debian 12 (Bookworm) and Ubuntu 22.04+.
 
-        $ apt install git-all              # Distributed version control system
-        $ apt install sqlitebrowser        # UI for SQLite
-        $ apt install libcairo2-dev        # Graphics library
-        $ apt install htop                 # A better top
-        $ apt install tree                 # Pretty print a directory structure
-        $ apt install wget                 # Http client
-        $ apt install hub                  # Extends git with github features
-        $ apt install bash-completion      # If bash is used as shell
-        $ apt install sshuttle iptables    # Needed for tunneling into CERN.
-        $ snap install spectacle           # Organise windows with keyboard shortcuts
+**System libraries**
+
+These are needed to compile the Python packages that Invenio depends on:
+
+.. code-block:: console
+
+    $ sudo apt-get update
+    $ sudo apt-get install -y \
+        build-essential python3-dev libssl-dev \
+        libcairo2-dev libfreetype-dev libgeoip-dev gettext libglib2.0-dev \
+        imagemagick libmagickwand-dev \
+        libjpeg-dev libpng-dev libtiff-dev \
+        libffi-dev libmemcached-dev \
+        libxml2-dev libxslt1-dev \
+        libreadline-dev xz-utils zlib1g-dev \
+        libbz2-dev libsqlite3-dev libncurses-dev tk-dev liblzma-dev
+
+.. note::
+
+    **Debian 11 (Bullseye) or older:** replace ``libfreetype-dev`` with
+    ``libfreetype6-dev`` and ``libncurses-dev`` with
+    ``libncurses5-dev libncursesw5-dev``.
+
+**CLI development tools**
+
+.. code-block:: console
+
+    $ sudo apt-get install -y git wget curl htop tree
+
+GitHub CLI:
+
+.. code-block:: console
+
+    $ curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+    $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+        https://cli.github.com/packages stable main" \
+        | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    $ sudo apt-get update && sudo apt-get install -y gh
+
+Chromedriver (for end-to-end tests):
+
+.. code-block:: console
+
+    $ sudo apt-get install -y chromium-driver   # Debian
+    $ sudo apt-get install -y chromium-chromedriver   # Ubuntu
 
 **Docker**
 
-To install docker you can follow the instructions in `docker for Ubuntu. <https://docs.docker.com/engine/install/ubuntu/>`_
-
-If you get the following error after installing Docker and running simple commands:
-
-.. code-block:: console
-
-    Got permission denied ... /var/run/docker.sock: connect: permission denied
-
-see `here <https://stackoverflow.com/questions/48568172/docker-sock-permission-denied/>`_ for some tips on how to solve it.
-
-**docker-compose**
-
-For defining and running multi-container Docker applications.
+Install Docker Engine from the
+`official repository <https://docs.docker.com/engine/install/debian/>`_:
 
 .. code-block:: console
 
-    $ sudo apt install docker-compose
-
-**Google Chrome**
-
-Needed for some end-to-end tests.
-
-.. code-block:: console
-
-    $ sudo apt install gdebi-core wget
-    $ wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-    $ sudo gdebi google-chrome-stable_current_amd64.deb
-
-**OC CLI**
-
-Needed if you deploy on openshift.
-
-Download the latest OpenShift Origin files. As of this writing, that version number is 3.11.0.
-
-.. code-block:: console
-
-    $ wget https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
-
-Once the file is downloaded, extract it:
-
-.. code-block:: console
-
-    $ tar xvzf openshift*.tar.gz
-
-Change into the newly-created directory:
-
-.. code-block:: console
-
-    $ cd openshift-origin-client-tools*/
-
-Move the kubectl and oc binaries:
-
-.. code-block:: console
-
-    $ sudo mv  oc kubectl  /usr/local/bin/
-
-**Installation problems**
-If during the installation you encounter broken packages, try the following command:
-
-.. code-block:: sh
-
-    $ sudo apt --fix-broken install
-
-**Python**
-
-Invenio is developed using Python and JavaScript.
-
-
-If you want to check which version of Python you have, try the following:
-
-.. code-block:: sh
-
-    # Check the system Python version
-    $ python --version
-
-    # Check the Python 2 version
-    $ python2 --version
-
-    # Check the Python 3 version
-    $ python3 --version
-
-To install Python 3.8 type the following commands:
-
-.. code-block:: sh
-
+    $ sudo apt-get install -y ca-certificates gnupg
+    $ sudo install -m 0755 -d /etc/apt/keyrings
+    $ curl -fsSL https://download.docker.com/linux/debian/gpg \
+        | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+        https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+        | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     $ sudo apt-get update
-    $ sudo apt-get install python3.8 python3-pip
+    $ sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
-In the following `list <https://invenio.readthedocs.io/en/latest/getting-started/quickstart/installation.html#prerequisites/>`_ you can check if your system has the necessary requirements.
+.. note::
 
-We highly recommend that install ``pyenv`` and ``nvm`` - both tools manage version of python and node
-respectively. Install the following packages:
+    For **Ubuntu**, replace ``download.docker.com/linux/debian`` with
+    ``download.docker.com/linux/ubuntu`` in the commands above.
 
-**nvm**
+See `Docker post-install`_ below.
+
+**Fonts**
 
 .. code-block:: console
 
-    $ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
+    $ sudo apt-get install -y fonts-dejavu
 
-To check if you have the latest version of node installed type the following commands:
+NixOS
+^^^^^
+
+NixOS is different from traditional distributions. The idiomatic approach is
+to use a ``shell.nix`` (or ``flake.nix``) for project-local dev environments
+and ``configuration.nix`` for system-wide tools like Docker and fonts.
+
+**Project dev shell (shell.nix)**
+
+Create a ``shell.nix`` at the root of your Invenio project:
+
+.. code-block:: nix
+
+    { pkgs ? import <nixpkgs> {} }:
+
+    pkgs.mkShell {
+      buildInputs = with pkgs; [
+        # Build toolchain
+        gcc gnumake pkg-config openssl
+
+        # System libraries for Python packages
+        cairo freetype geoip gettext glib imagemagick
+        libjpeg libffi libmemcached libpng libtiff
+        libxml2 libxslt readline xz zlib
+
+        # pyenv build dependencies
+        bzip2 sqlite ncurses tcl tk
+
+        # CLI tools
+        git gh chromedriver nodejs wget curl htop tree
+
+        # Python version management
+        pyenv
+      ];
+
+      shellHook = ''
+        export PYENV_ROOT="$HOME/.pyenv"
+        export PATH="$PYENV_ROOT/bin:$PATH"
+        eval "$(pyenv init -)"
+      '';
+    }
+
+Enter the dev shell:
+
+.. code-block:: console
+
+    $ nix-shell
+
+Or with flakes:
+
+.. code-block:: console
+
+    $ nix develop
+
+**System configuration (configuration.nix)**
+
+Add system-wide packages in ``/etc/nixos/configuration.nix``:
+
+.. code-block:: nix
+
+    {
+      # Docker
+      virtualisation.docker.enable = true;
+      users.users.<your-user>.extraGroups = [ "docker" ];
+
+      # Fonts
+      fonts.packages = with pkgs; [ dejavu_fonts ];
+
+      # System-wide CLI tools (optional)
+      environment.systemPackages = with pkgs; [
+        git gh docker-compose htop tree
+      ];
+    }
+
+Rebuild:
+
+.. code-block:: console
+
+    $ sudo nixos-rebuild switch
+
+.. note::
+
+    **nvm** is not packaged in nixpkgs. Use ``nodejs`` from nixpkgs
+    directly (pinned via ``shell.nix``), or install nvm via the upstream
+    script as described in `Node.js via nvm`_.
+
+Alpine Linux
+^^^^^^^^^^^^
+
+Alpine uses **musl libc** instead of glibc. Most Python packages build fine,
+but some pre-built binary wheels may not be available -- pip will compile
+them from source, which is why the ``-dev`` packages below are essential.
+
+**Enable the community repository**
+
+Several packages (imagemagick, docker, gh, npm) live in the community
+repository:
+
+.. code-block:: console
+
+    $ setup-apkrepos -cf
+    $ apk update
+
+**System libraries**
+
+.. code-block:: console
+
+    $ apk add \
+        build-base python3-dev openssl-dev linux-headers \
+        cairo-dev freetype-dev geoip-dev gettext-dev glib-dev \
+        imagemagick-dev \
+        libjpeg-turbo-dev libpng-dev tiff-dev \
+        libffi-dev libmemcached-dev \
+        libxml2-dev libxslt-dev \
+        readline-dev xz-dev zlib-dev \
+        bzip2-dev sqlite-dev ncurses-dev tk-dev
+
+**CLI development tools**
+
+.. code-block:: console
+
+    $ apk add git github-cli wget curl htop tree bash
+
+Chromedriver:
+
+.. code-block:: console
+
+    $ apk add chromium-chromedriver
+
+**Docker**
+
+.. code-block:: console
+
+    $ apk add docker docker-cli-compose
+    $ rc-update add docker default
+    $ service docker start
+
+See `Docker post-install`_ below.
+
+**Node.js**
+
+.. code-block:: console
+
+    $ apk add nodejs npm
+
+**Fonts**
+
+.. code-block:: console
+
+    $ apk add ttf-dejavu
+
+.. note::
+
+    If a Python package fails to install with wheel errors, ensure you have
+    all the ``-dev`` headers above. Packages that ship only ``manylinux``
+    wheels must be built from source on Alpine.
+
+Arch Linux
+^^^^^^^^^^
+
+**System libraries**
+
+.. code-block:: console
+
+    $ sudo pacman -S --needed \
+        base-devel python openssl \
+        cairo freetype2 geoip gettext glib2 \
+        imagemagick \
+        libjpeg-turbo libpng libtiff \
+        libffi libmemcached-awesome \
+        libxml2 libxslt \
+        readline xz zlib \
+        bzip2 sqlite ncurses tk
+
+.. note::
+
+    ``libmemcached-awesome`` is the maintained replacement for the legacy
+    ``libmemcached`` package.
+
+**CLI development tools**
+
+.. code-block:: console
+
+    $ sudo pacman -S --needed git github-cli wget curl htop tree
+
+Chromedriver (AUR):
+
+.. code-block:: console
+
+    $ yay -S chromedriver   # or: paru -S chromedriver
+
+**Docker**
+
+.. code-block:: console
+
+    $ sudo pacman -S --needed docker docker-compose
+    $ sudo systemctl enable --now docker.service
+
+See `Docker post-install`_ below.
+
+**Python & Node.js version managers**
+
+Both ``pyenv`` and ``nvm`` are available in the official repos:
+
+.. code-block:: console
+
+    $ sudo pacman -S --needed pyenv nvm nodejs npm
+
+**Fonts**
+
+.. code-block:: console
+
+    $ sudo pacman -S --needed ttf-dejavu
+
+Shared setup (all distributions)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The steps below are the same regardless of which Linux distribution you use.
+
+.. _pyenv-setup:
+
+**Python via pyenv**
+
+If you did not install pyenv from your package manager (Arch and NixOS
+provide it), install it from source:
+
+.. code-block:: console
+
+    $ curl https://pyenv.run | bash
+
+Add the following to your ``~/.bashrc`` or ``~/.zshrc``:
 
 .. code-block:: sh
-
-    $ nvm use --lts
-
-**Pyenv**
-
-Update and install the required dependencies.
-
-.. code-block:: console
-
-    $ sudo apt update -y
-    $ sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
-
-Clone the repository
-
-.. code-block:: console
-
-    $ git clone https://github.com/pyenv/pyenv.git ~/.pyenv
-
-Configure the environment.
-
-.. code-block:: console
-
-    $ echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-    $ echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-    $ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-Restart shell.
-
-.. code-block:: console
-
-    $ exec "$SHELL"
-
-**Pipenv**
-
-Pipenv is a packaging tool for Python that solves some common problems associated with the typical workflow using pip and virtualenv. We suggest the following installation guide:
-
-https://realpython.com/pipenv-guide/#pipenv-introduction
-
-**virtualenv**
-
-virtualenv is a CLI tool that needs a Python interpreter to run. We recommend the following installation guide:
-
-https://virtualenv.pypa.io/en/latest/installation.html
-
-**virtualenvwrapper**
-
-Note that after the installation, virtualenvwrapper.sh can be found in :code:`~/.local/bin`
-
-.. code-block::
-
-    $ pip3 install --user virtualenvwrapper
-
-Once you have installed above packages, you can proceed with installing Python versions.
-The following will install Python 3.6, 3.7 and 3.8 and set the default Python installation to Python 3.8:
-
-.. code-block:: console
-
-    $ pyenv install 3.6.9
-    $ pyenv install 3.7.8
-    $ pyenv install 3.8.5
-    $ pyenv global 3.8.5
-
-Install the latest patch-level release for node.
-
-.. code-block:: console
-
-    $ nvm install --lts
-
-You should edit your `.bashrc` or `.zshrc` file to initialise pyenv:
-
-.. code-block:: sh
-
-    # nvm setup
-    export NVM_DIR="$HOME/.nvm"
-    [ -s "/usr/local/opt/nvm/nvm.sh" ] && . "/usr/local/opt/nvm/nvm.sh"
 
     # pyenv
+    export PYENV_ROOT="$HOME/.pyenv"
+    export PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"
-
-    # pyenv-virtualenv
     eval "$(pyenv virtualenv-init -)"
 
-    # pyenv-virtualenvwrapper
-    pyenv virtualenvwrapper
-
-Now, you can create e.g. Python virtual environments using the following
-commands:
+Reload your shell, then install Python versions:
 
 .. code-block:: console
 
-    $ mkvirtualenv <name>
-    $ mkvirtualenv -p python3.7 <name>
-    $ workon <name>
+    $ pyenv install 3.6.15
+    $ pyenv install 3.7.17
+    $ pyenv install 3.8.20
+    $ pyenv global 3.8.20
 
-
-To deactivate the virtual environment simple type:
+Create virtual environments:
 
 .. code-block:: console
 
-     $ deactivate
+    $ pyenv virtualenv 3.8.20 my-invenio-env
+    $ pyenv activate my-invenio-env
+
+Or, if you prefer **pyenv-virtualenvwrapper**:
+
+.. code-block:: console
+
+    $ pip install virtualenvwrapper
+    $ pyenv virtualenvwrapper
+    $ mkvirtualenv my-invenio-env
+    $ workon my-invenio-env
+
+To deactivate the virtual environment:
+
+.. code-block:: console
+
+    $ deactivate
+
+.. _nvm-setup:
+
+**Node.js via nvm**
+
+Install nvm:
+
+.. code-block:: console
+
+    $ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash
+
+Add to your ``~/.bashrc`` or ``~/.zshrc`` (the installer usually does this
+automatically):
+
+.. code-block:: sh
+
+    export NVM_DIR="$HOME/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+Install Node.js:
+
+.. code-block:: console
+
+    $ nvm install 14
+    $ nvm use 14
+
+.. _docker-post-install:
+
+**Docker post-install**
+
+Add your user to the ``docker`` group so you can run Docker without ``sudo``:
+
+.. code-block:: console
+
+    $ sudo usermod -aG docker $USER
+
+Log out and back in (or run ``newgrp docker``) for the group change to take
+effect. Verify:
+
+.. code-block:: console
+
+    $ docker run hello-world
+
+**Elasticsearch vm.max_map_count**
+
+Elasticsearch requires a higher virtual memory map limit than most Linux
+defaults. Set it persistently:
+
+.. code-block:: console
+
+    $ sudo sysctl -w vm.max_map_count=262144
+
+To make it permanent across reboots:
+
+.. code-block:: console
+
+    $ echo "vm.max_map_count=262144" | sudo tee -a /etc/sysctl.d/99-elasticsearch.conf
+    $ sudo sysctl --system
+
+.. note::
+
+    On **NixOS**, add to ``configuration.nix`` instead:
+
+    .. code-block:: nix
+
+        boot.kernel.sysctl."vm.max_map_count" = 262144;
+
+**Fonts**
+
+All distributions above include a step to install DejaVu Sans. If you
+skipped it, install the ``dejavu`` font package for your distro (needed for
+generating DOI badges).
 
 **cookiecutter**
 
-Tool to bootstrap new modules from templates.
+Tool to bootstrap new modules from templates:
 
 .. code-block:: console
 
-    pip install cookiecutter
+    $ pip install cookiecutter
 
 Editor
 ------


### PR DESCRIPTION
## Summary

* Replaces the placeholder Linux section ("Want to write it? Contact us on the chat!") and the partial Ubuntu-only instructions with comprehensive setup guides for **four distributions**: Debian/Ubuntu, NixOS, Alpine Linux, and Arch Linux.
* Each distro section covers system libraries, CLI tools, Docker installation, chromedriver, and fonts (DejaVu Sans).
* Adds a shared setup section covering pyenv, nvm, Docker post-install (user group), Elasticsearch `vm.max_map_count` tuning, and cookiecutter.
* Modernizes package names and tool versions (nvm v0.40.0, current Debian package names, Docker Compose v2 plugin).

## Test plan

- [ ] Build the Sphinx docs locally (`cd docs && make html`) and verify the Linux section renders correctly with proper heading hierarchy
- [ ] Verify all internal cross-references (`Shared setup`, `Docker post-install`, `Node.js via nvm`) resolve correctly
- [ ] Spot-check package names against each distro's package repository