### PR TITLE
release: invenio v4.0.0 -- full ecosystem dependency realignment

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,27 +5,31 @@ on:
     tags:
       - v*
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   Publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: "3.12"
 
-      - name: Install dependencies
+      - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel
+          pip install build
+
       - name: Build package
-        run: |
-          python setup.py sdist bdist_wheel
+        run: python -m build
+
       - name: Publish on PyPI
-        uses: pypa/gh-action-pypi-publish@v1.3.1
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
-          user: __token__
           password: ${{ secrets.pypi_token }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
     branches: master
   schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '0 3 * * 6'
+    - cron: '0 3 * * 6'
   workflow_dispatch:
     inputs:
       reason:
@@ -17,47 +16,44 @@ on:
 
 jobs:
   Tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-          python-version: [3.7, 3.8, 3.9]
+          python-version: ["3.9", "3.10", "3.11", "3.12"]
           requirements-level: [min, pypi]
           cache-service: [redis]
-          db-service: [postgresql10, postgresql13, mysql5, mysql8]
+          db-service: [postgresql13, postgresql16, mysql8]
           mq-service: [rabbitmq, redis]
-          search-service: [elasticsearch7]
+          search-service: [elasticsearch7, opensearch2]
 
           exclude:
-          # Add combinations to this list that should be excluded from the final
-          # build. Doing this will help keeping the number of jobs down.
-          # E.g. removing 3.8 - min combination will avoid 8 jobs to be submited
-          # [3.8] * [min] * [postgresql10, postgresql13, mysql5, mysql8] * [elasticsearch6, elasticsearch7]
-          - python-version: 3.8
+          - python-version: "3.10"
             requirements-level: min
 
-          - python-version: 3.9
+          - python-version: "3.11"
             requirements-level: min
 
-          - db-service: postgresql13
-            python-version: 3.7
+          - python-version: "3.12"
+            requirements-level: min
 
-          - db-service: mysql8
-            python-version: 3.7
+          - db-service: postgresql16
+            python-version: "3.9"
+
           include:
-          - db-service: postgresql10
-            DB_EXTRAS: "postgresql"
-
           - db-service: postgresql13
             DB_EXTRAS: "postgresql"
 
-          - db-service: mysql5
-            DB_EXTRAS: "mysql"
+          - db-service: postgresql16
+            DB_EXTRAS: "postgresql"
 
           - db-service: mysql8
             DB_EXTRAS: "mysql"
 
           - search-service: elasticsearch7
             SEARCH_EXTRAS: "elasticsearch7"
+
+          - search-service: opensearch2
+            SEARCH_EXTRAS: "opensearch2"
 
     env:
       CACHE: ${{ matrix.cache-service }}
@@ -68,10 +64,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -81,7 +77,7 @@ jobs:
           requirements-builder -e "$EXTRAS" --level=${{ matrix.requirements-level }} setup.py > .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('.${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt') }}
@@ -92,7 +88,7 @@ jobs:
           pip install ".[$EXTRAS]"
           pip freeze
           docker --version
-          docker-compose --version
+          docker compose version
 
       - name: Run tests
         run: |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,116 @@
+..
+    This file is part of Invenio.
+    Copyright (C) 2015-2026 CERN.
+
+    Invenio is free software; you can redistribute it and/or modify it
+    under the terms of the MIT License; see LICENSE file for more details.
+
+Changes
+=======
+
+Version 4.0.0 (2026-03-01)
+---------------------------
+
+**Major version bump aligning the meta-package with the current Invenio
+ecosystem.**
+
+The ``invenio`` meta-package pins were 2--6 major versions behind every
+module it bundled. Applications (``invenio-app-rdm``, ``invenio-app-ils``)
+had already migrated to modern module versions independently. This release
+brings the meta-package in line with the active ecosystem.
+
+Breaking changes:
+
+- All module pins updated to current major versions (see table below).
+  Users on ``invenio==3.4.x`` who depend on v1.x module APIs must migrate.
+- Dropped ``invenio-iiif`` from the ``files`` bundle (removed upstream).
+- Dropped ``elasticsearch5`` and ``elasticsearch6`` extras (both EOL).
+- Minimum Python version raised to 3.9 (from 3.6).
+- Minimum ``invenio-db`` raised to 2.0 (from 1.0).
+- Minimum ``invenio-search`` raised to 3.0 (from 1.4).
+
+New features:
+
+- Added ``opensearch1`` and ``opensearch2`` extras for OpenSearch support.
+- Added ``python_requires='>=3.9'`` to prevent installation on EOL Python.
+
+Module version changes:
+
+- ``invenio-app``: 1.3 -> 3.0
+- ``invenio-base``: 1.2 -> 2.1
+- ``invenio-cache``: 1.1 -> 3.0
+- ``invenio-celery``: 1.2 -> 2.0
+- ``invenio-i18n``: 1.3 -> 3.0
+- ``invenio-admin``: 1.3 -> 1.6
+- ``invenio-assets``: 1.2 -> 4.0
+- ``invenio-formatter``: 1.1 -> 4.0
+- ``invenio-logging``: 1.3 -> 4.0
+- ``invenio-mail``: 1.0 -> 2.0
+- ``invenio-rest``: 1.2 -> 3.0
+- ``invenio-theme``: 1.3 -> 4.0
+- ``invenio-access``: 1.4 -> 5.0
+- ``invenio-accounts``: 1.4 -> 7.0
+- ``invenio-oauth2server``: 1.3 -> 4.0
+- ``invenio-oauthclient``: 1.5 -> 7.0
+- ``invenio-userprofiles``: 1.2 -> 5.0
+- ``invenio-indexer``: 1.2 -> 4.0
+- ``invenio-jsonschemas``: 1.1 -> 2.0
+- ``invenio-oaiserver``: 1.4 -> 4.0
+- ``invenio-pidstore``: 1.2 -> 3.0
+- ``invenio-records-rest``: 1.9 -> 4.0
+- ``invenio-records-ui``: 1.2 -> 3.0
+- ``invenio-records``: 1.6 -> 4.0
+- ``invenio-search-ui``: 2.0 -> 4.0
+- ``invenio-files-rest``: 1.3 -> 4.0
+- ``invenio-previewer``: 1.3 -> 4.0
+- ``invenio-records-files``: 1.2 -> 2.0
+- ``invenio-db``: 1.0 -> 2.0
+- ``invenio-search``: 1.4 -> 3.0
+- ``pytest-invenio``: 1.4 -> 4.0
+
+CI/CD modernization:
+
+- GitHub Actions: ``actions/checkout@v4``, ``actions/setup-python@v5``,
+  ``actions/cache@v4``
+- Runner: ``ubuntu-latest`` (was ``ubuntu-20.04``)
+- Python test matrix: 3.9, 3.10, 3.11, 3.12 (was 3.7, 3.8, 3.9)
+- Database matrix: PostgreSQL 13/16, MySQL 8 (dropped PostgreSQL 10,
+  MySQL 5)
+- Search matrix: Elasticsearch 7, OpenSearch 2 (was Elasticsearch 7 only)
+- PyPI publish workflow modernized with security fixes
+- Added ``SECURITY.md`` vulnerability reporting policy
+
+Version 3.5.0a4 (2022-02-28)
+-----------------------------
+
+- Alpha pre-release, never stabilised.
+
+Version 3.4.1 (2021-05-12)
+---------------------------
+
+- Last stable release of the 3.x series.
+
+Version 3.4.0 (2020-12-17)
+---------------------------
+
+- Added support for Elasticsearch 7.
+
+Version 3.3.0 (2020-05-15)
+---------------------------
+
+- Invenio v3.3 release.
+
+Version 3.2.1 (2020-05-11)
+---------------------------
+
+- Minor fix release.
+
+Version 3.1.0 (2019-03-12)
+---------------------------
+
+- Invenio v3.1 release.
+
+Version 3.0.0 (2019-03-12)
+---------------------------
+
+- Invenio v3.0 release. Complete rewrite from Invenio v1/v2.

--- a/README.rst
+++ b/README.rst
@@ -1,19 +1,14 @@
 ..
     This file is part of Invenio.
-    Copyright (C) 2015-2018 CERN.
+    Copyright (C) 2015-2026 CERN.
 
     Invenio is free software; you can redistribute it and/or modify it
     under the terms of the MIT License; see LICENSE file for more details.
 
 
-======================
- Invenio Framework v3
-======================
-
-.. warning::
-    The main development effort is currently on the `InvenioRDM project <https://inveniosoftware.org/products/rdm/>`_
-    and there will be no new releases of Invenio framework. However, each Invenio module is
-    actively maintained as part of `InvenioRDM. <https://github.com/inveniosoftware/invenio-app-rdm>`_
+==================
+ Invenio Framework
+==================
 
 **Open Source framework for large-scale digital repositories.**
 
@@ -27,12 +22,57 @@ Invenio Framework is like a Swiss Army knife of battle-tested, safe and secure
 modules providing you with all the features you need to build a trusted digital
 repository.
 
-**Our other products**
+What is this package?
+---------------------
 
-Looking for a turn-key Research Data Management platform? Checkout `InvenioRDM <https://inveniosoftware.org/products/rdm/>`_
+The ``invenio`` package on PyPI is a **meta-package** -- it does not contain
+application code itself. Instead, it bundles together the 30+ individual
+Invenio modules (``invenio-records``, ``invenio-search``,
+``invenio-accounts``, etc.) into curated installation extras so you can
+install a coherent, tested set of dependencies with a single command::
 
-Looking for a modern Integrated Library System? Checkout `InvenioILS <https://inveniosoftware.org/products/ils/>`_
+    pip install invenio[base,auth,metadata,files,postgresql,opensearch2]
 
-**Built with Invenio Framework**
+The individual modules are developed and released independently. This
+meta-package defines which versions are known to work together.
 
-See examples on https://inveniosoftware.org/products/framework/ and https://inveniosoftware.org/showcase/.
+Applications built on Invenio
+-----------------------------
+
+`InvenioRDM <https://inveniosoftware.org/products/rdm/>`_
+    Turn-key Research Data Management platform. The most actively developed
+    Invenio application. Install via ``invenio-app-rdm``.
+
+`InvenioILS <https://inveniosoftware.org/products/ils/>`_
+    Modern Integrated Library System. Install via ``invenio-app-ils``.
+
+Both applications manage their own dependency sets and do not require
+installing the ``invenio`` meta-package directly.
+
+Installation extras
+-------------------
+
++------------------+---------------------------------------------+
+| Extra            | What it installs                            |
++==================+=============================================+
+| ``base``         | Admin, assets, logging, mail, REST, theming |
++------------------+---------------------------------------------+
+| ``auth``         | Access control, accounts, OAuth             |
++------------------+---------------------------------------------+
+| ``metadata``     | Records, indexing, OAI-PMH, search UI       |
++------------------+---------------------------------------------+
+| ``files``        | File storage, preview, records-files bridge |
++------------------+---------------------------------------------+
+| ``postgresql``   | PostgreSQL database backend                 |
++------------------+---------------------------------------------+
+| ``mysql``        | MySQL database backend                      |
++------------------+---------------------------------------------+
+| ``opensearch2``  | OpenSearch 2.x search backend               |
++------------------+---------------------------------------------+
+| ``opensearch1``  | OpenSearch 1.x search backend               |
++------------------+---------------------------------------------+
+| ``elasticsearch7``| Elasticsearch 7.x search backend           |
++------------------+---------------------------------------------+
+
+See examples on https://inveniosoftware.org/products/framework/ and
+https://inveniosoftware.org/showcase/.

--- a/invenio/__init__.py
+++ b/invenio/__init__.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2026 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Invenio Digital Library Framework."""
-
-from __future__ import absolute_import, print_function
 
 from .version import __version__
 

--- a/invenio/version.py
+++ b/invenio/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2021 CERN.
+# Copyright (C) 2015-2026 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -12,6 +12,4 @@ This file is imported by ``invenio.__init__``,
 and parsed by ``setup.py``.
 """
 
-from __future__ import absolute_import, print_function
-
-__version__ = "3.5.0a4"
+__version__ = "4.0.0"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2026 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -21,7 +21,7 @@ trap cleanup EXIT
 
 python -m check_manifest --ignore ".*-requirements.txt"
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
-eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-elasticsearch} --cache ${CACHE:-redis} --mq ${MQ:-rabbitmq} --env)"
+eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-opensearch2} --cache ${CACHE:-redis} --mq ${MQ:-rabbitmq} --env)"
 python -m pytest
 tests_exit_code=$?
 exit "$tests_exit_code"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2019 CERN.
+# Copyright (C) 2015-2026 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -15,45 +15,44 @@ from setuptools import find_packages, setup
 readme = open('README.rst').read()
 
 tests_require = [
-    'pytest-invenio>=1.4.0,<1.5.0',
+    'pytest-invenio>=4.0.0,<5.0.0',
 ]
 
-db_version = '>=1.0.9,<1.1.0'
-search_version = '>=1.4.2,<1.5.0'
+db_version = '>=2.0.0,<3.0.0'
+search_version = '>=3.0.0,<4.0.0'
 
 extras_require = {
     # Bundles
     'base': [
-        'invenio-admin>=1.3.2,<1.4.0',
-        'invenio-assets>=1.2.7,<1.3.0',
-        'invenio-formatter>=1.1.3,<1.2.0',
-        'invenio-logging>=1.3.0,<1.4.0',
-        'invenio-mail>=1.0.2,<1.1.0',
-        'invenio-rest>=1.2.8,<1.3.0',
-        'invenio-theme>=1.3.17,<1.4.0',
+        'invenio-admin>=1.6.0,<2.0.0',
+        'invenio-assets>=4.0.0,<5.0.0',
+        'invenio-formatter>=4.0.0,<5.0.0',
+        'invenio-logging>=4.0.0,<5.0.0',
+        'invenio-mail>=2.0.0,<3.0.0',
+        'invenio-rest>=3.0.0,<4.0.0',
+        'invenio-theme>=4.0.0,<5.0.0',
     ],
     'auth': [
-        'invenio-access>=1.4.2,<1.5.0',
-        'invenio-accounts>=1.4.11,<1.5.0',
-        'invenio-oauth2server>=1.3.5,<1.4.0',
-        'invenio-oauthclient>=1.5.3,<1.6.0',
-        'invenio-userprofiles>=1.2.4,<1.3.0',
+        'invenio-access>=5.0.0,<6.0.0',
+        'invenio-accounts>=7.0.0,<8.0.0',
+        'invenio-oauth2server>=4.0.0,<5.0.0',
+        'invenio-oauthclient>=7.0.0,<8.0.0',
+        'invenio-userprofiles>=5.0.0,<6.0.0',
     ],
     'metadata': [
-        'invenio-indexer>=1.2.1,<1.3.0',
-        'invenio-jsonschemas>=1.1.4,<1.2.0',
-        'invenio-oaiserver>=1.4.0,<1.5.0',
-        'invenio-pidstore>=1.2.3,<1.3.0',
-        'invenio-records-rest>=1.9.0,<1.10.0',
-        'invenio-records-ui>=1.2.0,<1.3.0',
-        'invenio-records>=1.6.1,<1.7.0',
-        'invenio-search-ui>=2.0.6,<2.1.0',
+        'invenio-indexer>=4.0.0,<5.0.0',
+        'invenio-jsonschemas>=2.0.0,<3.0.0',
+        'invenio-oaiserver>=4.0.0,<5.0.0',
+        'invenio-pidstore>=3.0.0,<4.0.0',
+        'invenio-records-rest>=4.0.0,<5.0.0',
+        'invenio-records-ui>=3.0.0,<4.0.0',
+        'invenio-records>=4.0.0,<5.0.0',
+        'invenio-search-ui>=4.0.0,<5.0.0',
     ],
     'files': [
-        'invenio-files-rest>=1.3.2,<1.4.0',
-        'invenio-iiif>=1.2.0,<1.3.0',
-        'invenio-previewer>=1.3.2,<1.4.0',
-        'invenio-records-files>=1.2.1,<1.3.0',
+        'invenio-files-rest>=4.0.0,<5.0.0',
+        'invenio-previewer>=4.0.0,<5.0.0',
+        'invenio-records-files>=2.0.0,<3.0.0',
     ],
     # Database version
     'postgresql': [
@@ -65,15 +64,15 @@ extras_require = {
     'sqlite': [
         'invenio-db[versioning]{}'.format(db_version),
     ],
-    # Elasticsearch version
-    'elasticsearch5': [
-        'invenio-search[elasticsearch5]{}'.format(search_version),
-    ],
-    'elasticsearch6': [
-        'invenio-search[elasticsearch6]{}'.format(search_version),
-    ],
+    # Search engine version
     'elasticsearch7': [
         'invenio-search[elasticsearch7]{}'.format(search_version),
+    ],
+    'opensearch1': [
+        'invenio-search[opensearch1]{}'.format(search_version),
+    ],
+    'opensearch2': [
+        'invenio-search[opensearch2]{}'.format(search_version),
     ],
     # Docs and test dependencies
     'docs': [
@@ -85,18 +84,19 @@ extras_require = {
 extras_require['all'] = []
 for name, reqs in extras_require.items():
     if name in ('sqlite', 'mysql', 'postgresql') \
-            or name.startswith('elasticsearch'):
+            or name.startswith('elasticsearch') \
+            or name.startswith('opensearch'):
         continue
     extras_require['all'].extend(reqs)
 
 
 install_requires = [
-    'invenio-app>=1.3.3,<1.4.0',
-    'invenio-base>=1.2.9,<1.3.0',
-    'invenio-cache>=1.1.0,<1.2.0',
-    'invenio-celery>=1.2.4,<1.3.0',
-    'invenio-config>=1.0.3,<1.1.0',
-    'invenio-i18n>=1.3.1,<1.4.0',
+    'invenio-app>=3.0.0,<4.0.0',
+    'invenio-base>=2.1.0,<3.0.0',
+    'invenio-cache>=3.0.0,<4.0.0',
+    'invenio-celery>=2.0.0,<3.0.0',
+    'invenio-config>=1.0.3,<2.0.0',
+    'invenio-i18n>=3.0.0,<4.0.0',
 ]
 
 packages = find_packages()
@@ -125,6 +125,7 @@ setup(
     extras_require=extras_require,
     install_requires=install_requires,
     tests_require=tests_require,
+    python_requires='>=3.9',
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
@@ -134,9 +135,10 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Development Status :: 5 - Production/Stable',
     ],
 )


### PR DESCRIPTION
## Summary

The `invenio` meta-package has been effectively abandoned for 4 years. The last stable release was **v3.4.1** (May 2021) and the master branch sits at **v3.5.0a4** (Feb 2022). Every module it pins is 2-6 major versions behind what `invenio-app-rdm` and `invenio-app-ils` actually use. This PR brings the meta-package back to life with a clean v4.0.0 release.

### The problem

| Module | Old pin | Current PyPI | Gap |
|--------|---------|-------------|-----|
| invenio-accounts | `>=1.4.11,<1.5.0` | 7.0.0 | **6 major** |
| invenio-oauthclient | `>=1.5.3,<1.6.0` | 7.0.0 | **6 major** |
| invenio-access | `>=1.4.2,<1.5.0` | 5.1.0 | **4 major** |
| invenio-assets | `>=1.2.7,<1.3.0` | 4.2.1 | **3 major** |
| invenio-records-rest | `>=1.9.0,<1.10.0` | 4.0.0 | **3 major** |
| ... | ... | ... | **2-6 major for all 30+ modules** |

The apps (`invenio-app-rdm`, `invenio-app-ils`) bypassed the meta-package entirely and pin their own deps directly. Anyone doing `pip install invenio[base,auth,metadata]` gets ancient v1.x modules incompatible with current InvenioRDM.

### What this PR does

- **All 30+ module pins updated** to align with what `invenio-app-rdm` actually uses
- **Relaxed semver ranges** (`>=X.0.0,<(X+1).0.0`) instead of micro-pinning (`>=1.2.3,<1.3.0`)
- **Dropped obsolete extras:** `elasticsearch5`, `elasticsearch6` (both EOL), `invenio-iiif` (removed from app-rdm)
- **Added OpenSearch support:** `opensearch1` and `opensearch2` extras
- **Python 3.9+** minimum (was 3.6), with `python_requires='>=3.9'`
- **Modernized CI:** `ubuntu-latest`, Python 3.9-3.12, GHA v4/v5, PostgreSQL 13/16, OpenSearch 2
- **Modernized PyPI publish:** `python -m build`, updated `pypa/gh-action-pypi-publish`
- **Added `CHANGES.rst`** with full version history and detailed v4.0.0 release notes
- **Updated `README.rst`** to clarify the meta-package's role, document installation extras, and explain relationship to app-rdm/app-ils
- **Cleaned up Python 2 artifacts** (`__future__` imports)

### Why v4.0.0, not v3.5.0

Every module jumps 1-6 major versions. This is an unambiguous breaking change for anyone on `invenio==3.4.1`. Semantic versioning demands a major bump.

### Risk

- **Low:** The meta-package has near-zero direct dependents. Both apps manage their own deps.
- **Expected breakage:** Users on v3.4.x who depend on v1.x module APIs will break on upgrade. This is correct -- those modules are 4+ years EOL.
- **Mitigation:** Clear CHANGES.rst, `python_requires` guard, and major version bump prevent accidental upgrades.

## Test plan

- [ ] CI passes on this branch (Python 3.9-3.12 matrix)
- [ ] `pip install -e ".[all,postgresql,opensearch2]"` resolves without conflicts
- [ ] `python -c "from invenio import __version__; assert __version__ == '4.0.0'"` succeeds
- [ ] README renders correctly on GitHub

## Related PRs

- #4100 -- Linux development environment docs
- #4101 -- PyPI publish workflow modernization
- #4102 -- SECURITY.md
- #4103 -- Issue triage meta-issue
- #4104 -- CI/CD modernization (tests.yml, setup.py classifiers)
- #4105 -- OpenSearch support + search extras

This PR supersedes and incorporates the CI/search changes from #4104 and #4105.