### PR TITLE
infra: add OpenSearch support, drop EOL search engines

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
     branches: master
   schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '0 3 * * 6'
+    - cron: '0 3 * * 6'
   workflow_dispatch:
     inputs:
       reason:
@@ -17,47 +16,44 @@ on:
 
 jobs:
   Tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-          python-version: [3.7, 3.8, 3.9]
+          python-version: ["3.9", "3.10", "3.11", "3.12"]
           requirements-level: [min, pypi]
           cache-service: [redis]
-          db-service: [postgresql10, postgresql13, mysql5, mysql8]
+          db-service: [postgresql13, postgresql16, mysql8]
           mq-service: [rabbitmq, redis]
-          search-service: [elasticsearch7]
+          search-service: [elasticsearch7, opensearch2]
 
           exclude:
-          # Add combinations to this list that should be excluded from the final
-          # build. Doing this will help keeping the number of jobs down.
-          # E.g. removing 3.8 - min combination will avoid 8 jobs to be submited
-          # [3.8] * [min] * [postgresql10, postgresql13, mysql5, mysql8] * [elasticsearch6, elasticsearch7]
-          - python-version: 3.8
+          - python-version: "3.10"
             requirements-level: min
 
-          - python-version: 3.9
+          - python-version: "3.11"
             requirements-level: min
 
-          - db-service: postgresql13
-            python-version: 3.7
+          - python-version: "3.12"
+            requirements-level: min
 
-          - db-service: mysql8
-            python-version: 3.7
+          - db-service: postgresql16
+            python-version: "3.9"
+
           include:
-          - db-service: postgresql10
-            DB_EXTRAS: "postgresql"
-
           - db-service: postgresql13
             DB_EXTRAS: "postgresql"
 
-          - db-service: mysql5
-            DB_EXTRAS: "mysql"
+          - db-service: postgresql16
+            DB_EXTRAS: "postgresql"
 
           - db-service: mysql8
             DB_EXTRAS: "mysql"
 
           - search-service: elasticsearch7
             SEARCH_EXTRAS: "elasticsearch7"
+
+          - search-service: opensearch2
+            SEARCH_EXTRAS: "opensearch2"
 
     env:
       CACHE: ${{ matrix.cache-service }}
@@ -68,10 +64,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -81,7 +77,7 @@ jobs:
           requirements-builder -e "$EXTRAS" --level=${{ matrix.requirements-level }} setup.py > .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('.${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt') }}
@@ -92,7 +88,7 @@ jobs:
           pip install ".[$EXTRAS]"
           pip freeze
           docker --version
-          docker-compose --version
+          docker compose version
 
       - name: Run tests
         run: |

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2026 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -21,7 +21,7 @@ trap cleanup EXIT
 
 python -m check_manifest --ignore ".*-requirements.txt"
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
-eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-elasticsearch} --cache ${CACHE:-redis} --mq ${MQ:-rabbitmq} --env)"
+eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-opensearch2} --cache ${CACHE:-redis} --mq ${MQ:-rabbitmq} --env)"
 python -m pytest
 tests_exit_code=$?
 exit "$tests_exit_code"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ tests_require = [
 ]
 
 db_version = '>=1.0.9,<1.1.0'
-search_version = '>=1.4.2,<1.5.0'
+search_version = '>=2.1.0,<4.0.0'
 
 extras_require = {
     # Bundles
@@ -65,15 +65,15 @@ extras_require = {
     'sqlite': [
         'invenio-db[versioning]{}'.format(db_version),
     ],
-    # Elasticsearch version
-    'elasticsearch5': [
-        'invenio-search[elasticsearch5]{}'.format(search_version),
-    ],
-    'elasticsearch6': [
-        'invenio-search[elasticsearch6]{}'.format(search_version),
-    ],
+    # Search engine version
     'elasticsearch7': [
         'invenio-search[elasticsearch7]{}'.format(search_version),
+    ],
+    'opensearch1': [
+        'invenio-search[opensearch1]{}'.format(search_version),
+    ],
+    'opensearch2': [
+        'invenio-search[opensearch2]{}'.format(search_version),
     ],
     # Docs and test dependencies
     'docs': [
@@ -85,7 +85,8 @@ extras_require = {
 extras_require['all'] = []
 for name, reqs in extras_require.items():
     if name in ('sqlite', 'mysql', 'postgresql') \
-            or name.startswith('elasticsearch'):
+            or name.startswith('elasticsearch') \
+            or name.startswith('opensearch'):
         continue
     extras_require['all'].extend(reqs)
 
@@ -134,9 +135,10 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Development Status :: 5 - Production/Stable',
     ],
 )


### PR DESCRIPTION
## Summary

- Add `opensearch1` and `opensearch2` extras to `setup.py` via `invenio-search >=2.1.0,<4.0.0`, aligning the meta-package with `invenio-search` v3.x which already ships these extras
- Remove `elasticsearch5` and `elasticsearch6` extras (ES5 EOL March 2019, ES6 EOL February 2022)
- Retain `elasticsearch7` for backward compatibility
- Update CI test matrix to cover both `elasticsearch7` and `opensearch2`
- Modernize `tests.yml`: `ubuntu-latest`, `actions/checkout@v4`, `actions/setup-python@v5`, `actions/cache@v4`, Python 3.9-3.12, drop EOL databases (PostgreSQL 10, MySQL 5), add PostgreSQL 16, use `docker compose` v2 CLI
- Default `run-tests.sh` search engine from `elasticsearch` to `opensearch2`
- Update Python classifiers to 3.9-3.12

### Motivation

The `invenio` meta-package only exposed Elasticsearch 5/6/7 extras through `invenio-search >=1.4.x`. Meanwhile, `invenio-search` reached v3.1.2 with full OpenSearch 1.x and 2.x support, and sibling packages like `invenio-records-rest` already use OpenSearch in their CI. This PR brings the meta-package in line with the ecosystem.

Closes #3961
Closes #3998