### PR TITLE
ci: modernize PyPI publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,27 +5,31 @@ on:
     tags:
       - v*
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   Publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: "3.12"
 
-      - name: Install dependencies
+      - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel
+          pip install build
+
       - name: Build package
-        run: |
-          python setup.py sdist bdist_wheel
+        run: python -m build
+
       - name: Publish on PyPI
-        uses: pypa/gh-action-pypi-publish@v1.3.1
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
-          user: __token__
           password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
## Summary

Comprehensive modernization of the PyPI publish workflow (`.github/workflows/pypi-publish.yml`). Supersedes #4097.

**What changed:**

* **`pypa/gh-action-pypi-publish`**: v1.3.1 -> v1.13.0 — fixes security vulnerability [GHSA-vxmw-7h4f-hqxh](https://github.com/pypa/gh-action-pypi-publish/security/advisories/GHSA-vxmw-7h4f-hqxh)
* **`actions/checkout`**: v2 -> v4 — v2 uses Node 12 which GitHub no longer supports
* **`actions/setup-python`**: v2 -> v5 — same Node 12 deprecation
* **Runner**: `ubuntu-20.04` -> `ubuntu-latest` — 20.04 runners are deprecated
* **Python**: 3.7 -> 3.12 — Python 3.7 reached end-of-life in June 2023 (the built package still supports whatever versions `setup.py` declares)
* **Build method**: `python setup.py sdist bdist_wheel` -> `python -m build` — `setup.py` direct invocation is deprecated per [PEP 517](https://peps.python.org/pep-0517/)
* **Permissions**: added top-level `id-token: write` + `contents: read` for Trusted Publisher readiness
* **Removed** deprecated `user: __token__` input (no longer needed by pypi-publish v1.13.0)

## Test plan

- [ ] Verify workflow YAML is valid (GitHub Actions linter)
- [ ] Confirm next tag push triggers the workflow and builds/publishes successfully
- [ ] Verify `python -m build` produces identical sdist and wheel to `python setup.py sdist bdist_wheel`