### PR TITLE
ci: modernize test matrix and update Python classifiers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
     branches: master
   schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '0 3 * * 6'
+    - cron: '0 3 * * 6'
   workflow_dispatch:
     inputs:
       reason:
@@ -17,41 +16,35 @@ on:
 
 jobs:
   Tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-          python-version: [3.7, 3.8, 3.9]
+          python-version: ["3.9", "3.10", "3.11", "3.12"]
           requirements-level: [min, pypi]
           cache-service: [redis]
-          db-service: [postgresql10, postgresql13, mysql5, mysql8]
+          db-service: [postgresql13, postgresql16, mysql8]
           mq-service: [rabbitmq, redis]
           search-service: [elasticsearch7]
 
           exclude:
-          # Add combinations to this list that should be excluded from the final
-          # build. Doing this will help keeping the number of jobs down.
-          # E.g. removing 3.8 - min combination will avoid 8 jobs to be submited
-          # [3.8] * [min] * [postgresql10, postgresql13, mysql5, mysql8] * [elasticsearch6, elasticsearch7]
-          - python-version: 3.8
+          - python-version: "3.10"
             requirements-level: min
 
-          - python-version: 3.9
+          - python-version: "3.11"
             requirements-level: min
 
-          - db-service: postgresql13
-            python-version: 3.7
+          - python-version: "3.12"
+            requirements-level: min
 
-          - db-service: mysql8
-            python-version: 3.7
+          - db-service: postgresql16
+            python-version: "3.9"
+
           include:
-          - db-service: postgresql10
-            DB_EXTRAS: "postgresql"
-
           - db-service: postgresql13
             DB_EXTRAS: "postgresql"
 
-          - db-service: mysql5
-            DB_EXTRAS: "mysql"
+          - db-service: postgresql16
+            DB_EXTRAS: "postgresql"
 
           - db-service: mysql8
             DB_EXTRAS: "mysql"
@@ -68,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -81,7 +74,7 @@ jobs:
           requirements-builder -e "$EXTRAS" --level=${{ matrix.requirements-level }} setup.py > .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('.${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt') }}
@@ -92,7 +85,7 @@ jobs:
           pip install ".[$EXTRAS]"
           pip freeze
           docker --version
-          docker-compose --version
+          docker compose version
 
       - name: Run tests
         run: |

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2026 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/setup.py
+++ b/setup.py
@@ -134,9 +134,10 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Development Status :: 5 - Production/Stable',
     ],
 )


### PR DESCRIPTION
## Summary

- Replaces deprecated `ubuntu-20.04` runner with `ubuntu-latest`
- Bumps `actions/checkout` v2 -> v4, `actions/setup-python` v2 -> v5, `actions/cache` v2 -> v4 (v2 uses unsupported Node 12 runtime)
- Updates Python test matrix from `[3.7, 3.8, 3.9]` to `[3.9, 3.10, 3.11, 3.12]` (3.7 EOL June 2023, 3.8 EOL Oct 2024)
- Removes EOL database versions from the matrix: PostgreSQL 10 and MySQL 5
- Adds PostgreSQL 16 to the test matrix
- Replaces deprecated `docker-compose` CLI with `docker compose` v2
- Updates `setup.py` classifiers to match the tested Python versions

## Motivation

All recent CI runs show `action_required` or `cancelled` status because the workflow uses deprecated components. This PR brings the CI pipeline back to a functional state.

Combined with #4101 (which modernizes the PyPI publish workflow), this addresses all deprecated CI/CD infrastructure in the repository.

## Test plan

- [x] Verify YAML syntax is valid
- [x] Matrix exclusions are correct (only `min` level runs on oldest Python)
- [ ] Maintainers: confirm `docker-services-cli` supports `postgresql16` service name
- [ ] Maintainers: verify CI runs green after merge

Addresses #3998, relates to #4040